### PR TITLE
chore: add git-workflow skill and teams infrastructure

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -5,6 +5,7 @@ skills:
   - codebase-architecture
   - obsidian-plugin-dev
   - tdd
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 ---
 

--- a/.claude/agents/docs-agent.md
+++ b/.claude/agents/docs-agent.md
@@ -4,6 +4,7 @@ description: Agent-optimized documentation writer. Creates structured, machine-r
 skills:
   - docs-agent
   - codebase-architecture
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 ---
 

--- a/.claude/agents/docs-human.md
+++ b/.claude/agents/docs-human.md
@@ -4,6 +4,7 @@ description: Human-readable documentation writer. Creates decision logs, status 
 skills:
   - docs-human
   - codebase-architecture
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 ---
 

--- a/.claude/agents/elaboration-designer.md
+++ b/.claude/agents/elaboration-designer.md
@@ -4,6 +4,7 @@ description: Note elaboration system designer. Specializes in placeholder detect
 skills:
   - note-elaboration
   - tdd
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, Agent
 ---
 

--- a/.claude/agents/plugin-architect.md
+++ b/.claude/agents/plugin-architect.md
@@ -4,6 +4,7 @@ description: Obsidian plugin architecture specialist. Designs plugin structure, 
 skills:
   - obsidian-plugin-dev
   - tdd
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, Agent
 ---
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -3,6 +3,7 @@ name: security
 description: Security auditor. Reviews code for secrets, command injection, input validation, API key handling, and .gitignore enforcement. Implements security guardrails.
 skills:
   - security-audit
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 ---
 

--- a/.claude/agents/transcription-engineer.md
+++ b/.claude/agents/transcription-engineer.md
@@ -4,6 +4,7 @@ description: Media transcription pipeline engineer. Specializes in audio/video t
 skills:
   - media-transcription
   - tdd
+  - git-workflow
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, Agent
 ---
 

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: git-workflow
+description: Git branching strategy, commit standards, and PR workflow for the Auto Notes project. Use when performing any git operations (commits, branches, pushes, PRs).
+user_invocable: false
+---
+
+# Git Workflow Standards
+
+## Identity
+
+All git operations MUST use the project bot identity:
+
+```bash
+git -c user.email=bot@wafflenet.io -c user.name=bot <command>
+```
+
+Never use a personal identity or the default git config for this project.
+
+## Branch Strategy
+
+### Main is protected
+- **NEVER push directly to `main`.**
+- All work happens on feature branches.
+- Changes reach `main` only through pull requests.
+
+### Branch naming
+- `feat/<short-description>` — new features
+- `fix/<short-description>` — bug fixes
+- `refactor/<short-description>` — restructuring without behavior change
+- `chore/<short-description>` — tooling, config, docs, CI
+
+### Creating a branch
+```bash
+git checkout main && git pull
+git -c user.email=bot@wafflenet.io -c user.name=bot checkout -b feat/my-feature
+```
+
+## Commits
+
+### Message format
+```
+<type>: <concise summary>
+
+<optional body — why, not what>
+
+Co-Authored-By: Claude <bot@wafflenet.io>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `chore`, `test`, `docs`
+
+### Rules
+- Do NOT attribute `https://anthropic.com/claude-code` or `noreply@anthropic.com` in commits.
+- Use `Co-Authored-By: Claude <bot@wafflenet.io>` instead.
+- Pass commit messages via HEREDOC for proper formatting.
+- Never skip hooks (`--no-verify`) or bypass signing unless explicitly asked.
+- Prefer new commits over amending.
+
+### Example
+```bash
+git -c user.email=bot@wafflenet.io -c user.name=bot commit -m "$(cat <<'EOF'
+feat: add vault-wide enrichment scan command
+
+Three-phase scan: collect eligible files, confirm with user,
+then generate enrichment proposals with cancellation support.
+
+Co-Authored-By: Claude <bot@wafflenet.io>
+EOF
+)"
+```
+
+## Push & Pull Requests
+
+### Pushing
+```bash
+git -c user.email=bot@wafflenet.io -c user.name=bot push -u origin feat/my-feature
+```
+
+### Creating PRs (no human in the loop)
+After pushing, create the PR immediately using `gh`:
+
+```bash
+gh pr create --title "feat: short title" --body "$(cat <<'EOF'
+## Summary
+- Bullet points describing changes
+
+## Test plan
+- [ ] Tests pass (`npm test`)
+- [ ] Build passes (`npx tsc --noEmit --skipLibCheck && node esbuild.config.mjs production`)
+
+Co-Authored-By: Claude <bot@wafflenet.io>
+EOF
+)"
+```
+
+- PR title should be under 70 characters.
+- Always target `main` as the base branch.
+- Push and PR without waiting for human approval — the user reviews in GitHub.
+
+## Parallel Work (Worktrees)
+
+When multiple agents work in parallel on files that might conflict:
+
+1. **Use git worktrees** to isolate work:
+   ```bash
+   git worktree add ../auto-notes-feat-x feat/feature-x
+   ```
+
+2. **Lock files** — if two agents suspect they'll edit the same file, one should finish first. Communicate via the team task list which files are being modified.
+
+3. **Clean up** worktrees after merging:
+   ```bash
+   git worktree remove ../auto-notes-feat-x
+   ```
+
+## Pre-flight Checklist
+
+Before pushing any branch:
+1. `npx tsc --noEmit --skipLibCheck` — types pass
+2. `npm test` — all tests pass
+3. `node esbuild.config.mjs production` — build succeeds
+4. `git diff main...HEAD` — review all changes since branching

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,12 @@ Output: `main.js` (single bundle, Obsidian loads this)
 | Module | Path | Purpose | Public API |
 |--------|------|---------|------------|
 | main | `src/main.ts` | Plugin entry, module orchestration, view registration | `AutoNotesPlugin` (default) |
-| settings | `src/settings.ts` | Settings interfaces, defaults, model options | `AutoNotesSettings`, `DEFAULT_SETTINGS`, `AIProvider`, `MODEL_OPTIONS` |
+| settings | `src/settings.ts` | Settings interfaces, defaults, model options | `AutoNotesSettings`, `DEFAULT_SETTINGS`, `AIProvider`, `MODEL_OPTIONS`, `TagVocabularyEntry` |
 | settings-tab | `src/settings-tab.ts` | Obsidian settings UI | `AutoNotesSettingTab` |
 | elaboration | `src/elaboration/` | Stub note detection, AI proposal generation | `ElaborationModule`, types |
 | audio | `src/audio/` | Audio transcription (Whisper, Deepgram, local), post-processing | `AudioModule`, `AudioTranscriptionModal`, types |
 | video | `src/video/` | Video download (YouTube/TikTok), audio extraction, transcription | `VideoModule`, `detectPlatform`, `isSupportedUrl`, types |
-| enrichment | `src/enrichment/` | Tag scoring, link resolution, external refs, frontmatter | `EnrichmentModule`, types |
+| enrichment | `src/enrichment/` | Metadata classification, topic extraction, link resolution, external refs, frontmatter | `EnrichmentModule`, `TagVocabularyEntry`, types |
 | tidy | `src/tidy/` | Spelling correction and markdown formatting via AI | `TidyModule`, `TidySnapshot` |
 | shared | `src/shared/` | AI client, file utils, validation, notifications, frontmatter | `AIClient`, `NotificationManager`, file/validation utils |
 | views | `src/views/` | Unified sidebar for elaboration + enrichment proposals | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE`, `UnifiedItem` |
@@ -65,6 +65,7 @@ Key: `video` depends on `audio` (reuses transcription pipeline). All feature mod
 | `auto-notes:transcribe-video-file` | Transcribe local video file | callback (stub) |
 | `auto-notes:check-dependencies` | Check external tool availability | callback |
 | `auto-notes:enrich-current-note` | Enrich current note | editorCallback |
+| `auto-notes:scan-vault-enrichment` | Scan vault for enrichment | callback |
 | `auto-notes:undo-enrichment` | Undo last enrichment on current note | editorCallback |
 | `auto-notes:tidy-current-note` | Tidy current note | editorCallback |
 | `auto-notes:undo-tidy` | Undo last tidy on current note | editorCallback |
@@ -149,9 +150,12 @@ AutoNotesSettings {
   enrichment: EnrichmentSettings {
     enabled: boolean                                // default: true
     autoEnrich: boolean                             // default: true
-    maxTags: number                                 // default: 10
+    maxTags: number                                 // default: 5
     maxInternalLinks: number                        // default: 15
     maxExternalLinks: number                        // default: 3
+    maxTopicLinks: number                           // default: 10
+    suggestNewNotes: boolean                        // default: true
+    tagVocabulary: TagVocabularyEntry[]              // default: 3 entries (Status, Type, Source)
     internalLinkThreshold: number                   // default: 0.3
     weights: EnrichmentWeightSettings {
       sameFolder: number                            // default: 1.0

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,107 +84,159 @@ graph TD
 | **Elaboration** | Detects stub/placeholder notes, generates AI-powered content proposals, manages proposal lifecycle | `src/elaboration/` |
 | **Audio** | Transcribes audio files via Whisper/Deepgram APIs, with optional AI post-processing | `src/audio/` |
 | **Video** | Downloads video from YouTube/TikTok via yt-dlp, extracts audio, delegates to Audio for transcription | `src/video/` |
-| **Enrichment** | Suggests tags, internal links, external references, and frontmatter based on vault analysis + AI | `src/enrichment/` |
-| **Tidy** | Fixes spelling and formats markdown via AI. No content changes — cosmetic only | `src/tidy/` |
+| **Enrichment** | Classifies notes with vocabulary-based tags, extracts topics as internal links, suggests external references and frontmatter | `src/enrichment/` |
+| **Tidy** | Fixes spelling and formats markdown via AI. No content changes -- cosmetic only | `src/tidy/` |
 | **Views** | Unified sidebar combining elaboration + enrichment proposals in one pane | `src/views/` |
 | **Shared** | AI client (3 providers), validation/sanitization, notifications, file utilities, frontmatter parsing | `src/shared/` |
 | **Settings** | Type definitions, defaults, model options for all modules | `src/settings.ts`, `src/settings-tab.ts` |
 
 ---
 
+## Enrichment Architecture (Redesigned)
+
+The enrichment module was redesigned to align with Obsidian conventions. The key insight: **tags are metadata classifiers, topics are links**.
+
+### Before (TagScorer)
+
+Tags were treated as topic labels (`#machine-learning`, `#python`). Scored by vault frequency and folder proximity.
+
+### After (MetadataClassifier + TopicExtractor)
+
+```
+Note content
+    |
+    +---> MetadataClassifier.classify()
+    |         Uses user-defined tagVocabulary
+    |         Validates against vocabulary (rejects hallucinations)
+    |         Output: tags like #draft, #reference, #meeting-notes
+    |
+    +---> TopicExtractor.extractTopics()
+    |         AI identifies 5-15 key concepts
+    |         Matched to existing vault notes by title
+    |         Output: [[internal link]] candidates
+    |
+    +---> LinkResolver.findInternalLinks()
+    |         Graph hops (1-2 hops in link graph)
+    |         Shared tags (2+ tags in common)
+    |         Folder proximity (same/sibling folders)
+    |         Output: proximity-based link candidates
+    |
+    +---> LinkResolver.mergeTopicCandidates()
+              Topic relevance dominates (base: 0.7)
+              Graph proximity adds small bonus (* 0.2)
+              Output: final ranked link suggestions
+```
+
+### Vault-Wide Scan (4-Phase Flow)
+
+```
+Phase 1: Scan     -- collect eligible files, warm VaultAnalyzer caches
+Phase 2: Confirm  -- user confirms before expensive AI calls
+Phase 3: Generate -- per-file enrichment (cancellable, with rollback)
+                     TopicExtractor accumulates unmatched topics
+Phase 4: Resolve  -- topics referenced by 2+ notes become new-note suggestions
+                     injected into existing proposals
+```
+
+Single-note enrichment skips Phase 4 (no cross-note evidence available).
+
+---
+
 ## Data Flow
 
-### Elaboration: Detect → Propose → Review → Apply
+### Elaboration: Detect, Propose, Review, Apply
 
 ```
 Vault scan or single note scan
-    ↓
+    |
 PlaceholderDetector checks: word count, TODO markers, empty sections, sparse links
-    ↓
+    |
 Candidates confirmed via NotificationManager (two-phase for vault scans)
-    ↓
-ProposalGenerator gathers linked note context → AIClient.complete()
-    ↓
+    |
+ProposalGenerator gathers linked note context --> AIClient.complete()
+    |
 sanitizeAIResponse() on AI output
-    ↓
+    |
 Proposal saved as JSON in .auto-notes/proposals/
-    ↓
+    |
 User reviews in Unified Proposal View (editable textarea)
-    ↓
+    |
 Accept: blockquote original content, append sanitized AI additions
 Reject: mark status as rejected
-    ↓
-If accepted + autoEnrich enabled → enrichment.enrich(filePath)
+    |
+If accepted + autoEnrich enabled --> enrichment.enrich(filePath)
 ```
 
-### Audio Transcription: Record → Transcribe → Post-Process → Insert
+### Audio Transcription: Record, Transcribe, Post-Process, Insert
 
 ```
 User selects audio file (modal) or triggers inline transcription
-    ↓
+    |
 Audio data sent to Whisper API / Deepgram (via fetch with AbortController timeout)
-    ↓
+    |
 Optional: PostProcessor cleans transcript via AIClient
-    ↓
-Result inserted as blockquote below audio embed (inline) or as new note (standalone)
-    ↓
-If autoEnrich enabled → enrichment.enrich(filePath)
+    |
+Result inserted as blockquote below audio embed
+    |
+If autoEnrich enabled --> enrichment.enrich(filePath)
 ```
 
-### Video Transcription: URL → Download → Extract → Transcribe
+### Video Transcription: URL, Download, Extract, Transcribe
 
 ```
-User pastes URL → sanitizeUrl() → detectPlatform()
-    ↓
+User pastes URL --> sanitizeUrl() --> detectPlatform()
+    |
 AudioExtractor: yt-dlp --dump-json (metadata), yt-dlp -x (audio download)
-    ↓
+    |
 Optional: download video file to vault (downloadFolder setting)
-    ↓
-AudioModule.transcribe(audioBuffer) — same pipeline as audio
-    ↓
+    |
+AudioModule.transcribe(audioBuffer) -- same pipeline as audio
+    |
 Insert blockquote + optional video embed in note
-    ↓
+    |
 Cleanup temp audio file from os.tmpdir()
-    ↓
-If autoEnrich enabled → enrichment.enrich(filePath)
+    |
+If autoEnrich enabled --> enrichment.enrich(filePath)
 ```
 
-### Enrichment: Analyze → Score → Propose → Apply
+### Enrichment: Analyze, Score, Propose, Apply
 
 ```
 Triggered by callback (auto-enrich) or manual command
-    ↓
-VaultAnalyzer builds tag index + link graph from MetadataCache
-    ↓
-Parallel scoring:
-  TagScorer: AI candidates × vault frequency × proximity weight
-  LinkResolver: graph hops + shared tags + folder proximity
-  PromptBuilder: AI-suggested external links + frontmatter
-    ↓
+    |
+Parallel enrichment:
+  MetadataClassifier.classify()  -- vocabulary-based tag classification
+  TopicExtractor.extractTopics() -- AI topics --> internal link candidates
+  LinkResolver.findInternalLinks() -- graph hops + shared tags + folder proximity
+  PromptBuilder.suggestExternalLinks() -- AI with conservative prompt
+  PromptBuilder.suggestFrontmatter() -- AI with allowlisted keys
+    |
+LinkResolver.mergeTopicCandidates(topicLinks, graphLinks) -- merge and deduplicate
+    |
 Proposal saved as JSON in .auto-notes/enrichments/
-    ↓
+    |
 User reviews in Unified Proposal View (per-item checkboxes)
-    ↓
+    |
 Accept Selected: EnrichmentApplier merges tags, adds sections with markers
 Reject: mark status as rejected
 ```
 
-### Tidy: Snapshot → AI Fix → Apply (immediate)
+### Tidy: Snapshot, AI Fix, Apply (immediate)
 
 ```
 User triggers tidy command on current note
-    ↓
+    |
 TidyStore saves snapshot of original content (for undo)
-    ↓
+    |
 parseFrontmatter() separates frontmatter from body
-    ↓
+    |
 AIClient.complete() with constrained prompt (spelling + formatting only)
-    ↓
+    |
 sanitizeAIResponse() + stripCodeFences()
-    ↓
-serializeFrontmatter(original_frontmatter, tidied_body) → vault.modify()
-    ↓
-Undo: TidyStore.load() → vault.modify(original) → TidyStore.remove()
+    |
+serializeFrontmatter(original_frontmatter, tidied_body) --> vault.modify()
+    |
+Undo: TidyStore.load() --> vault.modify(original) --> TidyStore.remove()
 ```
 
 ---
@@ -194,22 +246,22 @@ Undo: TidyStore.load() → vault.modify(original) → TidyStore.remove()
 All inter-module communication flows through `main.ts` via simple callback assignments:
 
 ```
-┌─────────────┐     onProposalAccepted(path)     ┌─────────────┐
-│ Elaboration │ ─────────────────────────────────→│ Enrichment  │
-└─────────────┘                                   └─────────────┘
-                                                        ↑
-┌─────────────┐     onTranscriptionComplete(path)       │
-│   Audio     │ ────────────────────────────────────────┘
-└─────────────┘                                         ↑
-                                                        │
-┌─────────────┐     onTranscriptionComplete(path)       │
-│   Video     │ ────────────────────────────────────────┘
-└─────────────┘
++--------------+     onProposalAccepted(path)     +--------------+
+| Elaboration  | -------------------------------->| Enrichment   |
++--------------+                                  +--------------+
+                                                        ^
++--------------+     onTranscriptionComplete(path)      |
+|   Audio      | ---------------------------------------+
++--------------+                                        ^
+                                                        |
++--------------+     onTranscriptionComplete(path)      |
+|   Video      | ---------------------------------------+
++--------------+
 
-┌─────────────┐     onViewRefreshNeeded()         ┌─────────────┐
-│ Elaboration │ ─────────────────────────────────→│  Unified    │
-│ Enrichment  │ ─────────────────────────────────→│  View       │
-└─────────────┘                                   └─────────────┘
++--------------+     onViewRefreshNeeded()         +--------------+
+| Elaboration  | --------------------------------->|  Unified     |
+| Enrichment   | --------------------------------->|  View        |
++--------------+                                   +--------------+
 ```
 
 Callbacks are only wired when `enrichment.enabled && enrichment.autoEnrich` is true. Modules declare nullable callback properties; `main.ts` assigns them during initialization. No event bus or pub-sub needed.
@@ -222,17 +274,18 @@ Settings are organized into six groups, each mapping to a module:
 
 ```
 AutoNotesSettings
-├── ai          → Provider, API key, model, temperature
-├── elaboration → Detection thresholds, scan behavior, proposal storage
-│   ├── detection → Word threshold, TODO markers, empty sections, excludes
-│   └── proposal  → Max per note, preserve frontmatter, include context
-├── audio       → Transcription provider, API keys, post-processing
-│   └── postProcessing → Filler removal, structure, key points, custom prompt
-├── video       → yt-dlp/ffmpeg paths, download folder, embed setting
-│   └── frameExtraction → (Not implemented) interval, vision model, max frames
-├── enrichment  → Auto-enrich, max tags/links, proximity weights, excludes
-│   └── weights → Same/sibling/cousin/distant folder weights, decay, minimum
-└── tidy        → Snapshot folder path
++-- ai          --> Provider, API key, model, temperature
++-- elaboration --> Detection thresholds, scan behavior, proposal storage
+|   +-- detection --> Word threshold, TODO markers, empty sections, excludes
+|   +-- proposal  --> Max per note, preserve frontmatter, include context
++-- audio       --> Transcription provider, API keys, post-processing
+|   +-- postProcessing --> Filler removal, structure, key points, custom prompt
++-- video       --> yt-dlp/ffmpeg paths, download folder, embed setting
+|   +-- frameExtraction --> (Not implemented) interval, vision model, max frames
++-- enrichment  --> Auto-enrich, max tags/links, tag vocabulary, proximity weights
+|   +-- tagVocabulary  --> TagVocabularyEntry[] (category, tags, description)
+|   +-- weights        --> Same/sibling/cousin/distant folder weights, decay, minimum
++-- tidy        --> Snapshot folder path
 ```
 
 Modules access settings via a `getSettings()` closure injected at construction time, ensuring they always read the latest values without event subscriptions.
@@ -244,25 +297,25 @@ Modules access settings via a `getSettings()` closure injected at construction t
 Elaboration and enrichment both use a proposal-based workflow. Tidy does not.
 
 ```
-                    ┌──────────┐
-                    │ Generated│
-                    └────┬─────┘
-                         │
-                    ┌────▼─────┐
-                    │ Pending  │ ← stored as JSON in .auto-notes/
-                    └────┬─────┘
-                         │
-              ┌──────────┴──────────┐
-              │                     │
-        ┌─────▼─────┐        ┌─────▼─────┐
-        │ Accepted  │        │ Rejected  │
-        └─────┬─────┘        └───────────┘
-              │
-              │ (enrichment only)
-        ┌─────▼──────────┐
-        │ Partially      │
-        │ Accepted       │
-        └────────────────┘
+                    +----------+
+                    | Generated|
+                    +----+-----+
+                         |
+                    +----v-----+
+                    | Pending  | <-- stored as JSON in .auto-notes/
+                    +----+-----+
+                         |
+              +----------+----------+
+              |                     |
+        +-----v-----+        +-----v-----+
+        | Accepted  |        | Rejected  |
+        +-----+-----+        +-----------+
+              |
+              | (enrichment only)
+        +-----v----------+
+        | Partially      |
+        | Accepted       |
+        +----------------+
 ```
 
 - **Elaboration proposals**: Accept applies full content (user can edit in textarea first). Original note content is blockquoted for preservation.
@@ -271,13 +324,35 @@ Elaboration and enrichment both use a proposal-based workflow. Tidy does not.
 
 ---
 
+## Multi-Agent Infrastructure
+
+The project uses specialized AI agents for different concerns, defined in `.claude/agents/`:
+
+| Agent | Role | Key Skills |
+|-------|------|------------|
+| architect | Enforces module patterns, dependency rules, naming | codebase-architecture, git-workflow |
+| security | Audits for vulnerabilities, validates sanitization | security-audit |
+| docs-agent | Maintains AGENTS.md files (machine-readable) | docs-agent |
+| docs-human | Maintains DECISIONS/STATUS/ARCHITECTURE.md | docs-human |
+| elaboration-designer | Designs stub detection and proposal generation | note-elaboration |
+| plugin-architect | Obsidian API patterns and plugin lifecycle | obsidian-plugin-dev |
+| transcription-engineer | Audio/video pipeline design | media-transcription |
+
+Agents coordinate via:
+- **Git workflow**: feature branches, PRs to protected main, bot identity
+- **Skills**: shared knowledge files in `.claude/skills/` (git-workflow, tdd, etc.)
+- **Worktrees**: parallel work on conflicting files without branch switching
+
+---
+
 ## Getting Started for Contributors
 
-1. Clone into Obsidian vault's plugin directory (see Development Setup in existing docs)
-2. `npm install` → `npm run dev` (watch mode)
+1. Clone into Obsidian vault's plugin directory
+2. `npm install` then `npm run dev` (watch mode)
 3. Module pattern: each feature in `src/<module>/` with `index.ts` exporting the module class
 4. Follow the FeatureModule contract: `constructor(plugin, getSettings, notifications)`, `onload()`, `onunload()`
 5. Types go in `<module>/types.ts`, tests co-located as `<name>.test.ts`
 6. All shared utilities imported from `../shared` (barrel export)
 7. Build check: `npm run build` (type-checks + bundles)
 8. Tests: `npm test`
+9. Git: create a feature branch, push, open PR. See `.claude/skills/git-workflow/SKILL.md` for full protocol.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,148 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-03-13: On-demand folder creation in stores
+
+**Context**: Store classes (ProposalStore, EnrichmentStore, TidyStore) relied on an `init()` call during plugin startup to create their storage folders. If the folder was deleted while the plugin was running, subsequent saves would fail.
+
+**Decision**: Add `await ensureFolder(this.app, this.folderPath)` at the top of every `save()` method, in addition to the existing `init()` call. The `ensureFolder` function in `shared/file-utils.ts` handles the race condition where a folder exists on disk but not in the vault cache.
+
+**Alternatives considered**:
+- Rely solely on `init()` (fails if folder deleted mid-session)
+- Create folder lazily on first save only, remove `init()` (startup validation is still useful)
+
+**Rationale**: Belt-and-suspenders approach. The `init()` call catches configuration errors early (bad path, permissions); the `save()` call handles runtime deletion. `ensureFolder` is idempotent and cheap.
+
+**Impact**: Stores are resilient to folder deletion during plugin runtime. No behavior change for normal usage.
+
+---
+
+## 2026-03-13: Git workflow -- protected main, feature branches, bot identity
+
+**Context**: The project was growing beyond solo development. Multiple agents (human and AI) needed to contribute without stepping on each other's work or breaking main.
+
+**Decision**: Establish a formal git workflow:
+- **Protected main**: never push directly; all changes via pull requests
+- **Feature branches**: `feat/`, `fix/`, `refactor/`, `chore/` prefixes
+- **Bot identity**: all git operations use `bot@wafflenet.io` / `bot` (never personal identities)
+- **Co-authored commits**: `Co-Authored-By: Claude <bot@wafflenet.io>` trailer
+- **Pre-flight checklist**: type-check, test, build before pushing
+- **Worktrees**: for parallel work on conflicting files
+
+**Alternatives considered**:
+- Trunk-based development (risky without CI/CD gate)
+- Personal identity for commits (confuses authorship tracking)
+- No formal workflow (works solo, breaks with multiple contributors)
+
+**Rationale**: Protected main prevents accidental breakage. Feature branches isolate work-in-progress. The bot identity creates a clear audit trail distinguishing automated from manual commits. Worktrees enable parallel agent work without branch switching.
+
+**Impact**: All contributors follow the same workflow. PRs are the only path to main. The git-workflow skill (`/.claude/skills/git-workflow/SKILL.md`) documents the full protocol.
+
+---
+
+## 2026-03-13: Teams infrastructure for multi-agent coordination
+
+**Context**: The project uses multiple specialized AI agents (architect, security, docs, elaboration-designer, transcription-engineer). These agents need clear role boundaries, shared skills, and coordination mechanisms.
+
+**Decision**: Create a teams infrastructure under `.claude/agents/` with dedicated agent definition files. Each agent has:
+- A name and description
+- A list of skills they can use
+- A list of allowed tools
+- Clear responsibility boundaries
+
+**Alternatives considered**:
+- Single monolithic agent (loses specialization benefits)
+- Ad-hoc agent instructions (inconsistent, hard to maintain)
+- External coordination tool (adds complexity, another dependency)
+
+**Rationale**: Explicit agent definitions prevent role confusion and scope creep. Skills are shared (any agent can use `git-workflow`), but responsibilities are distinct (only `security` audits for vulnerabilities). The file-based approach is version-controlled and easy to extend.
+
+**Impact**: Seven agents defined: architect, security, docs-agent, docs-human, elaboration-designer, plugin-architect, transcription-engineer. Adding a new agent means creating a new `.md` file in `.claude/agents/`.
+
+---
+
+## 2026-03-13: Enrichment redesign -- tags as metadata classifiers, topics as links
+
+**Context**: The original enrichment module used a `TagScorer` that treated tags as topic labels (e.g., `#machine-learning`, `#python`). This conflicted with Obsidian best practices: tags work best as metadata classifiers (status, type, source), while topics belong as `[[internal links]]` in the knowledge graph.
+
+**Decision**: Replace `TagScorer` with two new components:
+- **MetadataClassifier** (`metadata-classifier.ts`): classifies notes using a user-defined tag vocabulary. Tags are rare, purposeful metadata (e.g., `#draft`, `#reference`, `#meeting-notes`). AI classifications are validated against the vocabulary -- hallucinated tags are rejected.
+- **TopicExtractor** (`topic-extractor.ts`): extracts key concepts from note content and converts them to `[[internal link]]` candidates. Matched topics (existing vault notes) become link suggestions immediately. Unmatched topics are accumulated for cross-note resolution.
+
+**Alternatives considered**:
+- Keep TagScorer with frequency + proximity weighting (treats tags as topics, against Obsidian conventions)
+- Tags only, no topic extraction (misses link graph opportunities)
+- AI-only link suggestions without vault matching (ignores existing knowledge graph)
+
+**Rationale**: This aligns with the Obsidian community consensus: tags are for classification/filtering, links are for building a knowledge graph. A user who searches `#draft` expects to find incomplete notes, not every note mentioning "drafts." Topic extraction surfaces the concepts that should be linked, not tagged.
+
+**Impact**: The `TagVocabularyEntry` setting defines allowed tag categories. Users control exactly which tags the system can suggest. Topics become link candidates, enriching the knowledge graph. The old `TagScorer` class no longer exists.
+
+---
+
+## 2026-03-13: New-note suggestions require 2+ independent references
+
+**Context**: During vault-wide enrichment scans, the `TopicExtractor` identifies topics that do not match any existing vault note. These could be suggested as "create this new note" candidates. However, a single AI mention of a topic is weak evidence -- it might be noise.
+
+**Decision**: Only promote an unmatched topic to a new-note suggestion when 2 or more notes independently reference the same topic. The `TopicExtractor` accumulates unmatched topics in a `pendingNewTopics` map during the scan, then `resolveNewNoteCandidates()` filters for multi-reference topics in Phase 4.
+
+**Alternatives considered**:
+- Suggest new notes for any unmatched topic (too noisy, creates clutter)
+- Require 3+ references (too conservative, misses genuine connections)
+- Never suggest new notes (misses knowledge graph growth opportunities)
+- Human threshold setting (adds settings complexity for marginal benefit)
+
+**Rationale**: Two independent notes surfacing the same concept is strong evidence of a genuine hub topic worth creating. Single mentions are often contextual noise or AI hallucination. The 2-note threshold balances signal quality against discovery.
+
+**Impact**: Vault scans produce fewer but higher-quality new-note suggestions. Single-note enrichment never suggests new notes (no cross-note evidence available).
+
+---
+
+## 2026-03-13: Proximity scoring weights lowered -- topical relevance dominates
+
+**Context**: The original link scoring gave equal weight to folder proximity and topical relevance. This produced link suggestions biased toward nearby files even when topically unrelated.
+
+**Decision**: Reduce proximity scoring multipliers in `LinkResolver`:
+- Graph hop candidates: `proximity * 0.25` (was higher)
+- Shared tag candidates: `proximity * sharedCount * 0.15` (was higher)
+- Folder proximity candidates: `proximity * 0.15` (was higher)
+
+In `mergeTopicCandidates()`, topic relevance dominates: graph proximity adds only `existing.score * 0.2` as a bonus when a candidate appears in both sources. Topic base score is 0.7; proximity contributes at most 0.2 * proximity.
+
+**Alternatives considered**:
+- Keep equal weighting (proximity bias overwhelms topical relevance)
+- Remove proximity entirely (loses useful same-folder signal)
+- User-configurable balance slider (adds UI complexity for a tuning parameter)
+
+**Rationale**: Topic relevance is the primary signal -- a note about "React Hooks" should link to other React notes regardless of folder. Proximity is a tiebreaker, not a driver. The lowered weights ensure topically relevant notes in distant folders still surface.
+
+**Impact**: Link suggestions are more topically relevant and less biased by folder structure. The `weights` settings still control proximity tiers, but their influence on final scores is reduced.
+
+---
+
+## 2026-03-13: Vault-wide enrichment scan with 4-phase flow
+
+**Context**: Single-note enrichment worked well, but users needed a way to enrich their entire vault at once. A naive "loop over all files" approach would be expensive (many AI calls) and couldn't leverage cross-note evidence for new-note suggestions.
+
+**Decision**: Implement a 4-phase vault scan in `EnrichmentModule.scanVault()`:
+1. **Scan**: collect eligible files (respecting exclude rules), warm VaultAnalyzer caches
+2. **Confirm**: user confirmation via NotificationManager (gates expensive AI calls)
+3. **Generate**: per-file enrichment with progress tracking and cancellation. TopicExtractor accumulates unmatched topics across all files
+4. **Resolve**: `TopicExtractor.resolveNewNoteCandidates()` -- topics referenced by 2+ notes become new-note link suggestions, injected into existing proposals via `LinkResolver.mergeTopicCandidates()`
+
+On error or cancellation in Phase 3, all created proposals are rejected and pending topics are cleared.
+
+**Alternatives considered**:
+- Simple loop with per-note confirmation (too many dialogs)
+- Background processing without confirmation (expensive surprise API bills)
+- Batch AI calls for multiple notes at once (token limits, harder to cancel per-note)
+
+**Rationale**: The 4-phase design separates cheap operations (scan) from expensive ones (AI calls), giving the user a gate before costs are incurred. Phase 4 is the key innovation: cross-note topic resolution can only happen after all notes have been processed, so it must be a separate post-processing step.
+
+**Impact**: Users can enrich their entire vault with one command. The confirmation step prevents accidental API charges. Cross-note topic resolution produces new-note suggestions that single-note enrichment cannot.
+
+---
+
 ## 2026-03-13: Tidy module uses immediate apply, no proposals
 
 **Context**: The tidy feature (spelling/formatting correction) was being designed. Other modules (elaboration, enrichment) use a proposal-review workflow where changes are stored as JSON proposals and presented in a sidebar for user approval.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,90 +1,58 @@
 # Project Status
 
 **Last updated**: 2026-03-13
-**Phase**: All five feature modules implemented; enrichment, tidy, and unified view are new since last status update
+**Phase**: Core features complete; enrichment redesigned with vocabulary-based classification and topic extraction
 
 ---
 
 ## Feature Completion Matrix
 
-| Feature | Core Logic | UI | Security | Tests | Status |
-|---------|:---:|:---:|:---:|:---:|--------|
-| Elaboration — detection & proposals | Yes | Yes | Yes | No | **Working** |
-| Elaboration — review (unified sidebar) | Yes | Yes | — | No | **Working** |
-| Audio — Whisper API transcription | Yes | Yes | Yes | No | **Working** |
-| Audio — Deepgram transcription | Yes | Yes | Yes | No | **Working** |
-| Audio — inline note transcription | Yes | Yes | Yes | No | **Working** |
-| Audio — local Whisper | — | — | — | No | Not started (throws) |
-| Audio — post-processing | Yes | — | Yes | No | **Working** |
-| Video — URL detection (YT + TikTok) | Yes | — | Yes | Yes | **Working** |
-| Video — yt-dlp download + transcribe | Yes | Yes | Yes | No | **Working** |
-| Video — download + embed in note | Yes | — | Yes | No | **Working** |
-| Video — local file transcription | — | — | — | No | Not started (stub) |
-| Video — frame extraction | — | — | — | No | Not started (placeholder) |
-| Enrichment — tag scoring | Yes | Yes | Yes | No | **Working** |
-| Enrichment — internal link resolution | Yes | Yes | Yes | No | **Working** |
-| Enrichment — external refs + frontmatter | Yes | Yes | Yes | No | **Working** |
-| Enrichment — undo | Yes | — | — | Yes | **Working** |
-| Tidy — spelling/formatting | Yes | — | Yes | Yes | **Working** |
-| Tidy — undo | Yes | — | — | Yes | **Working** |
-| Unified proposal sidebar | Yes | Yes | — | No | **Working** |
-| Shared — AIClient (3 providers) | Yes | — | Yes | No | **Working** |
-| Shared — NotificationManager | Yes | — | — | Yes | **Working** |
-| Shared — validation & sanitization | Yes | — | Yes | Yes | **Working** |
-| Shared — frontmatter utils | Yes | — | — | Yes | **Working** |
-| Test infrastructure (Vitest + mocks) | Yes | — | — | — | **Working** |
+| Feature | Core Logic | UI | Tests | Status |
+|---------|:---:|:---:|:---:|--------|
+| Elaboration -- detection and proposals | Yes | Yes | Partial | **Working** |
+| Elaboration -- unified sidebar review | Yes | Yes | No | **Working** |
+| Audio -- Whisper API transcription | Yes | Yes | No | **Working** |
+| Audio -- Deepgram transcription | Yes | Yes | No | **Working** |
+| Audio -- local Whisper | -- | -- | No | Not started (throws) |
+| Video -- URL detection (YT + TikTok) | Yes | -- | Yes | **Working** |
+| Video -- yt-dlp download + transcribe | Yes | Yes | No | **Working** |
+| Video -- local file transcription | -- | -- | No | Not started (stub) |
+| Video -- frame extraction | -- | -- | No | Not started (placeholder) |
+| Enrichment -- metadata classification (vocabulary-based) | Yes | Yes | Yes | **Working** |
+| Enrichment -- topic extraction (AI topics to links) | Yes | Yes | Yes | **Working** |
+| Enrichment -- link resolution (graph + topic merge) | Yes | Yes | Yes | **Working** |
+| Enrichment -- external refs + frontmatter | Yes | Yes | No | **Working** |
+| Enrichment -- vault-wide scan (4-phase) | Yes | Yes | No | **Working** |
+| Enrichment -- undo | Yes | -- | Yes | **Working** |
+| Tidy -- spelling/formatting | Yes | -- | Yes | **Working** |
+| Tidy -- undo | Yes | -- | Yes | **Working** |
+| Shared -- AIClient (3 providers) | Yes | -- | No | **Working** |
+| Shared -- NotificationManager | Yes | -- | Yes | **Working** |
+| Shared -- validation and sanitization | Yes | -- | Yes | **Working** |
 
 ---
 
-## What's Working
+## Current Focus
 
-- **Full plugin lifecycle**: load, settings, conditional module init, unload
-- **Five feature modules**: elaboration, audio, video, enrichment, tidy — all functional
-- **Unified sidebar**: Single view for elaboration + enrichment proposals with inline review
-- **Cross-module automation**: Elaboration accept → auto-enrich; transcription complete → auto-enrich
-- **Centralized notifications**: Progress tracking, cancellation, confirmation dialogs
-- **Security layer**: Input validation, output sanitization, subprocess hardening, key redaction
-- **Three AI providers**: OpenAI, Anthropic, Ollama with model dropdowns
-- **Three transcription providers**: Whisper API, Deepgram (local Whisper stubbed)
-- **Video support**: YouTube + TikTok (all URL formats), download + embed option
+- **Enrichment redesign** (just completed): tags are now metadata classifiers via user-defined vocabulary; topics extracted by AI become `[[internal links]]`. TagScorer replaced by MetadataClassifier + TopicExtractor.
+- **Git workflow and teams infrastructure**: protected main branch, feature branches, bot identity, multi-agent coordination via `.claude/agents/`.
+- **Branch**: `chore/teams-and-git-workflow`
 
-## What's Not Implemented
+## Recent Changes
 
-- **Local Whisper transcription**: Provider defined but throws "not implemented"
-- **Local video file transcription**: Command shows "coming soon" notice
-- **Frame extraction**: `FrameExtractor` class is a placeholder
-- **Platform filtering**: `supportedPlatforms` toggles exist in settings but are not enforced
+- Replaced `TagScorer` with `MetadataClassifier` (vocabulary-based) and `TopicExtractor` (AI topics to links)
+- Added vault-wide enrichment scan command with 4-phase flow (scan, confirm, generate, resolve cross-note topics)
+- New-note suggestions only created when 2+ notes independently reference same unmatched topic
+- Lowered proximity scoring weights -- topical relevance now dominates link suggestions
+- Established git workflow: protected main, feature branches, `bot@wafflenet.io` identity
+- Created teams infrastructure with 7 agent definitions under `.claude/agents/`
+- Added on-demand folder creation in store `save()` methods via `ensureFolder`
 
 ## Known Issues
 
-- **Ribbon icons always visible**: Registered unconditionally; Obsidian has no `removeRibbonIcon` API
-- **`video.tempFolder` unused**: Audio extraction uses `os.tmpdir()` instead; setting remains for future frame extraction
-
-## Test Coverage
-
-| Module | Test Files | Coverage Area |
-|--------|-----------|---------------|
-| video/url-detector | `url-detector.test.ts` | YouTube + TikTok URL patterns (26 cases) |
-| video/note-scanner | `note-scanner.test.ts` | Note video URL scanning |
-| shared/validation | `validation.test.ts` | URL, path, AI response sanitization |
-| shared/notifications | `notifications.test.ts` | NotificationManager operations |
-| shared/frontmatter | `frontmatter-utils.test.ts` | Frontmatter parse/serialize/merge |
-| enrichment/weight-calc | `weight-calculator.test.ts` | Proximity weight algorithm |
-| enrichment/vault-analyzer | `vault-analyzer.test.ts` | Tag index and link graph |
-| enrichment/store | `enrichment-store.test.ts` | Proposal CRUD |
-| tidy/store | `tidy-store.test.ts` | Snapshot CRUD |
-| tidy/module | `tidy-module.test.ts` | Tidy pipeline |
-
-## Recent Changes (since last update)
-
-- Added enrichment module with proximity-weighted tag scoring, link resolution, and AI suggestions
-- Added tidy module with immediate-apply workflow and undo via snapshots
-- Unified elaboration + enrichment proposals into single sidebar view
-- Replaced modals with inline review panes and clickable note links
-- Added centralized `NotificationManager` with cancellation and two-phase vault scan
-- Wired cross-module callbacks (elaboration/transcription → auto-enrich)
-- Added video download-to-vault and embed-in-note settings
-- Removed unused output folder settings from audio and video
+- **Ribbon icons always visible**: registered unconditionally; Obsidian has no `removeRibbonIcon` API
+- **`video.tempFolder` unused**: audio extraction uses `os.tmpdir()` instead; setting remains for future frame extraction
+- **`supportedPlatforms` toggles not enforced**: settings exist but video module does not filter by them
 
 ## External Dependencies
 

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -56,6 +56,7 @@ interface Proposal {
 | `detector.ts` | `PlaceholderDetector` | Scans notes for stub signals |
 | `proposer.ts` | `ProposalGenerator` | AI proposal generation with context gathering |
 | `proposal-store.ts` | `ProposalStore` | CRUD for proposal JSON files |
+| `proposal-store.test.ts` | Tests | ProposalStore tests |
 | `proposal-view.ts` | `ProposalReviewView`, `PROPOSAL_VIEW_TYPE` | Legacy sidebar view (not registered by main.ts) |
 | `proposal-modal.ts` | `ProposalDetailModal` | Legacy modal for editing proposals |
 | `index.ts` | `ElaborationModule` | Orchestrator, commands, scan intervals |

--- a/src/enrichment/AGENTS.md
+++ b/src/enrichment/AGENTS.md
@@ -4,7 +4,7 @@ last-updated: 2026-03-13
 
 # Enrichment Module
 
-Adds tags, internal links, external references, and frontmatter attributes to notes using vault context analysis and AI suggestions.
+Adds tags, internal links, external references, and frontmatter attributes to notes using vocabulary-based metadata classification, AI topic extraction, vault graph analysis, and AI suggestions.
 
 ## Public API
 
@@ -16,6 +16,7 @@ class EnrichmentModule {
   onload(): Promise<void>
   onunload(): void
   enrich(filePath: string, trigger: EnrichmentTrigger): Promise<void>
+  scanVault(): Promise<number>
   getPendingProposals(): Promise<EnrichmentProposal[]>
   acceptSelectedFromView(id: string, accepted: AcceptedItems): Promise<void>
   rejectFromView(id: string): Promise<void>
@@ -49,7 +50,8 @@ interface AcceptedItems {
   frontmatter: string[]
 }
 
-interface TagCandidate { tag: string; rawScore: number; weightedScore: number; sources: string[] }
+interface TagCandidate { tag: string; category: string; confidence: number; rawScore: number; weightedScore: number; sources: string[] }
+interface TagVocabularyEntry { category: string; tags: string[]; description: string }
 interface InternalLinkCandidate { targetPath: string; displayText: string; relevanceScore: number; reason: string }
 interface ExternalLinkCandidate { url: string; title: string; reason: string }
 interface FrontmatterEnrichment { key: string; value: string | string[]; action: 'add' | 'merge' }
@@ -65,15 +67,19 @@ interface WeightConfig { sameFolder: number; siblingFolder: number; cousinFolder
 | `vault-analyzer.test.ts` | Tests | VaultAnalyzer tests |
 | `weight-calculator.ts` | `computeProximityWeight` | Pure function: folder proximity scoring |
 | `weight-calculator.test.ts` | Tests | Weight calculator tests |
-| `tag-scorer.ts` | `TagScorer` | AI + proximity-weighted tag ranking |
-| `link-resolver.ts` | `LinkResolver` | Internal link candidates from graph, tags, proximity |
+| `metadata-classifier.ts` | `MetadataClassifier` | AI-powered tag classification using user-defined vocabulary |
+| `metadata-classifier.test.ts` | Tests | MetadataClassifier tests |
+| `topic-extractor.ts` | `TopicExtractor` | AI-powered topic extraction, converts topics to internal link candidates |
+| `topic-extractor.test.ts` | Tests | TopicExtractor tests |
+| `link-resolver.ts` | `LinkResolver` | Graph-based internal link candidates, merges with topic candidates |
+| `link-resolver.test.ts` | Tests | LinkResolver tests |
 | `prompt-builder.ts` | `PromptBuilder` | AI-generated external links and frontmatter suggestions |
 | `enrichment-store.ts` | `EnrichmentStore` | CRUD for enrichment proposal JSON files |
 | `enrichment-store.test.ts` | Tests | EnrichmentStore tests |
 | `enrichment-applier.ts` | `EnrichmentApplier` | Applies/undoes enrichments to notes |
 | `enrichment-modal.ts` | `EnrichmentDetailModal` | Legacy per-item toggle modal |
 | `enrichment-view.ts` | `EnrichmentReviewView` | Legacy sidebar view (not registered) |
-| `index.ts` | `EnrichmentModule` | Orchestrator, commands, exclusion logic |
+| `index.ts` | `EnrichmentModule` | Orchestrator, commands, exclusion logic, vault scan |
 
 ## Data Flow
 
@@ -82,43 +88,79 @@ interface WeightConfig { sameFolder: number; siblingFolder: number; cousinFolder
    |
 2. Exclusion check: excludeFolders, excludeTags
    |
-3. Parallel scoring:
-   |  TagScorer.scoreTags() -- AI candidates + vault tag index + proximity weights
-   |  LinkResolver.findInternalLinks() -- link graph hops + shared tags + folder proximity
+3. Parallel enrichment (enrichFile):
+   |  MetadataClassifier.classify() -- vocabulary-based tag classification via AI
+   |  TopicExtractor.extractTopics() -- AI topic extraction -> internal link candidates
+   |  LinkResolver.findInternalLinks() -- graph hops + shared tags + folder proximity
    |  PromptBuilder.suggestExternalLinks() -- AI with conservative prompt
    |  PromptBuilder.suggestFrontmatter() -- AI with allowlisted keys
    |
-4. EnrichmentStore.save(proposal)
+4. LinkResolver.mergeTopicCandidates(topicLinks, graphLinks) -- merge and deduplicate
    |
-5. onViewRefreshNeeded() --> main.refreshUnifiedView()
+5. EnrichmentStore.save(proposal)
    |
-6. User review via UnifiedProposalView:
+6. onViewRefreshNeeded() --> main.refreshUnifiedView()
+   |
+7. User review via UnifiedProposalView:
    Accept Selected --> EnrichmentApplier.apply(proposal, accepted)
    Reject --> status = 'rejected'
 ```
 
-## Tag Scoring Algorithm
+## Vault Scan Flow (scanVault)
 
 ```
-1. AI suggests candidate tags (constrained to vault tags + up to 3 novel)
-2. For each candidate, look up vault-wide frequency from TagIndex
-3. For each file using the tag, compute proximity weight to source note
-4. Score = SUM(proximityWeights) * log2(1 + globalFrequency)
-5. Sort descending, take top maxTags
+Phase 1: Collect eligible files, warm VaultAnalyzer caches (tag index, link graph)
+Phase 2: User confirmation via NotificationManager.confirm()
+Phase 3: Cancellable per-file enrichFile() -- accumulates TopicExtractor pending topics
+Phase 4: TopicExtractor.resolveNewNoteCandidates() -- topics referenced by 2+ notes
+         become new-note link suggestions, injected into existing proposals via
+         LinkResolver.mergeTopicCandidates()
 ```
 
-Tag validation: `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$`
+On error or cancel in Phase 3: clears pending topics, rejects all created proposals.
 
-## Link Resolution Strategy
+## Metadata Classification (metadata-classifier.ts)
 
-Candidates from three sources (scored by proximity + overlap):
-1. Files 1-2 hops away in link graph (score * 0.6)
-2. Files sharing 2+ tags (score * 0.3 * sharedCount)
-3. Files in same/sibling folders (score * 0.4)
+Replaces the former `TagScorer`. Tags are now rare, purposeful metadata classifiers (status, type, source) rather than topic labels.
+
+```
+1. AI classifies note content against user-defined tagVocabulary
+2. Validates results against vocabulary lookup -- rejects hallucinated tags
+3. Filters out tags already on the note
+4. Validates tag format: ^[a-zA-Z0-9][a-zA-Z0-9_/-]{0,49}$
+5. Sorts by confidence descending, caps at maxTags
+```
+
+TagCandidate output: `{ tag, category, confidence, rawScore: 0, weightedScore: confidence, sources: [] }`
+
+## Topic Extraction (topic-extractor.ts)
+
+Converts note content into internal link candidates via AI-identified topics.
+
+```
+1. AI extracts 5-15 key concepts/topics from note content
+2. Matched topics (existing vault notes by title) become InternalLinkCandidate immediately
+   - Score: 0.7 base + proximity * 0.2
+3. Unmatched topics accumulated in pendingNewTopics (Map<normalized, {displayText, notePaths}>)
+4. resolveNewNoteCandidates(): only topics with 2+ referencing notes become suggestions
+   - Score: 0.5 fixed
+5. clearPending(): discards accumulated state (called after single-note enrichment)
+```
+
+## Link Resolution Strategy (link-resolver.ts)
+
+Graph-based candidates from three sources (scored by proximity):
+1. Files 1-2 hops away in link graph (proximity * 0.25)
+2. Files sharing 2+ tags (proximity * sharedCount * 0.15)
+3. Files in same/sibling folders (proximity * 0.15)
+
+`mergeTopicCandidates(topicCandidates, graphCandidates)`:
+- Topic relevance dominates; graph proximity adds a small bonus (existing.score * 0.2)
+- Deduplicates by targetPath, combines reasons
 
 Filtered by `internalLinkThreshold`, capped at `maxInternalLinks`.
 
-## Proximity Weight Algorithm (`weight-calculator.ts`)
+## Proximity Weight Algorithm (weight-calculator.ts)
 
 Pure function `computeProximityWeight(sourcePath, targetPath, config)`:
 1. Split paths into folder segments
@@ -128,7 +170,7 @@ Pure function `computeProximityWeight(sourcePath, targetPath, config)`:
 5. Apply linear decay per hop beyond tier minimum
 6. Clamp to [minWeight, tierWeight]
 
-## Enrichment Application (`enrichment-applier.ts`)
+## Enrichment Application (enrichment-applier.ts)
 
 - Tags: merged into frontmatter `tags` array via `mergeTags()`
 - Internal links: appended as `## Related Notes` section with markers
@@ -153,9 +195,12 @@ All under `settings.enrichment`:
 |-----|----------|
 | `enabled` | Module activation |
 | `autoEnrich` | Auto-trigger after elaboration/transcription |
-| `maxTags` | Max tags to suggest |
+| `maxTags` | Max tags to suggest (default: 5) |
 | `maxInternalLinks` | Max related note links |
 | `maxExternalLinks` | Max external references (0 = disable) |
+| `maxTopicLinks` | Max topic-extracted link candidates per note (default: 10) |
+| `suggestNewNotes` | Enable new-note suggestions for unmatched topics (default: true) |
+| `tagVocabulary` | TagVocabularyEntry[] defining classification categories |
 | `internalLinkThreshold` | Min relevance score for links |
 | `weights.*` | Proximity weight configuration |
 | `enrichmentFolderPath` | Proposal JSON storage |

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -122,13 +122,13 @@ All use Obsidian requestUrl via safeRequest() (handles errors, redacts secrets)
 
 | Utility | Used By |
 |---------|---------|
-| `AIClient` | elaboration/proposer, audio/post-processor, enrichment/tag-scorer, enrichment/prompt-builder, tidy/index |
+| `AIClient` | elaboration/proposer, audio/post-processor, enrichment/metadata-classifier, enrichment/topic-extractor, enrichment/prompt-builder, tidy/index |
 | `NotificationManager` | all feature modules (injected via constructor) |
 | `ensureFolder` | elaboration/proposal-store, enrichment/enrichment-store, tidy/tidy-store, video/index |
 | `wordCount` | elaboration/detector |
 | `sanitizeUrl` | video/index, video/audio-extractor |
 | `sanitizePath` | video/audio-extractor |
-| `sanitizeAIResponse` | elaboration/index, elaboration/proposer, audio/post-processor, enrichment/tag-scorer, enrichment/prompt-builder, tidy/index |
+| `sanitizeAIResponse` | elaboration/index, elaboration/proposer, audio/post-processor, enrichment/metadata-classifier, enrichment/topic-extractor, enrichment/prompt-builder, tidy/index |
 | `parseFrontmatter` | enrichment/index, enrichment/enrichment-applier, tidy/index |
 | `serializeFrontmatter` | enrichment/enrichment-applier, tidy/index |
 | `mergeTags` | enrichment/enrichment-applier |


### PR DESCRIPTION
## Summary
- New `git-workflow` skill codifying branching strategy: protected main, feature branches, `bot@wafflenet.io` identity, commit conventions, and automated PR creation without human in the loop
- Added `git-workflow` skill to all 7 agents (architect, security, docs-agent, docs-human, plugin-architect, elaboration-designer, transcription-engineer)
- Created `auto-notes-dev` team for coordinated multi-agent work

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — types pass
- [x] `npm test` — 155 tests pass
- [x] `node esbuild.config.mjs production` — build succeeds
- [x] Skill file loads correctly (visible in `/skills` output)

Co-Authored-By: Claude <bot@wafflenet.io>