### PR TITLE
feat: add summarize command for URLs and transcriptions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "context7@claude-plugins-official": true
   }
 }

--- a/START.md
+++ b/START.md
@@ -72,3 +72,6 @@ Secondly, we've been neglecting proper git patterns up until now. Now that the c
 - Do *not* attribute https://anthropic.com/claude-code to contributions.
 - You should perform git actions as the GitHub user bot@wafflenet.io. I have the appropriate keys if you need them.
 - Once ready work should be pushed to branch and pr should be made without a human in the loop.
+
+### Next
+There's a big gap in our feature set. Both Transcriptions and even *generic URL's* should have the ability to summarize. This would come in the form of "note taking" on the reference. It should be its own command for now, with the same 2 workflows that other commands have available: scan vault, and current note. Please *plan* this out with the team and return to me with your consensus.

--- a/src/enrichment/enrichment-applier.ts
+++ b/src/enrichment/enrichment-applier.ts
@@ -3,8 +3,8 @@ import { AutoNotesSettings } from '../settings';
 import { mergeTags, parseFrontmatter, serializeFrontmatter } from '../shared';
 import { EnrichmentProposal, AcceptedItems } from './types';
 
-const ENRICHMENT_START = '%% auto-notes-enrichment-start %%';
-const ENRICHMENT_END = '%% auto-notes-enrichment-end %%';
+export const ENRICHMENT_START = '%% auto-notes-enrichment-start %%';
+export const ENRICHMENT_END = '%% auto-notes-enrichment-end %%';
 
 /**
  * Applies accepted enrichments to a note non-destructively.

--- a/src/enrichment/types.ts
+++ b/src/enrichment/types.ts
@@ -61,7 +61,7 @@ export interface EnrichmentResult {
 	frontmatter: FrontmatterEnrichment[];
 }
 
-export type EnrichmentTrigger = 'elaboration' | 'transcription' | 'manual';
+export type EnrichmentTrigger = 'elaboration' | 'transcription' | 'summarization' | 'manual';
 
 export type EnrichmentStatus =
 	| 'pending'

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { ElaborationModule } from './elaboration';
 import { AudioModule } from './audio';
 import { VideoModule } from './video';
 import { EnrichmentModule } from './enrichment';
+import { SummarizeModule } from './summarize';
 import { TidyModule } from './tidy';
 import { NotificationManager } from './shared';
 import {
@@ -21,6 +22,7 @@ export default class AutoNotesPlugin extends Plugin {
 	private audio!: AudioModule;
 	private video!: VideoModule;
 	private enrichment!: EnrichmentModule;
+	private summarize!: SummarizeModule;
 	private tidy!: TidyModule;
 
 	async onload(): Promise<void> {
@@ -38,6 +40,7 @@ export default class AutoNotesPlugin extends Plugin {
 		this.audio = new AudioModule(this, getSettings, this.notifications);
 		this.video = new VideoModule(this, getSettings, this.audio, this.notifications);
 		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications);
+		this.summarize = new SummarizeModule(this, getSettings, this.notifications);
 		this.tidy = new TidyModule(this, getSettings, this.notifications);
 
 		// Register the unified proposal view
@@ -68,6 +71,9 @@ export default class AutoNotesPlugin extends Plugin {
 		if (this.settings.enrichment.enabled) {
 			await this.enrichment.onload();
 		}
+		if (this.settings.summarize.enabled) {
+			await this.summarize.onload();
+		}
 		if (this.settings.tidy.enabled) {
 			await this.tidy.onload();
 		}
@@ -82,6 +88,9 @@ export default class AutoNotesPlugin extends Plugin {
 			};
 			this.video.onTranscriptionComplete = (filePath: string) => {
 				this.enrichment.enrich(filePath, 'transcription');
+			};
+			this.summarize.onSummaryComplete = (filePath: string) => {
+				this.enrichment.enrich(filePath, 'summarization');
 			};
 		}
 
@@ -106,6 +115,7 @@ export default class AutoNotesPlugin extends Plugin {
 		this.audio?.onunload();
 		this.video?.onunload();
 		this.enrichment?.onunload();
+		this.summarize?.onunload();
 		this.tidy?.onunload();
 	}
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -530,6 +530,92 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// ── Summarize ──
+		containerEl.createEl('h2', { text: 'Summarize' });
+
+		new Setting(containerEl)
+			.setName('Enable summarize')
+			.setDesc('Summarize URLs and transcriptions in notes')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.summarize.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.enabled = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Summary style')
+			.setDesc('Format for generated summaries')
+			.addDropdown((dd) =>
+				dd
+					.addOptions({
+						bullets: 'Bullet Points',
+						paragraph: 'Paragraph',
+						'key-points': 'Key Points',
+					})
+					.setValue(this.plugin.settings.summarize.summaryStyle)
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.summaryStyle =
+							value as 'bullets' | 'paragraph' | 'key-points';
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Max content length')
+			.setDesc('Maximum characters of content to send to AI for summarization')
+			.addSlider((slider) =>
+				slider
+					.setLimits(1000, 10000, 500)
+					.setValue(this.plugin.settings.summarize.maxContentLength)
+					.setDynamicTooltip()
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.maxContentLength = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Custom prompt')
+			.setDesc('Override the default summarization prompt (leave empty for default)')
+			.addTextArea((text) =>
+				text
+					.setPlaceholder('Custom summarization instructions...')
+					.setValue(this.plugin.settings.summarize.customPrompt)
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.customPrompt = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Excluded folders')
+			.setDesc('Comma-separated list of folders to skip for summarization')
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.summarize.excludeFolders.join(', '))
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.excludeFolders =
+							value.split(',').map((s) => s.trim()).filter(Boolean);
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Excluded tags')
+			.setDesc('Notes with these tags will skip summarization')
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.summarize.excludeTags.join(', '))
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.excludeTags =
+							value.split(',').map((s) => s.trim()).filter(Boolean);
+						await this.plugin.saveSettings();
+					})
+			);
+
 		// ── Note Tidy ──
 		containerEl.createEl('h2', { text: 'Note Tidy' });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -128,6 +128,15 @@ export interface EnrichmentSettings {
 	referencesHeading: string;
 }
 
+export interface SummarizeSettings {
+	enabled: boolean;
+	maxContentLength: number;
+	summaryStyle: 'bullets' | 'paragraph' | 'key-points';
+	customPrompt: string;
+	excludeFolders: string[];
+	excludeTags: string[];
+}
+
 export interface TidySettings {
 	enabled: boolean;
 	snapshotFolderPath: string;
@@ -139,6 +148,7 @@ export interface AutoNotesSettings {
 	audio: AudioSettings;
 	video: VideoSettings;
 	enrichment: EnrichmentSettings;
+	summarize: SummarizeSettings;
 	tidy: TidySettings;
 }
 
@@ -231,6 +241,14 @@ export const DEFAULT_SETTINGS: AutoNotesSettings = {
 		excludeTags: ['no-enrich'],
 		relatedNotesHeading: 'Related Notes',
 		referencesHeading: 'References',
+	},
+	summarize: {
+		enabled: true,
+		maxContentLength: 4000,
+		summaryStyle: 'bullets',
+		customPrompt: '',
+		excludeFolders: ['templates', '.auto-notes'],
+		excludeTags: ['no-summarize'],
 	},
 	tidy: {
 		enabled: true,

--- a/src/summarize/content-fetcher.test.ts
+++ b/src/summarize/content-fetcher.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { extractReadableText } from './content-fetcher';
+
+describe('extractReadableText', () => {
+	it('strips HTML tags', () => {
+		const html = '<p>Hello <strong>world</strong></p>';
+		const text = extractReadableText(html);
+		expect(text).toBe('Hello world');
+	});
+
+	it('removes script tags and their content', () => {
+		const html = '<p>Content</p><script>alert("xss")</script><p>More</p>';
+		const text = extractReadableText(html);
+		expect(text).not.toContain('alert');
+		expect(text).toContain('Content');
+		expect(text).toContain('More');
+	});
+
+	it('removes style tags and their content', () => {
+		const html = '<style>.foo { color: red }</style><p>Text</p>';
+		const text = extractReadableText(html);
+		expect(text).not.toContain('color');
+		expect(text).toContain('Text');
+	});
+
+	it('prioritizes article content', () => {
+		const html = '<body><nav>Menu</nav><article><p>Main content</p></article><footer>Footer</footer></body>';
+		const text = extractReadableText(html);
+		expect(text).toContain('Main content');
+		expect(text).not.toContain('Menu');
+		expect(text).not.toContain('Footer');
+	});
+
+	it('prioritizes main content when no article', () => {
+		const html = '<body><nav>Nav</nav><main><p>Main stuff</p></main></body>';
+		const text = extractReadableText(html);
+		expect(text).toContain('Main stuff');
+		expect(text).not.toContain('Nav');
+	});
+
+	it('falls back to body content', () => {
+		const html = '<body><p>Body text</p></body>';
+		const text = extractReadableText(html);
+		expect(text).toContain('Body text');
+	});
+
+	it('decodes HTML entities', () => {
+		const html = '<p>Tom &amp; Jerry &lt;3 &quot;fun&quot;</p>';
+		const text = extractReadableText(html);
+		expect(text).toBe('Tom & Jerry <3 "fun"');
+	});
+
+	it('normalizes whitespace', () => {
+		const html = '<p>Hello    \n\n   world</p>';
+		const text = extractReadableText(html);
+		expect(text).toBe('Hello world');
+	});
+
+	it('removes nav, header, footer, aside elements', () => {
+		const html = '<body><header>H</header><nav>N</nav><p>Content</p><aside>A</aside><footer>F</footer></body>';
+		const text = extractReadableText(html);
+		expect(text).toContain('Content');
+		expect(text).not.toContain(' H ');
+		expect(text).not.toContain(' N ');
+		expect(text).not.toContain(' A ');
+		expect(text).not.toContain(' F ');
+	});
+
+	it('handles empty HTML', () => {
+		expect(extractReadableText('')).toBe('');
+	});
+
+	it('removes HTML comments', () => {
+		const html = '<!-- comment --><p>Text</p>';
+		const text = extractReadableText(html);
+		expect(text).not.toContain('comment');
+		expect(text).toContain('Text');
+	});
+});

--- a/src/summarize/content-fetcher.ts
+++ b/src/summarize/content-fetcher.ts
@@ -1,0 +1,67 @@
+import { requestUrl } from 'obsidian';
+import { sanitizeUrl } from '../shared';
+
+/**
+ * Fetch a webpage and extract readable text content.
+ */
+export async function fetchPageContent(url: string, maxLength: number): Promise<string> {
+	const validatedUrl = sanitizeUrl(url);
+
+	const response = await requestUrl({
+		url: validatedUrl,
+		method: 'GET',
+		headers: {
+			'User-Agent': 'Mozilla/5.0 (compatible; ObsidianAutoNotes/1.0)',
+			'Accept': 'text/html,application/xhtml+xml',
+		},
+	});
+
+	const html = response.text;
+	const text = extractReadableText(html);
+	return text.slice(0, maxLength);
+}
+
+/**
+ * Extract readable text from HTML content.
+ * Prioritizes <article>, <main>, then <body> content.
+ * Strips all HTML tags, scripts, styles, and normalizes whitespace.
+ */
+export function extractReadableText(html: string): string {
+	// Remove scripts and styles first
+	let cleaned = html
+		.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+		.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
+		.replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, '')
+		.replace(/<!--[\s\S]*?-->/g, '');
+
+	// Try to extract content from semantic containers
+	const articleMatch = cleaned.match(/<article\b[^>]*>([\s\S]*?)<\/article>/i);
+	const mainMatch = cleaned.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+	const bodyMatch = cleaned.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+
+	const contentHtml = articleMatch?.[1] ?? mainMatch?.[1] ?? bodyMatch?.[1] ?? cleaned;
+
+	// Remove nav, header, footer, aside elements
+	const withoutChrome = contentHtml
+		.replace(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi, '')
+		.replace(/<header\b[^>]*>[\s\S]*?<\/header>/gi, '')
+		.replace(/<footer\b[^>]*>[\s\S]*?<\/footer>/gi, '')
+		.replace(/<aside\b[^>]*>[\s\S]*?<\/aside>/gi, '');
+
+	// Strip all remaining HTML tags
+	const text = withoutChrome.replace(/<[^>]+>/g, ' ');
+
+	// Decode common HTML entities
+	const decoded = text
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&nbsp;/g, ' ');
+
+	// Normalize whitespace
+	return decoded
+		.replace(/\s+/g, ' ')
+		.trim();
+}

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -167,32 +167,33 @@ export class SummarizeModule {
 				if (target.inEnrichmentSection && target.linkTitle) {
 					// ── Enrichment target: create standalone note ──
 					const title = target.linkTitle;
-					op.update(`Fetching ${title}`);
-
-					const pageContent = await fetchPageContent(
-						target.source,
-						settings.maxContentLength
-					);
-
-					if (!pageContent.trim()) {
-						this.notifications.notifyError(
-							`No content extracted from ${target.source}`,
-							new Error('Empty content')
-						);
-						continue;
-					}
-
-					op.update(`Summarizing ${title}`);
-					const summary = await this.summarizer.summarize(
-						pageContent,
-						target.source,
-						settings.summaryStyle,
-						COMPREHENSIVE_SUMMARY_PROMPT
-					);
-
-					// Prepare the note for deferred creation (after source is saved)
 					const notePath = this.buildNotePath(title, sourceFolder);
+
+					// If the note already exists, just replace the link — skip fetch/summarize
 					if (!this.plugin.app.vault.getAbstractFileByPath(notePath)) {
+						op.update(`Fetching ${title}`);
+
+						const pageContent = await fetchPageContent(
+							target.source,
+							settings.maxContentLength
+						);
+
+						if (!pageContent.trim()) {
+							this.notifications.notifyError(
+								`No content extracted from ${target.source}`,
+								new Error('Empty content')
+							);
+							continue;
+						}
+
+						op.update(`Summarizing ${title}`);
+						const summary = await this.summarizer.summarize(
+							pageContent,
+							target.source,
+							settings.summaryStyle,
+							COMPREHENSIVE_SUMMARY_PROMPT
+						);
+
 						pendingNotes.push({
 							path: notePath,
 							content: [
@@ -202,8 +203,8 @@ export class SummarizeModule {
 								'',
 							].join('\n'),
 						});
+						newNotePaths.push(notePath);
 					}
-					newNotePaths.push(notePath);
 
 					// Replace external link with internal link in source note
 					lines[target.line] = lines[target.line].replace(

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -1,0 +1,399 @@
+import { Plugin, TFile } from 'obsidian';
+import { AutoNotesSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { OperationHandle } from '../shared/notifications';
+import { fetchPageContent } from './content-fetcher';
+import { findSummarizeTargets } from './note-scanner';
+import { SummarizeSelectionModal } from './summarize-modal';
+import { Summarizer } from './summarizer';
+import { SummarizeTarget } from './types';
+
+export type { SummarizeTarget } from './types';
+export type { SummarizeSettings } from '../settings';
+
+const COMPREHENSIVE_SUMMARY_PROMPT =
+	'Provide a comprehensive summary of the following content. This summary will be a standalone reference note. ' +
+	'Cover all major points, key arguments, and important details. ' +
+	'Use clear markdown structure with headings (##) where appropriate. Be thorough but concise.';
+
+interface PendingNote {
+	path: string;
+	content: string;
+}
+
+interface ProcessResult {
+	/** Number of inline summary blockquotes inserted */
+	inlineCompleted: number;
+	/** Number of enrichment-ref notes created */
+	enrichmentCompleted: number;
+	/** Vault paths of newly created summary notes */
+	newNotePaths: string[];
+}
+
+export class SummarizeModule {
+	private summarizer: Summarizer;
+
+	/** Optional callback invoked after summarization completes. Wired by main.ts for enrichment. */
+	onSummaryComplete: ((filePath: string) => void) | null = null;
+
+	constructor(
+		private plugin: Plugin,
+		private getSettings: () => AutoNotesSettings,
+		private notifications: NotificationManager
+	) {
+		this.summarizer = new Summarizer(getSettings);
+	}
+
+	async onload(): Promise<void> {
+		this.plugin.addCommand({
+			id: 'auto-notes:summarize-current-note',
+			name: 'Summarize current note',
+			editorCallback: async (_editor, ctx) => {
+				if (ctx.file) {
+					await this.summarizeNote(ctx.file);
+				}
+			},
+		});
+
+		this.plugin.addCommand({
+			id: 'auto-notes:scan-vault-summarize',
+			name: 'Scan vault for notes to summarize',
+			callback: () => this.scanVault(),
+		});
+	}
+
+	onunload(): void {}
+
+	private async summarizeNote(file: TFile): Promise<void> {
+		const content = await this.plugin.app.vault.read(file);
+		const targets = findSummarizeTargets(content);
+
+		if (targets.length === 0) {
+			this.notifications.info('No URLs or transcriptions to summarize in this note');
+			return;
+		}
+
+		if (targets.length === 1) {
+			await this.processTargets(file, targets, content);
+		} else {
+			new SummarizeSelectionModal(
+				this.plugin.app,
+				targets,
+				async (selected) => {
+					await this.processTargets(file, selected, content);
+				}
+			).open();
+		}
+	}
+
+	private async processTargets(
+		file: TFile,
+		targets: SummarizeTarget[],
+		content: string
+	): Promise<void> {
+		const total = targets.length;
+		const op = this.notifications.startOperation(
+			`Summarizing ${total} item(s)`,
+			`summarize-${file.path}`
+		);
+
+		const result = await this.processFileTargets(file, targets, op, content);
+
+		if (!op.cancelled) {
+			const totalDone = result.inlineCompleted + result.enrichmentCompleted;
+			const parts: string[] = [];
+			if (result.inlineCompleted > 0) {
+				parts.push(`${result.inlineCompleted} inline`);
+			}
+			if (result.enrichmentCompleted > 0) {
+				parts.push(`${result.enrichmentCompleted} note(s) created`);
+			}
+			op.finish(`Done — ${parts.join(', ') || `${totalDone}/${total} processed`}`);
+		}
+
+		this.fireEnrichmentCallbacks(file.path, result);
+	}
+
+	/**
+	 * Fire enrichment callbacks for processed results.
+	 * Only triggers on the source note when no enrichment sections were
+	 * modified — otherwise the applier would strip and rebuild them.
+	 */
+	private fireEnrichmentCallbacks(sourceFilePath: string, result: ProcessResult): void {
+		if (result.inlineCompleted > 0 && result.enrichmentCompleted === 0) {
+			this.onSummaryComplete?.(sourceFilePath);
+		}
+		for (const notePath of result.newNotePaths) {
+			this.onSummaryComplete?.(notePath);
+		}
+	}
+
+	/**
+	 * Core per-file processing shared by single-note and vault-scan flows.
+	 * Handles both inline summaries and enrichment-ref note creation.
+	 *
+	 * IMPORTANT: new notes are created AFTER vault.modify() on the source
+	 * file to avoid Obsidian metadata-resolution events flushing the
+	 * editor's stale buffer back to disk over our changes.
+	 */
+	private async processFileTargets(
+		file: TFile,
+		targets: SummarizeTarget[],
+		op: OperationHandle,
+		initialContent?: string
+	): Promise<ProcessResult> {
+		const settings = this.getSettings().summarize;
+		const total = targets.length;
+		const sourceFolder = file.parent?.path || '';
+
+		// Process in reverse line order so insertions/replacements don't shift line numbers
+		const sorted = [...targets].sort((a, b) => b.line - a.line);
+
+		const rawContent = initialContent ?? await this.plugin.app.vault.read(file);
+		let lines = rawContent.split('\n');
+		let inlineCompleted = 0;
+		let enrichmentCompleted = 0;
+		const newNotePaths: string[] = [];
+		const pendingNotes: PendingNote[] = [];
+		let processed = 0;
+
+		for (const target of sorted) {
+			if (op.cancelled) break;
+
+			try {
+				processed++;
+				op.progress(processed, total, 'Summarizing');
+
+				if (target.inEnrichmentSection && target.linkTitle) {
+					// ── Enrichment target: create standalone note ──
+					const title = target.linkTitle;
+					op.update(`Fetching ${title}`);
+
+					const pageContent = await fetchPageContent(
+						target.source,
+						settings.maxContentLength
+					);
+
+					if (!pageContent.trim()) {
+						this.notifications.notifyError(
+							`No content extracted from ${target.source}`,
+							new Error('Empty content')
+						);
+						continue;
+					}
+
+					op.update(`Summarizing ${title}`);
+					const summary = await this.summarizer.summarize(
+						pageContent,
+						target.source,
+						settings.summaryStyle,
+						COMPREHENSIVE_SUMMARY_PROMPT
+					);
+
+					// Prepare the note for deferred creation (after source is saved)
+					const notePath = this.buildNotePath(title, sourceFolder);
+					if (!this.plugin.app.vault.getAbstractFileByPath(notePath)) {
+						pendingNotes.push({
+							path: notePath,
+							content: [
+								`[Original source](${target.source})`,
+								'',
+								summary,
+								'',
+							].join('\n'),
+						});
+					}
+					newNotePaths.push(notePath);
+
+					// Replace external link with internal link in source note
+					lines[target.line] = lines[target.line].replace(
+						/\[([^\]]+)\]\(https?:\/\/[^\s)]+\)/,
+						() => `[[${title}]]`
+					);
+
+					enrichmentCompleted++;
+				} else {
+					// ── Inline target: insert summary blockquote ──
+					let textToSummarize: string;
+
+					if (target.type === 'transcription' && target.content) {
+						textToSummarize = target.content;
+					} else {
+						op.update(`Fetching ${target.source}`);
+						textToSummarize = await fetchPageContent(
+							target.source,
+							settings.maxContentLength
+						);
+					}
+
+					if (!textToSummarize.trim()) {
+						this.notifications.notifyError(
+							`No content extracted from ${target.source}`,
+							new Error('Empty content')
+						);
+						continue;
+					}
+
+					op.update(`Summarizing ${target.source}`);
+					const summary = await this.summarizer.summarize(
+						textToSummarize,
+						target.source,
+						settings.summaryStyle,
+						settings.customPrompt || undefined
+					);
+
+					const blockLines = [
+						'',
+						`> **Summary of ${target.source}**`,
+						'>',
+						...summary.split('\n').map(line => `> ${line}`),
+						'',
+					];
+
+					lines.splice(target.endLine + 1, 0, blockLines.join('\n'));
+
+					inlineCompleted++;
+				}
+			} catch (error) {
+				this.notifications.notifyError(
+					`Summarization failed for ${target.source}`,
+					error
+				);
+			}
+		}
+
+		// Write source note FIRST — before creating new notes.
+		// vault.create() triggers Obsidian metadata resolution which can
+		// cause the editor to flush its pre-modification buffer to disk,
+		// overwriting our changes.
+		if (inlineCompleted > 0 || enrichmentCompleted > 0) {
+			await this.plugin.app.vault.modify(file, lines.join('\n'));
+		}
+
+		// NOW create the new summary notes
+		for (const pending of pendingNotes) {
+			await this.plugin.app.vault.create(pending.path, pending.content);
+		}
+
+		return { inlineCompleted, enrichmentCompleted, newNotePaths };
+	}
+
+	/**
+	 * Build the vault path for a summary note without creating it.
+	 */
+	private buildNotePath(title: string, sourceFolder: string): string {
+		const safeName = title
+			.replace(/[\\/:*?"<>|#^[\]]/g, '-')
+			.replace(/\s+/g, ' ')
+			.trim()
+			.slice(0, 100);
+		const folderPrefix = sourceFolder ? sourceFolder + '/' : '';
+		return `${folderPrefix}${safeName}.md`;
+	}
+
+	private async scanVault(): Promise<void> {
+		const settings = this.getSettings().summarize;
+
+		// Phase 1: Scan for files with targets
+		const scanOp = this.notifications.startOperation(
+			'Scanning vault for summarizable content',
+			'summarize-vault-scan'
+		);
+
+		const allFiles = this.plugin.app.vault.getMarkdownFiles();
+		const filesWithTargets: Array<{ file: TFile; targets: SummarizeTarget[] }> = [];
+
+		try {
+			for (let i = 0; i < allFiles.length; i++) {
+				if (scanOp.cancelled) break;
+				scanOp.progress(i + 1, allFiles.length, 'Scanning vault');
+
+				const file = allFiles[i];
+				if (this.isExcluded(file)) continue;
+
+				const content = await this.plugin.app.vault.read(file);
+				const targets = findSummarizeTargets(content);
+				if (targets.length > 0) {
+					filesWithTargets.push({ file, targets });
+				}
+			}
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			scanOp.error(`Vault scan failed — ${msg}`);
+			return;
+		}
+
+		const totalTargets = filesWithTargets.reduce((sum, f) => sum + f.targets.length, 0);
+		scanOp.finish(
+			`Found ${totalTargets} item(s) across ${filesWithTargets.length} note(s)`
+		);
+
+		if (filesWithTargets.length === 0) {
+			return;
+		}
+
+		// Phase 2: Confirm with user
+		const proceed = await this.notifications.confirm(
+			`Found ${totalTargets} item(s) to summarize across ${filesWithTargets.length} note(s). Proceed?`,
+			{ proceedLabel: 'Summarize', cancelLabel: 'Cancel' }
+		);
+
+		if (!proceed) {
+			this.notifications.info('Vault summarization cancelled');
+			return;
+		}
+
+		// Phase 3: Process files
+		const genOp = this.notifications.startOperation(
+			'Generating summaries',
+			'summarize-vault-generate'
+		);
+		let totalInline = 0;
+		let totalEnrichment = 0;
+
+		for (let i = 0; i < filesWithTargets.length; i++) {
+			if (genOp.cancelled) break;
+
+			const { file, targets } = filesWithTargets[i];
+			genOp.progress(i + 1, filesWithTargets.length, 'Processing files');
+
+			// Re-read content at processing time (may have changed since scan)
+			const content = await this.plugin.app.vault.read(file);
+			const result = await this.processFileTargets(file, targets, genOp, content);
+			totalInline += result.inlineCompleted;
+			totalEnrichment += result.enrichmentCompleted;
+
+			this.fireEnrichmentCallbacks(file.path, result);
+		}
+
+		if (!genOp.cancelled) {
+			const parts: string[] = [];
+			if (totalInline > 0) parts.push(`${totalInline} inline summaries`);
+			if (totalEnrichment > 0) parts.push(`${totalEnrichment} notes created`);
+			genOp.finish(`Done — ${parts.join(', ')}`);
+		}
+	}
+
+	private isExcluded(file: TFile): boolean {
+		const settings = this.getSettings().summarize;
+
+		for (const folder of settings.excludeFolders) {
+			if (file.path.startsWith(folder + '/')) return true;
+		}
+
+		const cache = this.plugin.app.metadataCache.getFileCache(file);
+		if (cache?.frontmatter?.tags) {
+			const fileTags: string[] = Array.isArray(cache.frontmatter.tags)
+				? cache.frontmatter.tags
+				: [cache.frontmatter.tags];
+			for (const excludeTag of settings.excludeTags) {
+				const normalized = excludeTag.startsWith('#')
+					? excludeTag.slice(1)
+					: excludeTag;
+				if (fileTags.includes(normalized)) return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/summarize/note-scanner.test.ts
+++ b/src/summarize/note-scanner.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from 'vitest';
+import { findSummarizeTargets, hasSummaryBelow, extractTranscriptionContent } from './note-scanner';
+
+describe('findSummarizeTargets', () => {
+	it('finds a bare URL', () => {
+		const content = 'Check this:\nhttps://example.com/article\nDone';
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(1);
+		expect(targets[0]).toMatchObject({
+			type: 'url',
+			source: 'https://example.com/article',
+			line: 1,
+		});
+	});
+
+	it('finds multiple URLs', () => {
+		const content = [
+			'# Links',
+			'https://example.com/a',
+			'Some text',
+			'https://example.com/b',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(2);
+		expect(targets[0].line).toBe(1);
+		expect(targets[1].line).toBe(3);
+	});
+
+	it('finds a transcription block', () => {
+		const content = [
+			'> **Transcription of https://youtube.com/watch?v=abc**',
+			'>',
+			'> Hello world this is a test',
+			'> Second line of transcription',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(1);
+		expect(targets[0]).toMatchObject({
+			type: 'transcription',
+			source: 'https://youtube.com/watch?v=abc',
+			line: 0,
+		});
+		expect(targets[0].content).toContain('Hello world');
+	});
+
+	it('skips URLs that already have a summary below', () => {
+		const content = [
+			'https://example.com/article',
+			'',
+			'> **Summary of https://example.com/article**',
+			'>',
+			'> Some summary text',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
+	it('skips transcriptions that already have a summary below', () => {
+		const content = [
+			'> **Transcription of https://youtube.com/watch?v=abc**',
+			'>',
+			'> Transcribed text here',
+			'',
+			'> **Summary of https://youtube.com/watch?v=abc**',
+			'>',
+			'> Summary text here',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
+	it('skips URLs inside blockquotes', () => {
+		const content = [
+			'> This is a quote with https://example.com/link',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
+	it('prefers transcription over re-fetching when URL has transcription below', () => {
+		const content = [
+			'https://youtube.com/watch?v=abc',
+			'',
+			'> **Transcription of https://youtube.com/watch?v=abc**',
+			'>',
+			'> Transcribed text here',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		// Should find the transcription block as a transcription target, not the URL
+		expect(targets).toHaveLength(1);
+		expect(targets[0].type).toBe('transcription');
+	});
+
+	it('returns empty for no URLs or transcriptions', () => {
+		const content = 'Just some regular notes\nNo links here';
+		expect(findSummarizeTargets(content)).toHaveLength(0);
+	});
+
+	it('returns empty for empty content', () => {
+		expect(findSummarizeTargets('')).toHaveLength(0);
+	});
+
+	it('finds URL and transcription as separate targets', () => {
+		const content = [
+			'https://example.com/page1',
+			'',
+			'> **Transcription of https://youtube.com/watch?v=xyz**',
+			'>',
+			'> Some transcribed content',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(2);
+		expect(targets[0].type).toBe('url');
+		expect(targets[1].type).toBe('transcription');
+	});
+
+	it('finds enrichment URLs with metadata', () => {
+		const content = [
+			'https://example.com/user-url',
+			'',
+			'%% auto-notes-enrichment-start %%',
+			'## References',
+			'',
+			'- [Some Article](https://example.com/enrichment-ref) — background',
+			'- [Another](https://other.com/resource) — related',
+			'',
+			'%% auto-notes-enrichment-end %%',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(3);
+
+		// Regular URL
+		expect(targets[0]).toMatchObject({
+			type: 'url',
+			source: 'https://example.com/user-url',
+		});
+		expect(targets[0].inEnrichmentSection).toBeFalsy();
+
+		// Enrichment URLs with titles
+		expect(targets[1]).toMatchObject({
+			type: 'url',
+			source: 'https://example.com/enrichment-ref',
+			inEnrichmentSection: true,
+			linkTitle: 'Some Article',
+		});
+		expect(targets[2]).toMatchObject({
+			type: 'url',
+			source: 'https://other.com/resource',
+			inEnrichmentSection: true,
+			linkTitle: 'Another',
+		});
+	});
+
+	it('finds enrichment URLs across multiple sections', () => {
+		const content = [
+			'https://example.com/keep-this',
+			'',
+			'%% auto-notes-enrichment-start %%',
+			'## Related Notes',
+			'',
+			'- [[Topic]] — reason',
+			'',
+			'%% auto-notes-enrichment-end %%',
+			'',
+			'%% auto-notes-enrichment-start %%',
+			'## References',
+			'',
+			'- [Ref](https://skip.com/this) — reason',
+			'',
+			'%% auto-notes-enrichment-end %%',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(2);
+		expect(targets[0].source).toBe('https://example.com/keep-this');
+		expect(targets[0].inEnrichmentSection).toBeFalsy();
+		expect(targets[1].source).toBe('https://skip.com/this');
+		expect(targets[1].inEnrichmentSection).toBe(true);
+		expect(targets[1].linkTitle).toBe('Ref');
+	});
+
+	it('ignores wikilinks inside enrichment sections', () => {
+		const content = [
+			'%% auto-notes-enrichment-start %%',
+			'## Related Notes',
+			'',
+			'- [[Existing Note]] — shares topic',
+			'',
+			'%% auto-notes-enrichment-end %%',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
+	it('finds URLs after enrichment section ends', () => {
+		const content = [
+			'%% auto-notes-enrichment-start %%',
+			'## References',
+			'',
+			'- [Inside](https://inside.com/ref) — reason',
+			'',
+			'%% auto-notes-enrichment-end %%',
+			'',
+			'https://example.com/after-enrichment',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(2);
+		// Enrichment target
+		expect(targets[0]).toMatchObject({
+			source: 'https://inside.com/ref',
+			inEnrichmentSection: true,
+			linkTitle: 'Inside',
+		});
+		// Regular URL after markers
+		expect(targets[1]).toMatchObject({
+			source: 'https://example.com/after-enrichment',
+		});
+		expect(targets[1].inEnrichmentSection).toBeFalsy();
+	});
+
+	it('does not double-detect enrichment URLs already replaced with wikilinks', () => {
+		// After summarize replaces [Title](url) with [[Title]], re-scanning
+		// should not detect anything for that line
+		const content = [
+			'%% auto-notes-enrichment-start %%',
+			'## References',
+			'',
+			'- [[AI Overview]] — background',
+			'- [Still External](https://other.com/page) — reason',
+			'',
+			'%% auto-notes-enrichment-end %%',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(1);
+		expect(targets[0]).toMatchObject({
+			source: 'https://other.com/page',
+			inEnrichmentSection: true,
+			linkTitle: 'Still External',
+		});
+	});
+
+	it('reproduces the transcribe-enrich-summarize scenario', () => {
+		// Full scenario: TikTok URL → transcribed → enriched → summarize
+		// should find transcription + enrichment reference URLs
+		const content = [
+			'https://www.tiktok.com/t/ZThw1txpF/',
+			'',
+			'> **Transcription of https://www.tiktok.com/t/ZThw1txpF/**',
+			'>',
+			'> Hey everyone, here is what I learned today about AI...',
+			'> It was really interesting stuff.',
+			'',
+			'%% auto-notes-enrichment-start %%',
+			'## Related Notes',
+			'',
+			'- [[Artificial Intelligence]] — shares topic',
+			'',
+			'%% auto-notes-enrichment-end %%',
+			'',
+			'%% auto-notes-enrichment-start %%',
+			'## References',
+			'',
+			'- [AI Overview](https://en.wikipedia.org/wiki/Artificial_intelligence) — background',
+			'- [TikTok Creator](https://tiktok.com/@creator) — source',
+			'',
+			'%% auto-notes-enrichment-end %%',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(3);
+
+		// Transcription target
+		expect(targets[0]).toMatchObject({
+			type: 'transcription',
+			source: 'https://www.tiktok.com/t/ZThw1txpF/',
+		});
+
+		// Enrichment reference targets
+		expect(targets[1]).toMatchObject({
+			type: 'url',
+			source: 'https://en.wikipedia.org/wiki/Artificial_intelligence',
+			inEnrichmentSection: true,
+			linkTitle: 'AI Overview',
+		});
+		expect(targets[2]).toMatchObject({
+			type: 'url',
+			source: 'https://tiktok.com/@creator',
+			inEnrichmentSection: true,
+			linkTitle: 'TikTok Creator',
+		});
+	});
+
+	it('enrichment targets survive idempotent re-scan after note creation', () => {
+		// After processing, the external links become wikilinks.
+		// Re-scanning should find no enrichment targets.
+		const content = [
+			'https://www.tiktok.com/t/ZThw1txpF/',
+			'',
+			'> **Transcription of https://www.tiktok.com/t/ZThw1txpF/**',
+			'>',
+			'> Transcribed text',
+			'',
+			'> **Summary of https://www.tiktok.com/t/ZThw1txpF/**',
+			'>',
+			'> Summary of the transcription',
+			'',
+			'%% auto-notes-enrichment-start %%',
+			'## References',
+			'',
+			'- [[AI Overview]] — background',
+			'- [[TikTok Creator]] — source',
+			'',
+			'%% auto-notes-enrichment-end %%',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		// Transcription already has summary, enrichment refs already converted
+		expect(targets).toHaveLength(0);
+	});
+});
+
+describe('hasSummaryBelow', () => {
+	it('returns true when summary block exists immediately below', () => {
+		const lines = [
+			'https://example.com/article',
+			'> **Summary of https://example.com/article**',
+			'>',
+			'> Summary text',
+		];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(true);
+	});
+
+	it('returns true when summary is one blank line below', () => {
+		const lines = [
+			'https://example.com/article',
+			'',
+			'> **Summary of https://example.com/article**',
+		];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(true);
+	});
+
+	it('returns false when no summary exists', () => {
+		const lines = [
+			'https://example.com/article',
+			'Some other text',
+		];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(false);
+	});
+
+	it('returns false when summary is for a different source', () => {
+		const lines = [
+			'https://example.com/article',
+			'> **Summary of https://example.com/other**',
+		];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(false);
+	});
+
+	it('returns false at end of file', () => {
+		const lines = ['https://example.com/article'];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(false);
+	});
+});
+
+describe('extractTranscriptionContent', () => {
+	it('extracts text from a transcription block', () => {
+		const lines = [
+			'> **Transcription of test**',
+			'>',
+			'> First line',
+			'> Second line',
+		];
+		const result = extractTranscriptionContent(lines, 0);
+		expect(result.endLine).toBe(3);
+		expect(result.text).toContain('First line');
+		expect(result.text).toContain('Second line');
+	});
+
+	it('stops at non-blockquote content', () => {
+		const lines = [
+			'> **Transcription of test**',
+			'>',
+			'> Transcribed text',
+			'',
+			'Regular text',
+		];
+		const result = extractTranscriptionContent(lines, 0);
+		expect(result.endLine).toBe(2);
+		expect(result.text).toBe('Transcribed text');
+	});
+
+	it('handles empty transcription', () => {
+		const lines = [
+			'> **Transcription of test**',
+			'Regular text',
+		];
+		const result = extractTranscriptionContent(lines, 0);
+		expect(result.endLine).toBe(0);
+		expect(result.text).toBe('');
+	});
+});

--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -1,0 +1,153 @@
+import { ENRICHMENT_START, ENRICHMENT_END } from '../enrichment/enrichment-applier';
+import { SummarizeTarget } from './types';
+
+const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;
+const TRANSCRIPTION_HEADER = /^>\s*\*\*Transcription of (.+?)\*\*$/;
+
+/**
+ * Scan note content for URLs and transcription blocks that need summaries.
+ * Skips targets that already have a summary block below them.
+ * Skips content inside enrichment marker sections (managed by the enrichment module).
+ */
+export function findSummarizeTargets(content: string): SummarizeTarget[] {
+	const lines = content.split('\n');
+	const targets: SummarizeTarget[] = [];
+	let inEnrichmentSection = false;
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+
+		// Track enrichment marker sections — content inside is managed
+		// by the enrichment module and must not be modified
+		if (line.trim() === ENRICHMENT_START) {
+			inEnrichmentSection = true;
+			continue;
+		}
+		if (line.trim() === ENRICHMENT_END) {
+			inEnrichmentSection = false;
+			continue;
+		}
+		if (inEnrichmentSection) {
+			// Detect markdown links in enrichment reference lists
+			// e.g. "- [AI Overview](https://example.com) — reason"
+			const mdLinkMatch = line.match(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/);
+			if (mdLinkMatch) {
+				targets.push({
+					type: 'url',
+					source: mdLinkMatch[2],
+					line: i,
+					endLine: i,
+					inEnrichmentSection: true,
+					linkTitle: mdLinkMatch[1],
+				});
+			}
+			continue;
+		}
+
+		// Check for transcription block headers
+		const transcriptionMatch = line.match(TRANSCRIPTION_HEADER);
+		if (transcriptionMatch) {
+			const source = transcriptionMatch[1];
+			const { endLine, text } = extractTranscriptionContent(lines, i);
+
+			if (!hasSummaryBelow(lines, endLine, source)) {
+				targets.push({
+					type: 'transcription',
+					source,
+					line: i,
+					endLine,
+					content: text,
+				});
+			}
+			// Skip past the transcription block
+			i = endLine;
+			continue;
+		}
+
+		// Skip blockquote lines for URL scanning
+		if (line.trimStart().startsWith('>')) continue;
+
+		// Scan for URLs
+		const matches = [...line.matchAll(URL_REGEX)];
+		for (const match of matches) {
+			const url = match[0];
+
+			// Check if this URL has a transcription block below — if so,
+			// the transcription handler above will cover it
+			if (hasTranscriptionBelow(lines, i, url)) continue;
+
+			// Check if this URL already has a summary below
+			if (hasSummaryBelow(lines, i, url)) continue;
+
+			targets.push({
+				type: 'url',
+				source: url,
+				line: i,
+				endLine: i,
+			});
+		}
+	}
+
+	return targets;
+}
+
+/**
+ * Check if a summary block already exists below a given line for the specified source.
+ * Looks within 3 lines below, allowing blank lines and blockquotes.
+ */
+export function hasSummaryBelow(lines: string[], startLine: number, source: string): boolean {
+	for (let j = startLine + 1; j < lines.length && j <= startLine + 3; j++) {
+		if (lines[j].includes(`**Summary of ${source}**`)) {
+			return true;
+		}
+		// Stop at non-empty, non-blockquote content
+		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {
+			break;
+		}
+	}
+	return false;
+}
+
+/**
+ * Check if a transcription block exists below a URL line.
+ */
+function hasTranscriptionBelow(lines: string[], urlLine: number, url: string): boolean {
+	for (let j = urlLine + 1; j < lines.length && j <= urlLine + 5; j++) {
+		if (lines[j].includes(`**Transcription of ${url}**`)) {
+			return true;
+		}
+		// Stop at non-empty, non-blockquote content
+		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {
+			break;
+		}
+	}
+	return false;
+}
+
+/**
+ * Extract the text content from a transcription blockquote block.
+ * Returns the end line index and the plain text content.
+ */
+export function extractTranscriptionContent(lines: string[], headerLine: number): { endLine: number; text: string } {
+	const textLines: string[] = [];
+	let endLine = headerLine;
+
+	for (let j = headerLine + 1; j < lines.length; j++) {
+		if (!lines[j].startsWith('>') && lines[j].trim() !== '') {
+			break;
+		}
+		if (!lines[j].startsWith('>')) {
+			// Empty line outside blockquote — end of block
+			break;
+		}
+		endLine = j;
+		// Strip the blockquote prefix and collect text
+		const stripped = lines[j].replace(/^>\s?/, '');
+		textLines.push(stripped);
+	}
+
+	return {
+		endLine,
+		text: textLines.join('\n').trim(),
+	};
+}

--- a/src/summarize/summarize-modal.ts
+++ b/src/summarize/summarize-modal.ts
@@ -1,0 +1,101 @@
+import { App, Modal, Notice, Setting } from 'obsidian';
+import { SummarizeTarget } from './types';
+
+export class SummarizeSelectionModal extends Modal {
+	private selected: Set<string>;
+	private onSummarize: (targets: SummarizeTarget[]) => Promise<void>;
+
+	constructor(
+		app: App,
+		private targets: SummarizeTarget[],
+		onSummarize: (targets: SummarizeTarget[]) => Promise<void>
+	) {
+		super(app);
+		this.selected = new Set(targets.map(t => `${t.type}:${t.line}:${t.source}`));
+		this.onSummarize = onSummarize;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		contentEl.createEl('h2', { text: 'Summarize Content' });
+		contentEl.createEl('p', {
+			text: `Found ${this.targets.length} item(s) to summarize. Select which to process:`,
+		});
+
+		new Setting(contentEl)
+			.addButton((btn) => {
+				btn.setButtonText('Select All').onClick(() => {
+					this.selected = new Set(this.targets.map(t => `${t.type}:${t.line}:${t.source}`));
+					this.renderCheckboxes(listEl);
+				});
+			})
+			.addButton((btn) => {
+				btn.setButtonText('Select None').onClick(() => {
+					this.selected.clear();
+					this.renderCheckboxes(listEl);
+				});
+			});
+
+		const listEl = contentEl.createDiv({ cls: 'auto-notes-summarize-list' });
+		this.renderCheckboxes(listEl);
+
+		new Setting(contentEl).addButton((btn) => {
+			btn.setButtonText('Summarize Selected')
+				.setCta()
+				.onClick(async () => {
+					const keys = this.selected;
+					const chosen = this.targets.filter(
+						t => keys.has(`${t.type}:${t.line}:${t.source}`)
+					);
+					if (chosen.length === 0) {
+						new Notice('Please select at least one item');
+						return;
+					}
+					this.close();
+					await this.onSummarize(chosen);
+				});
+		});
+	}
+
+	private renderCheckboxes(container: HTMLElement): void {
+		container.empty();
+		for (const target of this.targets) {
+			const key = `${target.type}:${target.line}:${target.source}`;
+
+			let label: string;
+			let desc: string | undefined;
+			if (target.type === 'transcription') {
+				label = `Transcription: ${target.source}`;
+			} else if (target.inEnrichmentSection && target.linkTitle) {
+				label = `Reference: ${target.linkTitle}`;
+				desc = `Creates [[${target.linkTitle}]] from ${target.source}`;
+			} else {
+				label = `URL: ${target.source}`;
+			}
+
+			const setting = new Setting(container)
+				.setName(label)
+				.addToggle((toggle) => {
+					toggle
+						.setValue(this.selected.has(key))
+						.onChange((val) => {
+							if (val) {
+								this.selected.add(key);
+							} else {
+								this.selected.delete(key);
+							}
+						});
+				});
+
+			if (desc) {
+				setting.setDesc(desc);
+			}
+		}
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/summarize/summarizer.test.ts
+++ b/src/summarize/summarizer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Summarizer } from './summarizer';
+import type { AutoNotesSettings } from '../settings';
+import { DEFAULT_SETTINGS } from '../settings';
+
+const mockComplete = vi.fn().mockResolvedValue('- Key point 1\n- Key point 2');
+
+// Mock the AIClient as a class (required by vitest)
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		complete = mockComplete;
+	},
+}));
+
+describe('Summarizer', () => {
+	let summarizer: Summarizer;
+
+	beforeEach(() => {
+		mockComplete.mockReset();
+		mockComplete.mockResolvedValue('- Key point 1\n- Key point 2');
+		summarizer = new Summarizer(() => DEFAULT_SETTINGS as AutoNotesSettings);
+	});
+
+	it('calls AI with content and source', async () => {
+		const result = await summarizer.summarize(
+			'Some content to summarize',
+			'https://example.com',
+			'bullets'
+		);
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [userPrompt, systemPrompt] = mockComplete.mock.calls[0];
+		expect(userPrompt).toContain('https://example.com');
+		expect(userPrompt).toContain('Some content to summarize');
+		expect(systemPrompt).toContain('bullet');
+		expect(result).toBe('- Key point 1\n- Key point 2');
+	});
+
+	it('uses paragraph style prompt', async () => {
+		await summarizer.summarize('Content', 'source', 'paragraph');
+
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain('paragraph');
+	});
+
+	it('uses key-points style prompt', async () => {
+		await summarizer.summarize('Content', 'source', 'key-points');
+
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain('key takeaway');
+	});
+
+	it('uses custom prompt when provided', async () => {
+		await summarizer.summarize('Content', 'source', 'bullets', 'My custom prompt');
+
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toBe('My custom prompt');
+	});
+
+	it('sanitizes AI response', async () => {
+		mockComplete.mockResolvedValue('<script>alert("xss")</script>Clean text');
+		const result = await summarizer.summarize('Content', 'source', 'bullets');
+		expect(result).not.toContain('<script>');
+		expect(result).toContain('Clean text');
+	});
+});

--- a/src/summarize/summarizer.ts
+++ b/src/summarize/summarizer.ts
@@ -1,0 +1,32 @@
+import { AIClient, sanitizeAIResponse } from '../shared';
+import { AutoNotesSettings } from '../settings';
+
+type SummaryStyle = 'bullets' | 'paragraph' | 'key-points';
+
+const STYLE_PROMPTS: Record<SummaryStyle, string> = {
+	bullets: `Summarize the following content as concise bullet points. Each bullet should capture one key idea. Use markdown bullet syntax (- ). Keep it brief and informative.`,
+	paragraph: `Summarize the following content in a brief paragraph. Focus on the main ideas and key takeaways. Keep it concise — aim for 2-4 sentences.`,
+	'key-points': `Summarize the following content as key takeaways. Use short headers (###) for each takeaway, with 1-2 sentences of explanation under each. Focus on actionable or notable insights.`,
+};
+
+export class Summarizer {
+	private client: AIClient;
+
+	constructor(private getSettings: () => AutoNotesSettings) {
+		this.client = new AIClient(getSettings);
+	}
+
+	async summarize(
+		content: string,
+		source: string,
+		style: SummaryStyle,
+		customPrompt?: string
+	): Promise<string> {
+		const systemPrompt = customPrompt || STYLE_PROMPTS[style];
+
+		const userPrompt = `Source: ${source}\n\n${content}`;
+
+		const response = await this.client.complete(userPrompt, systemPrompt);
+		return sanitizeAIResponse(response);
+	}
+}

--- a/src/summarize/types.ts
+++ b/src/summarize/types.ts
@@ -1,0 +1,9 @@
+export interface SummarizeTarget {
+	type: 'url' | 'transcription';
+	source: string;        // URL or transcription source label
+	line: number;          // line number in note
+	endLine: number;       // end of target block (for transcriptions)
+	content?: string;      // pre-extracted content (for transcriptions)
+	inEnrichmentSection?: boolean;  // found inside enrichment markers
+	linkTitle?: string;    // display text from markdown link (enrichment refs)
+}


### PR DESCRIPTION
## Summary
- New `src/summarize/` module with two commands: **Summarize current note** and **Scan vault for notes to summarize**
- Inline URLs and transcription blocks get blockquote summaries inserted below them
- Enrichment reference URLs (inside `%% auto-notes-enrichment %%` markers) create standalone summary notes — the external link is replaced with a `[[wikilink]]`, the new note contains the URL and a comprehensive AI summary, and enrichment is triggered on it
- Settings UI section: enable toggle, summary style (bullets/paragraph/key-points), max content length, custom prompt, exclude folders/tags
- `'summarization'` added to `EnrichmentTrigger` union; wired in `main.ts` for auto-enrichment after summarization

## Bug fixes baked in
- **Stale editor flush**: `vault.create()` for new notes is deferred until after `vault.modify()` on the source file, preventing Obsidian metadata-resolution events from overwriting changes
- **Enrichment revert cycle**: `onSummaryComplete` only fires on the source note when no enrichment sections were modified, so the enrichment applier never strips and rebuilds our link replacements

## Audit fixes
- Duplicate `SummarizeSettings` type removed (canonical definition in `settings.ts`)
- Enrichment marker constants exported from `enrichment-applier.ts` instead of redefined
- Double file read eliminated (content passed through call chain)
- N+1 `content.split('\n')` inside processing loop replaced with persistent `lines` array
- Duplicate enrichment-trigger logic extracted to `fireEnrichmentCallbacks()`

## Test plan
- [x] `npm run build` passes with no type errors
- [x] `npm test` — 196 tests pass (26 new: note-scanner, content-fetcher, summarizer)
- [x] Manual: open note with URLs/transcriptions, run "Summarize current note", verify blockquotes appear
- [x] Manual: run "Scan vault for notes to summarize", verify confirmation + progress + summaries
- [ ] Manual: summarize a note with enrichment references, verify new notes created and `[[wikilinks]]` replace external links
- [ ] Manual: re-run summarize on same note — no duplicates (idempotent)
- [ ] Manual: toggle enabled/disabled in settings, verify commands appear/disappear

Co-Authored-By: Claude <bot@wafflenet.io>