### PR TITLE
fix: folder picker default selection not matching input text

### DIFF
--- a/src/shared/folder-picker-modal.test.ts
+++ b/src/shared/folder-picker-modal.test.ts
@@ -126,4 +126,49 @@ describe('FolderPickerModal', () => {
 
 		expect(el.createEl).toHaveBeenCalledWith('div', { text: 'projects' });
 	});
+
+	it('getSuggestions ranks exact path match above root when query matches a folder', () => {
+		const { root } = buildFolderTree();
+		const app = createMockApp(root);
+		const modal = new FolderPickerModal(app, vi.fn());
+
+		const results = modal.getSuggestions('notes/daily');
+		const paths = results.map(f => f.path);
+
+		expect(paths[0]).toBe('notes/daily');
+		expect(paths).toContain('/');
+	});
+
+	it('getSuggestions keeps root first when query is empty', () => {
+		const { root } = buildFolderTree();
+		const app = createMockApp(root);
+		const modal = new FolderPickerModal(app, vi.fn());
+
+		const results = modal.getSuggestions('');
+
+		expect(results[0].isRoot()).toBe(true);
+	});
+
+	it('getSuggestions keeps root first when query has no exact match', () => {
+		const { root } = buildFolderTree();
+		const app = createMockApp(root);
+		const modal = new FolderPickerModal(app, vi.fn());
+
+		const results = modal.getSuggestions('not');
+		const paths = results.map(f => f.path);
+
+		expect(paths[0]).toBe('/');
+		expect(paths).toContain('notes');
+		expect(paths).toContain('notes/daily');
+	});
+
+	it('getSuggestions exact match is case-insensitive', () => {
+		const { root } = buildFolderTree();
+		const app = createMockApp(root);
+		const modal = new FolderPickerModal(app, vi.fn());
+
+		const results = modal.getSuggestions('PROJECTS');
+
+		expect(results[0].path).toBe('projects');
+	});
 });

--- a/src/shared/folder-picker-modal.ts
+++ b/src/shared/folder-picker-modal.ts
@@ -21,9 +21,22 @@ export class FolderPickerModal extends SuggestModal<TFolder> {
 	getSuggestions(query: string): TFolder[] {
 		const folders = this.collectFolders(this.app.vault.getRoot());
 		const lower = query.toLowerCase();
-		return folders.filter(
+		const filtered = folders.filter(
 			f => f.isRoot() || f.path.toLowerCase().includes(lower)
 		);
+		return filtered.sort((a, b) => {
+			const aPath = a.path.toLowerCase();
+			const bPath = b.path.toLowerCase();
+			const aExact = aPath === lower;
+			const bExact = bPath === lower;
+			// Exact match always comes first
+			if (aExact && !bExact) return -1;
+			if (bExact && !aExact) return 1;
+			// When no exact match is involved, root comes before non-root
+			if (a.isRoot() && !b.isRoot()) return -1;
+			if (b.isRoot() && !a.isRoot()) return 1;
+			return 0;
+		});
 	}
 
 	renderSuggestion(folder: TFolder, el: HTMLElement): void {


### PR DESCRIPTION
## Summary
- Sort `getSuggestions()` results in `FolderPickerModal` so an exact path match for the current query appears first in the list
- Vault root only ranks first when the query is empty or has no exact folder match
- Adds four new test cases covering exact-match ranking, empty-query root priority, partial-query root priority, and case-insensitive exact matching

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (208 tests, including 4 new)
- [x] `node esbuild.config.mjs production` succeeds

Closes #5

Co-Authored-By: Claude <bot@wafflenet.io>