### PR TITLE
feat: auto-transcribe video URLs before summarizing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,10 @@ export default class AutoNotesPlugin extends Plugin {
 		this.audio = new AudioModule(this, getSettings, this.notifications);
 		this.video = new VideoModule(this, getSettings, this.audio, this.notifications);
 		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications);
-		this.summarize = new SummarizeModule(this, getSettings, this.notifications);
+		this.summarize = new SummarizeModule(
+			this, getSettings, this.notifications,
+			(url, parentOp) => this.video.transcribeUrl(url, parentOp)
+		);
 		this.tidy = new TidyModule(this, getSettings, this.notifications);
 		this.organize = new OrganizeModule(this, getSettings, this.notifications);
 

--- a/src/summarize/content-fetcher.test.ts
+++ b/src/summarize/content-fetcher.test.ts
@@ -1,5 +1,51 @@
-import { describe, it, expect } from 'vitest';
-import { extractReadableText } from './content-fetcher';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { extractReadableText, fetchPageContent } from './content-fetcher';
+import { isSupportedUrl } from '../video/url-detector';
+
+/**
+ * Tests for the content fetcher and video URL detection integration.
+ * The fetchContentForUrl logic in SummarizeModule delegates to either
+ * the video transcription pipeline or fetchPageContent based on
+ * isSupportedUrl(). These tests verify that isSupportedUrl correctly
+ * identifies video URLs, and that fetchPageContent + extractReadableText
+ * work as expected for non-video URLs.
+ */
+
+describe('isSupportedUrl integration with summarize', () => {
+	it('identifies YouTube watch URLs as video', () => {
+		expect(isSupportedUrl('https://youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true);
+		expect(isSupportedUrl('https://www.youtube.com/watch?v=abc123')).toBe(true);
+	});
+
+	it('identifies YouTube short URLs as video', () => {
+		expect(isSupportedUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true);
+	});
+
+	it('identifies YouTube Shorts as video', () => {
+		expect(isSupportedUrl('https://youtube.com/shorts/dQw4w9WgXcQ')).toBe(true);
+	});
+
+	it('identifies TikTok URLs as video', () => {
+		expect(isSupportedUrl('https://www.tiktok.com/@user/video/1234567890')).toBe(true);
+		expect(isSupportedUrl('https://www.tiktok.com/t/ZThw1txpF/')).toBe(true);
+		expect(isSupportedUrl('https://vm.tiktok.com/ZMxxxxxxx/')).toBe(true);
+	});
+
+	it('does not flag regular article URLs as video', () => {
+		expect(isSupportedUrl('https://example.com/article')).toBe(false);
+		expect(isSupportedUrl('https://en.wikipedia.org/wiki/Topic')).toBe(false);
+		expect(isSupportedUrl('https://blog.example.com/post-123')).toBe(false);
+	});
+
+	it('does not flag YouTube channel URLs as video', () => {
+		expect(isSupportedUrl('https://youtube.com/channel/UCxxxx')).toBe(false);
+		expect(isSupportedUrl('https://youtube.com/@username')).toBe(false);
+	});
+
+	it('does not flag empty strings', () => {
+		expect(isSupportedUrl('')).toBe(false);
+	});
+});
 
 describe('extractReadableText', () => {
 	it('strips HTML tags', () => {

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -2,6 +2,7 @@ import { Plugin, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
 import { FolderPickerModal, getMarkdownFiles, NotificationManager } from '../shared';
 import { OperationHandle } from '../shared/notifications';
+import { isSupportedUrl } from '../video/url-detector';
 import { fetchPageContent } from './content-fetcher';
 import { findSummarizeTargets } from './note-scanner';
 import { SummarizeSelectionModal } from './summarize-modal';
@@ -10,6 +11,15 @@ import { SummarizeTarget } from './types';
 
 export type { SummarizeTarget } from './types';
 export type { SummarizeSettings } from '../settings';
+
+/**
+ * Function that transcribes a video URL and returns the transcript text.
+ * Injected by main.ts from the VideoModule.
+ */
+export type TranscribeUrlFn = (
+	url: string,
+	parentOp?: { update: (msg: string) => void }
+) => Promise<string>;
 
 const COMPREHENSIVE_SUMMARY_PROMPT =
 	'Provide a comprehensive summary of the following content. This summary will be a standalone reference note. ' +
@@ -34,6 +44,7 @@ interface ProcessResult {
 
 export class SummarizeModule {
 	private summarizer: Summarizer;
+	private transcribeUrl: TranscribeUrlFn | null;
 
 	/** Optional callback invoked after summarization completes. Wired by main.ts for enrichment. */
 	onSummaryComplete: ((filePath: string) => void) | null = null;
@@ -41,9 +52,11 @@ export class SummarizeModule {
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => AutoNotesSettings,
-		private notifications: NotificationManager
+		private notifications: NotificationManager,
+		transcribeUrl?: TranscribeUrlFn
 	) {
 		this.summarizer = new Summarizer(getSettings);
+		this.transcribeUrl = transcribeUrl ?? null;
 	}
 
 	async onload(): Promise<void> {
@@ -188,9 +201,10 @@ export class SummarizeModule {
 					if (!noteAlreadyExists) {
 						op.update(`Fetching ${title}`);
 
-						const pageContent = await fetchPageContent(
+						const pageContent = await this.fetchContentForUrl(
 							target.source,
-							settings.maxContentLength
+							settings.maxContentLength,
+							op
 						);
 
 						if (!pageContent.trim()) {
@@ -240,9 +254,10 @@ export class SummarizeModule {
 						textToSummarize = target.content;
 					} else {
 						op.update(`Fetching ${target.source}`);
-						textToSummarize = await fetchPageContent(
+						textToSummarize = await this.fetchContentForUrl(
 							target.source,
-							settings.maxContentLength
+							settings.maxContentLength,
+							op
 						);
 					}
 
@@ -296,6 +311,31 @@ export class SummarizeModule {
 		}
 
 		return { inlineCompleted, enrichmentCompleted, linksUpdated, newNotePaths };
+	}
+
+	/**
+	 * Fetch content for a URL. If the URL is a recognized video platform
+	 * and a transcription function is available, transcribe the video
+	 * instead of fetching the page HTML (which yields little useful text
+	 * from JS-rendered video pages).
+	 */
+	private async fetchContentForUrl(
+		url: string,
+		maxLength: number,
+		op: OperationHandle
+	): Promise<string> {
+		if (this.transcribeUrl && isSupportedUrl(url)) {
+			try {
+				op.update(`Transcribing video ${url}`);
+				const transcript = await this.transcribeUrl(url, op);
+				return transcript.slice(0, maxLength);
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				throw new Error(`Video transcription failed for ${url}: ${msg}`);
+			}
+		}
+
+		return fetchPageContent(url, maxLength);
 	}
 
 	/**

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -74,6 +74,19 @@ export class VideoModule {
 
 	onunload(): void {}
 
+	/**
+	 * Transcribe a video URL and return the transcript text without creating
+	 * a note. Used by the summarize module to auto-transcribe video URLs
+	 * before summarizing.
+	 */
+	async transcribeUrl(
+		url: string,
+		parentOp?: { update: (msg: string) => void }
+	): Promise<string> {
+		const result = await this.processUrl(url, { insertMode: false }, parentOp);
+		return result.processed || result.raw;
+	}
+
 	async processUrl(
 		url: string,
 		options?: VideoProcessOptions,


### PR DESCRIPTION
## Summary
- When `fetchPageContent()` encounters a video URL (YouTube, TikTok), the summarize module now auto-transcribes the video via the existing video/audio pipeline and summarizes the transcript -- instead of attempting a useless HTTP GET on the JS-rendered video page
- Adds `VideoModule.transcribeUrl(url)` -- a public method that returns transcript text without creating a note in the vault
- Adds `TranscribeUrlFn` type and `fetchContentForUrl()` private helper in `SummarizeModule` that routes video URLs to transcription and non-video URLs to the existing `fetchPageContent()`
- Wires the dependency in `main.ts` via closure injection, keeping the module boundary clean
- Only the summary appears in the note; the full transcription is discarded unless the user separately runs the transcribe command

## Changed files
- `src/video/index.ts` -- new `transcribeUrl()` public method
- `src/summarize/index.ts` -- `TranscribeUrlFn` type, constructor parameter, `fetchContentForUrl()` helper
- `src/main.ts` -- wires `video.transcribeUrl` into `SummarizeModule`
- `src/summarize/content-fetcher.test.ts` -- adds video URL detection integration tests

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (260 tests, 21 files)
- [x] `node esbuild.config.mjs production` builds successfully
- [ ] Manual: paste a YouTube URL in a note, run Summarize -- should transcribe then summarize
- [ ] Manual: paste a regular article URL, run Summarize -- should fetch HTML as before
- [ ] Manual: paste a TikTok URL in enrichment references, run Summarize -- should transcribe and create summary note

Closes #18

Co-Authored-By: Claude <bot@wafflenet.io>