### PR TITLE
fix: scope organize to current note after summarize (#29)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,13 @@ export default class AutoNotesPlugin extends Plugin {
 			};
 		}
 
+		// Wire summarize auto-organize callback (single-note only, never vault-wide)
+		if (this.settings.summarize.autoOrganizeOnSummarize && this.settings.organize.enabled) {
+			this.summarize.onOrganizeRequested = (file) => {
+				this.organize.organizeNote(file);
+			};
+		}
+
 		// Single ribbon icon + command for the unified view
 		this.addRibbonIcon('sparkles', 'Review proposals', () => {
 			this.activateUnifiedView();

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -616,6 +616,18 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 					})
 			);
 
+		new Setting(containerEl)
+			.setName('Auto-organize after summarize')
+			.setDesc('Automatically organize the current note after summarization completes (single-note only, not vault-wide)')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.summarize.autoOrganizeOnSummarize)
+					.onChange(async (value) => {
+						this.plugin.settings.summarize.autoOrganizeOnSummarize = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
 		// ── Note Tidy ──
 		containerEl.createEl('h2', { text: 'Note Tidy' });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -135,6 +135,7 @@ export interface SummarizeSettings {
 	customPrompt: string;
 	excludeFolders: string[];
 	excludeTags: string[];
+	autoOrganizeOnSummarize: boolean;
 }
 
 export interface TidySettings {
@@ -272,6 +273,7 @@ export const DEFAULT_SETTINGS: AutoNotesSettings = {
 		customPrompt: '',
 		excludeFolders: ['templates', '.auto-notes'],
 		excludeTags: ['no-summarize'],
+		autoOrganizeOnSummarize: false,
 	},
 	tidy: {
 		enabled: true,

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -49,6 +49,9 @@ export class SummarizeModule {
 	/** Optional callback invoked after summarization completes. Wired by main.ts for enrichment. */
 	onSummaryComplete: ((filePath: string) => void) | null = null;
 
+	/** Optional callback invoked after single-note summarize to organize the note. Wired by main.ts. */
+	onOrganizeRequested: ((file: TFile) => void) | null = null;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => AutoNotesSettings,
@@ -137,6 +140,11 @@ export class SummarizeModule {
 		}
 
 		this.fireEnrichmentCallbacks(file.path, result);
+
+		// Trigger single-note organize (never vault-wide scan)
+		if (this.getSettings().summarize.autoOrganizeOnSummarize) {
+			this.onOrganizeRequested?.(file);
+		}
 	}
 
 	/**

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SummarizeModule } from './index';
+import { DEFAULT_SETTINGS } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+
+// Mock the content fetcher to avoid real network calls
+vi.mock('./content-fetcher', () => ({
+	fetchPageContent: vi.fn().mockResolvedValue('Some fetched content for testing.'),
+}));
+
+// Mock the summarizer to return a canned summary
+vi.mock('./summarizer', () => ({
+	Summarizer: class MockSummarizer {
+		summarize = vi.fn().mockResolvedValue('This is a test summary.');
+	},
+}));
+
+// Mock the note scanner to control what targets are found
+vi.mock('./note-scanner', () => ({
+	findSummarizeTargets: vi.fn().mockReturnValue([
+		{ type: 'url', source: 'https://example.com', line: 2, endLine: 2 },
+	]),
+}));
+
+// Mock the video URL detector
+vi.mock('../video/url-detector', () => ({
+	isSupportedUrl: vi.fn().mockReturnValue(false),
+}));
+
+// Mock the shared module to avoid folder picker / getMarkdownFiles issues
+vi.mock('../shared', () => ({
+	FolderPickerModal: vi.fn(),
+	getMarkdownFiles: vi.fn().mockReturnValue([]),
+	NotificationManager: vi.fn(),
+}));
+
+function createMockNotifications() {
+	const handle = {
+		update: vi.fn(),
+		progress: vi.fn(),
+		finish: vi.fn(),
+		error: vi.fn(),
+		cancelled: false,
+	};
+	return {
+		startOperation: vi.fn().mockReturnValue(handle),
+		info: vi.fn(),
+		success: vi.fn(),
+		notifyError: vi.fn(),
+		confirm: vi.fn().mockResolvedValue(true),
+		_handle: handle,
+	};
+}
+
+describe('SummarizeModule organize scope', () => {
+	let module: SummarizeModule;
+	let mockPlugin: any;
+	let mockNotifications: ReturnType<typeof createMockNotifications>;
+	let settings: typeof DEFAULT_SETTINGS;
+
+	beforeEach(() => {
+		settings = structuredClone(DEFAULT_SETTINGS);
+		settings.summarize.autoOrganizeOnSummarize = true;
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Note\n\nhttps://example.com\n'),
+					modify: vi.fn().mockResolvedValue(undefined),
+					create: vi.fn().mockResolvedValue(new TFile()),
+					getAbstractFileByPath: vi.fn().mockReturnValue(null),
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+				},
+				workspace: {
+					getActiveFile: vi.fn().mockReturnValue(null),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+
+		mockNotifications = createMockNotifications();
+		module = new SummarizeModule(
+			mockPlugin as any,
+			() => settings,
+			mockNotifications as any
+		);
+	});
+
+	it('calls onOrganizeRequested with the file after single-note summarize', async () => {
+		const organizeCallback = vi.fn();
+		module.onOrganizeRequested = organizeCallback;
+
+		// Register commands so we can invoke the summarize command
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = new TFile('notes/test.md') as any;
+		await summarizeCmd.editorCallback({}, { file });
+
+		expect(organizeCallback).toHaveBeenCalledTimes(1);
+		expect(organizeCallback).toHaveBeenCalledWith(file);
+	});
+
+	it('does not call onOrganizeRequested when autoOrganizeOnSummarize is false', async () => {
+		settings.summarize.autoOrganizeOnSummarize = false;
+
+		const organizeCallback = vi.fn();
+		module.onOrganizeRequested = organizeCallback;
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = new TFile('notes/test.md') as any;
+		await summarizeCmd.editorCallback({}, { file });
+
+		expect(organizeCallback).not.toHaveBeenCalled();
+	});
+
+	it('does not call onOrganizeRequested when callback is not set', async () => {
+		// When onOrganizeRequested is null (not wired), summarize completes
+		// without attempting any organize operation
+		module.onOrganizeRequested = null;
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = new TFile('notes/test.md') as any;
+
+		// Should not throw even with autoOrganizeOnSummarize enabled
+		await expect(
+			summarizeCmd.editorCallback({}, { file })
+		).resolves.not.toThrow();
+	});
+
+	it('fires onOrganizeRequested with the correct file, not scanDirectory', async () => {
+		// This test verifies the core fix: single-note summarize
+		// uses organizeNote(file) scope, not vault-wide scanDirectory.
+		const organizeCallback = vi.fn();
+		module.onOrganizeRequested = organizeCallback;
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const specificFile = new TFile('projects/research/my-note.md') as any;
+		await summarizeCmd.editorCallback({}, { file: specificFile });
+
+		// The callback receives the EXACT file that was summarized
+		expect(organizeCallback).toHaveBeenCalledWith(specificFile);
+		// And it was called exactly once (not per-vault-file)
+		expect(organizeCallback).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `onOrganizeRequested` callback to `SummarizeModule` that fires only from the single-note `processTargets` path, never from the vault-wide `scanVault` flow
- Wire the callback in `main.ts` to call `organize.organizeNote(file)` (single-file scope) when enabled
- Add `autoOrganizeOnSummarize` setting (default `false`) to `SummarizeSettings` with a toggle in the settings UI
- Add 4 tests verifying: callback fires with the correct file after single-note summarize, callback does not fire when disabled, null callback is safe, and callback receives the exact file (not vault-wide)

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (297 tests, 0 failures)
- [x] `node esbuild.config.mjs production` builds successfully

Closes #29

Co-Authored-By: Claude <bot@wafflenet.io>