### PR TITLE
fix: cap embedded video height for portrait aspect ratios (#25)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,1 +1,13 @@
 /* Auto Notes plugin styles */
+
+/*
+ * Cap the height of embedded videos so portrait-oriented content
+ * (TikTok, Instagram Reels, phone recordings) does not dominate the note.
+ * Landscape videos are unaffected because they hit width constraints first.
+ */
+.markdown-preview-view video,
+.markdown-reading-view video,
+.markdown-source-view video {
+  max-height: 50vh;
+  width: auto;
+}


### PR DESCRIPTION
## Summary
- Add `max-height: 50vh` and `width: auto` CSS rules for `<video>` elements in all three Obsidian view modes (preview, reading, source)
- Portrait-oriented videos (TikTok, Instagram Reels, phone recordings) no longer blow out the vertical space of a note
- Landscape videos are unaffected since they hit width constraints before the height cap

## Test plan
- [ ] Embed a portrait video (e.g., TikTok, phone recording) via `![[filename]]` and confirm it is capped at roughly half the viewport height
- [ ] Embed a landscape video and confirm it renders the same as before (width-constrained)
- [ ] Verify the video maintains its native aspect ratio (no stretching or cropping)
- [ ] Check all three view modes: reading view, live preview, and source view with rendered embeds
- [ ] `npx tsc --noEmit --skipLibCheck` passes
- [ ] `npm test` passes (293/293)
- [ ] `node esbuild.config.mjs production` succeeds

Closes #25

Co-Authored-By: Claude <bot@wafflenet.io>