### PR TITLE
chore: enable skill-creator plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "typescript-lsp@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Adds `skill-creator@claude-plugins-official` to `.claude/settings.json`

## Test plan
- [x] Verify settings JSON is valid
- [x] No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)