### PR TITLE
fix: raise organize confidence thresholds to reduce folder sprawl (#37)

### DIFF
--- a/src/organize/content-analyzer.test.ts
+++ b/src/organize/content-analyzer.test.ts
@@ -92,12 +92,12 @@ describe('ContentAnalyzer', () => {
 	});
 
 	describe('topicsFromTags', () => {
-		it('converts tags to topics with 0.5 confidence', () => {
+		it('converts tags to topics with 0.3 confidence', () => {
 			const analyzer = makeAnalyzer();
 			const result = analyzer.topicsFromTags(['#machine-learning', '#research']);
 			expect(result).toHaveLength(2);
 			expect(result[0].label).toBe('machine-learning');
-			expect(result[0].confidence).toBe(0.5);
+			expect(result[0].confidence).toBe(0.3);
 		});
 
 		it('removes hash prefix and converts slashes to spaces', () => {

--- a/src/organize/content-analyzer.ts
+++ b/src/organize/content-analyzer.ts
@@ -148,7 +148,7 @@ export class ContentAnalyzer {
 					.replace(/\//g, ' ')
 					.toLowerCase()
 					.trim(),
-				confidence: 0.5,
+				confidence: 0.3,
 			}))
 			.filter(t => t.label.length > 0);
 	}

--- a/src/organize/directory-matcher.test.ts
+++ b/src/organize/directory-matcher.test.ts
@@ -142,10 +142,14 @@ describe('DirectoryMatcher', () => {
 	});
 
 	describe('determineAction', () => {
-		it('returns move action when existing directory scores above threshold', () => {
+		it('returns move action when existing directory scores above threshold (0.6)', () => {
 			const app = makeMockApp(['machine learning', 'other']);
 			const matcher = new DirectoryMatcher(app);
-			const analysis = makeAnalysis({ notePath: 'inbox/test.md' });
+			// confidence=1.0 produces exact match score of 0.6 * 1.0 = 0.6 (meets threshold)
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'machine learning', confidence: 1.0 }],
+			});
 
 			const action = matcher.determineAction(analysis);
 			expect(action.type).toBe('move');
@@ -154,10 +158,30 @@ describe('DirectoryMatcher', () => {
 			}
 		});
 
-		it('returns propose-new-directory when no directory scores above threshold', () => {
+		it('does not move when directory score is below threshold (0.6)', () => {
+			const app = makeMockApp(['machine learning', 'other']);
+			const matcher = new DirectoryMatcher(app);
+			// confidence=0.5 produces exact match score of 0.6 * 0.5 = 0.3 (below 0.6)
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'machine learning', confidence: 0.5 }],
+			});
+
+			const action = matcher.determineAction(analysis);
+			// Score 0.3 < 0.6 threshold, so no move; but confidence 0.5 < 0.9, so no proposal either
+			expect(action.type).toBe('move');
+			if (action.type === 'move') {
+				expect(action.targetDirectory).toBe('inbox');
+			}
+		});
+
+		it('returns propose-new-directory when no directory scores above threshold and confidence >= 0.9', () => {
 			const app = makeMockApp(['cooking', 'travel']);
 			const matcher = new DirectoryMatcher(app);
-			const analysis = makeAnalysis({ notePath: 'inbox/test.md' });
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'machine learning', confidence: 0.95 }],
+			});
 
 			const action = matcher.determineAction(analysis);
 			expect(action.type).toBe('propose-new-directory');
@@ -165,6 +189,51 @@ describe('DirectoryMatcher', () => {
 				expect(action.targetDirectory).toBeTruthy();
 				expect(action.reasoning).toContain('machine learning');
 			}
+		});
+
+		it('does not propose new directory when topic confidence is below threshold', () => {
+			const app = makeMockApp(['cooking', 'travel']);
+			const matcher = new DirectoryMatcher(app);
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'machine learning', confidence: 0.7 }],
+			});
+
+			const action = matcher.determineAction(analysis);
+			// 0.7 confidence < 0.9 threshold, so note stays put
+			expect(action.type).toBe('move');
+			if (action.type === 'move') {
+				expect(action.targetDirectory).toBe('inbox');
+			}
+		});
+
+		it('does not propose new directory when tag-derived topics have low confidence', () => {
+			const app = makeMockApp(['cooking', 'travel']);
+			const matcher = new DirectoryMatcher(app);
+			// Tag-derived topics have 0.3 confidence (after the fix), well below 0.9
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'programming', confidence: 0.3 }],
+			});
+
+			const action = matcher.determineAction(analysis);
+			expect(action.type).toBe('move');
+			if (action.type === 'move') {
+				expect(action.targetDirectory).toBe('inbox');
+			}
+		});
+
+		it('respects custom confidence threshold parameter', () => {
+			const app = makeMockApp(['cooking', 'travel']);
+			const matcher = new DirectoryMatcher(app);
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'machine learning', confidence: 0.6 }],
+			});
+
+			// With a lowered confidence threshold of 0.5, should propose new directory
+			const action = matcher.determineAction(analysis, 0.6, 0.5);
+			expect(action.type).toBe('propose-new-directory');
 		});
 
 		it('filters out the current directory from candidates', () => {
@@ -175,7 +244,7 @@ describe('DirectoryMatcher', () => {
 				topics: [{ label: 'notes', confidence: 0.9 }],
 			});
 
-			const action = matcher.determineAction(analysis, 0.01);
+			const action = matcher.determineAction(analysis, 0.01, 0.01);
 			// Should not suggest moving to the same directory
 			if (action.type === 'move') {
 				expect(action.targetDirectory).not.toBe('notes');

--- a/src/organize/directory-matcher.ts
+++ b/src/organize/directory-matcher.ts
@@ -39,10 +39,15 @@ export class DirectoryMatcher {
 	 *
 	 * @param minScoreThreshold - Minimum score for a directory to be considered
 	 *   a valid match (0-1). Below this, a new directory will be proposed.
+	 *   Default 0.6 — requires a strong topical match.
+	 * @param confidenceThreshold - Minimum confidence of the top topic required
+	 *   to propose a new directory (0-1). Default 0.9 — only highly confident
+	 *   topics justify new folder creation.
 	 */
 	determineAction(
 		analysis: ContentAnalysis,
-		minScoreThreshold = 0.3
+		minScoreThreshold = 0.6,
+		confidenceThreshold = 0.9
 	): OrganizeAction {
 		const scores = this.scoreDirectories(analysis);
 		const noteDir = this.getParentPath(analysis.notePath);
@@ -57,9 +62,10 @@ export class DirectoryMatcher {
 			};
 		}
 
-		// Propose a new directory based on the top topic
+		// Propose a new directory based on the top topic, but only when
+		// the AI is highly confident about the note's primary topic.
 		const topTopic = analysis.topics[0];
-		if (topTopic) {
+		if (topTopic && topTopic.confidence >= confidenceThreshold) {
 			const newDir = this.buildDirectoryPath(topTopic.label);
 			return {
 				type: 'propose-new-directory',
@@ -68,7 +74,7 @@ export class DirectoryMatcher {
 			};
 		}
 
-		// No topics extracted; keep in place
+		// No topics or confidence too low; keep in place
 		return {
 			type: 'move',
 			targetDirectory: noteDir,

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -318,7 +318,8 @@ export class OrganizeModule {
 			return null;
 		}
 
-		const action = this.matcher.determineAction(analysis);
+		const confidenceThreshold = this.getSettings().organize.organizeConfidenceThreshold;
+		const action = this.matcher.determineAction(analysis, undefined, confidenceThreshold);
 		const currentDir = this.getParentPath(file.path);
 
 		if (action.type === 'move') {

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -659,6 +659,20 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName('New folder confidence threshold')
+			.setDesc('Minimum topic confidence to propose a new folder (0.5-1.0). Higher = fewer new folders.')
+			.addSlider((slider) =>
+				slider
+					.setLimits(0.5, 1.0, 0.05)
+					.setValue(this.plugin.settings.organize.organizeConfidenceThreshold)
+					.setDynamicTooltip()
+					.onChange(async (value) => {
+						this.plugin.settings.organize.organizeConfidenceThreshold = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
 			.setName('Excluded folders')
 			.setDesc('Comma-separated list of folders to skip for organization')
 			.addText((text) =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,6 +149,8 @@ export interface OrganizeSettings {
 	snapshotFolderPath: string;
 	excludeFolders: string[];
 	excludeTags: string[];
+	/** Minimum topic confidence required to propose a new directory (0-1). */
+	organizeConfidenceThreshold: number;
 }
 
 export interface DeepDiveSettings {
@@ -285,6 +287,7 @@ export const DEFAULT_SETTINGS: AutoNotesSettings = {
 		snapshotFolderPath: '.auto-notes/organize/snapshots',
 		excludeFolders: ['templates', '.auto-notes'],
 		excludeTags: ['no-organize'],
+		organizeConfidenceThreshold: 0.9,
 	},
 	deepDive: {
 		enabled: true,


### PR DESCRIPTION
## Summary
- Raise `minScoreThreshold` default from `0.3` to `0.6` in `DirectoryMatcher.determineAction()` so notes only move to existing directories with a strong topical match
- Add a 90% confidence gate before emitting `propose-new-directory` actions -- low-confidence topics no longer spawn new folders
- Add `organizeConfidenceThreshold` setting (default `0.9`) with a slider in the settings tab so users can tune this
- Lower tag-fallback confidence from `0.5` to `0.3` in `ContentAnalyzer.topicsFromTags()` since tags alone are not high enough signal to reorganize

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (307 tests, including updated and new threshold tests)
- [x] `node esbuild.config.mjs production` builds cleanly

Closes #37

Co-Authored-By: Claude <bot@wafflenet.io>