### PR TITLE
fix: prevent Deep Dive badge text wrapping to 2 lines (#40)

### DIFF
--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -755,6 +755,7 @@ export class UnifiedProposalView extends ItemView {
 				border-radius: 3px;
 				margin-bottom: 4px;
 				width: min-content;
+				white-space: nowrap;
 			}
 			.auto-notes-badge--elaboration {
 				background: var(--interactive-accent);


### PR DESCRIPTION
## Summary
- Add `white-space: nowrap` to `.auto-notes-badge` CSS class to prevent multi-word badge text (e.g., "Deep Dive") from wrapping to 2 lines
- The existing `width: min-content` rule caused two-word labels to break across lines; `nowrap` keeps all badge text on a single line

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (307 tests)
- [x] `node esbuild.config.mjs production` builds successfully

Closes #40

Co-Authored-By: Claude <bot@wafflenet.io>