### PR TITLE
feat: default deep dive notes to a dedicated subfolder

### DIFF
--- a/src/deep-dive/deep-dive-store.test.ts
+++ b/src/deep-dive/deep-dive-store.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TFile, TFolder } from 'obsidian';
 import { DeepDiveStore } from './deep-dive-store';
+import { buildDeepDivePath } from './index';
 import { DeepDiveProposal, DeepDiveRun } from './types';
 
 // ── Mock Obsidian ──
@@ -179,6 +181,46 @@ describe('DeepDiveStore', () => {
 
 			const all = await store.loadAllProposals();
 			expect(all.length).toBe(0);
+		});
+	});
+
+	describe('buildDeepDivePath', () => {
+		function makeRootFile(path: string, parentPath?: string): TFile {
+			const file = { path, basename: path.split('/').pop()?.replace(/\.[^.]+$/, '') || '', parent: null } as TFile;
+			if (parentPath !== undefined) {
+				file.parent = { path: parentPath } as TFolder;
+			}
+			return file;
+		}
+
+		it('uses per-root subfolder with default setting', () => {
+			const root = makeRootFile('notes/Machine Learning.md', 'notes');
+			const result = buildDeepDivePath('Neural Networks', root, { noteOutputFolder: 'Deep Dives' });
+			expect(result).toBe('Deep Dives/Machine Learning/Neural Networks.md');
+		});
+
+		it('uses per-root subfolder with custom output folder', () => {
+			const root = makeRootFile('notes/Machine Learning.md', 'notes');
+			const result = buildDeepDivePath('Neural Networks', root, { noteOutputFolder: 'Custom Folder' });
+			expect(result).toBe('Custom Folder/Machine Learning/Neural Networks.md');
+		});
+
+		it('falls back to source folder when output folder is empty', () => {
+			const root = makeRootFile('notes/Machine Learning.md', 'notes');
+			const result = buildDeepDivePath('Neural Networks', root, { noteOutputFolder: '' });
+			expect(result).toBe('notes/Neural Networks.md');
+		});
+
+		it('falls back to vault root when output folder is empty and source has no parent', () => {
+			const root = makeRootFile('Machine Learning.md');
+			const result = buildDeepDivePath('Neural Networks', root, { noteOutputFolder: '' });
+			expect(result).toBe('Neural Networks.md');
+		});
+
+		it('sanitizes special characters in topic title', () => {
+			const root = makeRootFile('notes/Root.md', 'notes');
+			const result = buildDeepDivePath('What is AI? A "Deep" Look', root, { noteOutputFolder: 'Deep Dives' });
+			expect(result).toBe('Deep Dives/Root/What is AI- A -Deep- Look.md');
 		});
 	});
 

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -344,20 +344,7 @@ export class DeepDiveModule {
 	}
 
 	private buildProposedPath(topicTitle: string, rootFile: TFile): string {
-		const settings = this.getSettings().deepDive;
-		const safeName = topicTitle.replace(/[\\/:*?"<>|]/g, '-').trim();
-
-		let folder: string;
-		if (settings.noteOutputFolder) {
-			folder = settings.noteOutputFolder;
-		} else {
-			// Same folder as the source note
-			const parent = rootFile.parent?.path;
-			folder = parent || '';
-		}
-
-		const path = folder ? `${folder}/${safeName}.md` : `${safeName}.md`;
-		return normalizePath(path);
+		return buildDeepDivePath(topicTitle, rootFile, this.getSettings().deepDive);
 	}
 
 	private isExcluded(file: TFile): boolean {
@@ -389,4 +376,26 @@ export class DeepDiveModule {
 			Math.random().toString(36).slice(2, 10)
 		);
 	}
+}
+
+/** Exported for testing. Builds the proposed vault path for a deep-dive note. */
+export function buildDeepDivePath(
+	topicTitle: string,
+	rootFile: TFile,
+	settings: { noteOutputFolder: string },
+): string {
+	const safeName = topicTitle.replace(/[\\/:*?"<>|]/g, '-').trim();
+
+	let folder: string;
+	if (settings.noteOutputFolder) {
+		// Per-root subfolder: Deep Dives/Machine Learning/
+		folder = `${settings.noteOutputFolder}/${rootFile.basename}`;
+	} else {
+		// Same folder as source note (user explicitly cleared the setting)
+		const parent = rootFile.parent?.path;
+		folder = parent || '';
+	}
+
+	const path = folder ? `${folder}/${safeName}.md` : `${safeName}.md`;
+	return normalizePath(path);
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -757,10 +757,10 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Note output folder')
-			.setDesc('Where to create new notes (empty = same folder as source)')
+			.setDesc('Where to create new notes. Uses a subfolder per root note. (empty = same folder as source)')
 			.addText((text) =>
 				text
-					.setPlaceholder('Leave empty for source folder')
+					.setPlaceholder('Deep Dives')
 					.setValue(this.plugin.settings.deepDive.noteOutputFolder)
 					.onChange(async (value) => {
 						this.plugin.settings.deepDive.noteOutputFolder = value;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -295,7 +295,7 @@ export const DEFAULT_SETTINGS: AutoNotesSettings = {
 		maxDepth: 3,
 		qualityThreshold: 0.4,
 		maxNotesPerRun: 50,
-		noteOutputFolder: '',
+		noteOutputFolder: 'Deep Dives',
 		excludeFolders: ['templates', '.auto-notes'],
 		excludeTags: ['no-deep-dive'],
 		autoEnrichOnAccept: true,


### PR DESCRIPTION
## Summary

- Deep dive notes now default to `Deep Dives/{root note name}/` subfolders instead of landing in the same folder as the source note
- Extracted `buildDeepDivePath()` as a testable utility with per-root subfolder logic
- Updated settings tab description and placeholder to reflect new behavior

Closes #43

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — type check passes
- [x] `npm test` — all 312 tests pass (5 new path-building tests)
- [x] `node esbuild.config.mjs production` — production build succeeds
- [ ] Manual: run deep dive on a note → verify notes land in `Deep Dives/{noteName}/`
- [ ] Manual: clear the output folder setting → verify notes land alongside source note

🤖 Generated with [Claude Code](https://claude.com/claude-code)