### PR TITLE
feat: add syllabus navigation to deep dive notes

### DIFF
--- a/src/deep-dive/deep-dive-store.test.ts
+++ b/src/deep-dive/deep-dive-store.test.ts
@@ -172,6 +172,24 @@ describe('DeepDiveStore', () => {
 		});
 	});
 
+	describe('loadProposalsByRunId', () => {
+		it('returns only proposals matching the run ID', async () => {
+			await store.saveProposal(makeProposal({ id: 'p1', runId: 'run-1' }));
+			await store.saveProposal(makeProposal({ id: 'p2', runId: 'run-1' }));
+			await store.saveProposal(makeProposal({ id: 'p3', runId: 'run-2' }));
+
+			const run1Proposals = await store.loadProposalsByRunId('run-1');
+			expect(run1Proposals.length).toBe(2);
+			expect(run1Proposals.map(p => p.id).sort()).toEqual(['p1', 'p2']);
+		});
+
+		it('returns empty array when no proposals match', async () => {
+			await store.saveProposal(makeProposal({ id: 'p1', runId: 'run-1' }));
+			const result = await store.loadProposalsByRunId('no-such-run');
+			expect(result).toEqual([]);
+		});
+	});
+
 	describe('deleteAllProposals', () => {
 		it('removes all proposals', async () => {
 			await store.saveProposal(makeProposal({ id: 'p1' }));

--- a/src/deep-dive/deep-dive-store.ts
+++ b/src/deep-dive/deep-dive-store.ts
@@ -73,6 +73,11 @@ export class DeepDiveStore {
 		return all.filter(p => p.status === 'pending');
 	}
 
+	async loadProposalsByRunId(runId: string): Promise<DeepDiveProposal[]> {
+		const all = await this.loadAllProposals();
+		return all.filter(p => p.runId === runId);
+	}
+
 	async updateProposalStatus(id: string, status: DeepDiveProposalStatus): Promise<void> {
 		const proposal = await this.loadProposal(id);
 		if (!proposal) return;

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -6,6 +6,14 @@ import { DirectoryMatcher } from '../organize/directory-matcher';
 import { DeepDiveStore } from './deep-dive-store';
 import { NoteGenerator } from './note-generator';
 import { scoreQuality } from './quality-scorer';
+import {
+	computeTraversalOrder,
+	buildNavigationContext,
+	renderNavigationBlock,
+	renderSyllabusContent,
+	syllabusPath,
+	injectNavigationBlock,
+} from './syllabus-navigator';
 import { TopicAnalyzer } from './topic-analyzer';
 import {
 	DeepDiveProposal,
@@ -21,6 +29,17 @@ export type {
 	DeepDiveProposalStatus,
 	DeepDiveRunStatus,
 } from './types';
+
+export type { TraversalNode, NavigationContext } from './syllabus-navigator';
+export {
+	computeTraversalOrder,
+	buildNavigationContext,
+	renderNavigationBlock,
+	renderSyllabusContent,
+	syllabusTitle,
+	syllabusPath,
+	injectNavigationBlock,
+} from './syllabus-navigator';
 
 export class DeepDiveModule {
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
@@ -74,7 +93,9 @@ export class DeepDiveModule {
 	}
 
 	/**
-	 * Accept a proposal: create the new note in the vault.
+	 * Accept a proposal: create the new note in the vault with navigation,
+	 * generate/update the syllabus index, and update navigation in all
+	 * previously accepted notes in the same run.
 	 */
 	async acceptProposal(id: string): Promise<void> {
 		const proposal = await this.store.loadProposal(id);
@@ -84,8 +105,11 @@ export class DeepDiveModule {
 		}
 
 		try {
-			await writeNote(this.plugin.app, proposal.proposedPath, proposal.proposedContent);
 			await this.store.updateProposalStatus(id, 'accepted');
+
+			// Build navigation for all accepted proposals in this run
+			await this.updateRunNavigation(proposal.runId, proposal.proposedPath, proposal.proposedContent);
+
 			this.notifications.success(`Created ${proposal.proposedPath}`);
 
 			// Trigger enrichment on the new note
@@ -111,13 +135,21 @@ export class DeepDiveModule {
 
 	/**
 	 * Reject a proposal and cascade-reject all its children.
+	 * Updates navigation in remaining accepted notes.
 	 */
 	async rejectProposal(id: string): Promise<void> {
+		const proposal = await this.store.loadProposal(id);
 		const rejected = await this.store.cascadeReject(id);
 		const count = rejected.length;
 		this.notifications.info(
 			count > 1 ? `Rejected ${count} proposals (including children)` : 'Proposal rejected'
 		);
+
+		// Update navigation for remaining accepted notes in the run
+		if (proposal) {
+			await this.updateRunNavigation(proposal.runId);
+		}
+
 		await this.onViewRefreshNeeded?.();
 	}
 
@@ -347,6 +379,63 @@ export class DeepDiveModule {
 			await this.store.saveRun(run);
 			const msg = error instanceof Error ? error.message : String(error);
 			genOp.error(`Deep dive failed — ${msg}`);
+		}
+	}
+
+	/**
+	 * Recompute and update navigation for all accepted proposals in a run.
+	 *
+	 * When newNotePath and newNoteContent are provided (accept flow), the new
+	 * note is written with navigation injected. All previously accepted notes
+	 * in the run are also updated with refreshed prev/next links. The syllabus
+	 * index note is generated or updated.
+	 */
+	private async updateRunNavigation(
+		runId: string,
+		newNotePath?: string,
+		newNoteContent?: string
+	): Promise<void> {
+		const run = await this.store.loadRun(runId);
+		if (!run) return;
+
+		const proposals = await this.store.loadProposalsByRunId(runId);
+		const nodes = computeTraversalOrder(proposals, run);
+
+		if (nodes.length === 0) {
+			// All proposals rejected — remove syllabus if it exists
+			const sPath = syllabusPath(run.rootNotePath, this.getSettings().deepDive.noteOutputFolder);
+			const existingSyllabus = this.plugin.app.vault.getAbstractFileByPath(normalizePath(sPath));
+			if (existingSyllabus instanceof TFile) {
+				await this.plugin.app.vault.delete(existingSyllabus);
+			}
+			return;
+		}
+
+		const sPath = syllabusPath(run.rootNotePath, this.getSettings().deepDive.noteOutputFolder);
+
+		// Write or update the syllabus index note
+		const syllabusContent = renderSyllabusContent(nodes, run);
+		await writeNote(this.plugin.app, sPath, syllabusContent);
+
+		// Update navigation in each accepted note
+		for (const node of nodes) {
+			const ctx = buildNavigationContext(node.proposalId, nodes, run, sPath);
+			if (!ctx) continue;
+
+			const navBlock = renderNavigationBlock(ctx);
+
+			if (newNotePath && node.proposedPath === newNotePath && newNoteContent) {
+				// This is the newly accepted note — inject nav into its content and write
+				const contentWithNav = injectNavigationBlock(newNoteContent, navBlock);
+				await writeNote(this.plugin.app, node.proposedPath, contentWithNav);
+			} else {
+				// Previously accepted note — read current content, update nav, write back
+				const existing = await readNote(this.plugin.app, node.proposedPath);
+				if (existing) {
+					const updated = injectNavigationBlock(existing, navBlock);
+					await writeNote(this.plugin.app, node.proposedPath, updated);
+				}
+			}
 		}
 	}
 

--- a/src/deep-dive/syllabus-navigator.test.ts
+++ b/src/deep-dive/syllabus-navigator.test.ts
@@ -1,0 +1,498 @@
+import { describe, it, expect } from 'vitest';
+import {
+	computeTraversalOrder,
+	wikiLink,
+	buildBreadcrumbs,
+	buildNavigationContext,
+	renderNavigationBlock,
+	syllabusTitle,
+	syllabusPath,
+	renderSyllabusContent,
+	injectNavigationBlock,
+	TraversalNode,
+} from './syllabus-navigator';
+import { DeepDiveProposal, DeepDiveRun } from './types';
+
+// ── Test factories ──
+
+function makeProposal(overrides: Partial<DeepDiveProposal> = {}): DeepDiveProposal {
+	return {
+		id: 'p1',
+		runId: 'run-1',
+		sourceNotePath: 'notes/Machine Learning.md',
+		topic: {
+			title: 'Neural Networks',
+			description: 'A topic about neural networks',
+			relevance: 0.9,
+			existsInVault: false,
+			relatedUrls: [],
+		},
+		proposedPath: 'Deep Dives/Machine Learning/Neural Networks.md',
+		proposedContent: '# Neural Networks',
+		depth: 0,
+		qualityScore: {
+			score: 0.8,
+			topicCount: 3,
+			wordCount: 200,
+			isTooGeneric: false,
+			hasHighOverlap: false,
+			reasoning: 'Good',
+		},
+		childProposalIds: [],
+		createdAt: '2026-03-16T00:00:00.000Z',
+		status: 'pending',
+		...overrides,
+	};
+}
+
+function makeRun(overrides: Partial<DeepDiveRun> = {}): DeepDiveRun {
+	return {
+		id: 'run-1',
+		rootNotePath: 'notes/Machine Learning.md',
+		maxDepth: 3,
+		qualityThreshold: 0.4,
+		proposalIds: [],
+		stats: { totalProposals: 0, byDepth: {}, earlyTerminations: 0 },
+		createdAt: '2026-03-16T00:00:00.000Z',
+		status: 'completed',
+		...overrides,
+	};
+}
+
+/**
+ * Build a complete test tree:
+ *
+ * Machine Learning (root note, not a proposal)
+ *   -> Neural Networks (p1, depth 0)
+ *       -> Backpropagation (p2, depth 1)
+ *       -> Activation Functions (p3, depth 1)
+ *   -> Gradient Descent (p4, depth 0)
+ *       -> Learning Rate Schedules (p5, depth 1)
+ *   -> Regularization Techniques (p6, depth 0)
+ */
+function buildTestTree() {
+	const proposals: DeepDiveProposal[] = [
+		makeProposal({
+			id: 'p1',
+			topic: { title: 'Neural Networks', description: '', relevance: 0.9, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'Deep Dives/Machine Learning/Neural Networks.md',
+			depth: 0,
+			childProposalIds: ['p2', 'p3'],
+			status: 'accepted',
+		}),
+		makeProposal({
+			id: 'p2',
+			sourceNotePath: 'Deep Dives/Machine Learning/Neural Networks.md',
+			topic: { title: 'Backpropagation', description: '', relevance: 0.85, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'Deep Dives/Machine Learning/Neural Networks/Backpropagation.md',
+			depth: 1,
+			childProposalIds: [],
+			status: 'accepted',
+		}),
+		makeProposal({
+			id: 'p3',
+			sourceNotePath: 'Deep Dives/Machine Learning/Neural Networks.md',
+			topic: { title: 'Activation Functions', description: '', relevance: 0.8, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'Deep Dives/Machine Learning/Neural Networks/Activation Functions.md',
+			depth: 1,
+			childProposalIds: [],
+			status: 'accepted',
+		}),
+		makeProposal({
+			id: 'p4',
+			topic: { title: 'Gradient Descent', description: '', relevance: 0.9, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'Deep Dives/Machine Learning/Gradient Descent.md',
+			depth: 0,
+			childProposalIds: ['p5'],
+			status: 'accepted',
+		}),
+		makeProposal({
+			id: 'p5',
+			sourceNotePath: 'Deep Dives/Machine Learning/Gradient Descent.md',
+			topic: { title: 'Learning Rate Schedules', description: '', relevance: 0.75, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'Deep Dives/Machine Learning/Gradient Descent/Learning Rate Schedules.md',
+			depth: 1,
+			childProposalIds: [],
+			status: 'accepted',
+		}),
+		makeProposal({
+			id: 'p6',
+			topic: { title: 'Regularization Techniques', description: '', relevance: 0.85, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'Deep Dives/Machine Learning/Regularization Techniques.md',
+			depth: 0,
+			childProposalIds: [],
+			status: 'accepted',
+		}),
+	];
+
+	const run = makeRun({
+		proposalIds: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+	});
+
+	return { proposals, run };
+}
+
+// ── Tests ──
+
+describe('wikiLink', () => {
+	it('extracts basename from a full path', () => {
+		expect(wikiLink('Deep Dives/Machine Learning/Neural Networks.md')).toBe('[[Neural Networks]]');
+	});
+
+	it('handles root-level paths', () => {
+		expect(wikiLink('Machine Learning.md')).toBe('[[Machine Learning]]');
+	});
+
+	it('handles paths without .md extension', () => {
+		expect(wikiLink('notes/Topic')).toBe('[[Topic]]');
+	});
+});
+
+describe('computeTraversalOrder', () => {
+	it('produces depth-first order for a complete tree', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes.map(n => n.title)).toEqual([
+			'Neural Networks',
+			'Backpropagation',
+			'Activation Functions',
+			'Gradient Descent',
+			'Learning Rate Schedules',
+			'Regularization Techniques',
+		]);
+	});
+
+	it('assigns correct indices', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes.map(n => n.index)).toEqual([0, 1, 2, 3, 4, 5]);
+	});
+
+	it('assigns correct parent IDs', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes[0].parentId).toBeNull();          // Neural Networks -> root
+		expect(nodes[1].parentId).toBe('p1');           // Backpropagation -> Neural Networks
+		expect(nodes[2].parentId).toBe('p1');           // Activation Functions -> Neural Networks
+		expect(nodes[3].parentId).toBeNull();           // Gradient Descent -> root
+		expect(nodes[4].parentId).toBe('p4');           // Learning Rate Schedules -> Gradient Descent
+		expect(nodes[5].parentId).toBeNull();           // Regularization Techniques -> root
+	});
+
+	it('skips rejected proposals', () => {
+		const { proposals, run } = buildTestTree();
+		// Reject Backpropagation
+		proposals[1].status = 'rejected';
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes.map(n => n.title)).toEqual([
+			'Neural Networks',
+			'Activation Functions',
+			'Gradient Descent',
+			'Learning Rate Schedules',
+			'Regularization Techniques',
+		]);
+	});
+
+	it('skips pending proposals', () => {
+		const { proposals, run } = buildTestTree();
+		// Mark Gradient Descent and its child as pending
+		proposals[3].status = 'pending';
+		proposals[4].status = 'pending';
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes.map(n => n.title)).toEqual([
+			'Neural Networks',
+			'Backpropagation',
+			'Activation Functions',
+			'Regularization Techniques',
+		]);
+	});
+
+	it('returns empty array when no proposals are accepted', () => {
+		const { proposals, run } = buildTestTree();
+		for (const p of proposals) p.status = 'rejected';
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes).toEqual([]);
+	});
+
+	it('handles a single accepted proposal', () => {
+		const proposals = [
+			makeProposal({
+				id: 'p1',
+				topic: { title: 'Topic A', description: '', relevance: 0.9, existsInVault: false, relatedUrls: [] },
+				proposedPath: 'Deep Dives/Root/Topic A.md',
+				depth: 0,
+				status: 'accepted',
+			}),
+		];
+		const run = makeRun({ proposalIds: ['p1'] });
+		const nodes = computeTraversalOrder(proposals, run);
+
+		expect(nodes.length).toBe(1);
+		expect(nodes[0].title).toBe('Topic A');
+		expect(nodes[0].parentId).toBeNull();
+	});
+
+	it('excludes accepted children of rejected parents from traversal', () => {
+		const { proposals, run } = buildTestTree();
+		// Reject Neural Networks — its children should not appear since
+		// they are children of a rejected node, even though they are 'accepted'.
+		// The tree structure means they only appear through their parent.
+		proposals[0].status = 'rejected';
+
+		const nodes = computeTraversalOrder(proposals, run);
+
+		// Backpropagation and Activation Functions should be excluded because
+		// their parent Neural Networks is rejected, and they are only reachable
+		// through Neural Networks in the tree.
+		expect(nodes.map(n => n.title)).toEqual([
+			'Gradient Descent',
+			'Learning Rate Schedules',
+			'Regularization Techniques',
+		]);
+	});
+});
+
+describe('buildBreadcrumbs', () => {
+	it('builds breadcrumbs for a root-level node', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const crumbs = buildBreadcrumbs(nodes[0], nodes, 'Machine Learning');
+
+		expect(crumbs).toEqual(['Machine Learning', 'Neural Networks']);
+	});
+
+	it('builds breadcrumbs for a depth-1 node', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const crumbs = buildBreadcrumbs(nodes[1], nodes, 'Machine Learning');
+
+		expect(crumbs).toEqual(['Machine Learning', 'Neural Networks', 'Backpropagation']);
+	});
+
+	it('builds breadcrumbs for a nested child of a different parent', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		// Learning Rate Schedules is child of Gradient Descent
+		const crumbs = buildBreadcrumbs(nodes[4], nodes, 'Machine Learning');
+
+		expect(crumbs).toEqual(['Machine Learning', 'Gradient Descent', 'Learning Rate Schedules']);
+	});
+});
+
+describe('buildNavigationContext', () => {
+	it('builds context for the first node', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p1', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md');
+
+		expect(ctx).not.toBeNull();
+		expect(ctx!.root.title).toBe('Machine Learning');
+		expect(ctx!.up).toBeNull();
+		expect(ctx!.prev).toBeNull();
+		expect(ctx!.next!.title).toBe('Backpropagation');
+		expect(ctx!.position).toBe(1);
+		expect(ctx!.total).toBe(6);
+		expect(ctx!.breadcrumbs).toEqual(['Machine Learning', 'Neural Networks']);
+	});
+
+	it('builds context for a middle node with prev and next', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p3', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md');
+
+		expect(ctx).not.toBeNull();
+		expect(ctx!.prev!.title).toBe('Backpropagation');
+		expect(ctx!.next!.title).toBe('Gradient Descent');
+		expect(ctx!.up!.title).toBe('Neural Networks');
+		expect(ctx!.position).toBe(3);
+	});
+
+	it('builds context for the last node', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p6', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md');
+
+		expect(ctx).not.toBeNull();
+		expect(ctx!.next).toBeNull();
+		expect(ctx!.prev!.title).toBe('Learning Rate Schedules');
+		expect(ctx!.position).toBe(6);
+	});
+
+	it('returns null for a proposal not in the traversal', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('non-existent', nodes, run, 'syllabus.md');
+
+		expect(ctx).toBeNull();
+	});
+});
+
+describe('renderNavigationBlock', () => {
+	it('renders a complete navigation block with all links', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p2', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md')!;
+		const block = renderNavigationBlock(ctx);
+
+		expect(block).toContain('> [!auto-notes-nav] Deep Dive Navigation');
+		expect(block).toContain('Machine Learning > Neural Networks > Backpropagation');
+		expect(block).toContain('**Root:** [[Machine Learning]]');
+		expect(block).toContain('**Up:** [[Neural Networks]]');
+		expect(block).toContain('**Prev:** [[Neural Networks]]');
+		expect(block).toContain('**Next:** [[Activation Functions]]');
+		expect(block).toContain('*Part 2 of 6 in [[Deep Dive -- Machine Learning]]*');
+	});
+
+	it('omits Up link for root-level proposals', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p1', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md')!;
+		const block = renderNavigationBlock(ctx);
+
+		expect(block).not.toContain('**Up:**');
+	});
+
+	it('omits Prev link for the first proposal', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p1', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md')!;
+		const block = renderNavigationBlock(ctx);
+
+		expect(block).not.toContain('**Prev:**');
+		expect(block).toContain('**Next:**');
+	});
+
+	it('omits Next link for the last proposal', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const ctx = buildNavigationContext('p6', nodes, run, 'Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md')!;
+		const block = renderNavigationBlock(ctx);
+
+		expect(block).toContain('**Prev:**');
+		expect(block).not.toContain('**Next:**');
+	});
+});
+
+describe('syllabusTitle', () => {
+	it('builds title from root note path', () => {
+		expect(syllabusTitle('notes/Machine Learning.md')).toBe('Deep Dive -- Machine Learning');
+	});
+
+	it('handles root-level note path', () => {
+		expect(syllabusTitle('Topic.md')).toBe('Deep Dive -- Topic');
+	});
+});
+
+describe('syllabusPath', () => {
+	it('builds path using output folder', () => {
+		const path = syllabusPath('notes/Machine Learning.md', 'Deep Dives');
+		expect(path).toBe('Deep Dives/Machine Learning/Deep Dive -- Machine Learning.md');
+	});
+
+	it('falls back to source folder when output folder is empty', () => {
+		const path = syllabusPath('notes/Machine Learning.md', '');
+		expect(path).toBe('notes/Deep Dive -- Machine Learning.md');
+	});
+});
+
+describe('renderSyllabusContent', () => {
+	it('renders a complete syllabus with numbered outline', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const content = renderSyllabusContent(nodes, run);
+
+		expect(content).toContain('# Deep Dive: Machine Learning');
+		expect(content).toContain('## Topics');
+		expect(content).toContain('1. [[Neural Networks]]');
+		expect(content).toContain('   1. [[Backpropagation]]');
+		expect(content).toContain('   2. [[Activation Functions]]');
+		expect(content).toContain('2. [[Gradient Descent]]');
+		expect(content).toContain('   1. [[Learning Rate Schedules]]');
+		expect(content).toContain('3. [[Regularization Techniques]]');
+		expect(content).toContain('*Generated from [[Machine Learning]] -- 6 notes across 2 depths*');
+	});
+
+	it('renders correctly with partial acceptance', () => {
+		const { proposals, run } = buildTestTree();
+		// Reject Backpropagation and Gradient Descent subtree
+		proposals[1].status = 'rejected';
+		proposals[3].status = 'rejected';
+		proposals[4].status = 'rejected';
+
+		const nodes = computeTraversalOrder(proposals, run);
+		const content = renderSyllabusContent(nodes, run);
+
+		expect(content).toContain('1. [[Neural Networks]]');
+		expect(content).toContain('   1. [[Activation Functions]]');
+		expect(content).toContain('2. [[Regularization Techniques]]');
+		expect(content).not.toContain('Backpropagation');
+		expect(content).not.toContain('Gradient Descent');
+		expect(content).toContain('-- 3 notes across 2 depths');
+	});
+
+	it('renders correctly with a single accepted proposal', () => {
+		const proposals = [
+			makeProposal({
+				id: 'p1',
+				topic: { title: 'Topic A', description: '', relevance: 0.9, existsInVault: false, relatedUrls: [] },
+				proposedPath: 'Deep Dives/Root/Topic A.md',
+				depth: 0,
+				status: 'accepted',
+			}),
+		];
+		const run = makeRun({ proposalIds: ['p1'] });
+		const nodes = computeTraversalOrder(proposals, run);
+		const content = renderSyllabusContent(nodes, run);
+
+		expect(content).toContain('1. [[Topic A]]');
+		expect(content).toContain('-- 1 note across 1 depth');
+	});
+});
+
+describe('injectNavigationBlock', () => {
+	const navBlock = '> [!auto-notes-nav] Deep Dive Navigation\n> **Root:** [[Root]]';
+
+	it('prepends nav block to content without frontmatter', () => {
+		const content = '# Neural Networks\n\nContent here.';
+		const result = injectNavigationBlock(content, navBlock);
+
+		expect(result).toBe(
+			'> [!auto-notes-nav] Deep Dive Navigation\n> **Root:** [[Root]]\n\n# Neural Networks\n\nContent here.'
+		);
+	});
+
+	it('inserts nav block after frontmatter', () => {
+		const content = '---\ntags: [topic]\n---\n# Neural Networks\n\nContent here.';
+		const result = injectNavigationBlock(content, navBlock);
+
+		expect(result).toBe(
+			'---\ntags: [topic]\n---\n> [!auto-notes-nav] Deep Dive Navigation\n> **Root:** [[Root]]\n\n# Neural Networks\n\nContent here.'
+		);
+	});
+
+	it('replaces existing nav block', () => {
+		const content = '> [!auto-notes-nav] Old Nav\n> Old content\n> More old content\n\n# Neural Networks\n\nContent here.';
+		const result = injectNavigationBlock(content, navBlock);
+
+		expect(result).toContain('> [!auto-notes-nav] Deep Dive Navigation');
+		expect(result).toContain('> **Root:** [[Root]]');
+		expect(result).not.toContain('Old Nav');
+		expect(result).not.toContain('Old content');
+		expect(result).toContain('# Neural Networks');
+	});
+
+	it('replaces existing nav block after frontmatter', () => {
+		const content = '---\ntags: [topic]\n---\n> [!auto-notes-nav] Old Nav\n> Old stuff\n\n# Neural Networks';
+		const result = injectNavigationBlock(content, navBlock);
+
+		expect(result).toContain('---\ntags: [topic]\n---\n');
+		expect(result).toContain('> [!auto-notes-nav] Deep Dive Navigation');
+		expect(result).not.toContain('Old Nav');
+	});
+});

--- a/src/deep-dive/syllabus-navigator.ts
+++ b/src/deep-dive/syllabus-navigator.ts
@@ -1,0 +1,338 @@
+import { DeepDiveProposal, DeepDiveRun } from './types';
+
+/**
+ * A node in the depth-first traversal of accepted proposals.
+ * Used to compute prev/next/up/root relationships.
+ */
+export interface TraversalNode {
+	proposalId: string;
+	title: string;
+	proposedPath: string;
+	depth: number;
+	/** Index in the DFS order (0-based) */
+	index: number;
+	/** Parent proposal ID (null for root-level proposals) */
+	parentId: string | null;
+	/** Child proposal IDs that are accepted */
+	childIds: string[];
+}
+
+/**
+ * Navigation context for a single accepted proposal.
+ */
+export interface NavigationContext {
+	/** Root note title and path */
+	root: { title: string; path: string };
+	/** Parent proposal (null for depth-0 proposals) */
+	up: { title: string; path: string } | null;
+	/** Previous proposal in DFS order (null for first) */
+	prev: { title: string; path: string } | null;
+	/** Next proposal in DFS order (null for last) */
+	next: { title: string; path: string } | null;
+	/** 1-based position in the traversal */
+	position: number;
+	/** Total accepted proposals */
+	total: number;
+	/** Breadcrumb path from root: ["Machine Learning", "Neural Networks", "Backpropagation"] */
+	breadcrumbs: string[];
+	/** Title and path of the syllabus note */
+	syllabus: { title: string; path: string };
+}
+
+/**
+ * Compute depth-first traversal order from accepted proposals in a run.
+ *
+ * The traversal follows the tree structure: for each parent node, visit its
+ * accepted children in order before moving to the next sibling. Only
+ * proposals with status 'accepted' are included.
+ */
+export function computeTraversalOrder(
+	proposals: DeepDiveProposal[],
+	run: DeepDiveRun
+): TraversalNode[] {
+	const proposalMap = new Map<string, DeepDiveProposal>();
+	for (const p of proposals) {
+		proposalMap.set(p.id, p);
+	}
+
+	// Find root-level proposals: those whose sourceNotePath matches the run's rootNotePath
+	const rootProposals = run.proposalIds
+		.map(id => proposalMap.get(id))
+		.filter((p): p is DeepDiveProposal =>
+			p !== undefined &&
+			p.status === 'accepted' &&
+			p.sourceNotePath === run.rootNotePath
+		);
+
+	const nodes: TraversalNode[] = [];
+
+	function visit(proposalId: string, parentId: string | null): void {
+		const proposal = proposalMap.get(proposalId);
+		if (!proposal || proposal.status !== 'accepted') return;
+
+		const acceptedChildIds = proposal.childProposalIds.filter(cid => {
+			const child = proposalMap.get(cid);
+			return child && child.status === 'accepted';
+		});
+
+		const node: TraversalNode = {
+			proposalId: proposal.id,
+			title: proposal.topic.title,
+			proposedPath: proposal.proposedPath,
+			depth: proposal.depth,
+			index: nodes.length,
+			parentId,
+			childIds: acceptedChildIds,
+		};
+		nodes.push(node);
+
+		// Recurse into accepted children
+		for (const childId of acceptedChildIds) {
+			visit(childId, proposal.id);
+		}
+	}
+
+	for (const rp of rootProposals) {
+		visit(rp.id, null);
+	}
+
+	return nodes;
+}
+
+/**
+ * Build a wiki-link for Obsidian from a file path.
+ * Extracts the basename (without extension) for the link text.
+ */
+export function wikiLink(path: string): string {
+	const basename = path.replace(/\.md$/, '').split('/').pop() || path;
+	return `[[${basename}]]`;
+}
+
+/**
+ * Build the breadcrumb path from root to a given node.
+ */
+export function buildBreadcrumbs(
+	node: TraversalNode,
+	nodes: TraversalNode[],
+	rootTitle: string
+): string[] {
+	const crumbs: string[] = [rootTitle];
+	const nodeMap = new Map<string, TraversalNode>();
+	for (const n of nodes) {
+		nodeMap.set(n.proposalId, n);
+	}
+
+	// Walk up the parent chain
+	const ancestors: string[] = [];
+	let current: TraversalNode | undefined = node;
+	while (current?.parentId) {
+		const parent = nodeMap.get(current.parentId);
+		if (parent) {
+			ancestors.unshift(parent.title);
+		}
+		current = parent;
+	}
+
+	crumbs.push(...ancestors, node.title);
+	return crumbs;
+}
+
+/**
+ * Build the navigation context for a given proposal.
+ */
+export function buildNavigationContext(
+	proposalId: string,
+	nodes: TraversalNode[],
+	run: DeepDiveRun,
+	syllabusPath: string
+): NavigationContext | null {
+	const nodeIndex = nodes.findIndex(n => n.proposalId === proposalId);
+	if (nodeIndex === -1) return null;
+
+	const node = nodes[nodeIndex];
+	const nodeMap = new Map<string, TraversalNode>();
+	for (const n of nodes) {
+		nodeMap.set(n.proposalId, n);
+	}
+
+	const rootTitle = run.rootNotePath.replace(/\.md$/, '').split('/').pop() || run.rootNotePath;
+	const syllabusTitle = `Deep Dive -- ${rootTitle}`;
+
+	// Find parent (up)
+	let up: { title: string; path: string } | null = null;
+	if (node.parentId) {
+		const parent = nodeMap.get(node.parentId);
+		if (parent) {
+			up = { title: parent.title, path: parent.proposedPath };
+		}
+	}
+
+	// Find prev/next in DFS order
+	const prev = nodeIndex > 0
+		? { title: nodes[nodeIndex - 1].title, path: nodes[nodeIndex - 1].proposedPath }
+		: null;
+	const next = nodeIndex < nodes.length - 1
+		? { title: nodes[nodeIndex + 1].title, path: nodes[nodeIndex + 1].proposedPath }
+		: null;
+
+	const breadcrumbs = buildBreadcrumbs(node, nodes, rootTitle);
+
+	return {
+		root: { title: rootTitle, path: run.rootNotePath },
+		up,
+		prev,
+		next,
+		position: nodeIndex + 1,
+		total: nodes.length,
+		breadcrumbs,
+		syllabus: { title: syllabusTitle, path: syllabusPath },
+	};
+}
+
+/**
+ * Render the navigation callout block for a deep dive note.
+ *
+ * Format:
+ * > [!auto-notes-nav] Deep Dive Navigation
+ * > Machine Learning > Neural Networks > Backpropagation
+ * > **Root:** [[Machine Learning]] | **Up:** [[Neural Networks]]
+ * > **Prev:** [[Activation Functions]] | **Next:** [[Regularization Techniques]]
+ * > *Part 3 of 6 in [[Deep Dive -- Machine Learning]]*
+ */
+export function renderNavigationBlock(ctx: NavigationContext): string {
+	const lines: string[] = [];
+	lines.push('> [!auto-notes-nav] Deep Dive Navigation');
+
+	// Breadcrumb line
+	const breadcrumbLine = ctx.breadcrumbs.join(' > ');
+	lines.push(`> ${breadcrumbLine}`);
+
+	// Root and Up line
+	const rootLink = `**Root:** ${wikiLink(ctx.root.path)}`;
+	if (ctx.up) {
+		lines.push(`> ${rootLink} | **Up:** ${wikiLink(ctx.up.path)}`);
+	} else {
+		lines.push(`> ${rootLink}`);
+	}
+
+	// Prev and Next line
+	const parts: string[] = [];
+	if (ctx.prev) {
+		parts.push(`**Prev:** ${wikiLink(ctx.prev.path)}`);
+	}
+	if (ctx.next) {
+		parts.push(`**Next:** ${wikiLink(ctx.next.path)}`);
+	}
+	if (parts.length > 0) {
+		lines.push(`> ${parts.join(' | ')}`);
+	}
+
+	// Position indicator
+	lines.push(`> *Part ${ctx.position} of ${ctx.total} in ${wikiLink(ctx.syllabus.path)}*`);
+
+	return lines.join('\n');
+}
+
+/**
+ * Build the syllabus note title from a root note path.
+ */
+export function syllabusTitle(rootNotePath: string): string {
+	const rootTitle = rootNotePath.replace(/\.md$/, '').split('/').pop() || rootNotePath;
+	return `Deep Dive -- ${rootTitle}`;
+}
+
+/**
+ * Build the syllabus note file path.
+ */
+export function syllabusPath(rootNotePath: string, noteOutputFolder: string): string {
+	const rootBasename = rootNotePath.replace(/\.md$/, '').split('/').pop() || 'Unknown';
+	const folder = noteOutputFolder
+		? `${noteOutputFolder}/${rootBasename}`
+		: rootNotePath.substring(0, rootNotePath.lastIndexOf('/')) || '';
+	const title = syllabusTitle(rootNotePath);
+	return folder ? `${folder}/${title}.md` : `${title}.md`;
+}
+
+/**
+ * Render the full syllabus index note content.
+ *
+ * Output:
+ * # Deep Dive: Machine Learning
+ *
+ * ## Topics
+ *
+ * 1. [[Neural Networks]]
+ *    1. [[Backpropagation]]
+ *    2. [[Activation Functions]]
+ * 2. [[Gradient Descent]]
+ *    1. [[Learning Rate Schedules]]
+ * 3. [[Regularization Techniques]]
+ *
+ * ---
+ * *Generated from [[Machine Learning]] -- 6 notes across 2 depths*
+ */
+export function renderSyllabusContent(
+	nodes: TraversalNode[],
+	run: DeepDiveRun
+): string {
+	const rootTitle = run.rootNotePath.replace(/\.md$/, '').split('/').pop() || run.rootNotePath;
+
+	const lines: string[] = [];
+	lines.push(`# Deep Dive: ${rootTitle}`);
+	lines.push('');
+	lines.push('## Topics');
+	lines.push('');
+
+	// Build numbered outline from tree structure
+	// Track numbering per parent (null = root level)
+	const counterByParent = new Map<string | null, number>();
+
+	for (const node of nodes) {
+		const parentKey = node.parentId;
+		const count = (counterByParent.get(parentKey) || 0) + 1;
+		counterByParent.set(parentKey, count);
+
+		const indent = '   '.repeat(node.depth);
+		const link = wikiLink(node.proposedPath);
+		lines.push(`${indent}${count}. ${link}`);
+	}
+
+	// Compute stats
+	const depthSet = new Set(nodes.map(n => n.depth));
+	const depthCount = depthSet.size;
+
+	lines.push('');
+	lines.push('---');
+	lines.push(`*Generated from ${wikiLink(run.rootNotePath)} -- ${nodes.length} note${nodes.length === 1 ? '' : 's'} across ${depthCount} depth${depthCount === 1 ? '' : 's'}*`);
+
+	return lines.join('\n');
+}
+
+/**
+ * Prepend or update the navigation block in a note's content.
+ *
+ * If the note already has a `> [!auto-notes-nav]` callout, replace it.
+ * Otherwise, prepend it at the top (after frontmatter if present).
+ */
+export function injectNavigationBlock(
+	content: string,
+	navBlock: string
+): string {
+	// Pattern to match an existing nav block (callout lines starting with >)
+	const navPattern = /^> \[!auto-notes-nav\][^\n]*(?:\n>[^\n]*)*\n?/m;
+
+	if (navPattern.test(content)) {
+		return content.replace(navPattern, navBlock + '\n');
+	}
+
+	// Check for frontmatter (---\n...\n---\n)
+	const frontmatterPattern = /^---\n[\s\S]*?\n---\n/;
+	const fmMatch = content.match(frontmatterPattern);
+
+	if (fmMatch) {
+		const afterFm = content.slice(fmMatch[0].length);
+		return fmMatch[0] + navBlock + '\n\n' + afterFm;
+	}
+
+	return navBlock + '\n\n' + content;
+}


### PR DESCRIPTION
## Summary
- Generates a syllabus index note (`Deep Dive — {Title}.md`) with the full topic tree as a navigable numbered outline
- Injects prev/next/up/root navigation callout (`> [!auto-notes-nav]`) into each accepted deep dive note
- Includes breadcrumb path and position indicator ("Part 3 of 6")
- Navigation computed at accept time — handles partial acceptance gracefully (rejected proposals skipped)
- Syllabus and nav blocks update dynamically as more proposals are accepted or rejected

Depends on #49 (nested folder structure)
Closes #42

## Test plan
- [ ] Accept a multi-depth deep dive run and verify syllabus note is created
- [ ] Verify depth-first traversal order matches syllabus outline
- [ ] Verify prev/next links wrap correctly at start/end of sequence
- [ ] Reject a middle proposal and verify nav links skip it
- [ ] Verify breadcrumbs show correct path from root
- [ ] Verify frontmatter-aware injection (nav block after frontmatter, not inside it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)