### PR TITLE
feat: add Mermaid diagrams for folder structure changes

### DIFF
--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -36,6 +36,7 @@ export {
 	buildNavigationContext,
 	renderNavigationBlock,
 	renderSyllabusContent,
+	buildTreeFromNodes,
 	syllabusTitle,
 	syllabusPath,
 	injectNavigationBlock,

--- a/src/deep-dive/syllabus-navigator.test.ts
+++ b/src/deep-dive/syllabus-navigator.test.ts
@@ -9,6 +9,7 @@ import {
 	syllabusPath,
 	renderSyllabusContent,
 	injectNavigationBlock,
+	buildTreeFromNodes,
 	TraversalNode,
 } from './syllabus-navigator';
 import { DeepDiveProposal, DeepDiveRun } from './types';
@@ -402,7 +403,7 @@ describe('syllabusPath', () => {
 });
 
 describe('renderSyllabusContent', () => {
-	it('renders a complete syllabus with numbered outline', () => {
+	it('renders a complete syllabus with numbered outline and topic map', () => {
 		const { proposals, run } = buildTestTree();
 		const nodes = computeTraversalOrder(proposals, run);
 		const content = renderSyllabusContent(nodes, run);
@@ -415,6 +416,11 @@ describe('renderSyllabusContent', () => {
 		expect(content).toContain('2. [[Gradient Descent]]');
 		expect(content).toContain('   1. [[Learning Rate Schedules]]');
 		expect(content).toContain('3. [[Regularization Techniques]]');
+		expect(content).toContain('## Topic Map');
+		expect(content).toContain('```mermaid');
+		expect(content).toContain('graph TD');
+		expect(content).toContain('["Machine Learning"]');
+		expect(content).toContain('["Neural Networks"]');
 		expect(content).toContain('*Generated from [[Machine Learning]] -- 6 notes across 2 depths*');
 	});
 
@@ -431,8 +437,9 @@ describe('renderSyllabusContent', () => {
 		expect(content).toContain('1. [[Neural Networks]]');
 		expect(content).toContain('   1. [[Activation Functions]]');
 		expect(content).toContain('2. [[Regularization Techniques]]');
-		expect(content).not.toContain('Backpropagation');
-		expect(content).not.toContain('Gradient Descent');
+		// Rejected topics should not appear in the Topics outline
+		expect(content).not.toContain('[[Backpropagation]]');
+		expect(content).not.toContain('[[Gradient Descent]]');
 		expect(content).toContain('-- 3 notes across 2 depths');
 	});
 
@@ -451,7 +458,59 @@ describe('renderSyllabusContent', () => {
 		const content = renderSyllabusContent(nodes, run);
 
 		expect(content).toContain('1. [[Topic A]]');
+		expect(content).toContain('## Topic Map');
 		expect(content).toContain('-- 1 note across 1 depth');
+	});
+
+	it('omits topic map section when there are no nodes', () => {
+		const { proposals, run } = buildTestTree();
+		for (const p of proposals) p.status = 'rejected';
+		const nodes = computeTraversalOrder(proposals, run);
+		const content = renderSyllabusContent(nodes, run);
+
+		expect(content).not.toContain('## Topic Map');
+		expect(content).not.toContain('```mermaid');
+	});
+});
+
+describe('buildTreeFromNodes', () => {
+	it('builds a tree with root and top-level children', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const tree = buildTreeFromNodes(nodes, 'Machine Learning');
+
+		expect(tree.label).toBe('Machine Learning');
+		expect(tree.children.length).toBe(3); // NN, GD, Reg
+		expect(tree.children[0].label).toBe('Neural Networks');
+		expect(tree.children[1].label).toBe('Gradient Descent');
+		expect(tree.children[2].label).toBe('Regularization Techniques');
+	});
+
+	it('builds nested children correctly', () => {
+		const { proposals, run } = buildTestTree();
+		const nodes = computeTraversalOrder(proposals, run);
+		const tree = buildTreeFromNodes(nodes, 'Machine Learning');
+
+		// Neural Networks should have Backpropagation and Activation Functions
+		const nn = tree.children[0];
+		expect(nn.children.length).toBe(2);
+		expect(nn.children[0].label).toBe('Backpropagation');
+		expect(nn.children[1].label).toBe('Activation Functions');
+
+		// Gradient Descent should have Learning Rate Schedules
+		const gd = tree.children[1];
+		expect(gd.children.length).toBe(1);
+		expect(gd.children[0].label).toBe('Learning Rate Schedules');
+
+		// Regularization Techniques should have no children
+		expect(tree.children[2].children.length).toBe(0);
+	});
+
+	it('handles empty node list', () => {
+		const tree = buildTreeFromNodes([], 'Root');
+
+		expect(tree.label).toBe('Root');
+		expect(tree.children.length).toBe(0);
 	});
 });
 

--- a/src/deep-dive/syllabus-navigator.ts
+++ b/src/deep-dive/syllabus-navigator.ts
@@ -1,4 +1,5 @@
 import { DeepDiveProposal, DeepDiveRun } from './types';
+import { generateTreeDiagram, TreeNode } from '../shared/diagram-generator';
 
 /**
  * A node in the depth-first traversal of accepted proposals.
@@ -254,6 +255,46 @@ export function syllabusPath(rootNotePath: string, noteOutputFolder: string): st
 }
 
 /**
+ * Convert traversal nodes into a TreeNode structure rooted at the run's
+ * root note. Used to generate a Mermaid tree diagram.
+ */
+export function buildTreeFromNodes(
+	nodes: TraversalNode[],
+	rootTitle: string
+): TreeNode {
+	const nodeMap = new Map<string, TreeNode>();
+
+	// Create TreeNode for each traversal node
+	for (const n of nodes) {
+		nodeMap.set(n.proposalId, {
+			id: n.proposalId,
+			label: n.title,
+			children: [],
+		});
+	}
+
+	// Build the root node
+	const root: TreeNode = {
+		id: 'root',
+		label: rootTitle,
+		children: [],
+	};
+
+	// Wire up parent-child relationships
+	for (const n of nodes) {
+		const treeNode = nodeMap.get(n.proposalId)!;
+		if (n.parentId && nodeMap.has(n.parentId)) {
+			nodeMap.get(n.parentId)!.children.push(treeNode);
+		} else {
+			// Top-level node — attach to root
+			root.children.push(treeNode);
+		}
+	}
+
+	return root;
+}
+
+/**
  * Render the full syllabus index note content.
  *
  * Output:
@@ -267,6 +308,13 @@ export function syllabusPath(rootNotePath: string, noteOutputFolder: string): st
  * 2. [[Gradient Descent]]
  *    1. [[Learning Rate Schedules]]
  * 3. [[Regularization Techniques]]
+ *
+ * ## Topic Map
+ *
+ * ```mermaid
+ * graph TD
+ *     ...
+ * ```
  *
  * ---
  * *Generated from [[Machine Learning]] -- 6 notes across 2 depths*
@@ -295,6 +343,17 @@ export function renderSyllabusContent(
 		const indent = '   '.repeat(node.depth);
 		const link = wikiLink(node.proposedPath);
 		lines.push(`${indent}${count}. ${link}`);
+	}
+
+	// Add Mermaid tree diagram
+	if (nodes.length > 0) {
+		const tree = buildTreeFromNodes(nodes, rootTitle);
+		const diagram = generateTreeDiagram(tree);
+
+		lines.push('');
+		lines.push('## Topic Map');
+		lines.push('');
+		lines.push(diagram);
 	}
 
 	// Compute stats

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -1,6 +1,7 @@
 import { Plugin, TFile, normalizePath } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
-import { FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder } from '../shared';
+import { FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder, writeNote, generateOrganizeSummary } from '../shared';
+import { MoveRecord } from '../shared/diagram-generator';
 import { ContentAnalyzer } from './content-analyzer';
 import { DirectoryMatcher } from './directory-matcher';
 import { OrganizeStore } from './organize-store';
@@ -175,16 +176,24 @@ export class OrganizeModule {
 		let movedCount = 0;
 		let proposalCount = 0;
 		let errorCount = 0;
+		const moveRecords: MoveRecord[] = [];
 
 		for (let i = 0; i < eligible.length; i++) {
 			if (genOp.cancelled) break;
 
 			genOp.progress(i + 1, eligible.length, 'Organizing notes');
 			try {
+				const originalPath = eligible[i].path;
 				const result = await this.organizeFile(eligible[i]);
 
 				if (result) {
-					if (result.movedDirectly) movedCount++;
+					if (result.movedDirectly && result.action.type === 'move') {
+						movedCount++;
+						const newPath = normalizePath(
+							`${result.action.targetDirectory}/${eligible[i].name}`
+						);
+						moveRecords.push({ originalPath, newPath });
+					}
 					if (result.proposalCreated) proposalCount++;
 				}
 			} catch (error) {
@@ -204,6 +213,16 @@ export class OrganizeModule {
 		if (proposalCount > 0) parts.push(`${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
 		if (errorCount > 0) parts.push(`${errorCount} failed`);
 		genOp.finish(parts.length > 0 ? parts.join(', ') : 'No changes needed');
+
+		// Generate organize summary with move diagram
+		if (moveRecords.length > 0) {
+			const summaryPath = await this.writeOrganizeSummary(moveRecords);
+			if (summaryPath) {
+				this.notifications.info(
+					`Organize summary saved to ${summaryPath}`
+				);
+			}
+		}
 
 		if (proposalCount > 0) {
 			await this.onViewRefreshNeeded?.();
@@ -261,6 +280,18 @@ export class OrganizeModule {
 
 			await this.store.updateProposalStatus(id, 'accepted');
 			this.notifications.success(`Moved to ${proposal.proposedDirectory}`);
+
+			// Generate organize summary with move diagram
+			const moveRecords: MoveRecord[] = [
+				{ originalPath: file.path, newPath },
+			];
+			const summaryPath = await this.writeOrganizeSummary(moveRecords);
+			if (summaryPath) {
+				this.notifications.info(
+					`Organize summary saved to ${summaryPath}`
+				);
+			}
+
 			await this.onViewRefreshNeeded?.();
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
@@ -422,10 +453,39 @@ export class OrganizeModule {
 		return candidatePath;
 	}
 
+	/**
+	 * Write an organize summary note containing a Mermaid move diagram.
+	 * Summaries are stored at .auto-notes/organize/summaries/{date}-organize-summary.md.
+	 * Returns the path of the summary note, or null on failure.
+	 */
+	private async writeOrganizeSummary(moves: MoveRecord[]): Promise<string | null> {
+		try {
+			const timestamp = new Date().toISOString();
+			const summaryPath = buildSummaryPath(timestamp);
+			const content = generateOrganizeSummary(moves, timestamp);
+			await writeNote(this.plugin.app, summaryPath, content);
+			return summaryPath;
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			console.warn(`[Auto Notes] Failed to write organize summary: ${msg}`);
+			return null;
+		}
+	}
+
 	private generateId(): string {
 		return (
 			Date.now().toString(36) +
 			Math.random().toString(36).slice(2, 10)
 		);
 	}
+}
+
+/**
+ * Build the vault path for an organize summary note.
+ * Format: .auto-notes/organize/summaries/{YYYY-MM-DD}-organize-summary.md
+ * Exported for testing.
+ */
+export function buildSummaryPath(timestamp: string): string {
+	const date = timestamp.split('T')[0] || timestamp;
+	return normalizePath(`.auto-notes/organize/summaries/${date}-organize-summary.md`);
 }

--- a/src/shared/diagram-generator.test.ts
+++ b/src/shared/diagram-generator.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import {
+	generateTreeDiagram,
+	generateMoveDiagram,
+	generateOrganizeSummary,
+	TreeNode,
+	MoveRecord,
+} from './diagram-generator';
+
+// ── generateTreeDiagram ──
+
+describe('generateTreeDiagram', () => {
+	it('generates a tree diagram from a multi-level topic tree', () => {
+		const root: TreeNode = {
+			id: 'ml',
+			label: 'Machine Learning',
+			children: [
+				{
+					id: 'nn',
+					label: 'Neural Networks',
+					children: [
+						{ id: 'bp', label: 'Backpropagation', children: [] },
+						{ id: 'af', label: 'Activation Functions', children: [] },
+					],
+				},
+				{
+					id: 'gd',
+					label: 'Gradient Descent',
+					children: [
+						{ id: 'lr', label: 'Learning Rate Schedules', children: [] },
+					],
+				},
+			],
+		};
+
+		const result = generateTreeDiagram(root);
+
+		expect(result).toContain('```mermaid');
+		expect(result).toContain('graph TD');
+		expect(result).toContain('["Machine Learning"]');
+		expect(result).toContain('["Neural Networks"]');
+		expect(result).toContain('["Backpropagation"]');
+		expect(result).toContain('["Activation Functions"]');
+		expect(result).toContain('["Gradient Descent"]');
+		expect(result).toContain('["Learning Rate Schedules"]');
+		expect(result).toMatch(/N\d+\[".+?"\] --> N\d+\[".+?"\]/);
+		expect(result).toContain('```');
+	});
+
+	it('handles a single-node tree with no children', () => {
+		const root: TreeNode = {
+			id: 'solo',
+			label: 'Solo Topic',
+			children: [],
+		};
+
+		const result = generateTreeDiagram(root);
+
+		expect(result).toContain('```mermaid');
+		expect(result).toContain('graph TD');
+		expect(result).toContain('["Solo Topic"]');
+		expect(result).not.toContain('-->');
+	});
+
+	it('sanitizes labels with special characters', () => {
+		const root: TreeNode = {
+			id: 'root',
+			label: 'Topic [with] "special" <chars>',
+			children: [
+				{ id: 'child', label: 'Child "node"', children: [] },
+			],
+		};
+
+		const result = generateTreeDiagram(root);
+
+		// Double quotes should be replaced with single quotes
+		expect(result).toContain("Topic with 'special' chars");
+		expect(result).toContain("Child 'node'");
+		// Brackets and angle brackets should be removed
+		expect(result).not.toContain('[with]');
+		expect(result).not.toContain('<chars>');
+	});
+
+	it('handles deeply nested trees', () => {
+		const root: TreeNode = {
+			id: 'a',
+			label: 'Level 0',
+			children: [{
+				id: 'b',
+				label: 'Level 1',
+				children: [{
+					id: 'c',
+					label: 'Level 2',
+					children: [{
+						id: 'd',
+						label: 'Level 3',
+						children: [],
+					}],
+				}],
+			}],
+		};
+
+		const result = generateTreeDiagram(root);
+
+		// Should have 3 edges: 0->1, 1->2, 2->3
+		const arrowCount = (result.match(/-->/g) || []).length;
+		expect(arrowCount).toBe(3);
+	});
+
+	it('wraps output in mermaid code fence', () => {
+		const root: TreeNode = {
+			id: 'r',
+			label: 'Root',
+			children: [{ id: 'c', label: 'Child', children: [] }],
+		};
+
+		const result = generateTreeDiagram(root);
+		const lines = result.split('\n');
+
+		expect(lines[0]).toBe('```mermaid');
+		expect(lines[lines.length - 1]).toBe('```');
+	});
+});
+
+// ── generateMoveDiagram ──
+
+describe('generateMoveDiagram', () => {
+	it('generates a move diagram from file move records', () => {
+		const moves: MoveRecord[] = [
+			{
+				originalPath: 'notes/neural-networks.md',
+				newPath: 'AI & ML/Neural Networks/neural-networks.md',
+			},
+			{
+				originalPath: 'notes/gradient-descent.md',
+				newPath: 'AI & ML/Optimization/gradient-descent.md',
+			},
+		];
+
+		const result = generateMoveDiagram(moves);
+
+		expect(result).toContain('```mermaid');
+		expect(result).toContain('graph LR');
+		expect(result).toContain('subgraph Before');
+		expect(result).toContain('subgraph After');
+		expect(result).toContain('["notes/neural-networks.md"]');
+		expect(result).toContain('["AI & ML/Neural Networks/neural-networks.md"]');
+		expect(result).toContain('["notes/gradient-descent.md"]');
+		expect(result).toContain('["AI & ML/Optimization/gradient-descent.md"]');
+		expect(result).toMatch(/A0 --> B0/);
+		expect(result).toMatch(/A1 --> B1/);
+	});
+
+	it('handles empty move list', () => {
+		const result = generateMoveDiagram([]);
+
+		expect(result).toContain('```mermaid');
+		expect(result).toContain('No files moved');
+	});
+
+	it('handles a single move', () => {
+		const moves: MoveRecord[] = [
+			{
+				originalPath: 'inbox/note.md',
+				newPath: 'projects/note.md',
+			},
+		];
+
+		const result = generateMoveDiagram(moves);
+
+		expect(result).toContain('subgraph Before');
+		expect(result).toContain('subgraph After');
+		expect(result).toContain('A0 --> B0');
+		// Should only have one arrow
+		const arrowCount = (result.match(/A\d+ --> B\d+/g) || []).length;
+		expect(arrowCount).toBe(1);
+	});
+
+	it('wraps output in mermaid code fence', () => {
+		const moves: MoveRecord[] = [
+			{ originalPath: 'a.md', newPath: 'b/a.md' },
+		];
+
+		const result = generateMoveDiagram(moves);
+		const lines = result.split('\n');
+
+		expect(lines[0]).toBe('```mermaid');
+		expect(lines[lines.length - 1]).toBe('```');
+	});
+
+	it('sanitizes labels with special characters in paths', () => {
+		const moves: MoveRecord[] = [
+			{
+				originalPath: 'notes/topic [draft].md',
+				newPath: 'final/topic draft.md',
+			},
+		];
+
+		const result = generateMoveDiagram(moves);
+
+		expect(result).not.toContain('[draft]');
+		expect(result).toContain('notes/topic draft.md');
+	});
+});
+
+// ── generateOrganizeSummary ──
+
+describe('generateOrganizeSummary', () => {
+	it('generates a complete summary note with diagram', () => {
+		const moves: MoveRecord[] = [
+			{
+				originalPath: 'inbox/note-1.md',
+				newPath: 'projects/note-1.md',
+			},
+			{
+				originalPath: 'inbox/note-2.md',
+				newPath: 'reference/note-2.md',
+			},
+		];
+
+		const result = generateOrganizeSummary(moves, '2026-03-16T12:00:00.000Z');
+
+		expect(result).toContain('# Organize Summary');
+		expect(result).toContain('**Date:** 2026-03-16');
+		expect(result).toContain('**Files moved:** 2');
+		expect(result).toContain('## Move Diagram');
+		expect(result).toContain('```mermaid');
+		expect(result).toContain('## Details');
+		expect(result).toContain('`inbox/note-1.md` -> `projects/note-1.md`');
+		expect(result).toContain('`inbox/note-2.md` -> `reference/note-2.md`');
+	});
+
+	it('handles empty moves', () => {
+		const result = generateOrganizeSummary([], '2026-03-16T12:00:00.000Z');
+
+		expect(result).toContain('**Files moved:** 0');
+		expect(result).toContain('No files moved');
+	});
+
+	it('extracts date from ISO timestamp', () => {
+		const result = generateOrganizeSummary([], '2026-01-15T09:30:00.000Z');
+
+		expect(result).toContain('**Date:** 2026-01-15');
+	});
+});

--- a/src/shared/diagram-generator.ts
+++ b/src/shared/diagram-generator.ts
@@ -1,0 +1,189 @@
+/**
+ * Generates Mermaid diagram code blocks for visualizing
+ * deep dive topic trees and organize move operations.
+ *
+ * Obsidian renders Mermaid code blocks natively, so no
+ * plugin dependency is needed.
+ */
+
+/** A node in a topic tree for deep dive diagrams. */
+export interface TreeNode {
+	/** Unique identifier for graph node naming */
+	id: string;
+	/** Display label */
+	label: string;
+	/** Children of this node */
+	children: TreeNode[];
+}
+
+/** A single file move record for organize diagrams. */
+export interface MoveRecord {
+	/** Original file path before the move */
+	originalPath: string;
+	/** New file path after the move */
+	newPath: string;
+}
+
+/**
+ * Sanitize a label for use inside Mermaid node definitions.
+ * Mermaid uses double quotes inside bracket notation, so we
+ * need to escape characters that would break the syntax.
+ */
+function sanitizeLabel(label: string): string {
+	return label
+		.replace(/"/g, "'")
+		.replace(/[[\]]/g, '')
+		.replace(/[<>]/g, '');
+}
+
+/**
+ * Generate a stable, short node ID from an arbitrary identifier.
+ * Mermaid node IDs must be alphanumeric (with underscores).
+ */
+function toNodeId(prefix: string, index: number): string {
+	return `${prefix}${index}`;
+}
+
+/**
+ * Generate a Mermaid top-down tree diagram from a topic tree.
+ *
+ * Output format:
+ * ```mermaid
+ * graph TD
+ *     N0["Machine Learning"] --> N1["Neural Networks"]
+ *     N0["Machine Learning"] --> N2["Gradient Descent"]
+ *     N1["Neural Networks"] --> N3["Backpropagation"]
+ *     N1["Neural Networks"] --> N4["Activation Functions"]
+ *     N2["Gradient Descent"] --> N5["Learning Rate Schedules"]
+ * ```
+ */
+export function generateTreeDiagram(root: TreeNode): string {
+	const edges: string[] = [];
+	let counter = 0;
+	const idMap = new Map<string, string>();
+
+	function assignId(nodeId: string): string {
+		if (!idMap.has(nodeId)) {
+			idMap.set(nodeId, toNodeId('N', counter++));
+		}
+		return idMap.get(nodeId)!;
+	}
+
+	function visit(node: TreeNode): void {
+		const parentMermaidId = assignId(node.id);
+		for (const child of node.children) {
+			const childMermaidId = assignId(child.id);
+			const parentLabel = sanitizeLabel(node.label);
+			const childLabel = sanitizeLabel(child.label);
+			edges.push(`    ${parentMermaidId}["${parentLabel}"] --> ${childMermaidId}["${childLabel}"]`);
+			visit(child);
+		}
+	}
+
+	visit(root);
+
+	if (edges.length === 0) {
+		// Single node, no edges — show just the root
+		const rootMermaidId = assignId(root.id);
+		const rootLabel = sanitizeLabel(root.label);
+		const lines = [
+			'```mermaid',
+			'graph TD',
+			`    ${rootMermaidId}["${rootLabel}"]`,
+			'```',
+		];
+		return lines.join('\n');
+	}
+
+	const lines = [
+		'```mermaid',
+		'graph TD',
+		...edges,
+		'```',
+	];
+	return lines.join('\n');
+}
+
+/**
+ * Generate a Mermaid left-right flowchart showing file moves.
+ *
+ * Output format:
+ * ```mermaid
+ * graph LR
+ *     subgraph Before
+ *         A0["notes/neural-networks.md"]
+ *         A1["notes/gradient-descent.md"]
+ *     end
+ *     subgraph After
+ *         B0["AI & ML/Neural Networks/neural-networks.md"]
+ *         B1["AI & ML/Optimization/gradient-descent.md"]
+ *     end
+ *     A0 --> B0
+ *     A1 --> B1
+ * ```
+ */
+export function generateMoveDiagram(moves: MoveRecord[]): string {
+	if (moves.length === 0) {
+		return '```mermaid\ngraph LR\n    EMPTY["No files moved"]\n```';
+	}
+
+	const beforeNodes: string[] = [];
+	const afterNodes: string[] = [];
+	const arrows: string[] = [];
+
+	for (let i = 0; i < moves.length; i++) {
+		const fromId = toNodeId('A', i);
+		const toId = toNodeId('B', i);
+		const fromLabel = sanitizeLabel(moves[i].originalPath);
+		const toLabel = sanitizeLabel(moves[i].newPath);
+
+		beforeNodes.push(`        ${fromId}["${fromLabel}"]`);
+		afterNodes.push(`        ${toId}["${toLabel}"]`);
+		arrows.push(`    ${fromId} --> ${toId}`);
+	}
+
+	const lines = [
+		'```mermaid',
+		'graph LR',
+		'    subgraph Before',
+		...beforeNodes,
+		'    end',
+		'    subgraph After',
+		...afterNodes,
+		'    end',
+		...arrows,
+		'```',
+	];
+	return lines.join('\n');
+}
+
+/**
+ * Generate a full organize summary note with a move diagram.
+ *
+ * Output includes a heading, timestamp, move count, and the Mermaid diagram.
+ */
+export function generateOrganizeSummary(
+	moves: MoveRecord[],
+	timestamp: string
+): string {
+	const date = timestamp.split('T')[0] || timestamp;
+	const lines: string[] = [];
+
+	lines.push('# Organize Summary');
+	lines.push('');
+	lines.push(`**Date:** ${date}`);
+	lines.push(`**Files moved:** ${moves.length}`);
+	lines.push('');
+	lines.push('## Move Diagram');
+	lines.push('');
+	lines.push(generateMoveDiagram(moves));
+	lines.push('');
+	lines.push('## Details');
+	lines.push('');
+
+	for (const move of moves) {
+		lines.push(`- \`${move.originalPath}\` -> \`${move.newPath}\``);
+	}
+
+	return lines.join('\n');
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -24,3 +24,9 @@ export {
 	mergeTags,
 } from './frontmatter-utils';
 export type { ParsedNote } from './frontmatter-utils';
+export {
+	generateTreeDiagram,
+	generateMoveDiagram,
+	generateOrganizeSummary,
+} from './diagram-generator';
+export type { TreeNode, MoveRecord } from './diagram-generator';


### PR DESCRIPTION
## Summary
- New `src/shared/diagram-generator.ts` utility with `generateTreeDiagram()` and `generateMoveDiagram()` functions
- Deep dive syllabus note now includes a "Topic Map" section with a Mermaid tree diagram of the exploration hierarchy
- Organize operations now write summary notes to `.auto-notes/organize/summaries/` with Mermaid before/after move diagrams
- Post-operation notices link to the summary notes

Depends on #42 (syllabus navigation)
Closes #48

## Test plan
- [ ] Accept a deep dive run and verify the syllabus note contains a Mermaid `graph TD` diagram
- [ ] Run an organize scan and verify a summary note is created with a Mermaid `graph LR` move diagram
- [ ] Accept an organize proposal and verify a summary note is written
- [ ] Verify diagrams render correctly in Obsidian's preview mode
- [ ] Verify special characters in note titles are sanitized in diagram labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)