### PR TITLE
Fix slider visual bugs: range, alignment, and missing tick marks

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -448,6 +448,7 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 				max: 1,
 				step: 0.05,
 				value: this.plugin.settings.enrichment.internalLinkThreshold,
+				showTicks: true,
 				onChange: async (value) => {
 					this.plugin.settings.enrichment.internalLinkThreshold = value;
 					await this.plugin.saveSettings();
@@ -479,6 +480,7 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 					max: 1,
 					step: 0.05,
 					value: this.plugin.settings.enrichment.weights[key],
+					showTicks: true,
 					onChange: async (value) => {
 						this.plugin.settings.enrichment.weights[key] = value;
 						await this.plugin.saveSettings();
@@ -753,6 +755,7 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 				max: 0.9,
 				step: 0.05,
 				value: this.plugin.settings.deepDive.qualityThreshold,
+				showTicks: true,
 				onChange: async (value) => {
 					this.plugin.settings.deepDive.qualityThreshold = value;
 					await this.plugin.saveSettings();

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,12 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 200px;
   gap: 0;
+}
+
+.auto-notes-slider-wrapper input[type="range"] {
+  width: 100%;
 }
 
 .auto-notes-slider-current-value {


### PR DESCRIPTION
## Summary

- Add `width: 100%` to range inputs inside `.auto-notes-slider-wrapper` so sliders stretch full width
- Add `min-width: 200px` to `.auto-notes-slider-wrapper` for consistent alignment across all settings
- Enable `showTicks: true` on 4 slider calls that were missing it: internal link threshold, proximity weight sliders (×6 via loop), and quality threshold

## Test plan

- [ ] Open plugin settings and verify all 9 sliders extend to full width
- [ ] Verify all sliders are visually aligned with each other
- [ ] Verify all 9 sliders display tick marks
- [ ] Confirm no regressions in slider value display or interaction

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>