### PR TITLE
Unify AI content into Obsidian callouts with shared registry

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
-import { NotificationManager } from '../shared';
+import { NotificationManager, buildCallout, CALLOUT_TYPES } from '../shared';
 import { NoteAudioModal } from './note-audio-modal';
 import { AudioEmbed } from './types';
 import { PostProcessor } from './post-processor';
@@ -88,13 +88,12 @@ export class AudioModule {
 					const result = await this.transcribe(data, file.name);
 					const text = result.processed || result.raw;
 
-					const transcriptionBlock = [
-						'',
-						`> **Transcription of ${file.name}**`,
-						'>',
-						...text.split('\n').map(line => `> ${line}`),
-						'',
-					].join('\n');
+					const transcriptionBlock = buildCallout(
+						CALLOUT_TYPES.transcription,
+						`Transcription of ${file.name}`,
+						text,
+						true
+					);
 
 					const content = await this.plugin.app.vault.read(activeFile);
 					await this.plugin.app.vault.modify(activeFile, content + transcriptionBlock);
@@ -156,7 +155,12 @@ export class AudioModule {
 	private hasTranscriptionBelow(lines: string[], embedLine: number, fileName: string): boolean {
 		// Look at the lines following the embed for a transcription block
 		for (let j = embedLine + 1; j < lines.length && j <= embedLine + 3; j++) {
+			// Legacy format
 			if (lines[j].includes(`**Transcription of ${fileName}**`)) {
+				return true;
+			}
+			// Callout format
+			if (lines[j].includes(`[!${CALLOUT_TYPES.transcription}]`) && lines[j].includes(`Transcription of ${fileName}`)) {
 				return true;
 			}
 			// Stop looking if we hit another embed or non-empty non-blank line that isn't a blockquote
@@ -198,13 +202,12 @@ export class AudioModule {
 				const text = result.processed || result.raw;
 
 				const lines = content.split('\n');
-				const transcriptionBlock = [
-					'',
-					`> **Transcription of ${embed.fileName}**`,
-					'>',
-					...text.split('\n').map(line => `> ${line}`),
-					'',
-				].join('\n');
+				const transcriptionBlock = buildCallout(
+					CALLOUT_TYPES.transcription,
+					`Transcription of ${embed.fileName}`,
+					text,
+					true
+				);
 
 				// Insert after the embed line
 				lines.splice(embed.line + 1, 0, transcriptionBlock);

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
-import { blockquoteOriginal, FolderPickerModal, getMarkdownFiles, NotificationManager, sanitizeAIResponse } from '../shared';
+import { buildCallout, CALLOUT_TYPES, FolderPickerModal, getMarkdownFiles, NotificationManager, sanitizeAIResponse } from '../shared';
 import { PlaceholderDetector } from './detector';
 import { ProposalStore } from './proposal-store';
 import { ProposalGenerator } from './proposer';
@@ -205,8 +205,12 @@ export class ElaborationModule {
 		const content = await this.plugin.app.vault.read(file);
 		const additions = editedContent ?? proposal.proposedAdditions;
 		const sanitizedAdditions = sanitizeAIResponse(additions);
-		const quotedContent = blockquoteOriginal(content);
-		const newContent = quotedContent + '\n\n' + sanitizedAdditions;
+		const callout = buildCallout(
+			CALLOUT_TYPES.elaboration,
+			'Elaboration',
+			sanitizedAdditions
+		);
+		const newContent = content.trimEnd() + '\n' + callout;
 		await this.plugin.app.vault.modify(file, newContent);
 
 		await this.store.updateStatus(id, 'accepted');

--- a/src/enrichment/enrichment-applier.ts
+++ b/src/enrichment/enrichment-applier.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
-import { mergeTags, parseFrontmatter, serializeFrontmatter } from '../shared';
+import { mergeTags, parseFrontmatter, serializeFrontmatter, buildCallout, CALLOUT_TYPES } from '../shared';
 import { EnrichmentProposal, AcceptedItems } from './types';
 
 export const ENRICHMENT_START = '%% auto-notes-enrichment-start %%';
@@ -143,30 +143,25 @@ export class EnrichmentApplier {
 		links: { targetPath: string; displayText: string; reason: string }[],
 		heading: string
 	): string {
-		const lines: string[] = [
-			ENRICHMENT_START,
-			`## ${heading}`,
-			'',
-		];
+		const bodyLines: string[] = [];
 		for (const link of links) {
 			// Sanitize display text and reason to prevent wikilink/markdown injection
 			const safeDisplay = link.displayText.replace(/[[\]|]/g, '');
 			const safeReason = link.reason.replace(/[[\]()]/g, '');
-			lines.push(`- [[${safeDisplay}]] — ${safeReason}`);
+			bodyLines.push(`- [[${safeDisplay}]] — ${safeReason}`);
 		}
-		lines.push('', ENRICHMENT_END);
-		return lines.join('\n');
+		return buildCallout(
+			CALLOUT_TYPES.enrichment,
+			heading,
+			bodyLines.join('\n')
+		).trim();
 	}
 
 	private buildRefsSection(
 		refs: { url: string; title: string; reason: string }[],
 		heading: string
 	): string {
-		const lines: string[] = [
-			ENRICHMENT_START,
-			`## ${heading}`,
-			'',
-		];
+		const bodyLines: string[] = [];
 		for (const ref of refs) {
 			// Sanitize AI-generated strings to prevent markdown injection
 			const safeTitle = ref.title.replace(/[[\]()]/g, '');
@@ -181,17 +176,21 @@ export class EnrichmentApplier {
 			} catch {
 				continue; // Skip invalid URLs
 			}
-			lines.push(`- [${safeTitle}](${safeUrl}) — ${safeReason}`);
+			bodyLines.push(`- [${safeTitle}](${safeUrl}) — ${safeReason}`);
 		}
-		lines.push('', ENRICHMENT_END);
-		return lines.join('\n');
+		return buildCallout(
+			CALLOUT_TYPES.enrichment,
+			heading,
+			bodyLines.join('\n')
+		).trim();
 	}
 
 	private removeEnrichmentSections(body: string): string {
+		let result = body;
+
+		// Remove legacy comment-marker sections
 		const startMarker = ENRICHMENT_START;
 		const endMarker = ENRICHMENT_END;
-
-		let result = body;
 		while (true) {
 			const startIdx = result.indexOf(startMarker);
 			if (startIdx === -1) break;
@@ -202,6 +201,13 @@ export class EnrichmentApplier {
 			const after = result.slice(endIdx + endMarker.length);
 			result = before + after;
 		}
+
+		// Remove callout-format enrichment sections
+		const calloutPattern = new RegExp(
+			`^> \\[!${CALLOUT_TYPES.enrichment}\\][^\\n]*(?:\\n>[^\\n]*)*\\n?`,
+			'gm'
+		);
+		result = result.replace(calloutPattern, '').replace(/\n{3,}/g, '\n\n');
 
 		return result;
 	}

--- a/src/shared/callouts.test.ts
+++ b/src/shared/callouts.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildCallout, CALLOUT_TYPES } from './callouts';
+
+describe('CALLOUT_TYPES', () => {
+	it('has all expected types', () => {
+		expect(CALLOUT_TYPES.summary).toBe('auto-notes-summary');
+		expect(CALLOUT_TYPES.transcription).toBe('auto-notes-transcription');
+		expect(CALLOUT_TYPES.enrichment).toBe('auto-notes-enrichment');
+		expect(CALLOUT_TYPES.elaboration).toBe('auto-notes-elaboration');
+		expect(CALLOUT_TYPES.deepDive).toBe('auto-notes-deep-dive');
+		expect(CALLOUT_TYPES.nav).toBe('auto-notes-nav');
+	});
+});
+
+describe('buildCallout', () => {
+	it('builds a basic callout', () => {
+		const result = buildCallout(CALLOUT_TYPES.summary, 'My Title', 'Body text');
+		expect(result).toBe([
+			'',
+			'> [!auto-notes-summary] My Title',
+			'> Body text',
+			'',
+		].join('\n'));
+	});
+
+	it('builds a collapsed callout', () => {
+		const result = buildCallout(CALLOUT_TYPES.transcription, 'Title', 'Content', true);
+		expect(result).toContain('> [!auto-notes-transcription]- Title');
+	});
+
+	it('handles multi-line body', () => {
+		const body = 'Line 1\nLine 2\nLine 3';
+		const result = buildCallout(CALLOUT_TYPES.enrichment, 'Related', body);
+		const lines = result.split('\n');
+		expect(lines[1]).toBe('> [!auto-notes-enrichment] Related');
+		expect(lines[2]).toBe('> Line 1');
+		expect(lines[3]).toBe('> Line 2');
+		expect(lines[4]).toBe('> Line 3');
+	});
+
+	it('has leading and trailing blank lines', () => {
+		const result = buildCallout(CALLOUT_TYPES.summary, 'T', 'B');
+		expect(result.startsWith('\n')).toBe(true);
+		expect(result.endsWith('\n')).toBe(true);
+	});
+
+	it('defaults to non-collapsed', () => {
+		const result = buildCallout(CALLOUT_TYPES.elaboration, 'Title', 'Body');
+		expect(result).toContain('> [!auto-notes-elaboration] Title');
+		expect(result).not.toContain(']-');
+	});
+});

--- a/src/shared/callouts.ts
+++ b/src/shared/callouts.ts
@@ -1,0 +1,39 @@
+/**
+ * Unified callout registry for all AI-generated content.
+ *
+ * Every AI content type uses an Obsidian callout (`> [!auto-notes-type]`)
+ * with a distinct type identifier. This module provides the registry of
+ * type names and a utility to build well-formed callout blocks.
+ */
+
+export const CALLOUT_TYPES = {
+	summary: 'auto-notes-summary',
+	transcription: 'auto-notes-transcription',
+	enrichment: 'auto-notes-enrichment',
+	elaboration: 'auto-notes-elaboration',
+	deepDive: 'auto-notes-deep-dive',
+	nav: 'auto-notes-nav',
+} as const;
+
+export type CalloutType = (typeof CALLOUT_TYPES)[keyof typeof CALLOUT_TYPES];
+
+/**
+ * Build an Obsidian callout block.
+ *
+ * @param type   - One of the CALLOUT_TYPES values (e.g. 'auto-notes-summary')
+ * @param title  - Title displayed on the callout header line
+ * @param body   - Content of the callout (may be multi-line)
+ * @param collapsed - If true, the callout renders collapsed by default (adds `-` suffix)
+ * @returns A complete callout block string with leading/trailing blank lines
+ */
+export function buildCallout(
+	type: CalloutType,
+	title: string,
+	body: string,
+	collapsed = false
+): string {
+	const collapseMarker = collapsed ? '-' : '';
+	const header = `> [!${type}]${collapseMarker} ${title}`;
+	const bodyLines = body.split('\n').map(line => `> ${line}`);
+	return ['', header, ...bodyLines, ''].join('\n');
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -18,6 +18,8 @@ export {
 	sanitizeAIResponse,
 	blockquoteOriginal,
 } from './validation';
+export { CALLOUT_TYPES, buildCallout } from './callouts';
+export type { CalloutType } from './callouts';
 export {
 	parseFrontmatter,
 	serializeFrontmatter,

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
-import { FolderPickerModal, getMarkdownFiles, NotificationManager } from '../shared';
+import { FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout, CALLOUT_TYPES } from '../shared';
 import { OperationHandle } from '../shared';
 import { isSupportedUrl } from '../video/url-detector';
 import { fetchPageContent } from './content-fetcher';
@@ -285,15 +285,13 @@ export class SummarizeModule {
 						settings.customPrompt || undefined
 					);
 
-					const blockLines = [
-						'',
-						`> **Summary of ${target.source}**`,
-						'>',
-						...summary.split('\n').map(line => `> ${line}`),
-						'',
-					];
+					const callout = buildCallout(
+						CALLOUT_TYPES.summary,
+						`Summary of ${target.source}`,
+						summary
+					);
 
-					lines.splice(target.endLine + 1, 0, ...blockLines);
+					lines.splice(target.endLine + 1, 0, ...callout.split('\n'));
 
 					inlineCompleted++;
 				}

--- a/src/summarize/note-scanner.test.ts
+++ b/src/summarize/note-scanner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { buildCallout, CALLOUT_TYPES } from '../shared/callouts';
 import { findSummarizeTargets, hasSummaryBelow, extractTranscriptionContent } from './note-scanner';
 
 describe('findSummarizeTargets', () => {
@@ -55,6 +56,17 @@ describe('findSummarizeTargets', () => {
 		expect(targets).toHaveLength(0);
 	});
 
+	it('skips URLs that already have a callout summary below', () => {
+		const content = [
+			'https://example.com/article',
+			'',
+			'> [!auto-notes-summary] Summary of https://example.com/article',
+			'> Some summary text',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
 	it('skips transcriptions that already have a summary below', () => {
 		const content = [
 			'> **Transcription of https://youtube.com/watch?v=abc**',
@@ -67,6 +79,85 @@ describe('findSummarizeTargets', () => {
 		].join('\n');
 		const targets = findSummarizeTargets(content);
 		expect(targets).toHaveLength(0);
+	});
+
+	it('finds a callout-format transcription block', () => {
+		const content = [
+			'> [!auto-notes-transcription]- Transcription of https://youtube.com/watch?v=abc',
+			'> Hello world this is a test',
+			'> Second line of transcription',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(1);
+		expect(targets[0]).toMatchObject({
+			type: 'transcription',
+			source: 'https://youtube.com/watch?v=abc',
+			line: 0,
+		});
+		expect(targets[0].content).toContain('Hello world');
+	});
+
+	it('skips callout transcription with callout summary below', () => {
+		const content = [
+			'> [!auto-notes-transcription]- Transcription of https://youtube.com/watch?v=abc',
+			'> Transcribed text',
+			'',
+			'> [!auto-notes-summary] Summary of https://youtube.com/watch?v=abc',
+			'> Summary text',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
+	it('finds enrichment URLs in callout-format enrichment sections', () => {
+		const content = [
+			'https://example.com/user-url',
+			'',
+			'> [!auto-notes-enrichment] References',
+			'> - [Some Article](https://example.com/enrichment-ref) — background',
+			'> - [Another](https://other.com/resource) — related',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(3);
+
+		expect(targets[0]).toMatchObject({
+			type: 'url',
+			source: 'https://example.com/user-url',
+		});
+		expect(targets[0].inEnrichmentSection).toBeFalsy();
+
+		expect(targets[1]).toMatchObject({
+			type: 'url',
+			source: 'https://example.com/enrichment-ref',
+			inEnrichmentSection: true,
+			linkTitle: 'Some Article',
+		});
+		expect(targets[2]).toMatchObject({
+			type: 'url',
+			source: 'https://other.com/resource',
+			inEnrichmentSection: true,
+			linkTitle: 'Another',
+		});
+	});
+
+	it('exits callout enrichment section at non-blockquote line', () => {
+		const content = [
+			'> [!auto-notes-enrichment] References',
+			'> - [Inside](https://inside.com/ref) — reason',
+			'',
+			'https://example.com/after-enrichment',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(2);
+		expect(targets[0]).toMatchObject({
+			source: 'https://inside.com/ref',
+			inEnrichmentSection: true,
+			linkTitle: 'Inside',
+		});
+		expect(targets[1]).toMatchObject({
+			source: 'https://example.com/after-enrichment',
+		});
+		expect(targets[1].inEnrichmentSection).toBeFalsy();
 	});
 
 	it('skips URLs inside blockquotes', () => {
@@ -356,6 +447,24 @@ describe('hasSummaryBelow', () => {
 		const lines = ['https://example.com/article'];
 		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(false);
 	});
+
+	it('returns true for callout-format summary below', () => {
+		const lines = [
+			'https://example.com/article',
+			'',
+			'> [!auto-notes-summary] Summary of https://example.com/article',
+			'> Summary text',
+		];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(true);
+	});
+
+	it('returns false for callout summary of different source', () => {
+		const lines = [
+			'https://example.com/article',
+			'> [!auto-notes-summary] Summary of https://example.com/other',
+		];
+		expect(hasSummaryBelow(lines, 0, 'https://example.com/article')).toBe(false);
+	});
 });
 
 describe('extractTranscriptionContent', () => {
@@ -401,7 +510,7 @@ describe('multi-URL inline insertion (integration)', () => {
 	 * Simulates the processFileTargets insertion logic in
 	 * src/summarize/index.ts to verify that all inline summaries
 	 * are correctly placed in the output. Uses the same algorithm:
-	 * scan targets, sort reverse by line, splice blockLines.
+	 * scan targets, sort reverse by line, splice callout lines.
 	 */
 	function simulateInsertion(
 		content: string,
@@ -415,15 +524,13 @@ describe('multi-URL inline insertion (integration)', () => {
 			const summary = summaries.get(target.source);
 			if (!summary) continue;
 
-			const blockLines = [
-				'',
-				`> **Summary of ${target.source}**`,
-				'>',
-				...summary.split('\n').map(line => `> ${line}`),
-				'',
-			];
+			const callout = buildCallout(
+				CALLOUT_TYPES.summary,
+				`Summary of ${target.source}`,
+				summary
+			);
 
-			lines.splice(target.endLine + 1, 0, ...blockLines);
+			lines.splice(target.endLine + 1, 0, ...callout.split('\n'));
 		}
 
 		return lines.join('\n');
@@ -445,9 +552,9 @@ describe('multi-URL inline insertion (integration)', () => {
 
 		const result = simulateInsertion(content, summaries);
 
-		expect(result).toContain('> **Summary of https://youtube.com/watch?v=abc**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://youtube.com/watch?v=abc');
 		expect(result).toContain('> Summary of first video.');
-		expect(result).toContain('> **Summary of https://youtube.com/watch?v=xyz**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://youtube.com/watch?v=xyz');
 		expect(result).toContain('> Summary of second video.');
 	});
 
@@ -468,11 +575,11 @@ describe('multi-URL inline insertion (integration)', () => {
 
 		const result = simulateInsertion(content, summaries);
 
-		expect(result).toContain('> **Summary of https://youtube.com/watch?v=first**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://youtube.com/watch?v=first');
 		expect(result).toContain('> First summary.');
-		expect(result).toContain('> **Summary of https://youtube.com/watch?v=second**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://youtube.com/watch?v=second');
 		expect(result).toContain('> Second summary.');
-		expect(result).toContain('> **Summary of https://youtube.com/watch?v=third**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://youtube.com/watch?v=third');
 		expect(result).toContain('> Third summary.');
 	});
 
@@ -564,8 +671,8 @@ describe('multi-URL inline insertion (integration)', () => {
 		const secondUrlIdx = lines.indexOf('https://example.com/second');
 
 		// Find the summary header lines
-		const firstSummaryIdx = lines.indexOf('> **Summary of https://example.com/first**');
-		const secondSummaryIdx = lines.indexOf('> **Summary of https://example.com/second**');
+		const firstSummaryIdx = lines.indexOf('> [!auto-notes-summary] Summary of https://example.com/first');
+		const secondSummaryIdx = lines.indexOf('> [!auto-notes-summary] Summary of https://example.com/second');
 
 		// Each summary should come after its URL and before the next URL
 		expect(firstSummaryIdx).toBeGreaterThan(firstUrlIdx);
@@ -587,9 +694,9 @@ describe('multi-URL inline insertion (integration)', () => {
 
 		const result = simulateInsertion(content, summaries);
 
-		expect(result).toContain('> **Summary of https://example.com/a**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://example.com/a');
 		expect(result).toContain('> Summary A.');
-		expect(result).toContain('> **Summary of https://example.com/b**');
+		expect(result).toContain('> [!auto-notes-summary] Summary of https://example.com/b');
 		expect(result).toContain('> Summary B.');
 	});
 });

--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -1,8 +1,15 @@
 import { ENRICHMENT_START, ENRICHMENT_END } from '../enrichment/enrichment-applier';
+import { CALLOUT_TYPES } from '../shared';
 import { SummarizeTarget } from './types';
 
 const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;
 const TRANSCRIPTION_HEADER = /^>\s*\*\*Transcription of (.+?)\*\*$/;
+const CALLOUT_TRANSCRIPTION_HEADER = new RegExp(
+	`^>\\s*\\[!${CALLOUT_TYPES.transcription}\\][-+]?\\s+Transcription of (.+)$`
+);
+const CALLOUT_SUMMARY_PREFIX = `[!${CALLOUT_TYPES.summary}]`;
+const CALLOUT_TRANSCRIPTION_PREFIX = `[!${CALLOUT_TYPES.transcription}]`;
+const CALLOUT_ENRICHMENT_PREFIX = `[!${CALLOUT_TYPES.enrichment}]`;
 
 /**
  * Scan note content for URLs and transcription blocks that need summaries.
@@ -13,24 +20,39 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
 	const lines = content.split('\n');
 	const targets: SummarizeTarget[] = [];
 	let inEnrichmentSection = false;
+	let enrichmentIsCallout = false;
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
 
-		// Track enrichment marker sections — content inside is managed
-		// by the enrichment module and must not be modified
+		// Track enrichment marker sections (legacy comment markers)
 		if (line.trim() === ENRICHMENT_START) {
 			inEnrichmentSection = true;
+			enrichmentIsCallout = false;
 			continue;
 		}
 		if (line.trim() === ENRICHMENT_END) {
 			inEnrichmentSection = false;
 			continue;
 		}
+
+		// Track callout-format enrichment sections
+		if (!inEnrichmentSection && line.includes(CALLOUT_ENRICHMENT_PREFIX)) {
+			inEnrichmentSection = true;
+			enrichmentIsCallout = true;
+		}
+		// Exit callout-format enrichment when we hit a non-blockquote, non-empty line
+		if (inEnrichmentSection && enrichmentIsCallout && !line.startsWith('>') && line.trim() !== '' && !line.includes(CALLOUT_ENRICHMENT_PREFIX)) {
+			inEnrichmentSection = false;
+			enrichmentIsCallout = false;
+		}
+
 		if (inEnrichmentSection) {
 			// Detect markdown links in enrichment reference lists
-			// e.g. "- [AI Overview](https://example.com) — reason"
-			const mdLinkMatch = line.match(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/);
+			// Legacy: "- [AI Overview](https://example.com) — reason"
+			// Callout: "> - [AI Overview](https://example.com) — reason"
+			const strippedLine = enrichmentIsCallout ? line.replace(/^>\s?/, '') : line;
+			const mdLinkMatch = strippedLine.match(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/);
 			if (mdLinkMatch) {
 				targets.push({
 					type: 'url',
@@ -44,7 +66,7 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
 			continue;
 		}
 
-		// Check for transcription block headers
+		// Check for transcription block headers (legacy blockquote format)
 		const transcriptionMatch = line.match(TRANSCRIPTION_HEADER);
 		if (transcriptionMatch) {
 			const source = transcriptionMatch[1];
@@ -59,7 +81,25 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
 					content: text,
 				});
 			}
-			// Skip past the transcription block
+			i = endLine;
+			continue;
+		}
+
+		// Check for transcription block headers (callout format)
+		const calloutTranscriptionMatch = line.match(CALLOUT_TRANSCRIPTION_HEADER);
+		if (calloutTranscriptionMatch) {
+			const source = calloutTranscriptionMatch[1];
+			const { endLine, text } = extractTranscriptionContent(lines, i);
+
+			if (!hasSummaryBelow(lines, endLine, source)) {
+				targets.push({
+					type: 'transcription',
+					source,
+					line: i,
+					endLine,
+					content: text,
+				});
+			}
 			i = endLine;
 			continue;
 		}
@@ -97,7 +137,12 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
  */
 export function hasSummaryBelow(lines: string[], startLine: number, source: string): boolean {
 	for (let j = startLine + 1; j < lines.length && j <= startLine + 3; j++) {
+		// Legacy format: > **Summary of <source>**
 		if (lines[j].includes(`**Summary of ${source}**`)) {
+			return true;
+		}
+		// Callout format: > [!auto-notes-summary] Summary of <source>
+		if (lines[j].includes(CALLOUT_SUMMARY_PREFIX) && lines[j].includes(`Summary of ${source}`)) {
 			return true;
 		}
 		// Stop at non-empty, non-blockquote content
@@ -113,7 +158,12 @@ export function hasSummaryBelow(lines: string[], startLine: number, source: stri
  */
 function hasTranscriptionBelow(lines: string[], urlLine: number, url: string): boolean {
 	for (let j = urlLine + 1; j < lines.length && j <= urlLine + 5; j++) {
+		// Legacy format: > **Transcription of <url>**
 		if (lines[j].includes(`**Transcription of ${url}**`)) {
+			return true;
+		}
+		// Callout format: > [!auto-notes-transcription] Transcription of <url>
+		if (lines[j].includes(CALLOUT_TRANSCRIPTION_PREFIX) && lines[j].includes(`Transcription of ${url}`)) {
 			return true;
 		}
 		// Stop at non-empty, non-blockquote content

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -1,7 +1,7 @@
 import { Plugin, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
 import { AudioModule, TranscriptionResult } from '../audio';
-import { ensureFolder, NotificationManager, sanitizeUrl } from '../shared';
+import { ensureFolder, NotificationManager, sanitizeUrl, buildCallout, CALLOUT_TYPES } from '../shared';
 import { AudioExtractor } from './audio-extractor';
 import { NoteVideoModal } from './note-video-modal';
 import { findVideoUrls } from './note-scanner';
@@ -218,12 +218,13 @@ export class VideoModule {
 					blockLines.push('');
 				}
 
-				blockLines.push(
-					`> **Transcription of ${embed.url}**`,
-					'>',
-					...text.split('\n').map(line => `> ${line}`),
-					''
+				const callout = buildCallout(
+					CALLOUT_TYPES.transcription,
+					`Transcription of ${embed.url}`,
+					text,
+					true
 				);
+				blockLines.push(callout);
 
 				lines.splice(embed.line + 1, 0, blockLines.join('\n'));
 				content = lines.join('\n');
@@ -267,12 +268,13 @@ export class VideoModule {
 					blockLines.push('');
 				}
 
-				blockLines.push(
-					`> **Transcription of ${url}**`,
-					'>',
-					...text.split('\n').map(line => `> ${line}`),
-					''
+				const callout = buildCallout(
+					CALLOUT_TYPES.transcription,
+					`Transcription of ${url}`,
+					text,
+					true
 				);
+				blockLines.push(callout);
 
 				const content = await this.plugin.app.vault.read(activeFile);
 				await this.plugin.app.vault.modify(activeFile, content + blockLines.join('\n'));

--- a/src/video/note-scanner.test.ts
+++ b/src/video/note-scanner.test.ts
@@ -79,6 +79,17 @@ describe('findVideoUrls', () => {
 		expect(result).toHaveLength(0);
 	});
 
+	it('skips URLs that already have a callout transcription below', () => {
+		const content = [
+			'https://youtube.com/watch?v=abc123',
+			'',
+			'> [!auto-notes-transcription]- Transcription of https://youtube.com/watch?v=abc123',
+			'> Some transcribed text',
+		].join('\n');
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(0);
+	});
+
 	it('returns URL that does not yet have a transcription', () => {
 		const content = [
 			'https://youtube.com/watch?v=abc123',
@@ -171,5 +182,23 @@ describe('hasTranscriptionBelow', () => {
 			'> **Transcription of https://youtube.com/watch?v=abc**',
 		];
 		expect(hasTranscriptionBelow(lines, 0, 'https://youtube.com/watch?v=abc')).toBe(true);
+	});
+
+	it('returns true for callout-format transcription below', () => {
+		const lines = [
+			'https://youtube.com/watch?v=abc',
+			'',
+			'> [!auto-notes-transcription]- Transcription of https://youtube.com/watch?v=abc',
+			'> text',
+		];
+		expect(hasTranscriptionBelow(lines, 0, 'https://youtube.com/watch?v=abc')).toBe(true);
+	});
+
+	it('returns false for callout transcription of different URL', () => {
+		const lines = [
+			'https://youtube.com/watch?v=abc',
+			'> [!auto-notes-transcription]- Transcription of https://youtube.com/watch?v=xyz',
+		];
+		expect(hasTranscriptionBelow(lines, 0, 'https://youtube.com/watch?v=abc')).toBe(false);
 	});
 });

--- a/src/video/note-scanner.ts
+++ b/src/video/note-scanner.ts
@@ -1,7 +1,9 @@
+import { CALLOUT_TYPES } from '../shared';
 import { VideoUrlEmbed } from './types';
 import { detectPlatform } from './url-detector';
 
 const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;
+const CALLOUT_TRANSCRIPTION_PREFIX = `[!${CALLOUT_TYPES.transcription}]`;
 
 export function findVideoUrls(content: string): VideoUrlEmbed[] {
 	const embeds: VideoUrlEmbed[] = [];
@@ -34,7 +36,12 @@ export function findVideoUrls(content: string): VideoUrlEmbed[] {
 
 export function hasTranscriptionBelow(lines: string[], embedLine: number, url: string): boolean {
 	for (let j = embedLine + 1; j < lines.length && j <= embedLine + 3; j++) {
+		// Legacy format
 		if (lines[j].includes(`**Transcription of ${url}**`)) {
+			return true;
+		}
+		// Callout format
+		if (lines[j].includes(CALLOUT_TRANSCRIPTION_PREFIX) && lines[j].includes(`Transcription of ${url}`)) {
 			return true;
 		}
 		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {

--- a/styles.css
+++ b/styles.css
@@ -57,3 +57,36 @@
   background-color: var(--text-faint);
   flex-shrink: 0;
 }
+
+/* ── AI content callout styles ── */
+
+.callout[data-callout^="auto-notes-"] {
+  --callout-blend-mode: normal;
+  border-left-width: 3px;
+  opacity: 0.95;
+}
+
+.callout[data-callout="auto-notes-summary"] {
+  --callout-color: 100, 160, 255;
+  --callout-icon: lucide-file-text;
+}
+
+.callout[data-callout="auto-notes-transcription"] {
+  --callout-color: 160, 120, 220;
+  --callout-icon: lucide-mic;
+}
+
+.callout[data-callout="auto-notes-enrichment"] {
+  --callout-color: 80, 180, 120;
+  --callout-icon: lucide-link;
+}
+
+.callout[data-callout="auto-notes-elaboration"] {
+  --callout-color: 220, 160, 60;
+  --callout-icon: lucide-pen-tool;
+}
+
+.callout[data-callout="auto-notes-deep-dive"] {
+  --callout-color: 60, 180, 200;
+  --callout-icon: lucide-layers;
+}


### PR DESCRIPTION
## Summary

Closes #39. Closes #31.

- Add shared callout registry (`src/shared/callouts.ts`) with `CALLOUT_TYPES` constants and `buildCallout()` utility for generating well-formed `> [!auto-notes-type]` blocks
- Migrate all AI content insertion — summaries, transcriptions (video + audio), enrichment sections, and elaboration — from ad-hoc blockquotes/comment markers to typed Obsidian callouts
- Add per-type CSS styling with distinct colors: blue (summary), purple (transcription), green (enrichment), amber (elaboration), teal (deep-dive)
- All detection functions (`hasSummaryBelow`, `hasTranscriptionBelow`, enrichment section tracking) recognize both legacy and new callout formats for backward compatibility
- Elaboration no longer blockquotes the user's original content — only AI additions are wrapped in a callout

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — type check passes
- [x] `npm test` — 387 tests pass (16 new: callout utility, callout-format detection, updated integration tests)
- [x] `node esbuild.config.mjs production` — build succeeds
- [ ] Manual: summarize a URL → `> [!auto-notes-summary]` callout with blue border
- [ ] Manual: transcribe video → collapsed `> [!auto-notes-transcription]-` callout with purple border
- [ ] Manual: run enrichment → `> [!auto-notes-enrichment]` callout with green border
- [ ] Manual: accept elaboration → `> [!auto-notes-elaboration]` callout, original content untouched
- [ ] Manual: old blockquote summaries/transcriptions still detected (no duplicates on re-run)
- [ ] Manual: old enrichment comment markers still detected and removed on re-enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)