### PR TITLE
fix: include audio embeds as summarization targets (#63)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,12 @@ export default class AutoNotesPlugin extends Plugin {
 		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications);
 		this.summarize = new SummarizeModule(
 			this, getSettings, this.notifications,
-			(url, parentOp) => this.video.transcribeUrl(url, parentOp)
+			(url, parentOp) => this.video.transcribeUrl(url, parentOp),
+			async (audioFile) => {
+				const data = await this.app.vault.readBinary(audioFile);
+				const result = await this.audio.transcribe(data, audioFile.name);
+				return result.processed || result.raw;
+			}
 		);
 		this.tidy = new TidyModule(this, getSettings, this.notifications);
 		this.organize = new OrganizeModule(this, getSettings, this.notifications);

--- a/src/summarize/audio-summarize.test.ts
+++ b/src/summarize/audio-summarize.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SummarizeModule, TranscribeAudioFn } from './index';
+import { DEFAULT_SETTINGS } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+
+// Mock the content fetcher to avoid real network calls
+vi.mock('./content-fetcher', () => ({
+	fetchPageContent: vi.fn().mockResolvedValue('Some fetched content for testing.'),
+}));
+
+// Mock the summarizer to return a canned summary
+vi.mock('./summarizer', () => ({
+	Summarizer: class MockSummarizer {
+		summarize = vi.fn().mockResolvedValue('This is a test summary.');
+	},
+}));
+
+// Mock the note scanner — let real implementation run for collectTargets
+vi.mock('./note-scanner', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./note-scanner')>();
+	return {
+		...actual,
+		findSummarizeTargets: actual.findSummarizeTargets,
+		hasSummaryBelow: actual.hasSummaryBelow,
+	};
+});
+
+// Mock the video module
+vi.mock('../video', () => ({
+	isSupportedUrl: vi.fn().mockReturnValue(false),
+}));
+
+// Mock the audio module — findAudioEmbeds returns controlled results
+const mockFindAudioEmbeds = vi.fn().mockReturnValue([]);
+vi.mock('../audio', () => ({
+	findAudioEmbeds: (...args: any[]) => mockFindAudioEmbeds(...args),
+}));
+
+// Mock the shared module
+vi.mock('../shared', () => ({
+	FolderPickerModal: vi.fn(),
+	getMarkdownFiles: vi.fn().mockReturnValue([]),
+	NotificationManager: vi.fn(),
+	CALLOUT_TYPES: { transcription: 'auto-notes-transcription', summary: 'auto-notes-summary' },
+	buildCallout: vi.fn((_type: string, title: string, content: string) =>
+		`\n> [!auto-notes-summary] ${title}\n> ${content}\n`
+	),
+}));
+
+function createMockNotifications() {
+	const handle = {
+		update: vi.fn(),
+		progress: vi.fn(),
+		finish: vi.fn(),
+		error: vi.fn(),
+		cancelled: false,
+	};
+	return {
+		startOperation: vi.fn().mockReturnValue(handle),
+		info: vi.fn(),
+		success: vi.fn(),
+		notifyError: vi.fn(),
+		confirm: vi.fn().mockResolvedValue(true),
+		_handle: handle,
+	};
+}
+
+function makeTFile(path: string): TFile {
+	const file = new TFile(path);
+	return file;
+}
+
+describe('SummarizeModule audio target detection', () => {
+	let module: SummarizeModule;
+	let mockPlugin: any;
+	let mockNotifications: ReturnType<typeof createMockNotifications>;
+	let settings: typeof DEFAULT_SETTINGS;
+	let transcribeAudioFn: TranscribeAudioFn & ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		settings = structuredClone(DEFAULT_SETTINGS);
+		mockFindAudioEmbeds.mockReset();
+
+		transcribeAudioFn = vi.fn().mockResolvedValue('Transcribed audio content.') as any;
+
+		const audioFile = makeTFile('audio/recording.mp3');
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Note\n\n![[recording.mp3]]\n'),
+					modify: vi.fn().mockResolvedValue(undefined),
+					create: vi.fn().mockResolvedValue(new TFile()),
+					getAbstractFileByPath: vi.fn().mockReturnValue(null),
+					readBinary: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+					getFirstLinkpathDest: vi.fn().mockReturnValue(audioFile),
+				},
+				workspace: {
+					getActiveFile: vi.fn().mockReturnValue(null),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+
+		mockNotifications = createMockNotifications();
+		module = new SummarizeModule(
+			mockPlugin as any,
+			() => settings,
+			mockNotifications as any,
+			undefined,
+			transcribeAudioFn
+		);
+	});
+
+	it('detects audio embeds as summarization targets', async () => {
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// transcribeAudioFn should have been called because the audio target was detected
+		expect(transcribeAudioFn).toHaveBeenCalled();
+	});
+
+	it('transcribes and summarizes audio targets', async () => {
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// The vault should have been modified with the summary
+		expect(mockPlugin.app.vault.modify).toHaveBeenCalled();
+
+		// The content written should contain the summary callout
+		const modifiedContent = mockPlugin.app.vault.modify.mock.calls[0][1];
+		expect(modifiedContent).toContain('Summary of recording.mp3');
+	});
+
+	it('resolves audio file through MetadataCache', async () => {
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// MetadataCache should have been used to resolve the audio file
+		expect(mockPlugin.app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+			'recording.mp3',
+			'notes/test.md'
+		);
+	});
+
+	it('skips audio embeds that already have a summary below', async () => {
+		const noteContent = [
+			'# Note',
+			'',
+			'![[recording.mp3]]',
+			'',
+			'> [!auto-notes-summary] Summary of recording.mp3',
+			'> Previous summary content',
+		].join('\n');
+
+		mockPlugin.app.vault.read.mockResolvedValue(noteContent);
+
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// Should not transcribe because the audio embed already has a summary
+		expect(transcribeAudioFn).not.toHaveBeenCalled();
+		// Should show "no targets" message
+		expect(mockNotifications.info).toHaveBeenCalledWith(
+			'No URLs, transcriptions, or audio to summarize in this note'
+		);
+	});
+
+	it('does not detect audio embeds when no transcribeAudio callback is provided', async () => {
+		// Create module without audio callback
+		const moduleNoAudio = new SummarizeModule(
+			mockPlugin as any,
+			() => settings,
+			mockNotifications as any,
+			undefined,
+			undefined
+		);
+
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await moduleNoAudio.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// findAudioEmbeds should not have been called when there is no audio callback
+		expect(mockFindAudioEmbeds).not.toHaveBeenCalled();
+	});
+
+	it('merges audio targets with URL targets in the targets list', async () => {
+		// When there are multiple targets, the selection modal opens.
+		// This test verifies the targets are collected correctly by checking
+		// that findAudioEmbeds is called alongside URL scanning.
+		const noteContent = [
+			'# Note',
+			'',
+			'![[recording.mp3]]',
+			'',
+			'https://example.com/article',
+		].join('\n');
+
+		mockPlugin.app.vault.read.mockResolvedValue(noteContent);
+
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// findAudioEmbeds should have been called to detect audio targets
+		expect(mockFindAudioEmbeds).toHaveBeenCalled();
+		// The modal opens because there are 2+ targets; no direct processing
+		// happens without user selection. This verifies the merge happened.
+	});
+
+	it('handles audio file not found in vault gracefully', async () => {
+		// Return null for getFirstLinkpathDest to simulate missing file
+		mockPlugin.app.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
+
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// Should report an error rather than crash
+		expect(mockNotifications.notifyError).toHaveBeenCalled();
+	});
+
+	it('handles empty transcription result', async () => {
+		transcribeAudioFn.mockResolvedValue('');
+
+		const audioFile = makeTFile('audio/recording.mp3');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'recording.mp3', file: audioFile, line: 2 },
+		]);
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/test.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// Should report error about empty content
+		expect(mockNotifications.notifyError).toHaveBeenCalledWith(
+			'No content extracted from recording.mp3',
+			expect.any(Error)
+		);
+	});
+
+	it('detects multiple audio embeds from the same note', async () => {
+		// With 2+ targets, the modal opens. We verify all audio embeds
+		// are detected by checking findAudioEmbeds was called.
+		// For single-target auto-process, see the single-embed tests above.
+		const noteContent = [
+			'# Lecture',
+			'',
+			'![[part1.mp3]]',
+			'',
+			'![[part2.wav]]',
+		].join('\n');
+
+		mockPlugin.app.vault.read.mockResolvedValue(noteContent);
+
+		const audioFile1 = makeTFile('audio/part1.mp3');
+		const audioFile2 = makeTFile('audio/part2.wav');
+		mockFindAudioEmbeds.mockReturnValue([
+			{ fileName: 'part1.mp3', file: audioFile1, line: 2 },
+			{ fileName: 'part2.wav', file: audioFile2, line: 4 },
+		]);
+
+		mockPlugin.app.metadataCache.getFirstLinkpathDest
+			.mockImplementation((name: string) => {
+				if (name === 'part1.mp3') return audioFile1;
+				if (name === 'part2.wav') return audioFile2;
+				return null;
+			});
+
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'auto-notes:summarize-current-note'
+		)[0];
+
+		const file = makeTFile('notes/lecture.md');
+		await summarizeCmd.editorCallback({}, { file });
+
+		// findAudioEmbeds was called, confirming both embeds were detected
+		expect(mockFindAudioEmbeds).toHaveBeenCalled();
+		// Modal is shown because there are 2 targets; neither transcribeAudioFn
+		// call happens without user confirmation through the modal.
+	});
+});
+
+describe('SummarizeTarget type: audio', () => {
+	it('has audio as a valid target type', () => {
+		const target = {
+			type: 'audio' as const,
+			source: 'recording.mp3',
+			line: 2,
+			endLine: 2,
+		};
+		expect(target.type).toBe('audio');
+	});
+});

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -3,8 +3,10 @@ import { AutoNotesSettings } from '../settings';
 import { FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout, CALLOUT_TYPES } from '../shared';
 import { OperationHandle } from '../shared';
 import { isSupportedUrl } from '../video';
+import { findAudioEmbeds } from '../audio';
 import { fetchPageContent } from './content-fetcher';
 import { findSummarizeTargets } from './note-scanner';
+import { hasSummaryBelow } from './note-scanner';
 import { SummarizeSelectionModal } from './summarize-modal';
 import { Summarizer } from './summarizer';
 import { SummarizeTarget } from './types';
@@ -19,6 +21,14 @@ export type { SummarizeSettings } from '../settings';
 export type TranscribeUrlFn = (
 	url: string,
 	parentOp?: { update: (msg: string) => void }
+) => Promise<string>;
+
+/**
+ * Function that transcribes an audio file and returns the transcript text.
+ * Injected by main.ts from the AudioModule.
+ */
+export type TranscribeAudioFn = (
+	file: TFile
 ) => Promise<string>;
 
 const COMPREHENSIVE_SUMMARY_PROMPT =
@@ -45,6 +55,7 @@ interface ProcessResult {
 export class SummarizeModule {
 	private summarizer: Summarizer;
 	private transcribeUrl: TranscribeUrlFn | null;
+	private transcribeAudio: TranscribeAudioFn | null;
 
 	/** Optional callback invoked after summarization completes. Wired by main.ts for enrichment. */
 	onSummaryComplete: ((filePath: string) => void) | null = null;
@@ -56,10 +67,12 @@ export class SummarizeModule {
 		private plugin: Plugin,
 		private getSettings: () => AutoNotesSettings,
 		private notifications: NotificationManager,
-		transcribeUrl?: TranscribeUrlFn
+		transcribeUrl?: TranscribeUrlFn,
+		transcribeAudio?: TranscribeAudioFn
 	) {
 		this.summarizer = new Summarizer(getSettings);
 		this.transcribeUrl = transcribeUrl ?? null;
+		this.transcribeAudio = transcribeAudio ?? null;
 	}
 
 	async onload(): Promise<void> {
@@ -91,10 +104,10 @@ export class SummarizeModule {
 
 	private async summarizeNote(file: TFile): Promise<void> {
 		const content = await this.plugin.app.vault.read(file);
-		const targets = findSummarizeTargets(content);
+		const targets = this.collectTargets(content, file.path);
 
 		if (targets.length === 0) {
-			this.notifications.info('No URLs or transcriptions to summarize in this note');
+			this.notifications.info('No URLs, transcriptions, or audio to summarize in this note');
 			return;
 		}
 
@@ -109,6 +122,41 @@ export class SummarizeModule {
 				}
 			).open();
 		}
+	}
+
+	/**
+	 * Collect all summarization targets from a note: URLs, transcription
+	 * blocks (from the pure string scanner), and audio embeds (requires
+	 * MetadataCache). Results are merged and sorted by line number.
+	 */
+	private collectTargets(content: string, sourcePath: string): SummarizeTarget[] {
+		const targets = findSummarizeTargets(content);
+
+		if (this.transcribeAudio) {
+			const lines = content.split('\n');
+			const audioEmbeds = findAudioEmbeds(
+				content,
+				sourcePath,
+				this.plugin.app.metadataCache
+			);
+
+			for (const embed of audioEmbeds) {
+				// Skip audio embeds that already have a summary below
+				if (hasSummaryBelow(lines, embed.line, embed.fileName)) continue;
+
+				targets.push({
+					type: 'audio',
+					source: embed.fileName,
+					line: embed.line,
+					endLine: embed.line,
+				});
+			}
+
+			// Re-sort by line number to maintain consistent ordering
+			targets.sort((a, b) => a.line - b.line);
+		}
+
+		return targets;
 	}
 
 	private async processTargets(
@@ -258,7 +306,14 @@ export class SummarizeModule {
 					// \u2500\u2500 Inline target: insert summary blockquote \u2500\u2500
 					let textToSummarize: string;
 
-					if (target.type === 'transcription' && target.content) {
+					if (target.type === 'audio' && this.transcribeAudio) {
+						op.update(`Transcribing audio ${target.source}`);
+						textToSummarize = await this.fetchContentForAudio(
+							target.source,
+							file,
+							settings.maxContentLength
+						);
+					} else if (target.type === 'transcription' && target.content) {
 						textToSummarize = target.content;
 					} else {
 						op.update(`Fetching ${target.source}`);
@@ -345,6 +400,28 @@ export class SummarizeModule {
 	}
 
 	/**
+	 * Transcribe an audio file embed and return its text content.
+	 * Resolves the file via MetadataCache, reads the binary data,
+	 * and calls the injected transcribeAudio callback.
+	 */
+	private async fetchContentForAudio(
+		fileName: string,
+		sourceFile: TFile,
+		maxLength: number
+	): Promise<string> {
+		const audioFile = this.plugin.app.metadataCache.getFirstLinkpathDest(
+			fileName,
+			sourceFile.path
+		);
+		if (!audioFile || !(audioFile instanceof TFile)) {
+			throw new Error(`Audio file not found in vault: ${fileName}`);
+		}
+
+		const transcript = await this.transcribeAudio!(audioFile);
+		return transcript.slice(0, maxLength);
+	}
+
+	/**
 	 * Build the vault path for a summary note without creating it.
 	 */
 	private buildNotePath(title: string, sourceFolder: string): string {
@@ -379,7 +456,7 @@ export class SummarizeModule {
 				if (this.isExcluded(file)) continue;
 
 				const content = await this.plugin.app.vault.read(file);
-				const targets = findSummarizeTargets(content);
+				const targets = this.collectTargets(content, file.path);
 				if (targets.length > 0) {
 					filesWithTargets.push({ file, targets });
 				}
@@ -430,7 +507,7 @@ export class SummarizeModule {
 			// changed since the initial scan, e.g. a previous file's
 			// enrichment callback modifying this file).
 			const content = await this.plugin.app.vault.read(file);
-			const targets = findSummarizeTargets(content);
+			const targets = this.collectTargets(content, file.path);
 			if (targets.length === 0) continue;
 			const result = await this.processFileTargets(file, targets, genOp, content);
 			totalInline += result.inlineCompleted;

--- a/src/summarize/summarize-modal.ts
+++ b/src/summarize/summarize-modal.ts
@@ -66,7 +66,9 @@ export class SummarizeSelectionModal extends Modal {
 
 			let label: string;
 			let desc: string | undefined;
-			if (target.type === 'transcription') {
+			if (target.type === 'audio') {
+				label = `Audio: ${target.source}`;
+			} else if (target.type === 'transcription') {
 				label = `Transcription: ${target.source}`;
 			} else if (target.inEnrichmentSection && target.linkTitle) {
 				label = `Reference: ${target.linkTitle}`;

--- a/src/summarize/types.ts
+++ b/src/summarize/types.ts
@@ -1,5 +1,5 @@
 export interface SummarizeTarget {
-	type: 'url' | 'transcription';
+	type: 'url' | 'transcription' | 'audio';
 	source: string;        // URL or transcription source label
 	line: number;          // line number in note
 	endLine: number;       // end of target block (for transcriptions)


### PR DESCRIPTION
## Summary
- Audio embeds (`![[recording.mp3]]`) are now detected as summarization targets
- Adds `'audio'` to the `SummarizeTarget.type` union in `src/summarize/types.ts`
- Creates `collectTargets()` in SummarizeModule that merges `findSummarizeTargets()` (pure string scanner) with `findAudioEmbeds()` (MetadataCache-aware), keeping the pure scanner unchanged
- Adds `fetchContentForAudio()` that resolves audio files via MetadataCache and calls the injected `transcribeAudio` callback
- Wires `AudioModule.transcribe()` into SummarizeModule via `main.ts`
- Adds "Audio: filename.mp3" label in the selection modal
- Skips audio embeds that already have a summary below them

## Test plan
- [x] TypeScript type-check passes (`npx tsc --noEmit --skipLibCheck`)
- [x] All 412 tests pass (`npm test`) -- 10 new tests added
- [x] Production build succeeds (`node esbuild.config.mjs production`)
- [x] Audio embeds are detected and converted to SummarizeTargets
- [x] Audio targets appear in the modal with "Audio: filename.mp3" labels
- [x] Audio targets are transcribed then summarized correctly
- [x] Already-summarized audio embeds are skipped
- [x] Missing audio files are handled gracefully
- [x] Empty transcription results show appropriate error

Co-Authored-By: Claude <bot@wafflenet.io>