### PR TITLE
feat: gate settings, commands, ribbon for mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -163,10 +163,12 @@ export default class AutoNotesPlugin extends Plugin {
 			this.activateUnifiedView();
 		});
 
-		// Unified transcription ribbon icon
-		this.addRibbonIcon('mic', 'Transcribe media', () => {
-			this.openUnifiedModal();
-		});
+		// Unified transcription ribbon icon (desktop only — mic icon implies video support)
+		if (Platform.isDesktop) {
+			this.addRibbonIcon('mic', 'Transcribe media', () => {
+				this.openUnifiedModal();
+			});
+		}
 
 		this.addCommand({
 			id: 'auto-notes:review-proposals',
@@ -183,8 +185,9 @@ export default class AutoNotesPlugin extends Plugin {
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
 		setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
 
-		// Unified transcription commands (if either audio or video enabled)
-		if (this.settings.audio.enabled || this.settings.video.enabled) {
+		// Unified transcription commands (audio on any platform, video on desktop only)
+		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video);
+		if (hasTranscription) {
 			this.addCommand({
 				id: 'auto-notes:transcribe-media',
 				name: 'Transcribe media',

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, Platform, PluginSettingTab, Setting } from 'obsidian';
 import type AutoNotesPlugin from './main';
 import { MODEL_OPTIONS } from './settings';
 import type { AIProvider } from './settings';
@@ -197,15 +197,19 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 					})
 			);
 
+		const providerOptions: Record<string, string> = {
+			'whisper-api': 'OpenAI Whisper API',
+			deepgram: 'Deepgram',
+		};
+		if (Platform.isDesktop) {
+			providerOptions['local-whisper'] = 'Local Whisper';
+		}
+
 		new Setting(containerEl)
 			.setName('Transcription provider')
 			.addDropdown((dd) =>
 				dd
-					.addOptions({
-						'whisper-api': 'OpenAI Whisper API',
-						deepgram: 'Deepgram',
-						'local-whisper': 'Local Whisper',
-					})
+					.addOptions(providerOptions)
 					.setValue(this.plugin.settings.audio.transcriptionProvider)
 					.onChange(async (value) => {
 						this.plugin.settings.audio.transcriptionProvider =
@@ -281,67 +285,69 @@ export class AutoNotesSettingTab extends PluginSettingTab {
 					})
 			);
 
-		// ── Video Transcription ──
-		containerEl.createEl('h3', { text: 'Video Transcription' });
+		// ── Video Transcription (desktop only — requires yt-dlp + ffmpeg) ──
+		if (Platform.isDesktop) {
+			containerEl.createEl('h3', { text: 'Video Transcription' });
 
-		new Setting(containerEl)
-			.setName('Enable video transcription')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.video.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.video.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
+			new Setting(containerEl)
+				.setName('Enable video transcription')
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.video.enabled)
+						.onChange(async (value) => {
+							this.plugin.settings.video.enabled = value;
+							await this.plugin.saveSettings();
+						})
+				);
 
-		new Setting(containerEl)
-			.setName('yt-dlp path')
-			.setDesc('Path to yt-dlp binary')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.video.ytDlpPath)
-					.onChange(async (value) => {
-						this.plugin.settings.video.ytDlpPath = value;
-						await this.plugin.saveSettings();
-					})
-			);
+			new Setting(containerEl)
+				.setName('yt-dlp path')
+				.setDesc('Path to yt-dlp binary')
+				.addText((text) =>
+					text
+						.setValue(this.plugin.settings.video.ytDlpPath)
+						.onChange(async (value) => {
+							this.plugin.settings.video.ytDlpPath = value;
+							await this.plugin.saveSettings();
+						})
+				);
 
-		new Setting(containerEl)
-			.setName('ffmpeg path')
-			.setDesc('Path to ffmpeg binary')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.video.ffmpegPath)
-					.onChange(async (value) => {
-						this.plugin.settings.video.ffmpegPath = value;
-						await this.plugin.saveSettings();
-					})
-			);
+			new Setting(containerEl)
+				.setName('ffmpeg path')
+				.setDesc('Path to ffmpeg binary')
+				.addText((text) =>
+					text
+						.setValue(this.plugin.settings.video.ffmpegPath)
+						.onChange(async (value) => {
+							this.plugin.settings.video.ffmpegPath = value;
+							await this.plugin.saveSettings();
+						})
+				);
 
-		new Setting(containerEl)
-			.setName('Video download folder')
-			.setDesc('Where to save downloaded video files in the vault')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.video.downloadFolder)
-					.onChange(async (value) => {
-						this.plugin.settings.video.downloadFolder = value;
-						await this.plugin.saveSettings();
-					})
-			);
+			new Setting(containerEl)
+				.setName('Video download folder')
+				.setDesc('Where to save downloaded video files in the vault')
+				.addText((text) =>
+					text
+						.setValue(this.plugin.settings.video.downloadFolder)
+						.onChange(async (value) => {
+							this.plugin.settings.video.downloadFolder = value;
+							await this.plugin.saveSettings();
+						})
+				);
 
-		new Setting(containerEl)
-			.setName('Embed video in note')
-			.setDesc('Add an embed link to the downloaded video file in the note')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.video.embedInNote)
-					.onChange(async (value) => {
-						this.plugin.settings.video.embedInNote = value;
-						await this.plugin.saveSettings();
-					})
-			);
+			new Setting(containerEl)
+				.setName('Embed video in note')
+				.setDesc('Add an embed link to the downloaded video file in the note')
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.video.embedInNote)
+						.onChange(async (value) => {
+							this.plugin.settings.video.embedInNote = value;
+							await this.plugin.saveSettings();
+						})
+				);
+		}
 
 		// ── Note Enrichment ──
 		containerEl.createEl('h2', { text: 'Note Enrichment' });

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Notice, Setting, TFile } from 'obsidian';
+import { App, Modal, Notice, Platform, Setting, TFile } from 'obsidian';
 import { AutoNotesSettings } from '../settings';
 import { AUDIO_EXTENSIONS } from '../audio';
 import { detectPlatform } from '../video';
@@ -56,8 +56,8 @@ export class UnifiedTranscriptionModal extends Modal {
 				.setDesc(ppStatus);
 		}
 
-		// URL section
-		if (this.enabledModules.video) {
+		// URL section (desktop only — video transcription requires yt-dlp + ffmpeg)
+		if (this.enabledModules.video && Platform.isDesktop) {
 			const platformBadge = contentEl.createDiv({
 				cls: 'auto-notes-platform-badge',
 			});


### PR DESCRIPTION
## Summary
- Hide entire Video Transcription settings section on mobile (requires yt-dlp + ffmpeg)
- Hide `local-whisper` provider option from audio transcription dropdown on mobile
- Gate `mic` ribbon icon behind `Platform.isDesktop`
- Gate transcription commands to only register when audio is enabled or video is available (desktop)
- Hide video URL input section in unified transcription modal on mobile

Closes #98

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — type checks pass
- [x] `npm test` — all 452 tests pass
- [ ] On mobile: no video settings visible, no mic ribbon, no video URL in modal
- [ ] On desktop: all features unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)