### PR TITLE
feat: portable ensureWithinVault + manifest flip

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
   "minAppVersion": "0.15.0",
   "description": "AI-powered note elaboration, audio transcription, and video transcription for Obsidian",
   "author": "Dustin Keeton",
-  "isDesktopOnly": true
+  "isDesktopOnly": false
 }

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { blockquoteOriginal } from './validation';
+import { blockquoteOriginal, ensureWithinVault } from './validation';
 
 describe('blockquoteOriginal', () => {
 	it('converts plain text to a blockquote with attribution', () => {
@@ -56,5 +56,55 @@ describe('blockquoteOriginal', () => {
 		// No valid frontmatter, so the whole thing gets blockquoted
 		expect(result).toContain('> ---');
 		expect(result).toContain('> Not actually frontmatter');
+	});
+});
+
+describe('ensureWithinVault', () => {
+	it('allows a simple relative path within the vault', () => {
+		const result = ensureWithinVault('notes/hello.md', '/vault');
+		expect(result).toBe('/vault/notes/hello.md');
+	});
+
+	it('resolves dot segments', () => {
+		const result = ensureWithinVault('notes/../notes/hello.md', '/vault');
+		expect(result).toBe('/vault/notes/hello.md');
+	});
+
+	it('resolves current-dir segments', () => {
+		const result = ensureWithinVault('./notes/hello.md', '/vault');
+		expect(result).toBe('/vault/notes/hello.md');
+	});
+
+	it('throws on path traversal that escapes the vault', () => {
+		expect(() => ensureWithinVault('../../etc/passwd', '/vault')).toThrow(
+			'Path escapes vault boundary'
+		);
+	});
+
+	it('throws on deeply nested traversal', () => {
+		expect(() =>
+			ensureWithinVault('notes/../../../etc/passwd', '/vault')
+		).toThrow('Path escapes vault boundary');
+	});
+
+	it('allows the vault root itself', () => {
+		const result = ensureWithinVault('.', '/vault');
+		expect(result).toBe('/vault');
+	});
+
+	it('normalizes backslashes to forward slashes', () => {
+		const result = ensureWithinVault('notes\\hello.md', '/vault');
+		expect(result).toBe('/vault/notes/hello.md');
+	});
+
+	it('handles absolute path inside vault', () => {
+		const result = ensureWithinVault('/vault/notes/hello.md', '/vault');
+		expect(result).toBe('/vault/notes/hello.md');
+	});
+
+	it('throws for absolute path outside vault', () => {
+		expect(() => ensureWithinVault('/other/path', '/vault')).toThrow(
+			'Path escapes vault boundary'
+		);
 	});
 });

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -68,18 +68,43 @@ export function sanitizePath(filePath: string): string {
 
 /**
  * Validates that a path resolves within a given base directory (vault boundary check).
+ * Uses portable string-based path resolution (no Node.js `path` module) so it works on mobile.
  * @throws Error if the path escapes the base directory.
  */
 export function ensureWithinVault(filePath: string, vaultBasePath: string): string {
-	const path = require('path') as typeof import('path');
-	const resolved = path.resolve(vaultBasePath, filePath);
-	const resolvedBase = path.resolve(vaultBasePath);
+	const resolved = portableResolve(vaultBasePath, filePath);
+	const resolvedBase = portableResolve(vaultBasePath);
 
 	if (!resolved.startsWith(resolvedBase + '/') && resolved !== resolvedBase) {
 		throw new Error('Path escapes vault boundary');
 	}
 
 	return resolved;
+}
+
+/**
+ * Portable path.resolve replacement: normalizes slashes, resolves `.` and `..` segments.
+ * If `relative` is absolute it is used as-is; otherwise it is joined to `base`.
+ */
+function portableResolve(base: string, relative?: string): string {
+	let combined = base.replace(/\\/g, '/');
+	if (relative) {
+		const rel = relative.replace(/\\/g, '/');
+		combined = rel.startsWith('/') ? rel : combined + '/' + rel;
+	}
+
+	const parts: string[] = [];
+	for (const seg of combined.split('/')) {
+		if (seg === '' || seg === '.') continue;
+		if (seg === '..') {
+			parts.pop();
+		} else {
+			parts.push(seg);
+		}
+	}
+
+	const prefix = combined.startsWith('/') ? '/' : '';
+	return prefix + parts.join('/');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace `require('path')` in `ensureWithinVault()` with portable string-based path resolution (works on mobile)
- Set `isDesktopOnly: false` in `manifest.json`
- Add 9 new tests for `ensureWithinVault` covering traversal attacks, dot segments, backslashes, absolute paths

Closes #99

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — type checks pass
- [x] `npm test` — all 461 tests pass (9 new)
- [ ] Verify `ensureWithinVault` blocks path traversal on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)