### PR TITLE
feat: mobile-responsive CSS

### DIFF
--- a/src/elaboration/proposal-modal.ts
+++ b/src/elaboration/proposal-modal.ts
@@ -44,7 +44,7 @@ export class ProposalDetailModal extends Modal {
 			cls: 'auto-notes-proposal-editor',
 		});
 		textarea.value = this.proposal.proposedAdditions;
-		textarea.rows = 20;
+		textarea.rows = 12;
 		textarea.style.width = '100%';
 		textarea.style.fontFamily = 'monospace';
 

--- a/styles.css
+++ b/styles.css
@@ -90,3 +90,39 @@
   --callout-color: 60, 180, 200;
   --callout-icon: lucide-layers;
 }
+
+/* ── Modal action buttons ── */
+
+.auto-notes-modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+/* ── Proposal editor textarea ── */
+
+.auto-notes-proposal-editor {
+  max-height: 60vh;
+  resize: vertical;
+}
+
+/* ── Mobile-responsive overrides ── */
+
+@media (max-width: 768px) {
+  .auto-notes-slider-wrapper {
+    min-width: 0;
+  }
+
+  .auto-notes-proposal-editor {
+    max-height: 40vh;
+  }
+
+  .auto-notes-modal-actions {
+    flex-direction: column;
+  }
+
+  .auto-notes-modal-actions button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `@media (max-width: 768px)` queries for mobile-friendly layout
- Define `.auto-notes-modal-actions` class (flex row with gap, stacks vertically on mobile)
- Define `.auto-notes-proposal-editor` class with `max-height: 60vh` (40vh on mobile)
- Remove `min-width: 200px` on slider wrapper for mobile
- Reduce textarea `rows` from 20 to 12 (CSS `max-height` handles overflow)

Closes #100

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — type checks pass
- [x] `npm test` — all 461 tests pass
- [ ] Verify modals, sliders, and buttons render properly on phone-sized screens
- [ ] No horizontal scrolling on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)