### PR TITLE
feat: enable agent teams and integrate with skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,10 @@
     "security-guidance@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "figma@claude-plugins-official": true
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }
 }

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -19,15 +19,89 @@ Run the full audit pipeline in consecutive order. Each agent audits the codebase
 
 ## Execution Steps
 
-1. Create a team named `audit-{timestamp}` with yourself as team lead
-2. Create 5 tasks with sequential blocking dependencies (task N+1 blocked by task N)
-3. Spawn agents one at a time. After each completes:
-   - Mark its task completed
-   - Shut it down
-   - Spawn the next agent
-4. For the second security pass, spawn a new security agent named `security-final`
-5. After all 5 complete, present the user a consolidated summary table of findings and fixes per agent
-6. Clean up: shut down all agents, delete the team
+### 1. Create Team
+
+```
+TeamCreate(team_name: "audit-{timestamp}")
+```
+
+### 2. Create Tasks with Dependencies
+
+```
+task1 = TaskCreate(description: "architect audit", team_name: "audit-{timestamp}")
+task2 = TaskCreate(description: "security pass 1", team_name: "audit-{timestamp}", addBlockedBy: [task1.id])
+task3 = TaskCreate(description: "docs-agent", team_name: "audit-{timestamp}", addBlockedBy: [task2.id])
+task4 = TaskCreate(description: "docs-human", team_name: "audit-{timestamp}", addBlockedBy: [task3.id])
+task5 = TaskCreate(description: "security pass 2", team_name: "audit-{timestamp}", addBlockedBy: [task4.id])
+```
+
+### 3. Spawn Agents Sequentially
+
+For each step, spawn the agent into the team, wait for completion, then proceed:
+
+```
+Agent(
+  subagent_type: "architect",
+  team_name: "audit-{timestamp}",
+  name: "architect",
+  prompt: <architect prompt>
+)
+# After completion:
+TaskUpdate(id: task1.id, status: "completed")
+```
+
+```
+Agent(
+  subagent_type: "security",
+  team_name: "audit-{timestamp}",
+  name: "security-pass1",
+  prompt: <security pass 1 prompt>
+)
+TaskUpdate(id: task2.id, status: "completed")
+```
+
+```
+Agent(
+  subagent_type: "docs-agent",
+  team_name: "audit-{timestamp}",
+  name: "docs-agent",
+  prompt: <docs-agent prompt>
+)
+TaskUpdate(id: task3.id, status: "completed")
+```
+
+```
+Agent(
+  subagent_type: "docs-human",
+  team_name: "audit-{timestamp}",
+  name: "docs-human",
+  prompt: <docs-human prompt>
+)
+TaskUpdate(id: task4.id, status: "completed")
+```
+
+```
+Agent(
+  subagent_type: "security",
+  team_name: "audit-{timestamp}",
+  name: "security-final",
+  prompt: <security pass 2 prompt>
+)
+TaskUpdate(id: task5.id, status: "completed")
+```
+
+### 4. Summary and Cleanup
+
+After all 5 complete, present the user a consolidated summary table of findings and fixes per agent, then clean up:
+
+```
+SendMessage(type: "shutdown_request", to: "architect")
+SendMessage(type: "shutdown_request", to: "security-pass1")
+SendMessage(type: "shutdown_request", to: "docs-agent")
+SendMessage(type: "shutdown_request", to: "docs-human")
+SendMessage(type: "shutdown_request", to: "security-final")
+TeamDelete(team_name: "audit-{timestamp}")
+```
 
 ## Agent Prompts
 
@@ -36,8 +110,8 @@ Each agent should:
 - Read the full codebase under `src/` and project root
 - Implement fixes directly (not just report)
 - Verify the build passes after changes (`npx tsc --noEmit`)
-- Send a findings summary to the team lead via SendMessage
-- Mark its task as completed via TaskUpdate
+- Send a findings summary to the team lead: `SendMessage(to: "team-lead", content: <summary>)`
+- Mark its task as completed: `TaskUpdate(id: <task_id>, status: "completed")`
 
 ### Architect (Task 1)
 Audit for: module pattern adherence, file structure conventions, naming (kebab-case files, PascalCase classes, camelCase functions), dependency rules (no circular deps), import paths (through index.ts), type exports in types.ts, main.ts lifecycle-only, index.ts as public API. Fix all issues.

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -137,6 +137,34 @@ See the `github-project-management` skill for the full GraphQL query catalog.
 
 ## Phase 4: Execute
 
+### Team Setup (multi-issue only)
+
+When delegating **2 or more issues**, create a team for coordination. Skip this for single-issue delegation.
+
+```
+TeamCreate(team_name: "delegate-{timestamp}")
+```
+
+Create a task per issue so agents can report progress:
+
+```
+# For each issue:
+task_N = TaskCreate(
+  description: "Issue #{number}: {title}",
+  team_name: "delegate-{timestamp}"
+)
+```
+
+For serial dependencies (e.g., shared/ bottleneck), chain tasks:
+
+```
+task_B = TaskCreate(
+  description: "Issue #{number}: {title}",
+  team_name: "delegate-{timestamp}",
+  addBlockedBy: [task_A.id]
+)
+```
+
 ### Branch naming
 
 Each agent gets a branch named per git-workflow conventions:
@@ -193,7 +221,22 @@ Errors in any step → log a warning and continue. Board updates must never bloc
 
 ### Spawning agents
 
-**Parallel groups** — spawn all agents in the group simultaneously using `isolation: "worktree"` on the Agent tool:
+**Parallel groups** — spawn all agents in the group simultaneously using `isolation: "worktree"`. When a team exists (multi-issue), include `team_name` and `name` for coordination:
+
+```
+Agent(
+  subagent_type: "plugin-architect",
+  isolation: "worktree",
+  team_name: "delegate-{timestamp}",
+  name: "issue-3-plugin-architect",
+  prompt: <agent prompt>,
+  description: "Issue #3: Fix UI hang"
+)
+```
+
+The `isolation: "worktree"` parameter automatically creates and cleans up a git worktree for the agent. No manual worktree management needed.
+
+**Single-issue fast path** — skip team creation entirely. Spawn a single agent without `team_name` or `name`:
 
 ```
 Agent(
@@ -203,8 +246,6 @@ Agent(
   description: "Issue #3: Fix UI hang"
 )
 ```
-
-The `isolation: "worktree"` parameter automatically creates and cleans up a git worktree for the agent. No manual worktree management needed.
 
 **Serial groups** — spawn agents one at a time in the main working directory. Wait for each to complete before spawning the next.
 
@@ -232,7 +273,8 @@ You are assigned to GitHub issue #{number}: {title}
    - npm test
    - node esbuild.config.mjs production
 5. Create a PR: gh pr create --title "{type}: {short description}" --body "..." targeting main
-6. Report back with a summary of changes made and the PR URL
+6. Mark your task as completed: TaskUpdate(id: <task_id>, status: "completed")
+7. Report back to the team lead: SendMessage(to: "team-lead", content: <summary with PR URL>)
 
 Branch name: {branch-name}
 ```
@@ -286,6 +328,17 @@ gh api graphql -f query='
 **Failed agents** leave the issue as "In Progress" — this is intentional, as stalled "In Progress" items are visible on the board as work that needs attention.
 
 Include any failures or skipped issues with reasons.
+
+### Team Cleanup (multi-issue only)
+
+After reporting, shut down the team:
+
+```
+# For each agent:
+SendMessage(type: "shutdown_request", to: "issue-{N}-{agent-type}")
+
+TeamDelete(team_name: "delegate-{timestamp}")
+```
 
 ## Error Handling
 

--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -46,3 +46,7 @@ After docs-agent completes, spawn the `docs-human` agent with this prompt:
 - Each step must complete before the next begins — the output of each informs the next.
 - The architect agent should NOT modify files — it only reports.
 - docs-agent and docs-human SHOULD modify their respective documentation files.
+
+## Why No Teams
+
+This skill intentionally does **not** use agent teams. The 3-step pipeline (architect → docs-agent → docs-human) is strictly sequential — each step's output is the next step's input. There is no parallelism to exploit, so team coordination overhead would add complexity with no benefit. If this pipeline gains a parallel step in the future, reconsider.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -96,7 +96,7 @@ EOF
 - Always target `main` as the base branch.
 - Push and PR without waiting for human approval — the user reviews in GitHub.
 
-## Parallel Work (Worktrees)
+## Parallel Work (Worktrees + Teams)
 
 When multiple agents work in parallel on files that might conflict:
 
@@ -105,12 +105,16 @@ When multiple agents work in parallel on files that might conflict:
    git worktree add ../auto-notes-feat-x feat/feature-x
    ```
 
-2. **Lock files** — if two agents suspect they'll edit the same file, one should finish first. Communicate via the team task list which files are being modified.
+2. **Lock files** — if two agents suspect they'll edit the same file, one should finish first. Use `TaskList(team_name: ...)` to check which files other agents are modifying.
 
-3. **Clean up** worktrees after merging:
+3. **Conflict alerting** — if you detect a potential conflict with another agent's work, notify them immediately: `SendMessage(to: "<agent-name>", content: "Conflict: I'm editing <file>")`.
+
+4. **Clean up** worktrees after merging:
    ```bash
    git worktree remove ../auto-notes-feat-x
    ```
+
+Teams and worktrees are orthogonal — teams provide coordination (task tracking, messaging), worktrees provide isolation (separate working directories). Use both together for parallel agent work.
 
 ## Pre-flight Checklist
 


### PR DESCRIPTION
## Summary
- Enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var in `.claude/settings.json`
- Update `audit` skill with concrete `TeamCreate`, `TaskCreate`, `TaskUpdate`, `SendMessage`, and `TeamDelete` invocations (replaces prose descriptions)
- Update `delegate` skill with conditional team setup for multi-issue delegation (2+ issues) and a single-issue fast path
- Update `git-workflow` skill's parallel work section with `TaskList` for lock visibility and `SendMessage` for conflict alerting
- Add "Why No Teams" design decision note to `docs` skill (sequential pipeline doesn't benefit from teams)

closes #75

## Test plan
- [ ] Start a new Claude Code session and verify `TeamCreate` is available as a tool
- [ ] Run `/audit` on a small focus area to smoke-test updated skill
- [ ] Run `/delegate` with a single issue to verify fast path
- [ ] Run `/delegate` with 2+ issues to verify team creation and coordination
- [ ] No build/test impact — all changes are `.claude/` config files

Co-Authored-By: Claude <bot@wafflenet.io>