### PR TITLE
feat: add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Verify versions
+        run: |
+          MANIFEST_VERSION=$(node -p "require('./manifest.json').version")
+          MANIFEST_MIN=$(node -p "require('./manifest.json').minAppVersion")
+          VERSIONS_MIN=$(node -p "require('./versions.json')['$MANIFEST_VERSION']")
+          if [ "$MANIFEST_MIN" != "$VERSIONS_MIN" ]; then
+            echo "ERROR: versions.json minAppVersion ($VERSIONS_MIN) does not match manifest.json minAppVersion ($MANIFEST_MIN) for version $MANIFEST_VERSION"
+            exit 1
+          fi
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: manifest.json version ($MANIFEST_VERSION) does not match tag version ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Build
+        run: node esbuild.config.mjs production
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            main.js
+            manifest.json
+            styles.css


### PR DESCRIPTION
## Summary
- Add release workflow triggered by `v*` tag pushes
- Verifies `versions.json` and `manifest.json` consistency and tag version match
- Builds production bundle and creates GitHub Release with `main.js`, `manifest.json`, `styles.css`
- Uses `softprops/action-gh-release@v2` with `permissions: contents: write`

## Test plan
- [ ] Verify workflow triggers on `v*` tag push
- [ ] Verify version consistency check catches mismatches
- [ ] Verify all three release assets are attached (main.js, manifest.json, styles.css)
- [ ] Verify BRAT can install from the GitHub Release

closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)