### PR TITLE
docs: add BRAT installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Synapse is not yet published to the Obsidian Community Plugin directory. To inst
 
 4. Open Obsidian, go to **Settings > Community plugins**, and enable **Synapse**.
 
+### Install via BRAT (Beta Reviewers Auto-update Tester)
+
+If you prefer automatic updates during the beta period:
+
+1. Install the [BRAT plugin](https://github.com/TfTHacker/obsidian42-brat) from the Obsidian Community Plugin directory.
+2. In BRAT settings, click **Add Beta Plugin**.
+3. Enter `dustinkeeton/obsidian-synapse` and click **Add Plugin**.
+4. Enable **Synapse** in **Settings > Community plugins**.
+
+BRAT will automatically check for updates and notify you when new versions are available.
+
 ### External tools (optional)
 
 For video transcription, you need these tools installed and available on your PATH:


### PR DESCRIPTION
## Summary
- Add BRAT (Beta Reviewers Auto-update Tester) installation section to README.md
- Provides step-by-step instructions for installing Synapse via BRAT
- Confirmed `versions.json` already matches `manifest.json` — no changes needed
- Related: #77 (CI workflow) and #78 (release workflow) handle the technical infrastructure

## Test plan
- [ ] Verify BRAT section appears after manual installation instructions
- [ ] Verify instructions are accurate for BRAT plugin workflow
- [ ] Verify `versions.json` consistency with `manifest.json`

closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)