### PR TITLE
feat: add Reject All button for proposals

### DIFF
--- a/src/views/unified-proposal-view.test.ts
+++ b/src/views/unified-proposal-view.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UnifiedProposalView, UnifiedItem, UnifiedViewCallbacks } from './unified-proposal-view';
+import type { Proposal } from '../elaboration';
+import type { EnrichmentProposal } from '../enrichment';
+import type { OrganizeProposal } from '../organize';
+import type { DeepDiveProposal } from '../deep-dive';
+
+// --- Helpers ----------------------------------------------------------------
+
+/** Stub WorkspaceLeaf that satisfies ItemView constructor. */
+function mockLeaf(): any {
+	return { view: {} };
+}
+
+/** Create a stub callbacks object with all methods as spies. */
+function mockCallbacks(): UnifiedViewCallbacks {
+	return {
+		onElaborationAccept: vi.fn().mockResolvedValue(undefined),
+		onElaborationReject: vi.fn().mockResolvedValue(undefined),
+		onEnrichmentAcceptSelected: vi.fn().mockResolvedValue(undefined),
+		onEnrichmentReject: vi.fn().mockResolvedValue(undefined),
+		onOrganizeAccept: vi.fn().mockResolvedValue(undefined),
+		onOrganizeReject: vi.fn().mockResolvedValue(undefined),
+		onDeepDiveAccept: vi.fn().mockResolvedValue(undefined),
+		onDeepDiveReject: vi.fn().mockResolvedValue(undefined),
+		onCheckpointDiscard: vi.fn().mockResolvedValue(undefined),
+		onCheckpointResume: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+/** Minimal elaboration proposal. */
+function makeElaborationItem(id = 'elab-1'): UnifiedItem {
+	return {
+		kind: 'elaboration',
+		data: {
+			id,
+			sourceNotePath: 'notes/test.md',
+			createdAt: '2024-01-01T00:00:00Z',
+			detectionReasons: [{ type: 'short-note', wordCount: 10 }],
+			originalContent: 'original',
+			proposedAdditions: 'additions',
+			insertionPoint: 'append',
+			status: 'pending',
+		} as Proposal,
+	};
+}
+
+/** Minimal enrichment proposal. */
+function makeEnrichmentItem(id = 'enrich-1'): UnifiedItem {
+	return {
+		kind: 'enrichment',
+		data: {
+			id,
+			sourceNotePath: 'notes/test.md',
+			createdAt: '2024-01-01T00:00:00Z',
+			triggerSource: 'manual',
+			result: {
+				tags: [],
+				internalLinks: [],
+				externalLinks: [],
+				frontmatter: [],
+			},
+			status: 'pending',
+		} as EnrichmentProposal,
+	};
+}
+
+/** Minimal organize proposal. */
+function makeOrganizeItem(id = 'org-1'): UnifiedItem {
+	return {
+		kind: 'organize',
+		data: {
+			id,
+			sourceNotePath: 'notes/test.md',
+			proposedDirectory: 'organized/',
+			reasoning: 'fits better here',
+			createdAt: '2024-01-01T00:00:00Z',
+			status: 'pending',
+		} as OrganizeProposal,
+	};
+}
+
+/** Minimal deep dive proposal. */
+function makeDeepDiveItem(id = 'dd-1'): UnifiedItem {
+	return {
+		kind: 'deep-dive',
+		data: {
+			id,
+			runId: 'run-1',
+			sourceNotePath: 'notes/test.md',
+			topic: { title: 'AI Ethics', description: 'desc', relevance: 0.9, existsInVault: false, relatedUrls: [] },
+			proposedPath: 'notes/ai-ethics.md',
+			proposedContent: '# AI Ethics\ncontent',
+			depth: 0,
+			qualityScore: { score: 0.8, topicCount: 3, wordCount: 100, isTooGeneric: false, hasHighOverlap: false, reasoning: 'good' },
+			childProposalIds: [],
+			createdAt: '2024-01-01T00:00:00Z',
+			status: 'pending',
+		} as DeepDiveProposal,
+	};
+}
+
+// --- Tests ------------------------------------------------------------------
+
+/** Create a deeply-recursive stub DOM element that supports all Obsidian HTML methods. */
+function stubEl(): any {
+	const el: any = {
+		style: {},
+		disabled: false,
+		value: '',
+		readOnly: false,
+		checked: false,
+		textContent: '',
+		empty: vi.fn(),
+		addClass: vi.fn(),
+		addEventListener: vi.fn(),
+		closest: vi.fn().mockReturnValue(null),
+		createEl: vi.fn().mockImplementation(() => stubEl()),
+		createDiv: vi.fn().mockImplementation(() => stubEl()),
+	};
+	return el;
+}
+
+describe('UnifiedProposalView reject-all', () => {
+	let view: any; // cast to any to access private methods
+	let callbacks: UnifiedViewCallbacks;
+
+	beforeEach(() => {
+		callbacks = mockCallbacks();
+		view = new UnifiedProposalView(mockLeaf(), callbacks);
+		// Stub contentEl with a recursive mock so render calls don't throw
+		view.contentEl = stubEl();
+	});
+
+	describe('rejectSingleItem', () => {
+		it('dispatches to onElaborationReject for elaboration items', async () => {
+			const item = makeElaborationItem('elab-42');
+			await view.rejectSingleItem(item);
+			expect(callbacks.onElaborationReject).toHaveBeenCalledWith('elab-42');
+		});
+
+		it('dispatches to onEnrichmentReject for enrichment items', async () => {
+			const item = makeEnrichmentItem('enrich-42');
+			await view.rejectSingleItem(item);
+			expect(callbacks.onEnrichmentReject).toHaveBeenCalledWith('enrich-42');
+		});
+
+		it('dispatches to onOrganizeReject for organize items', async () => {
+			const item = makeOrganizeItem('org-42');
+			await view.rejectSingleItem(item);
+			expect(callbacks.onOrganizeReject).toHaveBeenCalledWith('org-42');
+		});
+
+		it('dispatches to onDeepDiveReject for deep-dive items', async () => {
+			const item = makeDeepDiveItem('dd-42');
+			await view.rejectSingleItem(item);
+			expect(callbacks.onDeepDiveReject).toHaveBeenCalledWith('dd-42');
+		});
+	});
+
+	describe('rejectAll', () => {
+		it('rejects all items sequentially', async () => {
+			const items = [
+				makeElaborationItem('e1'),
+				makeEnrichmentItem('en1'),
+				makeOrganizeItem('o1'),
+				makeDeepDiveItem('d1'),
+			];
+			view.items = items;
+
+			await view.rejectAll();
+
+			expect(callbacks.onElaborationReject).toHaveBeenCalledWith('e1');
+			expect(callbacks.onEnrichmentReject).toHaveBeenCalledWith('en1');
+			expect(callbacks.onOrganizeReject).toHaveBeenCalledWith('o1');
+			expect(callbacks.onDeepDiveReject).toHaveBeenCalledWith('d1');
+		});
+
+		it('calls reject callbacks in presentation order', async () => {
+			const callOrder: string[] = [];
+			(callbacks.onElaborationReject as any).mockImplementation((id: string) => {
+				callOrder.push(`elab-${id}`);
+				return Promise.resolve();
+			});
+			(callbacks.onEnrichmentReject as any).mockImplementation((id: string) => {
+				callOrder.push(`enrich-${id}`);
+				return Promise.resolve();
+			});
+
+			view.items = [
+				makeElaborationItem('1'),
+				makeEnrichmentItem('2'),
+				makeElaborationItem('3'),
+			];
+
+			await view.rejectAll();
+
+			expect(callOrder).toEqual(['elab-1', 'enrich-2', 'elab-3']);
+		});
+
+		it('stops on first failure and reports partial progress', async () => {
+			(callbacks.onEnrichmentReject as any).mockRejectedValue(new Error('network'));
+
+			view.items = [
+				makeElaborationItem('e1'),
+				makeEnrichmentItem('en1'),
+				makeOrganizeItem('o1'),
+			];
+
+			await view.rejectAll();
+
+			// First item was rejected successfully
+			expect(callbacks.onElaborationReject).toHaveBeenCalledWith('e1');
+			// Second item failed
+			expect(callbacks.onEnrichmentReject).toHaveBeenCalledWith('en1');
+			// Third item was never attempted
+			expect(callbacks.onOrganizeReject).not.toHaveBeenCalled();
+		});
+
+		it('does nothing when already in progress', async () => {
+			view.items = [makeElaborationItem('e1'), makeElaborationItem('e2')];
+			view.rejectAllInProgress = true;
+
+			await view.rejectAll();
+
+			expect(callbacks.onElaborationReject).not.toHaveBeenCalled();
+		});
+
+		it('does nothing when acceptAll is in progress', async () => {
+			view.items = [makeElaborationItem('e1'), makeElaborationItem('e2')];
+			view.acceptAllInProgress = true;
+
+			await view.rejectAll();
+
+			expect(callbacks.onElaborationReject).not.toHaveBeenCalled();
+		});
+
+		it('resets rejectAllInProgress flag after completion', async () => {
+			view.items = [makeElaborationItem('e1'), makeElaborationItem('e2')];
+
+			await view.rejectAll();
+
+			expect(view.rejectAllInProgress).toBe(false);
+		});
+
+		it('resets rejectAllInProgress flag after failure', async () => {
+			(callbacks.onElaborationReject as any).mockRejectedValue(new Error('fail'));
+			view.items = [makeElaborationItem('e1')];
+
+			await view.rejectAll();
+
+			expect(view.rejectAllInProgress).toBe(false);
+		});
+
+		it('handles single proposal correctly (singular notice text)', async () => {
+			view.items = [makeElaborationItem('e1')];
+
+			// rejectAll should still work even with 1 item
+			// (the button is only shown for 2+, but the method itself has no guard)
+			await view.rejectAll();
+
+			expect(callbacks.onElaborationReject).toHaveBeenCalledWith('e1');
+		});
+	});
+
+	describe('acceptAll guards', () => {
+		it('does nothing when rejectAll is in progress', async () => {
+			view.items = [makeElaborationItem('e1'), makeElaborationItem('e2')];
+			view.rejectAllInProgress = true;
+
+			await view.acceptAll();
+
+			expect(callbacks.onElaborationAccept).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -50,6 +50,7 @@ export class UnifiedProposalView extends ItemView {
 	private reviewingDeepDive: DeepDiveProposal | null = null;
 
 	private acceptAllInProgress = false;
+	private rejectAllInProgress = false;
 
 	// Enrichment review selection state
 	private selectedTags = new Set<string>();
@@ -157,7 +158,7 @@ export class UnifiedProposalView extends ItemView {
 	 * Stops on the first failure, leaving remaining proposals untouched.
 	 */
 	private async acceptAll(): Promise<void> {
-		if (this.acceptAllInProgress) return;
+		if (this.acceptAllInProgress || this.rejectAllInProgress) return;
 		this.acceptAllInProgress = true;
 
 		// Snapshot the items in current presentation order
@@ -240,6 +241,76 @@ export class UnifiedProposalView extends ItemView {
 
 	/** Render a minimal progress indicator during batch accept. */
 	private renderAcceptAllProgress(current: number, total: number): void {
+		this.renderBulkProgress('Accepting', current, total);
+	}
+
+	// ── Reject All ────────────────────────────────────────────
+
+	/**
+	 * Reject every pending proposal in presentation order (top to bottom).
+	 * Runs sequentially to match acceptAll() behavior.
+	 * Stops on the first failure, leaving remaining proposals untouched.
+	 */
+	private async rejectAll(): Promise<void> {
+		if (this.rejectAllInProgress || this.acceptAllInProgress) return;
+		this.rejectAllInProgress = true;
+
+		// Snapshot the items in current presentation order
+		const snapshot = [...this.items];
+		const total = snapshot.length;
+		let rejected = 0;
+
+		// Show initial progress
+		this.renderRejectAllProgress(rejected, total);
+
+		for (const item of snapshot) {
+			try {
+				await this.rejectSingleItem(item);
+				rejected++;
+				this.renderRejectAllProgress(rejected, total);
+			} catch (err) {
+				this.rejectAllInProgress = false;
+				const label = this.itemLabel(item);
+				const message = err instanceof Error ? err.message : String(err);
+				new Notice(
+					`Reject All stopped: failed on "${label}" -- ${message}. ` +
+					`${rejected}/${total} rejected, ${total - rejected} remaining.`
+				);
+				this.render();
+				return;
+			}
+		}
+
+		this.rejectAllInProgress = false;
+		new Notice(`${rejected} proposal${rejected === 1 ? '' : 's'} rejected`);
+		this.render();
+	}
+
+	/** Call the appropriate reject callback for a single proposal item. */
+	private async rejectSingleItem(item: UnifiedItem): Promise<void> {
+		switch (item.kind) {
+			case 'elaboration':
+				await this.callbacks.onElaborationReject(item.data.id);
+				break;
+			case 'enrichment':
+				await this.callbacks.onEnrichmentReject(item.data.id);
+				break;
+			case 'organize':
+				await this.callbacks.onOrganizeReject(item.data.id);
+				break;
+			case 'deep-dive':
+				await this.callbacks.onDeepDiveReject(item.data.id);
+				break;
+		}
+	}
+
+	/** Render a minimal progress indicator during batch reject. */
+	private renderRejectAllProgress(current: number, total: number): void {
+		this.renderBulkProgress('Rejecting', current, total);
+	}
+
+	/** Render a progress indicator for bulk accept/reject operations. */
+	private renderBulkProgress(verb: string, current: number, total: number): void {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('synapse-view-root');
@@ -247,7 +318,7 @@ export class UnifiedProposalView extends ItemView {
 
 		const progressBar = contentEl.createDiv({ cls: 'synapse-accept-all-progress' });
 		progressBar.createEl('p', {
-			text: `Accepting ${current + 1}/${total}...`,
+			text: `${verb} ${current + 1}/${total}...`,
 			cls: 'synapse-accept-all-progress-text',
 		});
 
@@ -281,17 +352,28 @@ export class UnifiedProposalView extends ItemView {
 			return;
 		}
 
-		// Accept All button — only when 2+ proposals are pending
+		// Accept All / Reject All buttons — only when 2+ proposals are pending
 		if (this.items.length >= 2) {
-			const acceptAllBar = contentEl.createDiv({ cls: 'synapse-accept-all-bar' });
-			const acceptAllBtn = acceptAllBar.createEl('button', {
+			const bulkBar = contentEl.createDiv({ cls: 'synapse-accept-all-bar' });
+			const bulkInProgress = this.acceptAllInProgress || this.rejectAllInProgress;
+
+			const acceptAllBtn = bulkBar.createEl('button', {
 				text: 'Accept All',
 				cls: 'synapse-accept-all-btn mod-cta',
 			});
-			if (this.acceptAllInProgress) {
+			if (bulkInProgress) {
 				acceptAllBtn.disabled = true;
 			}
 			acceptAllBtn.addEventListener('click', () => this.acceptAll());
+
+			const rejectAllBtn = bulkBar.createEl('button', {
+				text: 'Reject All',
+				cls: 'synapse-reject-all-btn',
+			});
+			if (bulkInProgress) {
+				rejectAllBtn.disabled = true;
+			}
+			rejectAllBtn.addEventListener('click', () => this.rejectAll());
 		}
 
 		const list = contentEl.createDiv({ cls: 'synapse-proposal-list' });
@@ -1262,13 +1344,15 @@ export class UnifiedProposalView extends ItemView {
 				transition: width 0.2s ease;
 			}
 
-			/* ── Accept All ── */
+			/* ── Accept All / Reject All ── */
 			.synapse-accept-all-bar {
 				flex-shrink: 0;
+				display: flex;
+				gap: 6px;
 				margin-bottom: 8px;
 			}
 			.synapse-accept-all-btn {
-				width: 100%;
+				flex: 1;
 				padding: 6px 16px;
 				border-radius: 4px;
 				font-size: 13px;
@@ -1282,6 +1366,24 @@ export class UnifiedProposalView extends ItemView {
 				opacity: 0.9;
 			}
 			.synapse-accept-all-btn:disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
+			.synapse-reject-all-btn {
+				flex: 1;
+				padding: 6px 16px;
+				border-radius: 4px;
+				font-size: 13px;
+				font-weight: 600;
+				cursor: pointer;
+				border: 1px solid var(--background-modifier-border);
+				background: var(--background-primary);
+				color: var(--text-normal);
+			}
+			.synapse-reject-all-btn:hover {
+				background: var(--background-modifier-hover);
+			}
+			.synapse-reject-all-btn:disabled {
 				opacity: 0.5;
 				cursor: not-allowed;
 			}


### PR DESCRIPTION
## Summary
- Add a "Reject All" button next to "Accept All" in the unified proposal view, visible when 2+ proposals are pending
- Sequentially rejects every pending proposal using existing per-type reject callbacks (`onElaborationReject`, `onEnrichmentReject`, `onOrganizeReject`, `onDeepDiveReject`)
- Shows progress feedback during bulk reject (e.g., "Rejecting 3/7...") and stops on first failure with a descriptive notice
- Uses a non-destructive button style (no `mod-cta`) to visually distinguish from "Accept All"
- Adds mutual exclusion so Accept All and Reject All cannot run concurrently
- Refactors the progress renderer into a shared `renderBulkProgress()` method to reduce duplication

Closes #140

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (480 tests, including 13 new tests for reject-all)
- [x] `node esbuild.config.mjs production` builds cleanly
- [ ] Manual: open Synapse sidebar with 2+ proposals, verify "Reject All" button appears next to "Accept All"
- [ ] Manual: click "Reject All" and confirm progress bar and completion notice
- [ ] Manual: verify both buttons are disabled while either bulk operation is in progress

Co-Authored-By: Claude <bot@wafflenet.io>