### PR TITLE
chore: add authorUrl to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,6 @@
   "minAppVersion": "0.15.0",
   "description": "AI-powered note elaboration, audio transcription, and video transcription for Obsidian",
   "author": "Dustin Keeton",
+  "authorUrl": "https://github.com/dustinkeeton",
   "isDesktopOnly": false
 }


### PR DESCRIPTION
## Summary
- Adds `authorUrl` field to `manifest.json` pointing to the author's GitHub profile (`https://github.com/dustinkeeton`)
- Recommended metadata for Obsidian community plugins

closes #84

## Test plan
- [x] Build passes (`npm run build`)
- [x] `manifest.json` is valid JSON with the new field

Co-Authored-By: Claude <bot@wafflenet.io>