### PR TITLE
fix: strip code fences from AI elaboration output

### DIFF
--- a/src/deep-dive/note-generator.ts
+++ b/src/deep-dive/note-generator.ts
@@ -1,5 +1,5 @@
 import { SynapseSettings } from '../settings';
-import { AIClient, sanitizeAIResponse } from '../shared';
+import { AIClient, sanitizeAIResponse, stripCodeFences } from '../shared';
 import { ExtractedTopic } from './types';
 
 /**
@@ -46,12 +46,11 @@ Context from parent note (for reference, do not repeat):
 ${sourceContent.slice(0, 2000)}`;
 
 		const content = await this.aiClient.complete(userPrompt, systemPrompt);
-		return this.cleanContent(sanitizeAIResponse(content), topic, sourceTitle);
+		return this.cleanContent(stripCodeFences(sanitizeAIResponse(content)), topic, sourceTitle);
 	}
 
 	private cleanContent(content: string, topic: ExtractedTopic, sourceTitle: string): string {
-		// Strip markdown code fences if AI wrapped the entire response
-		let cleaned = content.replace(/^```(?:markdown|md)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+		let cleaned = content.trim();
 
 		// If AI added an H1 title, remove it (Obsidian uses filename)
 		cleaned = cleaned.replace(/^#\s+.+\n+/, '');

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -2,7 +2,7 @@ import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import {
 	buildCallout, CALLOUT_TYPES, FolderPickerModal, getMarkdownFiles,
-	NotificationManager, sanitizeAIResponse, CheckpointManager, generateId,
+	NotificationManager, sanitizeAIResponse, stripCodeFences, CheckpointManager, generateId,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { PlaceholderDetector } from './detector';
@@ -303,7 +303,7 @@ export class ElaborationModule {
 
 		const content = await this.plugin.app.vault.read(file);
 		const additions = editedContent ?? proposal.proposedAdditions;
-		const sanitizedAdditions = sanitizeAIResponse(additions);
+		const sanitizedAdditions = stripCodeFences(sanitizeAIResponse(additions));
 		const callout = buildCallout(
 			CALLOUT_TYPES.elaboration,
 			'Elaboration',

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -1,6 +1,6 @@
 import { App } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, sanitizeAIResponse } from '../shared';
+import { AIClient, sanitizeAIResponse, stripCodeFences } from '../shared';
 import { DetectionResult, Proposal } from './types';
 
 export class ProposalGenerator {
@@ -23,10 +23,10 @@ export class ProposalGenerator {
 		}
 
 		const prompt = this.buildPrompt(content, detection, contextNotes);
-		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format.`;
+		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences.`;
 
 		const rawAdditions = await this.aiClient.complete(prompt, systemPrompt);
-		const proposedAdditions = sanitizeAIResponse(rawAdditions);
+		const proposedAdditions = stripCodeFences(sanitizeAIResponse(rawAdditions));
 
 		return {
 			id: this.generateId(),

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -16,6 +16,7 @@ export {
 	sanitizePath,
 	ensureWithinVault,
 	sanitizeAIResponse,
+	stripCodeFences,
 	blockquoteOriginal,
 } from './validation';
 export { CALLOUT_TYPES, buildCallout } from './callouts';

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { blockquoteOriginal, ensureWithinVault } from './validation';
+import { blockquoteOriginal, ensureWithinVault, stripCodeFences } from './validation';
 
 describe('blockquoteOriginal', () => {
 	it('converts plain text to a blockquote with attribution', () => {
@@ -106,5 +106,57 @@ describe('ensureWithinVault', () => {
 		expect(() => ensureWithinVault('/other/path', '/vault')).toThrow(
 			'Path escapes vault boundary'
 		);
+	});
+});
+
+describe('stripCodeFences', () => {
+	it('strips plain code fences wrapping content', () => {
+		const input = '```\nHello world\n```';
+		expect(stripCodeFences(input)).toBe('Hello world');
+	});
+
+	it('strips fences with "markdown" specifier', () => {
+		const input = '```markdown\n## Heading\nSome text\n```';
+		expect(stripCodeFences(input)).toBe('## Heading\nSome text');
+	});
+
+	it('strips fences with "md" specifier', () => {
+		const input = '```md\n## Heading\nSome text\n```';
+		expect(stripCodeFences(input)).toBe('## Heading\nSome text');
+	});
+
+	it('preserves multi-line content inside fences', () => {
+		const input = '```\nLine 1\nLine 2\nLine 3\n```';
+		expect(stripCodeFences(input)).toBe('Line 1\nLine 2\nLine 3');
+	});
+
+	it('returns input unchanged when there are no fences', () => {
+		const input = 'Just some regular text\nwith multiple lines';
+		expect(stripCodeFences(input)).toBe(input);
+	});
+
+	it('does not strip when only an opening fence is present', () => {
+		const input = '```\nSome content without closing fence';
+		expect(stripCodeFences(input)).toBe(input);
+	});
+
+	it('does not strip when only a closing fence is present', () => {
+		const input = 'Some content without opening fence\n```';
+		expect(stripCodeFences(input)).toBe(input);
+	});
+
+	it('does not strip internal code blocks within larger content', () => {
+		const input = 'Before\n```js\nconst x = 1;\n```\nAfter';
+		expect(stripCodeFences(input)).toBe(input);
+	});
+
+	it('trims leading and trailing whitespace', () => {
+		const input = '  \n```\nContent\n```\n  ';
+		expect(stripCodeFences(input)).toBe('Content');
+	});
+
+	it('handles empty content inside fences', () => {
+		const input = '```\n```';
+		expect(stripCodeFences(input)).toBe('');
 	});
 });

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -129,6 +129,19 @@ export function sanitizeAIResponse(text: string): string {
 }
 
 /**
+ * Removes wrapping code fences that LLMs sometimes add despite instructions.
+ * Only strips when the entire text is wrapped in a single code fence block.
+ */
+export function stripCodeFences(text: string): string {
+	const trimmed = text.trim();
+	if (trimmed.startsWith('```') && trimmed.endsWith('```')) {
+		const lines = trimmed.split('\n');
+		return lines.slice(1, -1).join('\n');
+	}
+	return trimmed;
+}
+
+/**
  * Converts note body content into a blockquote with user-attribution.
  * Preserves YAML frontmatter (if present) outside the blockquote.
  */

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, NotificationManager, parseFrontmatter, sanitizeAIResponse, serializeFrontmatter, withRetry, generateId } from '../shared';
+import { AIClient, NotificationManager, parseFrontmatter, sanitizeAIResponse, stripCodeFences, serializeFrontmatter, withRetry, generateId } from '../shared';
 import { TidyStore } from './tidy-store';
 import { TidySnapshot } from './types';
 
@@ -102,7 +102,7 @@ export class TidyModule {
 
 			// Sanitize AI output then strip any code fences the AI may have wrapped it in
 			const sanitized = sanitizeAIResponse(tidiedBody);
-			const cleaned = this.stripCodeFences(sanitized);
+			const cleaned = stripCodeFences(sanitized);
 
 			// Reassemble with original frontmatter
 			const finalContent = parsed.frontmatter
@@ -128,17 +128,6 @@ export class TidyModule {
 		await this.plugin.app.vault.modify(file, snapshot.originalContent);
 		await this.store.remove(file.path);
 		this.notifications.success('Tidy undone');
-	}
-
-	/** Remove wrapping code fences that LLMs sometimes add despite instructions. */
-	private stripCodeFences(text: string): string {
-		const trimmed = text.trim();
-		if (trimmed.startsWith('```') && trimmed.endsWith('```')) {
-			// Remove first line (```markdown or ```) and last line (```)
-			const lines = trimmed.split('\n');
-			return lines.slice(1, -1).join('\n');
-		}
-		return trimmed;
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds explicit "Do not wrap the output in code fences" instruction to the elaboration system prompt
- Creates a shared `stripCodeFences()` utility in `src/shared/validation.ts` as a formatting normalizer (separate from security-focused `sanitizeAIResponse()`)
- Applies `stripCodeFences` as a post-processing step in elaboration (proposer + accept), tidy, and deep-dive modules
- Removes duplicate private `stripCodeFences` method from TidyModule and inline regex stripping from NoteGenerator
- Adds 10 test cases covering plain fences, language specifiers, multi-line content, no-fence passthrough, partial fences, internal code blocks, whitespace trimming, and empty content

closes #121

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (490 tests)
- [x] `node esbuild.config.mjs production` builds successfully

Co-Authored-By: Claude <bot@wafflenet.io>