### PR TITLE
feat: add content-aware summary templates with recipe detection

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -582,6 +582,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
+		new Setting(containerEl)
+			.setName('Auto-detect content templates')
+			.setDesc('Automatically detect content type (e.g. recipes) and use a specialized summary format')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.summarize.autoDetectTemplates)
+				.onChange(async (value) => {
+					this.plugin.settings.summarize.autoDetectTemplates = value;
+					await this.plugin.saveSettings();
+				}));
+
 		addEnhancedSlider(
 			new Setting(containerEl)
 				.setName('Max content length')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -133,6 +133,7 @@ export interface SummarizeSettings {
 	maxContentLength: number;
 	summaryStyle: 'bullets' | 'paragraph' | 'key-points';
 	customPrompt: string;
+	autoDetectTemplates: boolean;
 	excludeFolders: string[];
 	excludeTags: string[];
 	autoOrganizeOnSummarize: boolean;
@@ -278,6 +279,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		maxContentLength: 4000,
 		summaryStyle: 'bullets',
 		customPrompt: '',
+		autoDetectTemplates: true,
 		excludeFolders: ['templates', '.synapse'],
 		excludeTags: ['no-summarize'],
 		autoOrganizeOnSummarize: false,

--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -49,6 +49,8 @@ Exported types: `SummarizeTarget`, `SummarizeSettings`, `TranscribeUrlFn`, `Tran
 | `summarize-modal.ts` | `SummarizeSelectionModal` | Selection modal when multiple targets found |
 | `summarize-module.test.ts` | Tests | SummarizeModule integration tests |
 | `audio-summarize.test.ts` | Tests | Audio-embed summarization tests |
+| `templates.ts` | `detectContentTemplate`, `isRecipeContent`, `scoreRecipeContent`, `CONTENT_TEMPLATES` | Content-aware template detection (recipe format, extensible) |
+| `templates.test.ts` | Tests | Template detection unit tests |
 | `types.ts` | -- | `SummarizeTarget` |
 
 ## Data Flow
@@ -72,9 +74,11 @@ processFileTargets(file, targets, op, content)
       --> fetchContentForAudio(fileName, sourceFile)  [transcribeAudio callback]
       --> Summarizer.summarize(transcript, source, style)
       --> insert callout after target line
-    else:
+    else (inline target):
       --> fetchContentForUrl(url) or use transcription content
-      --> Summarizer.summarize(content, url, style)
+      --> determine effectivePrompt:
+            customPrompt > detectContentTemplate(content) > style default
+      --> Summarizer.summarize(content, url, style, effectivePrompt)
       --> insert callout after target line
   --> vault.modify(sourceFile)
   --> vault.create() for pending notes
@@ -151,10 +155,32 @@ this.summarize = new SummarizeModule(
 - `audio/` (findAudioEmbeds -- used in collectTargets)
 - `settings.ts` (SynapseSettings, SummarizeSettings)
 
+## Content-Aware Templates
+
+When `autoDetectTemplates` is enabled (default: true) and no `customPrompt` is set, the module runs `detectContentTemplate(content)` on inline-target content before summarization. If a template matches, its specialized prompt replaces the style-based default.
+
+Priority chain: `customPrompt` > template match > style default.
+
+Enrichment targets (standalone notes) always use `COMPREHENSIVE_SUMMARY_PROMPT` and are not affected by template detection.
+
+### Templates
+
+| ID | Name | Detection | Prompt Format |
+|----|------|-----------|---------------|
+| `recipe` | Recipe | Keyword scoring (structural headers, cooking verbs, measurements); threshold >= 5 | Structured recipe: title, times, servings, ingredients list, numbered instructions, notes |
+
+### Adding New Templates
+
+1. Create a detection function in `templates.ts` (pure function, no side effects).
+2. Define the specialized prompt string.
+3. Add a `ContentTemplate` entry to the `CONTENT_TEMPLATES` array.
+4. Add tests in `templates.test.ts` for both positive and negative detection.
+
 ## Tests
 
 - `summarizer.test.ts`
 - `content-fetcher.test.ts`
 - `note-scanner.test.ts`
 - `summarize-module.test.ts`
+- `templates.test.ts`
 - `audio-summarize.test.ts`

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -13,6 +13,7 @@ import { findSummarizeTargets } from './note-scanner';
 import { hasSummaryBelow } from './note-scanner';
 import { SummarizeSelectionModal } from './summarize-modal';
 import { Summarizer } from './summarizer';
+import { detectContentTemplate } from './templates';
 import { SummarizeTarget } from './types';
 
 export type { SummarizeTarget } from './types';
@@ -396,11 +397,21 @@ export class SummarizeModule {
 					}
 
 					op.update(`Summarizing ${target.source}`);
+
+					// Priority chain: customPrompt > template match > style default
+					let effectivePrompt = settings.customPrompt || undefined;
+					if (!effectivePrompt && settings.autoDetectTemplates) {
+						const template = detectContentTemplate(textToSummarize);
+						if (template) {
+							effectivePrompt = template.prompt;
+						}
+					}
+
 					const summary = await this.summarizer.summarize(
 						textToSummarize,
 						target.source,
 						settings.summaryStyle,
-						settings.customPrompt || undefined
+						effectivePrompt
 					);
 
 					const callout = buildCallout(

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -3,16 +3,23 @@ import { SummarizeModule } from './index';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import { fetchPageContent } from './content-fetcher';
 
 // Mock the content fetcher to avoid real network calls
 vi.mock('./content-fetcher', () => ({
 	fetchPageContent: vi.fn().mockResolvedValue('Some fetched content for testing.'),
 }));
 
-// Mock the summarizer to return a canned summary
+// Mock the summarizer to return a canned summary.
+// Track the last created instance so tests can inspect call args.
+let lastSummarizerInstance: { summarize: ReturnType<typeof vi.fn> };
 vi.mock('./summarizer', () => ({
 	Summarizer: class MockSummarizer {
 		summarize = vi.fn().mockResolvedValue('This is a test summary.');
+		constructor() {
+			// eslint-disable-next-line @typescript-eslint/no-this-alias
+			lastSummarizerInstance = this as any;
+		}
 	},
 }));
 
@@ -170,5 +177,130 @@ describe('SummarizeModule organize scope', () => {
 		expect(organizeCallback).toHaveBeenCalledWith(specificFile);
 		// And it was called exactly once (not per-vault-file)
 		expect(organizeCallback).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ── Content-Aware Template Detection Integration ──────────────────────
+
+const RECIPE_CONTENT = [
+	'# Chocolate Chip Cookies',
+	'',
+	'## Ingredients',
+	'- 2 cups all-purpose flour',
+	'- 1 cup butter',
+	'- 1 tsp vanilla extract',
+	'',
+	'## Instructions',
+	'1. Preheat oven to 375 degrees fahrenheit.',
+	'2. Whisk flour, baking soda, and salt together.',
+	'3. Stir in chocolate chips.',
+	'4. Bake for 10 minutes.',
+].join('\n');
+
+const NON_RECIPE_CONTENT = 'This is a plain news article about the economy.';
+
+describe('SummarizeModule content-aware templates', () => {
+	let module: SummarizeModule;
+	let mockPlugin: any;
+	let mockNotifications: ReturnType<typeof createMockNotifications>;
+	let settings: typeof DEFAULT_SETTINGS;
+
+	beforeEach(() => {
+		settings = structuredClone(DEFAULT_SETTINGS);
+		settings.summarize.autoOrganizeOnSummarize = false;
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Note\n\nhttps://example.com\n'),
+					modify: vi.fn().mockResolvedValue(undefined),
+					create: vi.fn().mockResolvedValue(new TFile()),
+					getAbstractFileByPath: vi.fn().mockReturnValue(null),
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+				},
+				workspace: {
+					getActiveFile: vi.fn().mockReturnValue(null),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+
+		mockNotifications = createMockNotifications();
+		module = new SummarizeModule(
+			mockPlugin as any,
+			() => settings,
+			mockNotifications as any,
+			createMockCheckpointManager() as any
+		);
+	});
+
+	async function invokeCommand(file: any): Promise<void> {
+		await module.onload();
+		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
+			(c: any) => c[0].id === 'synapse:summarize-current-note'
+		)[0];
+		await summarizeCmd.editorCallback({}, { file });
+	}
+
+	it('uses recipe template prompt when autoDetectTemplates is true and content matches', async () => {
+		settings.summarize.autoDetectTemplates = true;
+		settings.summarize.customPrompt = '';
+
+		// Return recipe content from the content fetcher
+		vi.mocked(fetchPageContent).mockResolvedValueOnce(RECIPE_CONTENT);
+
+		const file = new TFile('notes/recipe.md') as any;
+		await invokeCommand(file);
+
+		// The summarizer should have been called with the recipe template prompt
+		const summarizeCall = lastSummarizerInstance.summarize.mock.calls[0];
+		expect(summarizeCall[3]).toContain('Ingredients');
+		expect(summarizeCall[3]).toContain('Instructions');
+		expect(summarizeCall[3]).toContain('Notes');
+	});
+
+	it('skips template detection when autoDetectTemplates is false', async () => {
+		settings.summarize.autoDetectTemplates = false;
+		settings.summarize.customPrompt = '';
+
+		vi.mocked(fetchPageContent).mockResolvedValueOnce(RECIPE_CONTENT);
+
+		const file = new TFile('notes/recipe.md') as any;
+		await invokeCommand(file);
+
+		// The summarizer should have been called with undefined (style default)
+		const summarizeCall = lastSummarizerInstance.summarize.mock.calls[0];
+		expect(summarizeCall[3]).toBeUndefined();
+	});
+
+	it('customPrompt takes precedence over template detection', async () => {
+		settings.summarize.autoDetectTemplates = true;
+		settings.summarize.customPrompt = 'My custom override prompt';
+
+		vi.mocked(fetchPageContent).mockResolvedValueOnce(RECIPE_CONTENT);
+
+		const file = new TFile('notes/recipe.md') as any;
+		await invokeCommand(file);
+
+		// The summarizer should have been called with the custom prompt
+		const summarizeCall = lastSummarizerInstance.summarize.mock.calls[0];
+		expect(summarizeCall[3]).toBe('My custom override prompt');
+	});
+
+	it('falls back to style prompt when content does not match any template', async () => {
+		settings.summarize.autoDetectTemplates = true;
+		settings.summarize.customPrompt = '';
+
+		vi.mocked(fetchPageContent).mockResolvedValueOnce(NON_RECIPE_CONTENT);
+
+		const file = new TFile('notes/article.md') as any;
+		await invokeCommand(file);
+
+		// The summarizer should have been called with undefined (style default)
+		const summarizeCall = lastSummarizerInstance.summarize.mock.calls[0];
+		expect(summarizeCall[3]).toBeUndefined();
 	});
 });

--- a/src/summarize/templates.test.ts
+++ b/src/summarize/templates.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import {
+	detectContentTemplate,
+	isRecipeContent,
+	scoreRecipeContent,
+	CONTENT_TEMPLATES,
+} from './templates';
+
+// ── Recipe Detection ──────────────────────────────────────────────────
+
+describe('isRecipeContent', () => {
+	it('detects a classic recipe with ingredients, instructions, and cooking terms', () => {
+		const content = [
+			'# Chocolate Chip Cookies',
+			'',
+			'## Ingredients',
+			'- 2 cups all-purpose flour',
+			'- 1 cup butter',
+			'- 1 tsp vanilla extract',
+			'- 2 eggs',
+			'',
+			'## Instructions',
+			'1. Preheat oven to 375 degrees fahrenheit.',
+			'2. Whisk flour, baking soda, and salt together.',
+			'3. Stir in chocolate chips.',
+			'4. Bake for 10 minutes.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(true);
+	});
+
+	it('detects a recipe using "directions" header', () => {
+		const content = [
+			'# Simple Soup',
+			'',
+			'## Ingredients',
+			'- 1 lb chicken',
+			'- 2 cups broth',
+			'- 1 tbsp olive oil',
+			'',
+			'## Directions',
+			'1. Chop the chicken into cubes.',
+			'2. Boil broth and simmer for 20 minutes.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(true);
+	});
+
+	it('detects a recipe using "method" header', () => {
+		const content = [
+			'# Roasted Vegetables',
+			'',
+			'## Ingredients',
+			'- 1 lb carrots',
+			'- 2 tbsp olive oil',
+			'',
+			'## Method',
+			'1. Preheat oven to 400 degrees celsius.',
+			'2. Dice vegetables and roast for 30 minutes.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(true);
+	});
+
+	it('does not detect a news article as a recipe', () => {
+		const content = [
+			'# Breaking News: Economy Shows Signs of Recovery',
+			'',
+			'The latest economic indicators suggest a positive trend in the market.',
+			'Unemployment rates have dropped to 3.5% this quarter.',
+			'Analysts are optimistic about continued growth through the fiscal year.',
+			'The Federal Reserve announced it will maintain current interest rates.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(false);
+	});
+
+	it('does not detect meeting notes as a recipe', () => {
+		const content = [
+			'# Weekly Standup - March 15',
+			'',
+			'## Attendees',
+			'- Alice, Bob, Carol',
+			'',
+			'## Action Items',
+			'1. Alice to update the design docs by Friday.',
+			'2. Bob to review the PR for the login flow.',
+			'3. Carol to set up the staging environment.',
+			'',
+			'## Notes',
+			'- Sprint velocity increased this week.',
+			'- Need to prioritize bug fixes for v2.1 release.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(false);
+	});
+
+	it('does not detect code documentation as a recipe', () => {
+		const content = [
+			'# API Reference',
+			'',
+			'## Installation',
+			'```bash',
+			'npm install my-library',
+			'```',
+			'',
+			'## Usage',
+			'```typescript',
+			'import { Client } from "my-library";',
+			'const client = new Client({ apiKey: "xxx" });',
+			'const result = await client.query("select * from users");',
+			'```',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(false);
+	});
+
+	it('does not detect a restaurant review as a recipe', () => {
+		const content = [
+			'# Best Italian Restaurants in New York',
+			'',
+			'I visited several Italian restaurants this month. The pasta at Carbone was',
+			'outstanding. They serve a famous spicy rigatoni that everyone should try.',
+			'The service was impeccable and the ambiance was fantastic.',
+			'Overall, I would highly recommend this place for a special occasion.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(false);
+	});
+
+	it('does not detect a nutrition article as a recipe', () => {
+		const content = [
+			'# Benefits of a Mediterranean Diet',
+			'',
+			'Studies show that a Mediterranean diet rich in olive oil, fish, and vegetables',
+			'can reduce the risk of heart disease. Nutritionists recommend consuming at',
+			'least 5 servings of fruits and vegetables daily. The diet emphasizes whole',
+			'grains and lean proteins over processed foods.',
+		].join('\n');
+
+		expect(isRecipeContent(content)).toBe(false);
+	});
+});
+
+// ── Scoring Threshold ─────────────────────────────────────────────────
+
+describe('scoreRecipeContent', () => {
+	it('returns 0 for content with no recipe signals', () => {
+		const content = 'This is a plain paragraph about nothing related to cooking.';
+		expect(scoreRecipeContent(content)).toBe(0);
+	});
+
+	it('gives 2 points for a structural header match', () => {
+		const content = '## Ingredients\nSome text here.';
+		const score = scoreRecipeContent(content);
+		expect(score).toBeGreaterThanOrEqual(2);
+	});
+
+	it('gives points for cooking verbs', () => {
+		const content = 'Preheat the oven. Whisk the eggs. Bake until golden.';
+		const score = scoreRecipeContent(content);
+		// 3 cooking verbs = 3 points
+		expect(score).toBeGreaterThanOrEqual(3);
+	});
+
+	it('gives points for measurement terms', () => {
+		const content = 'Use 1 cup flour and 2 tbsp sugar. Bake at 350 degrees for 30 minutes.';
+		const score = scoreRecipeContent(content);
+		// cup + tbsp + degrees + minutes + bake = at least 5
+		expect(score).toBeGreaterThanOrEqual(5);
+	});
+
+	it('scores below threshold for borderline content', () => {
+		// Only 1 cooking verb and 1 measurement term -- not enough
+		const content = 'I love to bake. It usually takes about 30 minutes.';
+		expect(scoreRecipeContent(content)).toBeLessThan(5);
+	});
+});
+
+// ── detectContentTemplate ─────────────────────────────────────────────
+
+describe('detectContentTemplate', () => {
+	it('returns the recipe template for recipe content', () => {
+		const content = [
+			'# Pancakes',
+			'',
+			'## Ingredients',
+			'- 1 cup flour',
+			'- 2 tbsp sugar',
+			'- 1 tsp baking powder',
+			'',
+			'## Instructions',
+			'1. Whisk dry ingredients.',
+			'2. Stir in milk and eggs.',
+			'3. Cook on a griddle for 2 minutes per side.',
+		].join('\n');
+
+		const template = detectContentTemplate(content);
+		expect(template).not.toBeNull();
+		expect(template!.id).toBe('recipe');
+		expect(template!.name).toBe('Recipe');
+	});
+
+	it('returns null for non-recipe content', () => {
+		const content = [
+			'# Project Status Update',
+			'',
+			'The new release is scheduled for next month.',
+			'We have completed 80% of the planned features.',
+		].join('\n');
+
+		expect(detectContentTemplate(content)).toBeNull();
+	});
+});
+
+// ── Template Shape Validation ─────────────────────────────────────────
+
+describe('CONTENT_TEMPLATES', () => {
+	it('each template has a valid id, name, detect function, and prompt', () => {
+		for (const template of CONTENT_TEMPLATES) {
+			expect(typeof template.id).toBe('string');
+			expect(template.id.length).toBeGreaterThan(0);
+			expect(typeof template.name).toBe('string');
+			expect(template.name.length).toBeGreaterThan(0);
+			expect(typeof template.detect).toBe('function');
+			expect(typeof template.prompt).toBe('string');
+			expect(template.prompt.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('recipe template prompt includes structured output instructions', () => {
+		const recipe = CONTENT_TEMPLATES.find(t => t.id === 'recipe');
+		expect(recipe).toBeDefined();
+		expect(recipe!.prompt).toContain('Ingredients');
+		expect(recipe!.prompt).toContain('Instructions');
+		expect(recipe!.prompt).toContain('Notes');
+	});
+});

--- a/src/summarize/templates.ts
+++ b/src/summarize/templates.ts
@@ -1,0 +1,119 @@
+/**
+ * Content-aware summary templates.
+ *
+ * Each template defines a detection heuristic and a specialized prompt.
+ * When auto-detection is enabled and no custom prompt is set, the first
+ * matching template's prompt is used instead of the default style prompt.
+ */
+
+export interface ContentTemplate {
+	id: string;
+	name: string;
+	detect: (content: string) => boolean;
+	prompt: string;
+}
+
+// ── Recipe Detection ──────────────────────────────────────────────────
+
+const STRUCTURAL_PATTERNS: RegExp[] = [
+	/^#{1,3}\s*(ingredients|instructions|directions|method)\b/im,
+	/\b\d+\s*(?:cups?|tbsp|tsp|oz|lb|g|ml|liter)\b/i,
+	/^\s*\d+\.\s+\w/m,
+];
+
+const COOKING_VERBS: string[] = [
+	'preheat', 'bake', 'simmer', 'chop', 'dice', 'whisk', 'stir',
+	'roast', 'grill', 'saute', 'sauté', 'fry', 'boil', 'marinate',
+	'blanch', 'braise', 'broil', 'knead', 'fold', 'glaze', 'drain',
+	'mince', 'slice', 'julienne', 'deglaze', 'reduce', 'season',
+];
+
+const MEASUREMENT_TERMS: string[] = [
+	'cup', 'tbsp', 'tsp', 'oz', 'lb', 'gram', 'ml',
+	'minutes', 'degrees', 'fahrenheit', 'celsius',
+];
+
+/**
+ * Score content for recipe-like characteristics.
+ * Returns true if the score meets or exceeds the threshold (5).
+ */
+export function isRecipeContent(content: string): boolean {
+	return scoreRecipeContent(content) >= 5;
+}
+
+/**
+ * Compute a numeric recipe score for content. Exported for testing.
+ *
+ * Scoring:
+ *   - Structural signals (2 pts each): section headers, quantity patterns, numbered steps
+ *   - Cooking verbs (1 pt each, capped at unique matches)
+ *   - Measurement terms (1 pt each, capped at unique matches)
+ */
+export function scoreRecipeContent(content: string): number {
+	let score = 0;
+	const lower = content.toLowerCase();
+
+	// Structural signals — 2 points each
+	for (const pattern of STRUCTURAL_PATTERNS) {
+		if (pattern.test(content)) {
+			score += 2;
+		}
+	}
+
+	// Cooking verbs — 1 point each unique verb
+	for (const verb of COOKING_VERBS) {
+		const verbPattern = new RegExp(`\\b${verb}\\b`, 'i');
+		if (verbPattern.test(lower)) {
+			score += 1;
+		}
+	}
+
+	// Measurement terms — 1 point each unique term
+	for (const term of MEASUREMENT_TERMS) {
+		const termPattern = new RegExp(`\\b${term}s?\\b`, 'i');
+		if (termPattern.test(lower)) {
+			score += 1;
+		}
+	}
+
+	return score;
+}
+
+const RECIPE_PROMPT =
+	'You are summarizing recipe content. Produce a structured recipe summary using the following format:\n\n' +
+	'## [Recipe Title]\n\n' +
+	'**Prep time:** [time or "Not specified"]\n' +
+	'**Cook time:** [time or "Not specified"]\n' +
+	'**Total time:** [time or "Not specified"]\n' +
+	'**Servings:** [number or "Not specified"]\n\n' +
+	'### Ingredients\n' +
+	'- List each ingredient with quantity and preparation notes\n\n' +
+	'### Instructions\n' +
+	'1. Numbered steps, each a clear action\n\n' +
+	'### Notes\n' +
+	'- Any tips, substitutions, or storage instructions from the original content\n\n' +
+	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +
+	'Do not invent information that is not in the original text.';
+
+// ── Template Registry ─────────────────────────────────────────────────
+
+export const CONTENT_TEMPLATES: ContentTemplate[] = [
+	{
+		id: 'recipe',
+		name: 'Recipe',
+		detect: isRecipeContent,
+		prompt: RECIPE_PROMPT,
+	},
+];
+
+/**
+ * Iterate registered templates and return the first match, or null.
+ */
+export function detectContentTemplate(content: string): ContentTemplate | null {
+	for (const template of CONTENT_TEMPLATES) {
+		if (template.detect(content)) {
+			return template;
+		}
+	}
+	return null;
+}


### PR DESCRIPTION
## Summary

- Adds a template system that infers content type and applies a matching summary prompt, starting with recipe detection
- Recipe detection uses keyword-based scoring across structural signals (2pts), cooking verbs (1pt), and measurement terms (1pt) with a threshold of 5+ points
- Priority chain: custom prompt > template match > style default — existing behavior unchanged when no template matches

## Changes

- **New:** `src/summarize/templates.ts` — `ContentTemplate` interface, `detectContentTemplate()`, recipe detection and prompt
- **New:** `src/summarize/templates.test.ts` — 16 unit tests for detection (positive, negative, edge cases)
- **Modified:** `src/settings.ts` — added `autoDetectTemplates` setting (default: true)
- **Modified:** `src/settings-tab.ts` — added toggle in Summarize settings
- **Modified:** `src/summarize/index.ts` — wired template detection into inline target summarization
- **Modified:** `src/summarize/summarize-module.test.ts` — 4 integration tests
- **Modified:** `src/summarize/AGENTS.md` — documented template system

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (511 tests, 35 suites)
- [x] `node esbuild.config.mjs production` builds successfully
- [ ] Manual: summarize a recipe page → verify structured recipe output
- [ ] Manual: summarize a non-recipe page → verify normal bullet/paragraph output
- [ ] Manual: toggle off auto-detect → verify template detection skipped

closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)