### PR TITLE
feat: require exact ingredient amounts and step images in recipe template

### DIFF
--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -167,7 +167,7 @@ Enrichment targets (standalone notes) always use `COMPREHENSIVE_SUMMARY_PROMPT` 
 
 | ID | Name | Detection | Prompt Format |
 |----|------|-----------|---------------|
-| `recipe` | Recipe | Keyword scoring (structural headers, cooking verbs, measurements); threshold >= 5 | Structured recipe: title, times, servings, ingredients list, numbered instructions, notes |
+| `recipe` | Recipe | Keyword scoring (structural headers, cooking verbs, measurements); threshold >= 5 | Structured recipe: title, times, servings, ingredients with exact amounts, numbered instructions with step images, notes |
 
 ### Adding New Templates
 

--- a/src/summarize/templates.test.ts
+++ b/src/summarize/templates.test.ts
@@ -236,3 +236,21 @@ describe('CONTENT_TEMPLATES', () => {
 		expect(recipe!.prompt).toContain('Notes');
 	});
 });
+
+// ── RECIPE_PROMPT Content ────────────────────────────────────────────
+
+describe('RECIPE_PROMPT content', () => {
+	const recipe = CONTENT_TEMPLATES.find(t => t.id === 'recipe');
+
+	it('requires exact ingredient amounts', () => {
+		expect(recipe!.prompt).toContain('exact amount');
+	});
+
+	it('instructs to preserve original measurements', () => {
+		expect(recipe!.prompt).toContain('Preserve the original measurements');
+	});
+
+	it('instructs to include step images', () => {
+		expect(recipe!.prompt).toContain('![step description](image-url)');
+	});
+});

--- a/src/summarize/templates.ts
+++ b/src/summarize/templates.ts
@@ -87,9 +87,9 @@ const RECIPE_PROMPT =
 	'**Total time:** [time or "Not specified"]\n' +
 	'**Servings:** [number or "Not specified"]\n\n' +
 	'### Ingredients\n' +
-	'- List each ingredient with quantity and preparation notes\n\n' +
+	'- List each ingredient with its **exact amount** (e.g. "2 cups", "1 tbsp") and preparation notes. Preserve the original measurements from the source.\n\n' +
 	'### Instructions\n' +
-	'1. Numbered steps, each a clear action\n\n' +
+	'1. Numbered steps, each a clear action. If the source includes images associated with a step, include them using `![step description](image-url)` on a new line after the step text.\n\n' +
 	'### Notes\n' +
 	'- Any tips, substitutions, or storage instructions from the original content\n\n' +
 	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +


### PR DESCRIPTION
## Summary
- Updated `RECIPE_PROMPT` in `templates.ts` to require **exact amounts** (e.g. "2 cups", "1 tbsp") for ingredients, preserving original measurements from the source
- Updated `RECIPE_PROMPT` to instruct the AI to include step images using `![step description](image-url)` when the source contains images associated with a step
- Added three new test assertions in `templates.test.ts` verifying the updated prompt content
- Updated the Templates table in `AGENTS.md` to reflect the new prompt format

closes #149

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (514 tests, including 3 new prompt content assertions)
- [x] `node esbuild.config.mjs production` builds successfully

Co-Authored-By: Claude <bot@wafflenet.io>