### PR TITLE
fix: normalize TikTok URLs by stripping query params (#155)

### DIFF
--- a/src/summarize/content-fetcher.test.ts
+++ b/src/summarize/content-fetcher.test.ts
@@ -31,6 +31,12 @@ describe('isSupportedUrl integration with summarize', () => {
 		expect(isSupportedUrl('https://vm.tiktok.com/ZMxxxxxxx/')).toBe(true);
 	});
 
+	it('identifies TikTok URLs with query params as video', () => {
+		expect(isSupportedUrl('https://www.tiktok.com/@user/video/1234567890?is_from_webapp=1&sender_device=pc')).toBe(true);
+		expect(isSupportedUrl('https://www.tiktok.com/t/ZThw1txpF/?refer=creator&web_id=123')).toBe(true);
+		expect(isSupportedUrl('https://vm.tiktok.com/ZMxxxxxxx/?sender_device=mobile')).toBe(true);
+	});
+
 	it('does not flag regular article URLs as video', () => {
 		expect(isSupportedUrl('https://example.com/article')).toBe(false);
 		expect(isSupportedUrl('https://en.wikipedia.org/wiki/Topic')).toBe(false);

--- a/src/summarize/note-scanner.test.ts
+++ b/src/summarize/note-scanner.test.ts
@@ -379,6 +379,40 @@ describe('findSummarizeTargets', () => {
 		});
 	});
 
+	it('matches transcription/summary when URL has query params stripped', () => {
+		// A note with the bare URL on the first line, but the transcription
+		// header uses the same bare URL — should still match even if the
+		// original paste had query params.
+		const content = [
+			'https://www.tiktok.com/@user/video/123?is_from_webapp=1&sender_device=pc',
+			'',
+			'> **Transcription of https://www.tiktok.com/@user/video/123**',
+			'>',
+			'> Some transcribed text here.',
+			'',
+			'> **Summary of https://www.tiktok.com/@user/video/123**',
+			'>',
+			'> A summary.',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		// Transcription already has summary — no targets expected
+		expect(targets).toHaveLength(0);
+	});
+
+	it('matches when stored URL has params but header is bare', () => {
+		const content = [
+			'https://www.tiktok.com/@user/video/456?web_id=999',
+			'',
+			'> **Transcription of https://www.tiktok.com/@user/video/456**',
+			'>',
+			'> Text content.',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		// Transcription exists but no summary — should return transcription target
+		expect(targets).toHaveLength(1);
+		expect(targets[0].type).toBe('transcription');
+	});
+
 	it('enrichment targets survive idempotent re-scan after note creation', () => {
 		// After processing, the external links become wikilinks.
 		// Re-scanning should find no enrichment targets.

--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -3,6 +3,7 @@ import { CALLOUT_TYPES } from '../shared';
 import { SummarizeTarget } from './types';
 
 const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;
+const TIKTOK_HOST_RE = /(?:vm\.|vt\.)?tiktok\.com/;
 const TRANSCRIPTION_HEADER = /^>\s*\*\*Transcription of (.+?)\*\*$/;
 const CALLOUT_TRANSCRIPTION_HEADER = new RegExp(
 	`^>\\s*\\[!${CALLOUT_TYPES.transcription}\\][-+]?\\s+Transcription of (.+)$`
@@ -132,21 +133,34 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
 }
 
 /**
+ * Strip query parameters and fragment from TikTok URLs for comparison.
+ * Non-TikTok URLs are returned unchanged.
+ */
+function normalizeTikTokUrl(url: string): string {
+	if (TIKTOK_HOST_RE.test(url)) {
+		return url.replace(/[?#].*$/, '');
+	}
+	return url;
+}
+
+/**
  * Check if a summary block already exists below a given line for the specified source.
  * Looks within 3 lines below, allowing blank lines and blockquotes.
  */
 export function hasSummaryBelow(lines: string[], startLine: number, source: string): boolean {
+	const normalized = normalizeTikTokUrl(source);
 	for (let j = startLine + 1; j < lines.length && j <= startLine + 3; j++) {
+		const line = lines[j];
 		// Legacy format: > **Summary of <source>**
-		if (lines[j].includes(`**Summary of ${source}**`)) {
+		if (line.includes(`**Summary of ${source}**`) || line.includes(`**Summary of ${normalized}**`)) {
 			return true;
 		}
 		// Callout format: > [!synapse-summary] Summary of <source>
-		if (lines[j].includes(CALLOUT_SUMMARY_PREFIX) && lines[j].includes(`Summary of ${source}`)) {
+		if (line.includes(CALLOUT_SUMMARY_PREFIX) && (line.includes(`Summary of ${source}`) || line.includes(`Summary of ${normalized}`))) {
 			return true;
 		}
 		// Stop at non-empty, non-blockquote content
-		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {
+		if (line.trim().length > 0 && !line.startsWith('>') && line.trim() !== '') {
 			break;
 		}
 	}
@@ -157,17 +171,19 @@ export function hasSummaryBelow(lines: string[], startLine: number, source: stri
  * Check if a transcription block exists below a URL line.
  */
 function hasTranscriptionBelow(lines: string[], urlLine: number, url: string): boolean {
+	const normalized = normalizeTikTokUrl(url);
 	for (let j = urlLine + 1; j < lines.length && j <= urlLine + 5; j++) {
+		const line = lines[j];
 		// Legacy format: > **Transcription of <url>**
-		if (lines[j].includes(`**Transcription of ${url}**`)) {
+		if (line.includes(`**Transcription of ${url}**`) || line.includes(`**Transcription of ${normalized}**`)) {
 			return true;
 		}
 		// Callout format: > [!synapse-transcription] Transcription of <url>
-		if (lines[j].includes(CALLOUT_TRANSCRIPTION_PREFIX) && lines[j].includes(`Transcription of ${url}`)) {
+		if (line.includes(CALLOUT_TRANSCRIPTION_PREFIX) && (line.includes(`Transcription of ${url}`) || line.includes(`Transcription of ${normalized}`))) {
 			return true;
 		}
 		// Stop at non-empty, non-blockquote content
-		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {
+		if (line.trim().length > 0 && !line.startsWith('>') && line.trim() !== '') {
 			break;
 		}
 	}

--- a/src/video/url-detector.test.ts
+++ b/src/video/url-detector.test.ts
@@ -64,6 +64,37 @@ describe('detectPlatform', () => {
 			expect(result?.platform).toBe('tiktok');
 			expect(result?.videoId).toBe('short-url');
 		});
+
+		it('strips query params from full video URL', () => {
+			const result = detectPlatform(
+				'https://www.tiktok.com/@username/video/1234567890123456789?is_from_webapp=1&sender_device=pc&web_id=7890'
+			);
+			expect(result?.platform).toBe('tiktok');
+			expect(result?.videoId).toBe('1234567890123456789');
+			expect(result?.url).toBe('https://www.tiktok.com/@username/video/1234567890123456789');
+		});
+
+		it('strips query params from short share URL', () => {
+			const result = detectPlatform(
+				'https://www.tiktok.com/t/ZTh7nJafa/?refer=creator'
+			);
+			expect(result?.platform).toBe('tiktok');
+			expect(result?.url).toBe('https://www.tiktok.com/t/ZTh7nJafa/');
+		});
+
+		it('strips fragment from TikTok URL', () => {
+			const result = detectPlatform(
+				'https://www.tiktok.com/@user/video/123456789#some-fragment'
+			);
+			expect(result?.url).toBe('https://www.tiktok.com/@user/video/123456789');
+		});
+
+		it('strips query params from vm.tiktok.com URL', () => {
+			const result = detectPlatform(
+				'https://vm.tiktok.com/ZMxxxxxxx/?sender_device=mobile'
+			);
+			expect(result?.url).toBe('https://vm.tiktok.com/ZMxxxxxxx/');
+		});
 	});
 
 	describe('unsupported URLs', () => {

--- a/src/video/url-detector.ts
+++ b/src/video/url-detector.ts
@@ -9,6 +9,14 @@ const TIKTOK_VIDEO_REGEX =
 const TIKTOK_SHORT_REGEX =
 	/(?:vm\.|vt\.)?tiktok\.com\/(?:t\/)?[\w.-]+/;
 
+/**
+ * Strip query parameters and fragment from TikTok URLs so the canonical
+ * form is the bare path (e.g. `https://www.tiktok.com/@user/video/123`).
+ */
+function stripTikTokParams(url: string): string {
+	return url.replace(/[?#].*$/, '');
+}
+
 export function detectPlatform(url: string): UrlDetectionResult | null {
 	const ytMatch = url.match(YOUTUBE_REGEX);
 	if (ytMatch) {
@@ -17,13 +25,13 @@ export function detectPlatform(url: string): UrlDetectionResult | null {
 
 	const ttVideoMatch = url.match(TIKTOK_VIDEO_REGEX);
 	if (ttVideoMatch) {
-		return { platform: 'tiktok', videoId: ttVideoMatch[1], url };
+		return { platform: 'tiktok', videoId: ttVideoMatch[1], url: stripTikTokParams(url) };
 	}
 
 	// Short URLs don't contain a video ID — yt-dlp resolves the redirect
 	const ttShortMatch = url.match(TIKTOK_SHORT_REGEX);
 	if (ttShortMatch) {
-		return { platform: 'tiktok', videoId: 'short-url', url };
+		return { platform: 'tiktok', videoId: 'short-url', url: stripTikTokParams(url) };
 	}
 
 	return null;


### PR DESCRIPTION
## Summary
- Strip query parameters and fragments from TikTok URLs in `detectPlatform()` so the canonical form is the bare path (e.g. `https://www.tiktok.com/@user/video/123`)
- Update note-scanner `hasSummaryBelow()` and `hasTranscriptionBelow()` to normalize TikTok URLs before comparison, preventing duplicate processing when stored URLs have different query params
- Add test cases for TikTok URLs with common query params (`is_from_webapp`, `sender_device`, `web_id`, `refer`) across `url-detector.test.ts`, `content-fetcher.test.ts`, and `note-scanner.test.ts`

closes #155

## Test plan
- [x] All 545 existing tests pass
- [x] New tests verify query param stripping in `detectPlatform()`
- [x] New tests verify note-scanner deduplication with param-laden URLs
- [x] New tests verify `isSupportedUrl()` works with TikTok query params
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)