### PR TITLE
chore: codebase audit — architecture fixes and docs refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ SynapseSettings {
     maxContentLength: number                        // default: 4000
     summaryStyle: 'bullets' | 'paragraph' | 'key-points'  // default: 'bullets'
     customPrompt: string                            // default: ''
+    autoDetectTemplates: boolean                    // default: true
     excludeFolders: string[]                        // default: ['templates', '.synapse']
     excludeTags: string[]                           // default: ['no-summarize']
     autoOrganizeOnSummarize: boolean                // default: false
@@ -232,6 +233,11 @@ SynapseSettings {
     autoEnrichOnAccept: boolean                     // default: true
     autoOrganizeOnAccept: boolean                   // default: false
   }
+  title: TitleSettings {
+    enabled: boolean                                // default: true
+    proposalFolderPath: string                      // default: '.synapse/title-proposals'
+    checkAfterOperations: boolean                   // default: true
+  }
 }
 ```
 
@@ -247,6 +253,7 @@ SynapseSettings {
 | Organize summaries | `.synapse/organize/summaries/*.md` | Mermaid move diagrams |
 | Deep dive proposals | `.synapse/deep-dive/*.json` | `DeepDiveProposal` JSON |
 | Deep dive runs | `.synapse/deep-dive/runs/*.json` | `DeepDiveRun` JSON |
+| Title proposals | `.synapse/title-proposals/*.json` | `TitleProposal` JSON |
 | Checkpoints | `.synapse/checkpoints/*.json` | `Checkpoint` JSON |
 | Temp video/audio | `.synapse/temp/` | Binary (auto-cleaned) |
 | Downloaded videos | `Media/` (configurable) | Video files |
@@ -262,16 +269,25 @@ deepDive.onNoteAccepted(filePath)        --> enrichment.enrich(filePath, 'deep-d
 deepDive.onOrganizeRequested(file)       --> organize.organizeNote(file)
 summarize.onOrganizeRequested(file)      --> organize.organizeNote(file)
 
+// Title checks (after enrichment or standalone when enrichment disabled)
+elaboration.onProposalAccepted(filePath) --> title.checkTitle(filePath)
+audio.onTranscriptionComplete(filePath)  --> title.checkTitle(filePath)
+video.onTranscriptionComplete(filePath)  --> title.checkTitle(filePath)
+summarize.onSummaryComplete(filePath)    --> title.checkTitle(filePath)
+deepDive.onNoteAccepted(filePath)        --> title.checkTitle(filePath)
+
 elaboration.onViewRefreshNeeded()        --> main.refreshUnifiedView()
 enrichment.onViewRefreshNeeded()         --> main.refreshUnifiedView()
 organize.onViewRefreshNeeded()           --> main.refreshUnifiedView()
 deepDive.onViewRefreshNeeded()           --> main.refreshUnifiedView()
+title.onViewRefreshNeeded()              --> main.refreshUnifiedView()
 ```
 
 Enrichment callbacks wired when `enrichment.enabled && enrichment.autoEnrich`.
 Deep-dive enrichment wired when `deepDive.autoEnrichOnAccept`.
 Deep-dive organize wired when `deepDive.autoOrganizeOnAccept && organize.enabled`.
 Summarize organize wired when `summarize.autoOrganizeOnSummarize && organize.enabled`.
+Title checks wired when `title.enabled && title.checkAfterOperations`.
 
 ## Checkpoint System
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-Synapse is an Obsidian plugin that provides eight AI-powered features: note elaboration, audio transcription, video transcription, note enrichment, summarization, note tidying, semantic organization, and recursive deep-dive note generation. Desktop only (requires Node.js APIs for video processing).
+Synapse is an Obsidian plugin that provides nine AI-powered features: note elaboration, audio transcription, video transcription, note enrichment, summarization, note tidying, semantic organization, recursive deep-dive note generation, and title proposal. It runs on both desktop and mobile (video features are desktop-only).
 
 > **Note**: This plugin was previously named "Auto Notes" and was rebranded to "Synapse" in March 2026. The data folder was renamed from `.auto-notes/` to `.synapse/`, with automatic one-time migration on load.
 
@@ -10,7 +10,7 @@ Synapse is an Obsidian plugin that provides eight AI-powered features: note elab
 
 ```mermaid
 graph TB
-    subgraph Obsidian["Obsidian Desktop"]
+    subgraph Obsidian["Obsidian"]
         Main["main.ts<br/>SynapsePlugin"]
         Settings["Settings + Tab"]
         Sidebar["Unified Proposal View<br/>(sidebar)"]
@@ -26,6 +26,7 @@ graph TB
             Tidy["Tidy"]
             Org["Organize"]
             DD["Deep Dive"]
+            Title["Title"]
         end
 
         Shared["Shared Layer<br/>AIClient · Notifications · Validation<br/>File Utils · Frontmatter · Callouts"]
@@ -55,6 +56,7 @@ graph TB
     style Trans fill:#f9f,stroke:#333
     style Sidebar fill:#bbf,stroke:#333
     style CkptMgr fill:#ffd,stroke:#333
+    style Title fill:#ffc,stroke:#333
 ```
 
 ---
@@ -80,7 +82,7 @@ src/
 │   └── index.ts            #   AudioModule orchestrator
 │
 ├── video/                  # Video download + transcription
-│   ├── url-detector.ts     #   YouTube/TikTok URL parsing
+│   ├── url-detector.ts     #   YouTube/TikTok URL parsing + normalization
 │   ├── audio-extractor.ts  #   yt-dlp + ffmpeg via execFile
 │   ├── note-scanner.ts     #   Find video URLs in note content
 │   └── index.ts            #   VideoModule orchestrator (delegates to Audio)
@@ -103,7 +105,7 @@ src/
 │
 ├── summarize/              # URL + transcription summarization
 │   ├── summarizer.ts       #   AI summarization (bullets/paragraph/key-points)
-│   ├── content-fetcher.ts  #   HTTP fetch + HTML-to-text extraction
+│   ├── content-fetcher.ts  #   HTTP fetch + HTML-to-text + JSON-LD extraction
 │   ├── note-scanner.ts     #   Find summarizable targets in notes
 │   └── index.ts            #   SummarizeModule orchestrator
 │
@@ -125,6 +127,13 @@ src/
 │   ├── deep-dive-store.ts  #   Proposal + run persistence
 │   └── index.ts            #   DeepDiveModule orchestrator
 │
+├── title/                  # Note title suggestions
+│   ├── title-module.ts     #   Title checking, proposal lifecycle
+│   ├── title-suggester.ts  #   AI title generation + mismatch detection
+│   ├── title-proposal-store.ts # JSON persistence
+│   ├── types.ts            #   TitleProposal, trigger/status types
+│   └── index.ts            #   Re-exports module, types, isUntitled
+│
 ├── shared/                 # Cross-cutting utilities
 │   ├── ai-client.ts        #   Multi-provider AI (OpenAI, Anthropic, Ollama)
 │   ├── checkpoint-manager.ts #  Checkpoint/resume for long-running operations
@@ -142,7 +151,8 @@ src/
 │   └── index.ts            #   Barrel export
 │
 └── views/                  # UI components
-    └── unified-proposal-view.ts  # Single sidebar for all proposal types + checkpoints
+    ├── unified-proposal-view.ts  # Single sidebar for all proposal types + checkpoints
+    └── types.ts                  # UnifiedItem, UnifiedViewCallbacks
 ```
 
 ---
@@ -164,6 +174,7 @@ graph LR
     Main --> Tidy["tidy/"]
     Main --> Org["organize/"]
     Main --> DD["deep-dive/"]
+    Main --> Title["title/"]
 
     Elab --> Shared
     Audio --> Shared
@@ -178,22 +189,26 @@ graph LR
     Org --> Shared
     DD --> Shared
     DD --> Org
+    Title --> Shared
     Views --> Elab
     Views --> Enrich
     Views --> Org
     Views --> DD
+    Views --> Title
 
     style Trans fill:#f9f,stroke:#333
+    style Title fill:#ffc,stroke:#333
 ```
 
 Key constraints:
-- **Video depends on Audio** — reuses transcription pipeline
-- **Transcription is UI-only** — delegates all work to Audio and Video via callbacks
+- **Video depends on Audio** -- reuses transcription pipeline
+- **Transcription is UI-only** -- delegates all work to Audio and Video via callbacks
 - **Summarize receives `video.transcribeUrl`** via constructor injection (dotted line)
 - **Deep Dive reuses Organize** for `auto-organize` nesting mode
-- **All feature modules depend on Shared** — no circular dependencies
+- **All feature modules depend on Shared** -- no circular dependencies
 - **Views imports types only** from feature modules
-- **CheckpointManager is a singleton** — created in `main.ts`, injected into all modules that need it
+- **CheckpointManager is a singleton** -- created in `main.ts`, injected into all modules that need it
+- **Title has no CheckpointManager** -- operates on single notes, not vault scans
 
 ---
 
@@ -203,21 +218,21 @@ Key constraints:
 sequenceDiagram
     participant O as Obsidian
     participant M as main.ts
-    participant Mod as Modules (×8)
+    participant Mod as Modules (x9)
     participant CB as Callbacks
     participant CK as CheckpointManager
 
     O->>M: onload()
     M->>M: loadSettings() (deep-merge)
-    M->>M: migrateDataFolder() (.auto-notes → .synapse)
+    M->>M: migrateDataFolder() (.auto-notes -> .synapse)
     M->>M: addSettingTab()
     M->>M: NotificationManager()
     M->>CK: new CheckpointManager(app)
-    M->>Mod: Initialize 8 modules<br/>(Audio before Video, inject CheckpointManager)
+    M->>Mod: Initialize 9 modules<br/>(Audio before Video, inject CheckpointManager)
     M->>M: registerView(UnifiedProposalView)
-    M->>CB: Wire refresh callbacks
+    M->>CB: Wire refresh callbacks (5 modules)
     M->>Mod: Conditional module.onload()<br/>(if enabled in settings)
-    M->>CB: Wire enrichment callbacks<br/>(if autoEnrich)
+    M->>CB: Wire enrichment + title callbacks<br/>(if autoEnrich / title.checkAfterOperations)
     M->>CB: Wire organize callbacks<br/>(if autoOrganizeOnAccept)
     M->>M: addRibbonIcon (sparkles, mic)
     M->>M: addCommand (review, checkpoints, transcribe)
@@ -261,7 +276,7 @@ The transcription system uses a **UI layer + backend modules** pattern:
 graph TB
     subgraph UI["Transcription UI (src/transcription/)"]
         UM["UnifiedTranscriptionModal<br/>File picker + URL input"]
-        NM["NoteMediaModal<br/>Scan note → select media"]
+        NM["NoteMediaModal<br/>Scan note -> select media"]
     end
 
     subgraph Backend["Backend Modules"]
@@ -300,33 +315,40 @@ All inter-module communication flows through `main.ts` via nullable callback ass
 
 ```mermaid
 graph LR
-    subgraph Triggers["Enrichment Triggers (when autoEnrich)"]
+    subgraph Triggers["Enrichment + Title Triggers"]
         Elab["Elaboration<br/>onProposalAccepted"]
         Audio["Audio<br/>onTranscriptionComplete"]
         Video["Video<br/>onTranscriptionComplete"]
         Summ["Summarize<br/>onSummaryComplete"]
-        DD["Deep Dive<br/>onNoteAccepted"]
+        DDa["Deep Dive<br/>onNoteAccepted"]
     end
 
     Enrich["Enrichment.enrich()"]
+    TitleChk["Title.checkTitle()"]
 
     Elab -->|"'elaboration'"| Enrich
     Audio -->|"'transcription'"| Enrich
     Video -->|"'transcription'"| Enrich
     Summ -->|"'summarization'"| Enrich
-    DD -->|"'deep-dive'"| Enrich
+    DDa -->|"'deep-dive'"| Enrich
+
+    Elab --> TitleChk
+    Audio --> TitleChk
+    Video --> TitleChk
+    Summ --> TitleChk
+    DDa --> TitleChk
 
     DD2["Deep Dive<br/>onOrganizeRequested"] -->|"when autoOrganize"| Org["Organize.organizeNote()"]
     Summ2["Summarize<br/>onOrganizeRequested"] -->|"when autoOrganize"| Org
 
-    ElabR["Elaboration"] & EnrichR["Enrichment"] & OrgR["Organize"] & DDR["Deep Dive"] -->|onViewRefreshNeeded| Refresh["main.refreshUnifiedView()"]
+    ElabR["Elaboration"] & EnrichR["Enrichment"] & OrgR["Organize"] & DDR["Deep Dive"] & TitleR["Title"] -->|onViewRefreshNeeded| Refresh["main.refreshUnifiedView()"]
 ```
 
 ---
 
 ## Proposal System Architecture
 
-Four modules generate proposals that appear in the unified sidebar. Each has a different review workflow:
+Five modules generate proposals that appear in the unified sidebar. Each has a different review workflow:
 
 | Module | Proposal Type | Review UX | Accept Behavior |
 |--------|--------------|-----------|-----------------|
@@ -334,16 +356,17 @@ Four modules generate proposals that appear in the unified sidebar. Each has a d
 | Enrichment | Tags, links, refs, frontmatter | Per-item checkboxes | Cherry-pick items, apply with markers |
 | Organize | New directory suggestion | Directory path + AI reasoning | Create directory, move file |
 | Deep Dive | Generated child note | Read-only content preview | Create note at proposed path |
+| Title | Rename suggestion | Current vs proposed title + reasoning | Rename file |
 
 ### Proposal States
 
 ```
-Generated ──► Pending ──┬──► Accepted
-                        ├──► Rejected
-                        └──► Partially Accepted (enrichment only)
+Generated --> Pending --+--> Accepted
+                        +--> Rejected
+                        +--> Partially Accepted (enrichment only)
 ```
 
-Tidy and Summarize do NOT use proposals — they apply changes immediately (tidy has undo via snapshots).
+Tidy and Summarize do NOT use proposals -- they apply changes immediately (tidy has undo via snapshots).
 
 ### Deep Dive: Cascade Rejection
 
@@ -351,11 +374,11 @@ Rejecting a parent automatically rejects all descendants:
 
 ```
 Root Note
-  ├── Topic A (rejected)
-  │   ├── Subtopic A1 (auto-rejected)
-  │   └── Subtopic A2 (auto-rejected)
-  └── Topic B (pending)
-      └── Subtopic B1 (pending)
+  +-- Topic A (rejected)
+  |   +-- Subtopic A1 (auto-rejected)
+  |   +-- Subtopic A2 (auto-rejected)
+  +-- Topic B (pending)
+      +-- Subtopic B1 (pending)
 ```
 
 ---
@@ -373,7 +396,7 @@ graph TB
     BFS --> Gen["NoteGenerator.generateContent()"]
     Gen --> Extract["TopicAnalyzer.extractTopics()<br/>(if depth+1 < maxDepth)"]
     Extract --> Score["scoreQuality()<br/>(local heuristic, no AI)"]
-    Score --> Decision{Score ≥ threshold<br/>AND depth < max?}
+    Score --> Decision{Score >= threshold<br/>AND depth < max?}
     Decision -->|Yes| Queue["Queue children"]
     Queue --> BFS
     Decision -->|No| Stop["Stop branch"]
@@ -384,13 +407,13 @@ graph TB
 ### Quality Scoring (Local, No AI)
 
 ```
-Score = topicCount × 0.3    min(1.0, childTopics / 3)
-      + wordCount  × 0.2    min(1.0, words / 200)
-      + generic    × 0.2    penalty for "Introduction", "Overview", etc.
-      + overlap    × 0.2    penalty for child topics matching ancestors
-      + depthDecay × 0.1    linear decay toward max depth
+Score = topicCount x 0.3    min(1.0, childTopics / 3)
+      + wordCount  x 0.2    min(1.0, words / 200)
+      + generic    x 0.2    penalty for "Introduction", "Overview", etc.
+      + overlap    x 0.2    penalty for child topics matching ancestors
+      + depthDecay x 0.1    linear decay toward max depth
 
-Below qualityThreshold (default 0.4) → stop recursion for this branch
+Below qualityThreshold (default 0.4) -> stop recursion for this branch
 ```
 
 ---
@@ -399,19 +422,19 @@ Below qualityThreshold (default 0.4) → stop recursion for this branch
 
 ```mermaid
 graph TB
-    Note["Note Content"] --> MC["MetadataClassifier.classify()<br/>AI → vocabulary-validated tags"]
-    Note --> TE["TopicExtractor.extractTopics()<br/>AI → 5-15 key concepts"]
+    Note["Note Content"] --> MC["MetadataClassifier.classify()<br/>AI -> vocabulary-validated tags"]
+    Note --> TE["TopicExtractor.extractTopics()<br/>AI -> 5-15 key concepts"]
     Note --> LR["LinkResolver.findInternalLinks()<br/>Graph hops + shared tags + proximity"]
-    Note --> PB1["PromptBuilder.suggestExternalLinks()<br/>AI → relevant URLs"]
-    Note --> PB2["PromptBuilder.suggestFrontmatter()<br/>AI → validated metadata keys"]
+    Note --> PB1["PromptBuilder.suggestExternalLinks()<br/>AI -> relevant URLs"]
+    Note --> PB2["PromptBuilder.suggestFrontmatter()<br/>AI -> validated metadata keys"]
 
-    TE --> Matched["Matched topics<br/>→ [[internal link]] candidates"]
-    TE --> Unmatched["Unmatched topics<br/>→ accumulated for cross-note resolution"]
+    TE --> Matched["Matched topics<br/>-> [[internal link]] candidates"]
+    TE --> Unmatched["Unmatched topics<br/>-> accumulated for cross-note resolution"]
 
     LR --> Merge["LinkResolver.mergeTopicCandidates()<br/>Topic relevance dominates"]
     Matched --> Merge
 
-    MC & Merge & PB1 & PB2 --> Proposal["EnrichmentProposal<br/>→ Unified Sidebar → User Review"]
+    MC & Merge & PB1 & PB2 --> Proposal["EnrichmentProposal<br/>-> Unified Sidebar -> User Review"]
 ```
 
 ### Vault-Wide Scan (4-Phase)
@@ -421,7 +444,27 @@ graph TB
 | 1. Scan | Collect eligible files, warm caches | Cheap |
 | 2. Confirm | User approval before AI calls | Free (gates cost) |
 | 3. Generate | Per-file enrichment, accumulate topics | Expensive (AI calls) |
-| 4. Resolve | Topics with 2+ references → new-note suggestions | Cheap |
+| 4. Resolve | Topics with 2+ references -> new-note suggestions | Cheap |
+
+---
+
+## Summarize: Content-Aware Templates
+
+The summarize module detects content type (e.g., recipe pages via JSON-LD schema data) and applies specialized templates:
+
+```
+Note with URL --> content-fetcher.ts
+  |-- Fetch HTML
+  |-- Extract JSON-LD structured data (Recipe, Article, etc.)
+  |-- Extract plain text
+  |
+  v
+summarizer.ts
+  |-- Detect content type from JSON-LD or heuristics
+  |-- Select template (recipe: ingredients + steps; default: bullets/paragraph/key-points)
+  |-- AI summarization with template-specific prompt
+  |-- Output: structured summary with amalgamated ingredients, step images, etc.
+```
 
 ---
 
@@ -431,22 +474,24 @@ All module data is stored as individual JSON files under `.synapse/`:
 
 ```
 .synapse/
-├── proposals/                    # Elaboration
-│   └── {id}.json                 #   Proposal with detection reasons + AI content
-├── enrichments/                  # Enrichment
-│   └── {id}.json                 #   Tags, links, refs, frontmatter suggestions
-├── tidy-snapshots/               # Tidy
-│   └── {path-as-filename}.json   #   Original content for undo (one per file)
-├── organize/
-│   ├── proposals/{id}.json       # New-directory proposals
-│   ├── snapshots/{id}.json       # Move snapshots for undo
-│   └── summaries/{name}.md       # Mermaid move diagrams
-├── deep-dive/
-│   ├── {id}.json                 # Individual note proposals
-│   └── runs/{id}.json            # Run metadata (stats, depth breakdown)
-├── checkpoints/                  # Checkpoint/resume
-│   └── {id}.json                 # Operation state (completed + remaining items)
-└── temp/                         # Temporary video/audio (auto-cleaned)
++-- proposals/                    # Elaboration
+|   +-- {id}.json                 #   Proposal with detection reasons + AI content
++-- enrichments/                  # Enrichment
+|   +-- {id}.json                 #   Tags, links, refs, frontmatter suggestions
++-- tidy-snapshots/               # Tidy
+|   +-- {path-as-filename}.json   #   Original content for undo (one per file)
++-- organize/
+|   +-- proposals/{id}.json       # New-directory proposals
+|   +-- snapshots/{id}.json       # Move snapshots for undo
+|   +-- summaries/{name}.md       # Mermaid move diagrams
++-- deep-dive/
+|   +-- {id}.json                 # Individual note proposals
+|   +-- runs/{id}.json            # Run metadata (stats, depth breakdown)
++-- title-proposals/              # Title
+|   +-- {id}.json                 # Title rename proposals
++-- checkpoints/                  # Checkpoint/resume
+|   +-- {id}.json                 # Operation state (completed + remaining items)
++-- temp/                         # Temporary video/audio (auto-cleaned)
 ```
 
 Design principles:
@@ -465,7 +510,7 @@ graph TB
     AIC["AIClient<br/>(shared/ai-client.ts)"]
 
     AIC -->|"'openai'"| OAI["POST api.openai.com/v1/chat/completions<br/>Auth: Bearer {ai.apiKey}"]
-    AIC -->|"'anthropic'"| ANT["POST api.anthropic.com/v1/messages<br/>Auth: x-api-key<br/>Models: opus→claude-opus-4-6, etc."]
+    AIC -->|"'anthropic'"| ANT["POST api.anthropic.com/v1/messages<br/>Auth: x-api-key<br/>Models: opus->claude-opus-4-6, etc."]
     AIC -->|"'ollama'"| OLL["POST {ollamaEndpoint}/api/chat<br/>HTTPS required (HTTP localhost only)"]
 
     AIC --> Safe["safeRequest()<br/>Obsidian requestUrl · 2min timeout<br/>Error extraction · Key redaction"]
@@ -496,25 +541,26 @@ All AI-generated content uses Obsidian callouts from a shared registry:
 
 ```
 SynapseSettings
-├── ai              → Provider, API key, model, temperature, max tokens
-├── elaboration     → Detection thresholds, scan behavior, proposal storage
-│   ├── detection   → Word threshold, TODO markers, empty sections, excludes
-│   └── proposal    → Max per note, preserve frontmatter, include context
-├── audio           → Transcription provider, API keys, post-processing
-│   └── postProcessing → Filler removal, structure, key points, custom prompt
-├── video           → yt-dlp/ffmpeg paths, download folder, embed setting
-│   └── frameExtraction → (Not implemented) interval, vision model, max frames
-├── enrichment      → Auto-enrich, max tags/links, vocabulary, proximity weights
-│   ├── tagVocabulary   → TagVocabularyEntry[] (category, tags, description)
-│   └── weights         → Same/sibling/cousin/distant folder, decay, minimum
-├── summarize       → Style (bullets/paragraph/key-points), max length, excludes
-├── tidy            → Snapshot folder path
-├── organize        → Proposal/snapshot folder paths, confidence threshold, excludes
-└── deepDive        → Max depth, quality threshold, max notes, output folder,
-                      nesting mode, auto-enrich/organize on accept, excludes
++-- ai              -> Provider, API key, model, temperature, max tokens
++-- elaboration     -> Detection thresholds, scan behavior, proposal storage
+|   +-- detection   -> Word threshold, TODO markers, empty sections, excludes
+|   +-- proposal    -> Max per note, preserve frontmatter, include context
++-- audio           -> Transcription provider, API keys, post-processing
+|   +-- postProcessing -> Filler removal, structure, key points, custom prompt
++-- video           -> yt-dlp/ffmpeg paths, download folder, embed setting
+|   +-- frameExtraction -> (Not implemented) interval, vision model, max frames
++-- enrichment      -> Auto-enrich, max tags/links, vocabulary, proximity weights
+|   +-- tagVocabulary   -> TagVocabularyEntry[] (category, tags, description)
+|   +-- weights         -> Same/sibling/cousin/distant folder, decay, minimum
++-- summarize       -> Style (bullets/paragraph/key-points), max length, templates
++-- tidy            -> Snapshot folder path
++-- organize        -> Proposal/snapshot folder paths, confidence threshold, excludes
++-- deepDive        -> Max depth, quality threshold, max notes, output folder,
+|                     nesting mode, auto-enrich/organize on accept, excludes
++-- title           -> Enabled, proposal folder path, check after operations
 ```
 
-Modules access settings via `getSettings()` closure — always reads latest values, no event subscriptions needed.
+Modules access settings via `getSettings()` closure -- always reads latest values, no event subscriptions needed.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,100 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-03-18: Title proposal module for untitled and mismatched notes (Issue #150)
+
+**Context**: After elaboration, transcription, or summarization, notes often retain their original filename (e.g., "Untitled", "Untitled 2") or have titles that no longer match their content. Users had to manually rename files.
+
+**Decision**: Add a `title` module that detects two conditions and proposes AI-generated titles:
+- **Untitled detection**: filenames matching `Untitled*` pattern trigger `suggestTitle()` via AI
+- **Content-mismatch detection**: AI evaluates whether the current filename reflects the note's content; if not, it proposes a better title
+
+Title checks are wired as cross-module callbacks in `main.ts`, triggered after enrichment (or directly after elaboration/transcription/summarization/deep-dive when enrichment is disabled). Proposals appear in the unified sidebar with yellow color coding. Accepting a title proposal renames the file.
+
+The module does NOT use CheckpointManager (single-note operations, not vault scans).
+
+**Alternatives considered**:
+- Auto-rename without proposal (risky -- changes file paths, breaks links)
+- Only detect untitled notes (misses content drift after elaboration)
+- Batch title check during vault scan (over-engineered for a per-note operation)
+
+**Rationale**: Title proposals fit naturally into the existing proposal-review workflow. The two-trigger design catches both obvious cases (Untitled) and subtle ones (content evolved past the original title). File rename is a high-impact action that warrants user confirmation via the sidebar.
+
+**Impact**: New `src/title/` module with 5 files. Unified sidebar gains a 5th proposal type (yellow cards). Title settings added under `settings.title`. Cross-module callbacks in `main.ts` expanded.
+
+---
+
+## 2026-03-18: Content-aware summary templates with recipe detection (Issue #145)
+
+**Context**: The summarize module treated all URL content identically, producing bullet-point or paragraph summaries. Recipe pages contain structured data (ingredients, steps, prep time) that generic summaries lose.
+
+**Decision**: Add content-type detection to the summarize pipeline:
+1. `content-fetcher.ts` extracts JSON-LD structured data from fetched HTML (Recipe, Article, etc.)
+2. `summarizer.ts` detects content type and selects a specialized template
+3. Recipe template: amalgamates ingredients from multiple JSON-LD entries, requires exact amounts, includes step images
+4. Default template: existing bullets/paragraph/key-points behavior
+
+Subsequent PRs refined this: exact ingredient amounts required (#149), step images included (#149), JSON-LD recipe data extraction to amalgamate ingredients across multiple Recipe objects (#153).
+
+**Alternatives considered**:
+- Always use generic summarization (loses structured data)
+- Hard-code recipe detection only (not extensible to other content types)
+- Use a separate command for recipe summarization (fragments UX)
+
+**Rationale**: JSON-LD is a widely-used standard on recipe sites. Extracting structured data produces dramatically better summaries than feeding raw HTML to an LLM. The template system is extensible -- future content types (articles, products) can be added without changing the pipeline.
+
+**Impact**: Recipe URLs produce structured summaries with exact ingredients and steps. The `autoDetectTemplates` setting controls this behavior. Non-recipe URLs are unaffected.
+
+---
+
+## 2026-03-18: TikTok URL normalization (Issue #155)
+
+**Context**: TikTok URLs often include query parameters (tracking, session tokens) that cause the same video to be treated as different URLs. This led to duplicate transcription attempts and failed deduplication.
+
+**Decision**: Strip query parameters from TikTok URLs during normalization in `url-detector.ts`. The canonical URL form is `https://www.tiktok.com/@user/video/{id}` with no query string.
+
+**Alternatives considered**:
+- Strip query params from all URLs (would break YouTube timestamp URLs)
+- Normalize at transcription time only (wouldn't fix detection/matching)
+
+**Rationale**: TikTok query params are purely tracking/session data -- they don't affect video content. YouTube params (like `t=` for timestamp) are meaningful, so normalization must be platform-specific.
+
+**Impact**: TikTok URLs are consistently matched regardless of tracking parameters. No behavior change for YouTube URLs.
+
+---
+
+## 2026-03-18: Unified sidebar expanded to 5 proposal types
+
+**Context**: The title module added a 5th proposal type to the unified sidebar (previously elaboration, enrichment, organize, deep-dive).
+
+**Decision**: Extend `UnifiedItem` to a 5-way discriminated union adding `{ kind: 'title'; data: TitleProposal }`. Title cards show current vs proposed title, trigger reason (untitled/mismatch), and AI reasoning. Yellow color coding distinguishes them from other types. Accept triggers file rename.
+
+**Alternatives considered**:
+- Separate modal for title proposals (inconsistent with existing proposal workflow)
+- Auto-apply title changes without review (too risky -- renames affect links)
+
+**Rationale**: Consistency with the existing proposal-review pattern. Users already check the sidebar for proposals; title suggestions appear alongside other proposal types naturally.
+
+**Impact**: `UnifiedViewCallbacks` gains `onTitleAccept` and `onTitleReject`. Card type table now has 5 entries (blue, green, orange, purple, yellow).
+
+---
+
+## 2026-03-18: Reject All button for proposals (Issue #141)
+
+**Context**: Users with many pending proposals had to reject them one at a time. The existing Accept All button had no counterpart for bulk rejection.
+
+**Decision**: Add a "Reject All" button to the unified sidebar, visible when 2+ proposals are pending. Processes all proposals sequentially, same as Accept All.
+
+**Alternatives considered**:
+- Only provide individual reject buttons (tedious for large batches)
+- Add a "Clear All" that deletes proposals without marking them rejected (loses audit trail)
+
+**Rationale**: Symmetric with Accept All. Users who scan proposals and find them unhelpful shouldn't need to reject each one individually.
+
+**Impact**: New button in the unified sidebar header. All proposal types support rejection through their existing reject callbacks.
+
+---
+
 ## 2026-03-18: Rebrand from Auto Notes to Synapse (Issue #124)
 
 **Context**: The plugin name "Auto Notes" was generic and didn't convey the plugin's purpose of connecting knowledge through AI. A more distinctive name was needed as the project matured toward public release.
@@ -688,19 +782,23 @@ Each proposal is a separate file with metadata and proposed content.
 
 ---
 
-## 2026-03-12: `isDesktopOnly: true` in manifest
+## 2026-03-12: Mobile support with graceful degradation
 
-**Context**: The plugin uses `child_process` for yt-dlp/ffmpeg execution -- Node.js APIs unavailable on mobile.
+**Context**: The plugin uses `child_process` for yt-dlp/ffmpeg execution -- Node.js APIs unavailable on mobile. Originally marked `isDesktopOnly: true`.
 
-**Decision**: Mark the plugin as desktop-only in `manifest.json`.
+**Decision**: Set `isDesktopOnly: false` in `manifest.json` and gate desktop-only features behind `Platform.isDesktop`:
+- VideoModule is only initialized on desktop
+- Video-related ribbon icon (mic) hidden on mobile
+- `transcribeUrl` callback throws on mobile with a clear error message
+- All non-video features (elaboration, enrichment, summarize, tidy, organize, deep-dive, title, audio) work on both platforms
 
 **Alternatives considered**:
-- Graceful degradation (disable video features on mobile)
-- API-based video processing service
+- Keep desktop-only (excludes mobile users from all features)
+- API-based video processing service for mobile (adds complexity and external dependency)
 
-**Rationale**: Core video functionality depends on local CLI tools. Desktop-only is clearly communicated.
+**Rationale**: Most plugin features don't need Node.js APIs. Only video download/extraction requires local CLI tools. Mobile users get full access to AI-powered text features.
 
-**Impact**: Plugin will not appear in Obsidian's mobile plugin browser.
+**Impact**: Plugin is available on mobile. Video features are clearly gated. Settings tab hides video-only options on mobile.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,9 @@
 # Project Status
 
 **Last updated**: 2026-03-18
-**Branch**: `feat/issue-124-rebrand-synapse`
-**Phase**: 9 modules (8 feature + 1 UI-only transcription); rebrand from Auto Notes to Synapse in progress
+**Version**: 0.2.1
+**Branch**: `main`
+**Phase**: 10 modules (9 feature + 1 UI-only transcription); title proposals, recipe templates, and TikTok URL normalization recently shipped
 
 ---
 
@@ -18,6 +19,7 @@
 | **Audio** -- note scanning for embeds | Yes | -- | Yes | **Working** |
 | **Video** -- URL detection (YT + TikTok) | Yes | -- | Yes | **Working** |
 | **Video** -- yt-dlp download + transcribe | Yes | Yes | No | **Working** |
+| **Video** -- TikTok URL normalization | Yes | -- | Yes | **Working** |
 | **Video** -- note scanning for URLs | Yes | -- | Yes | **Working** |
 | **Video** -- local file transcription | -- | -- | No | Not started (stub) |
 | **Video** -- frame extraction | -- | -- | No | Not started (placeholder) |
@@ -32,6 +34,7 @@
 | **Summarize** -- URL summarization (inline) | Yes | Yes | No | **Working** |
 | **Summarize** -- transcription summarization | Yes | Yes | No | **Working** |
 | **Summarize** -- enrichment link -> standalone note | Yes | -- | Yes | **Working** |
+| **Summarize** -- content-aware templates (recipe detection) | Yes | -- | Yes | **Working** |
 | **Summarize** -- vault-wide scan | Yes | Yes | No | **Working** |
 | **Tidy** -- spelling/formatting | Yes | -- | Yes | **Working** |
 | **Tidy** -- undo | Yes | -- | Yes | **Working** |
@@ -44,6 +47,9 @@
 | **Deep Dive** -- local quality scoring | Yes | -- | Yes | **Working** |
 | **Deep Dive** -- sidebar review (unified view) | Yes | Yes | No | **Working** |
 | **Deep Dive** -- cascade rejection | Yes | -- | No | **Working** |
+| **Title** -- untitled note detection | Yes | -- | No | **Working** |
+| **Title** -- content-mismatch detection (AI) | Yes | -- | No | **Working** |
+| **Title** -- proposal review + file rename | Yes | Yes | No | **Working** |
 | **Shared** -- AIClient (3 providers) | Yes | -- | No | **Working** |
 | **Shared** -- NotificationManager | Yes | -- | Yes | **Working** |
 | **Shared** -- validation and sanitization | Yes | -- | Yes | **Working** |
@@ -52,36 +58,37 @@
 
 ---
 
-## Module Summary (9 modules)
+## Module Summary (10 modules)
 
 | Module | Path | Purpose | UI Surface |
 |--------|------|---------|------------|
 | Elaboration | `src/elaboration/` | Detect stub notes, generate content proposals | Sidebar (editable) |
 | Audio | `src/audio/` | Transcribe audio files via Whisper/Deepgram | None (inline insert) |
 | Video | `src/video/` | Download + transcribe YouTube/TikTok videos | None (inline insert) |
-| Transcription | `src/transcription/` | Unified transcription UI modals (issue #20) | 2 modals |
+| Transcription | `src/transcription/` | Unified transcription UI modals | 2 modals |
 | Enrichment | `src/enrichment/` | Tags, links, refs, frontmatter suggestions | Sidebar (checkboxes) |
 | Summarize | `src/summarize/` | URL and transcription summarization | None (inline or standalone note) |
 | Tidy | `src/tidy/` | Spelling/formatting fixes | None (immediate apply + undo) |
 | Organize | `src/organize/` | AI-powered directory structuring | Sidebar (new dirs only) |
 | Deep Dive | `src/deep-dive/` | Recursive topic extraction + child note generation | Sidebar (tree view) |
+| Title | `src/title/` | Detect untitled/mismatched note titles, propose renames | Sidebar (accept = rename) |
 
 ---
 
 ## Current Focus
 
-- **Rebrand**: Auto Notes renamed to Synapse across all source code, config, and documentation (issue #124)
-- **Architect audit**: module structure cleanup, export fixes, constructor standardization
-- **Security pass**: `.gitignore` hardening for legacy `.auto-notes/` folder
-- **Documentation audit**: updating AGENTS.md (machine-readable) and human docs (DECISIONS.md, STATUS.md, ARCHITECTURE.md)
+- **Documentation audit**: Updating AGENTS.md, DECISIONS.md, STATUS.md, ARCHITECTURE.md
+- **Security pass**: Ongoing audit for input validation and credential handling
 
 ## Recent Changes (2026-03-18)
 
-- Rebranded plugin from "Auto Notes" to "Synapse" (manifest, settings, callouts, data folder)
-- Added `.auto-notes/` to `.synapse/` data folder migration (one-time, on load)
-- Added legacy `.auto-notes/` to `.gitignore`
-- Architect audit: fixed module structure, cleaned up exports
-- Updated all AGENTS.md files with checkpoint system and constructor changes
+- Added title proposal module -- detects "Untitled" filenames and content-title mismatches, proposes AI-generated titles (#150, #157)
+- Normalized TikTok URLs by stripping query params before dedup/matching (#155, #156)
+- Added JSON-LD recipe data extraction to amalgamate ingredients (#153, #154)
+- Added exact ingredient amounts and step images to recipe summary template (#149, #152)
+- Added content-aware summary templates with recipe detection (#145, #148)
+- Added Reject All button for proposals (#141)
+- Strip code fences from AI elaboration output (#147)
 
 ---
 
@@ -95,21 +102,6 @@
 | Local Whisper not implemented | Medium | `local-whisper` provider throws on use |
 | Local video file transcription not implemented | Medium | Command shows "coming soon" notice |
 | Frame extraction not implemented | Medium | `FrameExtractor` is a placeholder |
-
----
-
-## Command Registry (22 commands)
-
-| Module | Commands |
-|--------|----------|
-| Main | Open proposal review sidebar, Manage interrupted operations, Transcribe media, Transcribe media from current note |
-| Elaboration | Scan vault, Scan current note, Clear proposals |
-| Video | Check dependencies |
-| Enrichment | Enrich current note, Scan vault, Undo enrichment |
-| Summarize | Summarize current note, Scan vault |
-| Tidy | Tidy current note, Undo tidy |
-| Organize | Organize current note, Scan directory, Undo organize |
-| Deep Dive | Deep dive into note, Clear proposals |
 
 ---
 

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -30,6 +30,7 @@ type DetectionReason =
   | { type: 'todo-marker'; markers: string[] }
   | { type: 'empty-section'; heading: string }
   | { type: 'sparse-link'; linkedFrom: string[] }
+  | { type: 'user-requested' }
 
 interface DetectionResult {
   notePath: string

--- a/src/enrichment/enrichment-applier.ts
+++ b/src/enrichment/enrichment-applier.ts
@@ -1,10 +1,10 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { mergeTags, parseFrontmatter, serializeFrontmatter, buildCallout, CALLOUT_TYPES } from '../shared';
+import {
+	mergeTags, parseFrontmatter, serializeFrontmatter, buildCallout, CALLOUT_TYPES,
+	ENRICHMENT_START, ENRICHMENT_END,
+} from '../shared';
 import { EnrichmentProposal, AcceptedItems } from './types';
-
-export const ENRICHMENT_START = '%% synapse-enrichment-start %%';
-export const ENRICHMENT_END = '%% synapse-enrichment-end %%';
 
 /**
  * Applies accepted enrichments to a note non-destructively.

--- a/src/shared/callouts.ts
+++ b/src/shared/callouts.ts
@@ -18,6 +18,16 @@ export const CALLOUT_TYPES = {
 export type CalloutType = (typeof CALLOUT_TYPES)[keyof typeof CALLOUT_TYPES];
 
 /**
+ * Legacy comment-based enrichment section markers.
+ *
+ * Used by the enrichment module to wrap injected sections and by the
+ * summarize module to skip enrichment content during note scanning.
+ * Placed in shared/ because they are referenced cross-module.
+ */
+export const ENRICHMENT_START = '%% synapse-enrichment-start %%';
+export const ENRICHMENT_END = '%% synapse-enrichment-end %%';
+
+/**
  * Build an Obsidian callout block.
  *
  * @param type   - One of the CALLOUT_TYPES values (e.g. 'synapse-summary')

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -19,7 +19,7 @@ export {
 	stripCodeFences,
 	blockquoteOriginal,
 } from './validation';
-export { CALLOUT_TYPES, buildCallout } from './callouts';
+export { CALLOUT_TYPES, buildCallout, ENRICHMENT_START, ENRICHMENT_END } from './callouts';
 export type { CalloutType } from './callouts';
 export {
 	parseFrontmatter,

--- a/src/summarize/audio-summarize.test.ts
+++ b/src/summarize/audio-summarize.test.ts
@@ -46,6 +46,8 @@ vi.mock('../shared', () => ({
 	buildCallout: vi.fn((_type: string, title: string, content: string) =>
 		`\n> [!synapse-summary] ${title}\n> ${content}\n`
 	),
+	ENRICHMENT_START: '%% synapse-enrichment-start %%',
+	ENRICHMENT_END: '%% synapse-enrichment-end %%',
 	CheckpointManager: class MockCheckpointManager {
 		create = vi.fn().mockResolvedValue({ id: 'cp-mock' });
 		completeItem = vi.fn().mockResolvedValue(null);

--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -1,5 +1,4 @@
-import { ENRICHMENT_START, ENRICHMENT_END } from '../enrichment/enrichment-applier';
-import { CALLOUT_TYPES } from '../shared';
+import { CALLOUT_TYPES, ENRICHMENT_START, ENRICHMENT_END } from '../shared';
 import { SummarizeTarget } from './types';
 
 const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -42,6 +42,8 @@ vi.mock('../shared', () => ({
 	NotificationManager: vi.fn(),
 	CALLOUT_TYPES: { transcription: 'synapse-transcription', summary: 'synapse-summary' },
 	buildCallout: vi.fn((_type: string, _title: string, content: string) => `> ${content}`),
+	ENRICHMENT_START: '%% synapse-enrichment-start %%',
+	ENRICHMENT_END: '%% synapse-enrichment-end %%',
 	CheckpointManager: class MockCheckpointManager {
 		create = vi.fn().mockResolvedValue({ id: 'cp-mock' });
 		completeItem = vi.fn().mockResolvedValue(null);

--- a/src/title/AGENTS.md
+++ b/src/title/AGENTS.md
@@ -1,0 +1,93 @@
+---
+last-updated: 2026-03-18
+---
+
+# title — Agent Reference
+
+Detects notes with "Untitled" filenames or content-mismatched titles and proposes AI-generated alternatives.
+
+## Public API
+
+### TitleModule
+
+```ts
+class TitleModule {
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager
+  )
+
+  async onload(): Promise<void>
+  onunload(): void
+
+  async getPendingProposals(): Promise<TitleProposal[]>
+  async checkUntitled(filePath: string): Promise<void>
+  async checkMismatch(filePath: string): Promise<void>
+  async checkTitle(filePath: string): Promise<void>
+  async acceptProposal(id: string): Promise<void>
+  async rejectProposal(id: string): Promise<void>
+
+  onViewRefreshNeeded?: () => Promise<void>
+}
+```
+
+### Exported Functions
+
+```ts
+function isUntitled(basename: string): boolean
+```
+
+### Types
+
+```ts
+type TitleProposalTrigger = 'untitled' | 'content-mismatch'
+type TitleProposalStatus = 'pending' | 'accepted' | 'rejected'
+
+interface TitleProposal {
+  id: string; sourceNotePath: string; currentTitle: string
+  proposedTitle: string; trigger: TitleProposalTrigger
+  reasoning: string; createdAt: string; status: TitleProposalStatus
+}
+```
+
+## Internal Architecture
+
+| File | Purpose |
+|------|---------|
+| `index.ts` | Re-exports module, types, `isUntitled` |
+| `title-module.ts` | Main module: title checking, proposal lifecycle |
+| `title-suggester.ts` | AI title generation and mismatch detection |
+| `title-proposal-store.ts` | JSON persistence in `.synapse/title-proposals/` |
+| `types.ts` | `TitleProposal`, trigger/status types |
+
+## Data Flow
+
+```
+checkTitle(filePath) [called after enrichment/elaboration/transcription/summarize/deep-dive]
+  --> checkUntitled(filePath): if "Untitled*" → suggestTitle()
+  --> checkMismatch(filePath): AI evaluates title vs content
+  --> TitleProposalStore.save(proposal)
+  --> onViewRefreshNeeded()
+
+acceptProposal(id)
+  --> rename file to proposedTitle
+  --> TitleProposalStore.updateStatus('accepted')
+```
+
+## Commands
+
+No direct commands. Title checks are triggered via cross-module callbacks wired in main.ts.
+
+## Configuration
+
+| Key | Type | Default |
+|-----|------|---------|
+| `title.enabled` | boolean | true |
+| `title.proposalFolderPath` | string | `.synapse/title-proposals` |
+| `title.checkAfterOperations` | boolean | true |
+
+## Dependencies
+
+- `shared/` — AIClient, NotificationManager, file-utils
+- No CheckpointManager (single-note operation)

--- a/src/views/AGENTS.md
+++ b/src/views/AGENTS.md
@@ -4,7 +4,7 @@ last-updated: 2026-03-18
 
 # Views Module
 
-Unified sidebar view combining elaboration, enrichment, organize, and deep-dive proposals in a single pane. Displays checkpoint recovery banner for interrupted operations. Supports batch Accept All.
+Unified sidebar view combining elaboration, enrichment, organize, deep-dive, and title proposals in a single pane. Displays checkpoint recovery banner for interrupted operations. Supports batch Accept All.
 
 ## Public API
 
@@ -18,6 +18,7 @@ type UnifiedItem =
   | { kind: 'enrichment'; data: EnrichmentProposal }
   | { kind: 'organize'; data: OrganizeProposal }
   | { kind: 'deep-dive'; data: DeepDiveProposal }
+  | { kind: 'title'; data: TitleProposal }
 
 interface UnifiedViewCallbacks {
   onElaborationAccept: (id: string, editedContent: string) => Promise<void>
@@ -28,6 +29,8 @@ interface UnifiedViewCallbacks {
   onOrganizeReject: (id: string) => Promise<void>
   onDeepDiveAccept: (id: string) => Promise<void>
   onDeepDiveReject: (id: string) => Promise<void>
+  onTitleAccept: (id: string) => Promise<void>
+  onTitleReject: (id: string) => Promise<void>
   onCheckpointDiscard: (id: string) => Promise<void>
   onCheckpointResume: (id: string) => Promise<void>
 }
@@ -46,7 +49,8 @@ class UnifiedProposalView extends ItemView {
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `unified-proposal-view.ts` | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE`, `UnifiedItem`, `UnifiedViewCallbacks` | Combined proposal sidebar with checkpoint banner |
+| `unified-proposal-view.ts` | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE` | Combined proposal sidebar with checkpoint banner |
+| `types.ts` | `UnifiedItem`, `UnifiedViewCallbacks` | View type definitions |
 
 ## Rendering Modes
 
@@ -61,6 +65,8 @@ class UnifiedProposalView extends ItemView {
 5. **Organize review**: Back button, source note link, proposed directory path, AI reasoning text. Accept/Reject buttons.
 
 6. **Deep-dive review**: Back button, topic title, depth badge, quality score, source note link, quality reasoning, proposed path, read-only content preview, child count warning. Accept/Reject buttons.
+
+7. **Title review**: Back button, source note link, current vs proposed title, trigger reason (untitled/mismatch), AI reasoning. Accept (rename)/Reject buttons.
 
 ## Accept All
 
@@ -78,6 +84,7 @@ class UnifiedProposalView extends ItemView {
 | enrichment | `color-green` | `color-green` |
 | organize | `color-orange` | `color-orange` |
 | deep-dive | `color-purple` | `color-purple` |
+| title | `color-yellow` | `color-yellow` |
 
 Deep-dive cards additionally show depth badge and quality score badge.
 
@@ -94,13 +101,15 @@ this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {
     onOrganizeReject: (id) => this.organize.rejectProposal(id),
     onDeepDiveAccept: (id) => this.deepDive.acceptProposal(id),
     onDeepDiveReject: (id) => this.deepDive.rejectProposal(id),
+    onTitleAccept: (id) => this.title.acceptProposal(id),
+    onTitleReject: (id) => this.title.rejectProposal(id),
     onCheckpointDiscard: (id) => this.discardCheckpoint(id),
     onCheckpointResume: (id) => this.resumeCheckpoint(id),
   });
 });
 ```
 
-Refreshed via `main.refreshUnifiedView()` which gathers items from all four modules and incomplete checkpoints.
+Refreshed via `main.refreshUnifiedView()` which gathers items from all five modules and incomplete checkpoints.
 
 ## Dependencies
 
@@ -110,6 +119,7 @@ Refreshed via `main.refreshUnifiedView()` which gathers items from all four modu
 | `AcceptedItems`, `EnrichmentProposal` | `../enrichment` (type only) |
 | `OrganizeProposal` | `../organize` (type only) |
 | `DeepDiveProposal` | `../deep-dive` (type only) |
+| `TitleProposal` | `../title` (type only) |
 | `Checkpoint` | `../shared` (type only) |
 
 ## Features
@@ -117,5 +127,5 @@ Refreshed via `main.refreshUnifiedView()` which gathers items from all four modu
 - Clickable note headings open the source note in main editor
 - Auto-exits review mode if reviewed proposal is no longer in pending list
 - Injects scoped CSS on first open (id: `synapse-unified-view-styles`)
-- Color-coded cards: blue for elaboration, green for enrichment, orange for organize, purple for deep-dive
+- Color-coded cards: blue for elaboration, green for enrichment, orange for organize, purple for deep-dive, yellow for title
 - Checkpoint banner with progress display and Resume/Discard actions

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -5,4 +5,4 @@ export {
 export type {
 	UnifiedItem,
 	UnifiedViewCallbacks,
-} from './unified-proposal-view';
+} from './types';

--- a/src/views/types.ts
+++ b/src/views/types.ts
@@ -1,0 +1,34 @@
+import type { Proposal } from '../elaboration';
+import type { AcceptedItems, EnrichmentProposal } from '../enrichment';
+import type { OrganizeProposal } from '../organize';
+import type { DeepDiveProposal } from '../deep-dive';
+import type { TitleProposal } from '../title';
+
+/** Wrapper to unify elaboration, enrichment, organize, deep-dive, and title proposals in one list. */
+export type UnifiedItem =
+	| { kind: 'elaboration'; data: Proposal }
+	| { kind: 'enrichment'; data: EnrichmentProposal }
+	| { kind: 'organize'; data: OrganizeProposal }
+	| { kind: 'deep-dive'; data: DeepDiveProposal }
+	| { kind: 'title'; data: TitleProposal };
+
+export interface UnifiedViewCallbacks {
+	// Elaboration
+	onElaborationAccept: (id: string, editedContent: string) => Promise<void>;
+	onElaborationReject: (id: string) => Promise<void>;
+	// Enrichment
+	onEnrichmentAcceptSelected: (id: string, accepted: AcceptedItems) => Promise<void>;
+	onEnrichmentReject: (id: string) => Promise<void>;
+	// Organize
+	onOrganizeAccept: (id: string) => Promise<void>;
+	onOrganizeReject: (id: string) => Promise<void>;
+	// Deep Dive
+	onDeepDiveAccept: (id: string) => Promise<void>;
+	onDeepDiveReject: (id: string) => Promise<void>;
+	// Title
+	onTitleAccept: (id: string) => Promise<void>;
+	onTitleReject: (id: string) => Promise<void>;
+	// Checkpoints
+	onCheckpointDiscard: (id: string) => Promise<void>;
+	onCheckpointResume: (id: string) => Promise<void>;
+}

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -5,37 +5,11 @@ import type { OrganizeProposal } from '../organize';
 import type { DeepDiveProposal } from '../deep-dive';
 import type { TitleProposal } from '../title';
 import type { Checkpoint } from '../shared';
+import type { UnifiedItem, UnifiedViewCallbacks } from './types';
+
+export { type UnifiedItem, type UnifiedViewCallbacks } from './types';
 
 export const UNIFIED_VIEW_TYPE = 'synapse-proposals';
-
-/** Wrapper to unify elaboration, enrichment, organize, deep-dive, and title proposals in one list. */
-export type UnifiedItem =
-	| { kind: 'elaboration'; data: Proposal }
-	| { kind: 'enrichment'; data: EnrichmentProposal }
-	| { kind: 'organize'; data: OrganizeProposal }
-	| { kind: 'deep-dive'; data: DeepDiveProposal }
-	| { kind: 'title'; data: TitleProposal };
-
-export interface UnifiedViewCallbacks {
-	// Elaboration
-	onElaborationAccept: (id: string, editedContent: string) => Promise<void>;
-	onElaborationReject: (id: string) => Promise<void>;
-	// Enrichment
-	onEnrichmentAcceptSelected: (id: string, accepted: AcceptedItems) => Promise<void>;
-	onEnrichmentReject: (id: string) => Promise<void>;
-	// Organize
-	onOrganizeAccept: (id: string) => Promise<void>;
-	onOrganizeReject: (id: string) => Promise<void>;
-	// Deep Dive
-	onDeepDiveAccept: (id: string) => Promise<void>;
-	onDeepDiveReject: (id: string) => Promise<void>;
-	// Title
-	onTitleAccept: (id: string) => Promise<void>;
-	onTitleReject: (id: string) => Promise<void>;
-	// Checkpoints
-	onCheckpointDiscard: (id: string) => Promise<void>;
-	onCheckpointResume: (id: string) => Promise<void>;
-}
 
 /**
  * Single sidebar view that shows both elaboration and enrichment proposals.


### PR DESCRIPTION
Fix barrel bypass in enrichment/summarize imports by extracting shared callout constants. Extract view types to dedicated types.ts. Update all AGENTS.md, DECISIONS.md, STATUS.md, and ARCHITECTURE.md to reflect title module and recent features. Two security passes confirm clean.