### PR TITLE
feat: preserve image embeds (external URLs and internal wiki-links) in AI content

### DIFF
--- a/src/deep-dive/note-generator.test.ts
+++ b/src/deep-dive/note-generator.test.ts
@@ -42,6 +42,7 @@ describe('NoteGenerator — image embed preservation', () => {
 		expect(systemPrompt).toContain(
 			'preserve them as markdown image embeds (![alt](url))'
 		);
+		expect(systemPrompt).toContain('embed them as ![[image.jpg]]');
 	});
 
 	it('image embed rule appears alongside the URL reference rule', async () => {
@@ -60,5 +61,6 @@ describe('NoteGenerator — image embed preservation', () => {
 		expect(systemPrompt).toContain(
 			'preserve them as markdown image embeds (![alt](url))'
 		);
+		expect(systemPrompt).toContain('embed them as ![[image.jpg]]');
 	});
 });

--- a/src/deep-dive/note-generator.test.ts
+++ b/src/deep-dive/note-generator.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NoteGenerator } from './note-generator';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { ExtractedTopic } from './types';
+
+const mockComplete = vi.fn().mockResolvedValue('---\ntags: [topic]\n---\n\n## Overview\n\nGenerated content.');
+
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		complete = mockComplete;
+	},
+}));
+
+describe('NoteGenerator — image embed preservation', () => {
+	let generator: NoteGenerator;
+
+	beforeEach(() => {
+		mockComplete.mockClear();
+		mockComplete.mockResolvedValue('---\ntags: [topic]\n---\n\n## Overview\n\nGenerated content.');
+
+		const settings = structuredClone(DEFAULT_SETTINGS);
+		generator = new NoteGenerator(() => settings);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('includes image embed preservation rule in system prompt', async () => {
+		const topic: ExtractedTopic = {
+			title: 'Test Topic',
+			description: 'A topic for testing',
+			relevance: 0.8,
+			existsInVault: false,
+			relatedUrls: [],
+		};
+
+		await generator.generateContent(topic, 'Parent Note', 'Source content here');
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain(
+			'preserve them as markdown image embeds (![alt](url))'
+		);
+	});
+
+	it('image embed rule appears alongside the URL reference rule', async () => {
+		const topic: ExtractedTopic = {
+			title: 'Test Topic',
+			description: 'A topic for testing',
+			relevance: 0.8,
+			existsInVault: false,
+			relatedUrls: ['https://example.com'],
+		};
+
+		await generator.generateContent(topic, 'Parent Note', 'Source content');
+
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain('reference them naturally in the text');
+		expect(systemPrompt).toContain(
+			'preserve them as markdown image embeds (![alt](url))'
+		);
+	});
+});

--- a/src/deep-dive/note-generator.ts
+++ b/src/deep-dive/note-generator.ts
@@ -31,7 +31,7 @@ Rules:
 - Be thorough but concise — aim for 200-500 words of body content
 - Include [[wikilinks]] to related concepts where natural
 - If URLs are provided, reference them naturally in the text
-- If image URLs are present, preserve them as markdown image embeds (![alt](url)) rather than describing the image
+- If image URLs are present, preserve them as markdown image embeds (![alt](url)) rather than describing the image. For internal images like [[image.jpg]], embed them as ![[image.jpg]]
 - Do NOT include the note title as an H1 — Obsidian uses the filename
 - Write in an encyclopedic, informative tone`;
 

--- a/src/deep-dive/note-generator.ts
+++ b/src/deep-dive/note-generator.ts
@@ -31,6 +31,7 @@ Rules:
 - Be thorough but concise — aim for 200-500 words of body content
 - Include [[wikilinks]] to related concepts where natural
 - If URLs are provided, reference them naturally in the text
+- If image URLs are present, preserve them as markdown image embeds (![alt](url)) rather than describing the image
 - Do NOT include the note title as an H1 — Obsidian uses the filename
 - Write in an encyclopedic, informative tone`;
 

--- a/src/elaboration/proposer.test.ts
+++ b/src/elaboration/proposer.test.ts
@@ -53,6 +53,7 @@ describe('ProposalGenerator — image embed preservation', () => {
 		expect(systemPrompt).toContain(
 			'preserve them as markdown image embeds (![alt](url))'
 		);
+		expect(systemPrompt).toContain('embed them as ![[image.jpg]]');
 	});
 
 	it('includes image embed instruction for stub detection as well', async () => {
@@ -68,5 +69,6 @@ describe('ProposalGenerator — image embed preservation', () => {
 		expect(systemPrompt).toContain(
 			'preserve them as markdown image embeds (![alt](url))'
 		);
+		expect(systemPrompt).toContain('embed them as ![[image.jpg]]');
 	});
 });

--- a/src/elaboration/proposer.test.ts
+++ b/src/elaboration/proposer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ProposalGenerator } from './proposer';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { DetectionResult } from './types';
+
+const mockComplete = vi.fn().mockResolvedValue('Expanded content here.');
+
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		complete = mockComplete;
+	},
+}));
+
+describe('ProposalGenerator — image embed preservation', () => {
+	let generator: ProposalGenerator;
+
+	beforeEach(() => {
+		mockComplete.mockClear();
+		mockComplete.mockResolvedValue('Expanded content here.');
+
+		const mockApp = {
+			vault: {
+				adapter: {
+					read: vi.fn().mockResolvedValue('# Note\n\nSome content with ![photo](https://example.com/img.png)'),
+				},
+				read: vi.fn(),
+			},
+			metadataCache: {
+				getCache: vi.fn().mockReturnValue(null),
+				getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+			},
+		};
+
+		const settings = structuredClone(DEFAULT_SETTINGS);
+		settings.elaboration.proposal.includeSourceContext = false;
+		generator = new ProposalGenerator(mockApp as any, () => settings);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('includes image embed preservation instruction in system prompt', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/test.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		await generator.generate(detection);
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain(
+			'preserve them as markdown image embeds (![alt](url))'
+		);
+	});
+
+	it('includes image embed instruction for stub detection as well', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/stub.md',
+			reasons: [{ type: 'short-note', wordCount: 10 }],
+		};
+
+		await generator.generate(detection);
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain(
+			'preserve them as markdown image embeds (![alt](url))'
+		);
+	});
+});

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -23,7 +23,7 @@ export class ProposalGenerator {
 		}
 
 		const prompt = this.buildPrompt(content, detection, contextNotes);
-		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. If the source content contains image URLs, preserve them as markdown image embeds (![alt](url)) rather than describing the image in text.`;
+		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. If the source content contains image URLs, preserve them as markdown image embeds (![alt](url)) rather than describing the image in text. For internal images referenced as [[image.jpg]], embed them as ![[image.jpg]].`;
 
 		const rawAdditions = await this.aiClient.complete(prompt, systemPrompt);
 		const proposedAdditions = stripCodeFences(sanitizeAIResponse(rawAdditions));

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -23,7 +23,7 @@ export class ProposalGenerator {
 		}
 
 		const prompt = this.buildPrompt(content, detection, contextNotes);
-		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences.`;
+		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. If the source content contains image URLs, preserve them as markdown image embeds (![alt](url)) rather than describing the image in text.`;
 
 		const rawAdditions = await this.aiClient.complete(prompt, systemPrompt);
 		const proposedAdditions = stripCodeFences(sanitizeAIResponse(rawAdditions));

--- a/src/summarize/summarizer.test.ts
+++ b/src/summarize/summarizer.test.ts
@@ -64,6 +64,7 @@ describe('Summarizer', () => {
 		expect(userPrompt).toContain(
 			'preserve them as markdown image embeds (![alt](url))'
 		);
+		expect(userPrompt).toContain('embed them as ![[image.jpg]]');
 	});
 
 	it('includes image embed instruction regardless of summary style', async () => {
@@ -74,6 +75,7 @@ describe('Summarizer', () => {
 			expect(userPrompt).toContain(
 				'preserve them as markdown image embeds (![alt](url))'
 			);
+			expect(userPrompt).toContain('embed them as ![[image.jpg]]');
 		}
 	});
 

--- a/src/summarize/summarizer.test.ts
+++ b/src/summarize/summarizer.test.ts
@@ -57,6 +57,26 @@ describe('Summarizer', () => {
 		expect(systemPrompt).toBe('My custom prompt');
 	});
 
+	it('includes image embed preservation instruction in user prompt', async () => {
+		await summarizer.summarize('Content with ![img](https://example.com/photo.jpg)', 'source', 'bullets');
+
+		const [userPrompt] = mockComplete.mock.calls[0];
+		expect(userPrompt).toContain(
+			'preserve them as markdown image embeds (![alt](url))'
+		);
+	});
+
+	it('includes image embed instruction regardless of summary style', async () => {
+		for (const style of ['bullets', 'paragraph', 'key-points'] as const) {
+			mockComplete.mockClear();
+			await summarizer.summarize('Content', 'source', style);
+			const [userPrompt] = mockComplete.mock.calls[0];
+			expect(userPrompt).toContain(
+				'preserve them as markdown image embeds (![alt](url))'
+			);
+		}
+	});
+
 	it('sanitizes AI response', async () => {
 		mockComplete.mockResolvedValue('<script>alert("xss")</script>Clean text');
 		const result = await summarizer.summarize('Content', 'source', 'bullets');

--- a/src/summarize/summarizer.ts
+++ b/src/summarize/summarizer.ts
@@ -24,7 +24,7 @@ export class Summarizer {
 	): Promise<string> {
 		const systemPrompt = customPrompt || STYLE_PROMPTS[style];
 
-		const userPrompt = `Source: ${source}\n\nIf image URLs are present in the source content, preserve them as markdown image embeds (![alt](url)) rather than describing the image.\n\n${content}`;
+		const userPrompt = `Source: ${source}\n\nIf image URLs are present in the source content, preserve them as markdown image embeds (![alt](url)) rather than describing the image. For internal images like [[image.jpg]], embed them as ![[image.jpg]].\n\n${content}`;
 
 		const response = await this.client.complete(userPrompt, systemPrompt);
 		return sanitizeAIResponse(response);

--- a/src/summarize/summarizer.ts
+++ b/src/summarize/summarizer.ts
@@ -24,7 +24,7 @@ export class Summarizer {
 	): Promise<string> {
 		const systemPrompt = customPrompt || STYLE_PROMPTS[style];
 
-		const userPrompt = `Source: ${source}\n\n${content}`;
+		const userPrompt = `Source: ${source}\n\nIf image URLs are present in the source content, preserve them as markdown image embeds (![alt](url)) rather than describing the image.\n\n${content}`;
 
 		const response = await this.client.complete(userPrompt, systemPrompt);
 		return sanitizeAIResponse(response);


### PR DESCRIPTION
## Summary
- Added image embed preservation instructions to **elaboration**, **deep-dive**, and **summarize** prompts so AI output retains `![alt](url)` syntax instead of describing images as text
- Extended instructions to also cover Obsidian's internal wiki-link image embeds (`![[image.jpg]]`), preventing the AI from stripping the `!` prefix or describing internal images as text
- Added test coverage for all three modules verifying both external and wiki-link embed instructions are present in prompts

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (574 tests, 40 files)
- [x] `node esbuild.config.mjs production` builds successfully

closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)