### PR TITLE
feat: add multi-modal AIClient and image OCR module (#162)

### DIFF
--- a/src/image/extractor.test.ts
+++ b/src/image/extractor.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ImageExtractor } from './extractor';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+
+const mockChat = vi.fn().mockResolvedValue('Extracted text from image');
+
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		chat = mockChat;
+	},
+}));
+
+function makeSettings(overrides?: Partial<SynapseSettings>): SynapseSettings {
+	return { ...structuredClone(DEFAULT_SETTINGS), ...overrides };
+}
+
+function makeImageBuffer(): ArrayBuffer {
+	// Minimal fake image data
+	const data = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+	return data.buffer;
+}
+
+describe('ImageExtractor', () => {
+	let extractor: ImageExtractor;
+	let settings: SynapseSettings;
+
+	beforeEach(() => {
+		mockChat.mockClear();
+		mockChat.mockResolvedValue('Extracted text from image');
+		settings = makeSettings();
+		extractor = new ImageExtractor(() => settings);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('sends correct content blocks to AIClient', async () => {
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'screenshot.png');
+
+		expect(mockChat).toHaveBeenCalledOnce();
+		const messages = mockChat.mock.calls[0][0];
+
+		// Should have system and user messages
+		expect(messages).toHaveLength(2);
+		expect(messages[0].role).toBe('system');
+		expect(messages[0].content).toContain('OCR assistant');
+
+		// User message should have ContentBlock[] with image and text blocks
+		expect(messages[1].role).toBe('user');
+		const content = messages[1].content;
+		expect(Array.isArray(content)).toBe(true);
+		expect(content).toHaveLength(2);
+		expect(content[0].type).toBe('image');
+		expect(content[0].mediaType).toBe('image/png');
+		expect(typeof content[0].data).toBe('string'); // base64
+		expect(content[1].type).toBe('text');
+		expect(content[1].text).toContain('Extract all visible text');
+	});
+
+	it('returns OCR result with text and source name', async () => {
+		const buffer = makeImageBuffer();
+		const result = await extractor.extract(buffer, 'photo.jpg');
+
+		expect(result.text).toBe('Extracted text from image');
+		expect(result.sourceName).toBe('photo.jpg');
+	});
+
+	it('handles "No text detected" response', async () => {
+		mockChat.mockResolvedValue('No text detected.');
+		const buffer = makeImageBuffer();
+		const result = await extractor.extract(buffer, 'blank.png');
+
+		expect(result.text).toBe('No text detected.');
+	});
+
+	it('uses vision model when configured', async () => {
+		settings.image.visionModel = 'gpt-4o';
+		settings.ai.model = 'gpt-4o-mini';
+
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'screenshot.png');
+
+		// The model should have been temporarily set to the vision model
+		// and restored after the call
+		expect(settings.ai.model).toBe('gpt-4o-mini');
+	});
+
+	it('falls back to default model when no vision model set', async () => {
+		settings.image.visionModel = '';
+		settings.ai.model = 'gpt-4o';
+
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'screenshot.png');
+
+		// Model should remain unchanged
+		expect(settings.ai.model).toBe('gpt-4o');
+		expect(mockChat).toHaveBeenCalledOnce();
+	});
+
+	it('maps jpeg extension to correct media type', async () => {
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'photo.jpeg');
+
+		const content = mockChat.mock.calls[0][0][1].content;
+		expect(content[0].mediaType).toBe('image/jpeg');
+	});
+
+	it('maps jpg extension to correct media type', async () => {
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'photo.jpg');
+
+		const content = mockChat.mock.calls[0][0][1].content;
+		expect(content[0].mediaType).toBe('image/jpeg');
+	});
+
+	it('maps webp extension to correct media type', async () => {
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'photo.webp');
+
+		const content = mockChat.mock.calls[0][0][1].content;
+		expect(content[0].mediaType).toBe('image/webp');
+	});
+
+	it('defaults to image/png for unknown extensions', async () => {
+		const buffer = makeImageBuffer();
+		await extractor.extract(buffer, 'photo.xyz');
+
+		const content = mockChat.mock.calls[0][0][1].content;
+		expect(content[0].mediaType).toBe('image/png');
+	});
+
+	it('restores model even if chat throws', async () => {
+		settings.image.visionModel = 'gpt-4o';
+		settings.ai.model = 'gpt-4o-mini';
+		mockChat.mockRejectedValue(new Error('API error'));
+
+		const buffer = makeImageBuffer();
+		await expect(extractor.extract(buffer, 'screenshot.png')).rejects.toThrow('API error');
+
+		// Model should be restored
+		expect(settings.ai.model).toBe('gpt-4o-mini');
+	});
+});

--- a/src/image/extractor.ts
+++ b/src/image/extractor.ts
@@ -1,0 +1,74 @@
+import { AIClient } from '../shared';
+import { SynapseSettings } from '../settings';
+import { ContentBlock } from '../shared/types';
+import { OCRResult } from './types';
+
+export class ImageExtractor {
+	private aiClient: AIClient;
+
+	constructor(private getSettings: () => SynapseSettings) {
+		this.aiClient = new AIClient(getSettings);
+	}
+
+	async extract(imageData: ArrayBuffer, fileName: string): Promise<OCRResult> {
+		const base64 = this.arrayBufferToBase64(imageData);
+		const mediaType = this.getMediaType(fileName);
+		const settings = this.getSettings();
+
+		const contentBlocks: ContentBlock[] = [
+			{
+				type: 'image',
+				data: base64,
+				mediaType,
+			},
+			{
+				type: 'text',
+				text: 'Extract all visible text from this image. Return only the extracted text, preserving the original layout and formatting as much as possible. If no text is found, respond with "No text detected."',
+			},
+		];
+
+		// Use the configured vision model or fall back to the default AI model
+		const visionModel = settings.image.visionModel || settings.ai.model;
+
+		// Temporarily override the model for this request if a vision model is set
+		const originalModel = settings.ai.model;
+		if (visionModel !== originalModel) {
+			settings.ai.model = visionModel;
+		}
+
+		try {
+			const text = await this.aiClient.chat([
+				{ role: 'system', content: 'You are an OCR assistant. Extract text from images accurately.' },
+				{ role: 'user', content: contentBlocks },
+			]);
+			return { text, sourceName: fileName };
+		} finally {
+			if (visionModel !== originalModel) {
+				settings.ai.model = originalModel;
+			}
+		}
+	}
+
+	private arrayBufferToBase64(buffer: ArrayBuffer): string {
+		const bytes = new Uint8Array(buffer);
+		let binary = '';
+		for (let i = 0; i < bytes.length; i++) {
+			binary += String.fromCharCode(bytes[i]);
+		}
+		return btoa(binary);
+	}
+
+	private getMediaType(fileName: string): string {
+		const ext = fileName.split('.').pop()?.toLowerCase() || '';
+		const mimeMap: Record<string, string> = {
+			png: 'image/png',
+			jpg: 'image/jpeg',
+			jpeg: 'image/jpeg',
+			gif: 'image/gif',
+			webp: 'image/webp',
+			bmp: 'image/bmp',
+			tiff: 'image/tiff',
+		};
+		return mimeMap[ext] || 'image/png';
+	}
+}

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -1,0 +1,181 @@
+import { Plugin, TFile } from 'obsidian';
+import { SynapseSettings } from '../settings';
+import {
+	NotificationManager, buildCallout, CALLOUT_TYPES, sanitizeAIResponse,
+	CheckpointManager, generateId,
+} from '../shared';
+import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
+import { findImageEmbeds } from './note-scanner';
+import { ImageEmbed } from './types';
+import { ImageExtractor } from './extractor';
+
+export { findImageEmbeds, IMAGE_EXTENSIONS, IMAGE_EMBED_REGEX } from './note-scanner';
+export type { ImageEmbed, OCRResult } from './types';
+
+export class ImageModule {
+	private extractor: ImageExtractor;
+
+	/** Optional callback invoked after OCR extraction completes. Wired by main.ts for enrichment. */
+	onExtractionComplete: ((filePath: string) => void) | null = null;
+
+	constructor(
+		private plugin: Plugin,
+		private getSettings: () => SynapseSettings,
+		private notifications: NotificationManager,
+		private checkpointManager: CheckpointManager
+	) {
+		this.extractor = new ImageExtractor(getSettings);
+	}
+
+	async onload(): Promise<void> {}
+	onunload(): void {}
+
+	async extractFromFile(file: TFile): Promise<void> {
+		const activeFile = this.plugin.app.workspace.getActiveFile();
+		if (!activeFile) {
+			this.notifications.info('Open a note first to insert the OCR result');
+			return;
+		}
+
+		const op = this.notifications.startOperation(
+			`Extracting text from ${file.name}...`,
+			`image-${file.path}`
+		);
+		try {
+			const data = await this.plugin.app.vault.readBinary(file);
+			const result = await this.extractor.extract(data, file.name);
+			const text = sanitizeAIResponse(result.text);
+
+			const ocrBlock = buildCallout(
+				CALLOUT_TYPES.ocr,
+				`OCR of ${file.name}`,
+				text,
+				true
+			);
+
+			const content = await this.plugin.app.vault.read(activeFile);
+			await this.plugin.app.vault.modify(activeFile, content + ocrBlock);
+			this.onExtractionComplete?.(activeFile.path);
+			op.finish(`OCR of ${file.name} added to note`);
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			op.error(`OCR extraction failed -- ${msg}`);
+		}
+	}
+
+	/**
+	 * Resume image OCR from a checkpoint (C1).
+	 */
+	async resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void> {
+		this.notifications.info(
+			`Image OCR checkpoint has ${checkpoint.remainingItems.length} remaining items. ` +
+			`Completed items are already saved. Please re-run OCR on the source note to continue.`
+		);
+		await this.checkpointManager.discard(checkpoint.id);
+	}
+
+	async extractAndInsert(
+		noteFile: TFile,
+		embeds: ImageEmbed[]
+	): Promise<void> {
+		const total = embeds.length;
+		let completed = 0;
+
+		const op = this.notifications.startOperation(
+			`Extracting text from ${total} image(s)...`,
+			`image-batch-${noteFile.path}`
+		);
+
+		// Create checkpoint for batch OCR
+		const checkpointItems: CheckpointWorkItem[] = embeds.map((e, i) => ({
+			id: `image-${i}-${e.fileName}`,
+			label: e.fileName,
+			payload: { fileName: e.fileName, line: e.line } as Record<string, unknown>,
+		}));
+		const checkpoint = await this.checkpointManager.create({
+			module: 'image',
+			operationLabel: `Image OCR: ${noteFile.basename} (${total} files)`,
+			items: checkpointItems,
+		});
+
+		// Register deferred task for sidebar refresh (I1)
+		await this.checkpointManager.addDeferredTask(checkpoint.id, {
+			id: generateId(),
+			type: 'refresh-sidebar-view',
+			data: {},
+		});
+
+		// Process in reverse line order so insertions don't shift line numbers
+		const sorted = [...embeds].sort((a, b) => b.line - a.line);
+
+		let content = await this.plugin.app.vault.read(noteFile);
+
+		for (let i = 0; i < sorted.length; i++) {
+			if (op.cancelled) break;
+			const embed = sorted[i];
+			// Delay between requests to avoid API rate limits
+			if (i > 0) {
+				await new Promise(resolve => setTimeout(resolve, 2000));
+			}
+			try {
+				op.progress(completed + 1, total, 'Extracting text from image');
+				const data = await this.plugin.app.vault.readBinary(embed.file);
+				const result = await this.extractor.extract(data, embed.fileName);
+				const text = sanitizeAIResponse(result.text);
+
+				const lines = content.split('\n');
+				const ocrBlock = buildCallout(
+					CALLOUT_TYPES.ocr,
+					`OCR of ${embed.fileName}`,
+					text,
+					true
+				);
+
+				// Insert after the embed line
+				lines.splice(embed.line + 1, 0, ocrBlock);
+				content = lines.join('\n');
+
+				completed++;
+
+				// Save checkpoint progress
+				const cpItemId = checkpointItems.find(
+					(ci) => ci.payload.fileName === embed.fileName
+				)?.id;
+				if (cpItemId) {
+					await this.checkpointManager.completeItem(checkpoint.id, cpItemId);
+				}
+			} catch (error) {
+				this.notifications.notifyError(`OCR extraction failed for ${embed.fileName}`, error);
+			}
+		}
+
+		// Write whatever we completed, even if cancelled partway
+		if (completed > 0) {
+			await this.plugin.app.vault.modify(noteFile, content);
+			this.onExtractionComplete?.(noteFile.path);
+		}
+		if (op.cancelled) {
+			// Discard checkpoint on user cancellation (C3)
+			await this.checkpointManager.discard(checkpoint.id);
+		} else {
+			// Mark checkpoint completed and dispatch deferred tasks (I1)
+			const tasks = await this.checkpointManager.complete(checkpoint.id);
+			this.dispatchDeferredTasks(tasks);
+			op.finish(`Done -- ${completed}/${total} OCR extractions added`);
+		}
+	}
+
+	/** Dispatch deferred tasks (I1). */
+	private dispatchDeferredTasks(tasks: DeferredTask[]): void {
+		for (const task of tasks) {
+			switch (task.type) {
+				case 'refresh-sidebar-view':
+					// Image module doesn't have a direct view refresh callback,
+					// but the deferred task system ensures it runs via main.ts dispatch
+					break;
+				default:
+					console.warn(`[Synapse] Unknown deferred task type: ${task.type}`);
+			}
+		}
+	}
+}

--- a/src/image/note-scanner.test.ts
+++ b/src/image/note-scanner.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { findImageEmbeds, hasExtractionBelow } from './note-scanner';
+import { TFile, MetadataCache } from 'obsidian';
+
+function mockMetadataCache(files: Record<string, TFile>): MetadataCache {
+	return {
+		getFirstLinkpathDest: vi.fn((linkpath: string) => files[linkpath] ?? null),
+	} as unknown as MetadataCache;
+}
+
+function makeTFile(name: string, path?: string): TFile {
+	const file = new TFile();
+	Object.assign(file, {
+		path: path ?? name,
+		name,
+		basename: name.replace(/\.[^.]+$/, ''),
+		extension: name.split('.').pop() || '',
+	});
+	return file;
+}
+
+describe('findImageEmbeds', () => {
+	it('finds image embeds in content', () => {
+		const file = makeTFile('screenshot.png', 'images/screenshot.png');
+		const cache = mockMetadataCache({ 'screenshot.png': file });
+
+		const content = '# Notes\n![[screenshot.png]]\nSome text';
+		const result = findImageEmbeds(content, 'notes/test.md', cache);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({ fileName: 'screenshot.png', file, line: 1 });
+	});
+
+	it('skips already-extracted embeds (legacy format)', () => {
+		const file = makeTFile('screenshot.png');
+		const cache = mockMetadataCache({ 'screenshot.png': file });
+
+		const content = [
+			'![[screenshot.png]]',
+			'',
+			'> **OCR of screenshot.png**',
+			'> Some text',
+		].join('\n');
+		const result = findImageEmbeds(content, 'test.md', cache);
+		expect(result).toHaveLength(0);
+	});
+
+	it('skips already-extracted embeds (callout format)', () => {
+		const file = makeTFile('screenshot.png');
+		const cache = mockMetadataCache({ 'screenshot.png': file });
+
+		const content = [
+			'![[screenshot.png]]',
+			'',
+			'> [!synapse-ocr]- OCR of screenshot.png',
+			'> Some text',
+		].join('\n');
+		const result = findImageEmbeds(content, 'test.md', cache);
+		expect(result).toHaveLength(0);
+	});
+
+	it('returns empty array for empty content', () => {
+		const cache = mockMetadataCache({});
+		expect(findImageEmbeds('', 'test.md', cache)).toHaveLength(0);
+	});
+
+	it('returns empty array for content with no image embeds', () => {
+		const cache = mockMetadataCache({});
+		const content = 'Just some text\n![[recording.mp3]]\nMore text';
+		expect(findImageEmbeds(content, 'test.md', cache)).toHaveLength(0);
+	});
+
+	it('finds multiple image embeds', () => {
+		const file1 = makeTFile('a.png');
+		const file2 = makeTFile('b.jpg');
+		const cache = mockMetadataCache({ 'a.png': file1, 'b.jpg': file2 });
+
+		const content = '![[a.png]]\nSome text\n![[b.jpg]]';
+		const result = findImageEmbeds(content, 'test.md', cache);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].line).toBe(0);
+		expect(result[1].line).toBe(2);
+	});
+
+	it('reports correct line numbers', () => {
+		const file = makeTFile('diagram.webp');
+		const cache = mockMetadataCache({ 'diagram.webp': file });
+
+		const content = '# Header\n\nSome notes\n\n![[diagram.webp]]';
+		const result = findImageEmbeds(content, 'test.md', cache);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].line).toBe(4);
+	});
+
+	it('ignores files that do not resolve', () => {
+		const cache = mockMetadataCache({});
+
+		const content = '![[missing.png]]';
+		const result = findImageEmbeds(content, 'test.md', cache);
+		expect(result).toHaveLength(0);
+	});
+
+	it('finds embeds with various image extensions', () => {
+		const files: Record<string, TFile> = {};
+		const extensions = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'tiff'];
+		for (const ext of extensions) {
+			files[`img.${ext}`] = makeTFile(`img.${ext}`);
+		}
+		const cache = mockMetadataCache(files);
+
+		const content = extensions.map(ext => `![[img.${ext}]]`).join('\n');
+		const result = findImageEmbeds(content, 'test.md', cache);
+
+		expect(result).toHaveLength(extensions.length);
+	});
+});
+
+describe('hasExtractionBelow', () => {
+	it('returns true when legacy extraction exists immediately below', () => {
+		const lines = [
+			'![[screenshot.png]]',
+			'> **OCR of screenshot.png**',
+			'> text',
+		];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(true);
+	});
+
+	it('returns true when extraction is 1 blank line below', () => {
+		const lines = [
+			'![[screenshot.png]]',
+			'',
+			'> **OCR of screenshot.png**',
+		];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(true);
+	});
+
+	it('returns true for callout-format extraction', () => {
+		const lines = [
+			'![[screenshot.png]]',
+			'',
+			'> [!synapse-ocr]- OCR of screenshot.png',
+			'> text',
+		];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(true);
+	});
+
+	it('returns false when no extraction exists', () => {
+		const lines = [
+			'![[screenshot.png]]',
+			'Some other text',
+		];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(false);
+	});
+
+	it('returns false when extraction is for a different file', () => {
+		const lines = [
+			'![[screenshot.png]]',
+			'> **OCR of other.png**',
+		];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(false);
+	});
+
+	it('returns false when embed is at the last line', () => {
+		const lines = ['![[screenshot.png]]'];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(false);
+	});
+
+	it('stops searching after non-blockquote content', () => {
+		const lines = [
+			'![[screenshot.png]]',
+			'Some unrelated text',
+			'> **OCR of screenshot.png**',
+		];
+		expect(hasExtractionBelow(lines, 0, 'screenshot.png')).toBe(false);
+	});
+});

--- a/src/image/note-scanner.ts
+++ b/src/image/note-scanner.ts
@@ -1,0 +1,54 @@
+import { TFile, MetadataCache } from 'obsidian';
+import { CALLOUT_TYPES } from '../shared';
+import { ImageEmbed } from './types';
+
+export const IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|webp|bmp|tiff)$/i;
+export const IMAGE_EMBED_REGEX = /!\[\[([^\]]+\.(?:png|jpg|jpeg|gif|webp|bmp|tiff))\]\]/gi;
+
+export function findImageEmbeds(
+	content: string,
+	sourcePath: string,
+	metadataCache: MetadataCache
+): ImageEmbed[] {
+	const embeds: ImageEmbed[] = [];
+	const lines = content.split('\n');
+
+	for (let i = 0; i < lines.length; i++) {
+		const matches = [...lines[i].matchAll(IMAGE_EMBED_REGEX)];
+		for (const match of matches) {
+			const fileName = match[1];
+
+			if (hasExtractionBelow(lines, i, fileName)) {
+				continue;
+			}
+
+			const file = metadataCache.getFirstLinkpathDest(
+				fileName,
+				sourcePath
+			);
+			if (file instanceof TFile && IMAGE_EXTENSIONS.test(file.name)) {
+				embeds.push({ fileName, file, line: i });
+			}
+		}
+	}
+
+	return embeds;
+}
+
+export function hasExtractionBelow(lines: string[], embedLine: number, fileName: string): boolean {
+	for (let j = embedLine + 1; j < lines.length && j <= embedLine + 3; j++) {
+		// Legacy format
+		if (lines[j].includes(`**OCR of ${fileName}**`)) {
+			return true;
+		}
+		// Callout format
+		if (lines[j].includes(`[!${CALLOUT_TYPES.ocr}]`) && lines[j].includes(`OCR of ${fileName}`)) {
+			return true;
+		}
+		// Stop looking if we hit another embed or non-empty non-blank line that isn't a blockquote
+		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {
+			break;
+		}
+	}
+	return false;
+}

--- a/src/image/types.ts
+++ b/src/image/types.ts
@@ -1,0 +1,14 @@
+import { TFile } from 'obsidian';
+
+export interface ImageEmbed {
+	fileName: string;
+	file: TFile;
+	line: number;
+}
+
+export interface OCRResult {
+	/** Extracted text from the image */
+	text: string;
+	/** Source image file name */
+	sourceName?: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { SynapseSettingTab } from './settings-tab';
 import { ElaborationModule } from './elaboration';
 import { AudioModule } from './audio';
 import { VideoModule } from './video';
+import { ImageModule } from './image';
 import { EnrichmentModule } from './enrichment';
 import { SummarizeModule } from './summarize';
 import { TidyModule } from './tidy';
@@ -15,6 +16,7 @@ import type { DeferredTask, Checkpoint } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
 import { findVideoUrls } from './video';
+import { findImageEmbeds } from './image';
 import {
 	UNIFIED_VIEW_TYPE,
 	UnifiedProposalView,
@@ -29,6 +31,7 @@ export default class SynapsePlugin extends Plugin {
 	private elaboration!: ElaborationModule;
 	private audio!: AudioModule;
 	private video: VideoModule | null = null;
+	private image!: ImageModule;
 	private enrichment!: EnrichmentModule;
 	private summarize!: SummarizeModule;
 	private tidy!: TidyModule;
@@ -62,6 +65,7 @@ export default class SynapsePlugin extends Plugin {
 		if (Platform.isDesktop) {
 			this.video = new VideoModule(this, getSettings, this.audio, this.notifications, this.checkpointManager);
 		}
+		this.image = new ImageModule(this, getSettings, this.notifications, this.checkpointManager);
 		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications, this.checkpointManager);
 		this.summarize = new SummarizeModule(
 			this, getSettings, this.notifications, this.checkpointManager,
@@ -115,6 +119,9 @@ export default class SynapsePlugin extends Plugin {
 		if (this.settings.video.enabled && this.video) {
 			await this.video.onload();
 		}
+		if (this.settings.image.enabled) {
+			await this.image.onload();
+		}
 		if (this.settings.enrichment.enabled) {
 			await this.enrichment.onload();
 		}
@@ -156,6 +163,12 @@ export default class SynapsePlugin extends Plugin {
 					}
 				};
 			}
+			this.image.onExtractionComplete = (filePath: string) => {
+				this.enrichment.enrich(filePath, 'transcription');
+				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
+					this.title.checkTitle(filePath);
+				}
+			};
 			this.summarize.onSummaryComplete = (filePath: string) => {
 				this.enrichment.enrich(filePath, 'summarization');
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
@@ -186,6 +199,9 @@ export default class SynapsePlugin extends Plugin {
 					this.title.checkTitle(filePath);
 				};
 			}
+			this.image.onExtractionComplete = (filePath: string) => {
+				this.title.checkTitle(filePath);
+			};
 			this.summarize.onSummaryComplete = (filePath: string) => {
 				this.title.checkTitle(filePath);
 			};
@@ -235,8 +251,8 @@ export default class SynapsePlugin extends Plugin {
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
 		setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
 
-		// Unified transcription commands (audio on any platform, video on desktop only)
-		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video);
+		// Unified transcription commands (audio on any platform, video on desktop only, image OCR)
+		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
 		if (hasTranscription) {
 			this.addCommand({
 				id: 'synapse:transcribe-media',
@@ -260,6 +276,7 @@ export default class SynapsePlugin extends Plugin {
 		this.elaboration?.onunload();
 		this.audio?.onunload();
 		this.video?.onunload();
+		this.image?.onunload();
 		this.enrichment?.onunload();
 		this.summarize?.onunload();
 		this.tidy?.onunload();
@@ -305,8 +322,11 @@ export default class SynapsePlugin extends Plugin {
 		const videoEmbeds = this.settings.video.enabled && this.video
 			? findVideoUrls(content)
 			: [];
+		const imageEmbeds = this.settings.image.enabled
+			? findImageEmbeds(content, file.path, this.app.metadataCache)
+			: [];
 
-		if (audioEmbeds.length === 0 && videoEmbeds.length === 0) {
+		if (audioEmbeds.length === 0 && videoEmbeds.length === 0 && imageEmbeds.length === 0) {
 			this.notifications.info('No media found in this note');
 			return;
 		}
@@ -315,11 +335,13 @@ export default class SynapsePlugin extends Plugin {
 			this.app,
 			audioEmbeds,
 			videoEmbeds,
+			imageEmbeds,
 			{
 				onTranscribeAudio: (selected) => this.audio.transcribeAndInsert(file, selected),
 				onTranscribeVideo: this.video
 					? (selected) => this.video!.transcribeAndInsert(file, selected)
 					: async () => { /* unreachable: video hidden on mobile */ },
+				onExtractImages: (selected) => this.image.extractAndInsert(file, selected),
 			}
 		).open();
 	}
@@ -377,6 +399,9 @@ export default class SynapsePlugin extends Plugin {
 				} else {
 					this.notifications.info('Video transcription is not available on mobile');
 				}
+				break;
+			case 'image':
+				await this.image.resumeFromCheckpoint(checkpoint);
 				break;
 			case 'summarize':
 				await this.summarize.resumeFromCheckpoint(checkpoint);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -95,6 +95,12 @@ export interface VideoSettings {
 	frameExtraction: FrameExtractionSettings;
 }
 
+export interface ImageSettings {
+	enabled: boolean;
+	visionModel: string;
+	language: string;
+}
+
 export interface EnrichmentWeightSettings {
 	sameFolder: number;
 	siblingFolder: number;
@@ -183,6 +189,7 @@ export interface SynapseSettings {
 	elaboration: ElaborationSettings;
 	audio: AudioSettings;
 	video: VideoSettings;
+	image: ImageSettings;
 	enrichment: EnrichmentSettings;
 	summarize: SummarizeSettings;
 	tidy: TidySettings;
@@ -252,6 +259,11 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 			visionModel: 'gpt-4o',
 			maxFrames: 20,
 		},
+	},
+	image: {
+		enabled: true,
+		visionModel: '',
+		language: '',
 	},
 	enrichment: {
 		enabled: true,

--- a/src/shared/ai-client.ts
+++ b/src/shared/ai-client.ts
@@ -1,6 +1,6 @@
 import { requestUrl, RequestUrlParam, RequestUrlResponse } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { ChatMessage } from './types';
+import { ChatMessage, ContentBlock } from './types';
 
 /** Redact API keys/tokens that may appear in API error response bodies. */
 function redactSecrets(text: string): string {
@@ -56,6 +56,61 @@ function resolveModelId(provider: string, model: string): string {
 	return model;
 }
 
+/**
+ * Convert ContentBlock[] to OpenAI's multimodal message format.
+ */
+function toOpenAIContent(blocks: ContentBlock[]): unknown[] {
+	return blocks.map(block => {
+		if (block.type === 'text') {
+			return { type: 'text', text: block.text };
+		}
+		return {
+			type: 'image_url',
+			image_url: { url: `data:${block.mediaType};base64,${block.data}` },
+		};
+	});
+}
+
+/**
+ * Convert ContentBlock[] to Anthropic's multimodal message format.
+ */
+function toAnthropicContent(blocks: ContentBlock[]): unknown[] {
+	return blocks.map(block => {
+		if (block.type === 'text') {
+			return { type: 'text', text: block.text };
+		}
+		return {
+			type: 'image',
+			source: {
+				type: 'base64',
+				media_type: block.mediaType,
+				data: block.data,
+			},
+		};
+	});
+}
+
+/**
+ * Convert ContentBlock[] to Ollama format: text goes into `content`,
+ * images go into a separate `images` array.
+ */
+function toOllamaMessage(role: string, blocks: ContentBlock[]): Record<string, unknown> {
+	const textParts: string[] = [];
+	const images: string[] = [];
+	for (const block of blocks) {
+		if (block.type === 'text') {
+			textParts.push(block.text);
+		} else {
+			images.push(block.data);
+		}
+	}
+	const msg: Record<string, unknown> = { role, content: textParts.join('\n') };
+	if (images.length > 0) {
+		msg.images = images;
+	}
+	return msg;
+}
+
 export class AIClient {
 	constructor(private getSettings: () => SynapseSettings) {}
 
@@ -95,7 +150,12 @@ export class AIClient {
 			},
 			body: JSON.stringify({
 				model,
-				messages,
+				messages: messages.map(m => ({
+					role: m.role,
+					content: typeof m.content === 'string'
+						? m.content
+						: toOpenAIContent(m.content),
+				})),
 				max_tokens: ai.maxTokens,
 				temperature: ai.temperature,
 			}),
@@ -115,11 +175,15 @@ export class AIClient {
 			temperature: ai.temperature,
 			messages: nonSystemMsgs.map(m => ({
 				role: m.role,
-				content: m.content,
+				content: typeof m.content === 'string'
+					? m.content
+					: toAnthropicContent(m.content),
 			})),
 		};
 		if (systemMsg) {
-			body.system = systemMsg.content;
+			body.system = typeof systemMsg.content === 'string'
+				? systemMsg.content
+				: systemMsg.content;
 		}
 
 		const response = await safeRequest({
@@ -157,7 +221,12 @@ export class AIClient {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				model,
-				messages,
+				messages: messages.map(m => {
+					if (typeof m.content === 'string') {
+						return { role: m.role, content: m.content };
+					}
+					return toOllamaMessage(m.role, m.content);
+				}),
 				stream: false,
 			}),
 		});

--- a/src/shared/callouts.ts
+++ b/src/shared/callouts.ts
@@ -13,6 +13,7 @@ export const CALLOUT_TYPES = {
 	elaboration: 'synapse-elaboration',
 	deepDive: 'synapse-deep-dive',
 	nav: 'synapse-nav',
+	ocr: 'synapse-ocr',
 } as const;
 
 export type CalloutType = (typeof CALLOUT_TYPES)[keyof typeof CALLOUT_TYPES];

--- a/src/shared/checkpoint-types.ts
+++ b/src/shared/checkpoint-types.ts
@@ -13,6 +13,7 @@ export type CheckpointModule =
 	| 'enrichment'
 	| 'audio'
 	| 'video'
+	| 'image'
 	| 'summarize'
 	| 'organize';
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,5 +1,5 @@
 export { AIClient } from './ai-client';
-export type { ChatMessage } from './types';
+export type { ChatMessage, ContentBlock, TextContentBlock, ImageContentBlock } from './types';
 export { withRetry, sleep, notifyError } from './api-utils';
 export {
 	ensureFolder,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,19 @@
+export interface ImageContentBlock {
+	type: 'image';
+	/** base64-encoded image data */
+	data: string;
+	/** MIME type, e.g. 'image/png' */
+	mediaType: string;
+}
+
+export interface TextContentBlock {
+	type: 'text';
+	text: string;
+}
+
+export type ContentBlock = TextContentBlock | ImageContentBlock;
+
 export interface ChatMessage {
 	role: 'system' | 'user' | 'assistant';
-	content: string;
+	content: string | ContentBlock[];
 }

--- a/src/transcription/note-media-modal.ts
+++ b/src/transcription/note-media-modal.ts
@@ -1,35 +1,45 @@
 import { App, Modal, Notice, Setting } from 'obsidian';
 import { AudioEmbed } from '../audio';
 import { VideoUrlEmbed } from '../video';
+import { ImageEmbed } from '../image';
 
 export class NoteMediaModal extends Modal {
 	private selectedAudio: Set<string>;
 	private selectedVideo: Set<string>;
+	private selectedImage: Set<string>;
 
 	constructor(
 		app: App,
 		private audioEmbeds: AudioEmbed[],
 		private videoEmbeds: VideoUrlEmbed[],
+		private imageEmbeds: ImageEmbed[],
 		private callbacks: {
 			onTranscribeAudio: (embeds: AudioEmbed[]) => Promise<void>;
 			onTranscribeVideo: (embeds: VideoUrlEmbed[]) => Promise<void>;
+			onExtractImages: (embeds: ImageEmbed[]) => Promise<void>;
 		}
 	) {
 		super(app);
 		this.selectedAudio = new Set(audioEmbeds.map(e => e.fileName));
 		this.selectedVideo = new Set(videoEmbeds.map(e => e.url));
+		this.selectedImage = new Set(imageEmbeds.map(e => e.fileName));
 	}
 
 	onOpen(): void {
 		const { contentEl } = this;
 		contentEl.empty();
 
-		contentEl.createEl('h2', { text: 'Transcribe Media from Note' });
+		contentEl.createEl('h2', { text: 'Process Media from Note' });
 
 		const audioCount = this.audioEmbeds.length;
 		const videoCount = this.videoEmbeds.length;
+		const imageCount = this.imageEmbeds.length;
+		const parts: string[] = [];
+		if (audioCount > 0) parts.push(`${audioCount} audio file(s)`);
+		if (videoCount > 0) parts.push(`${videoCount} video URL(s)`);
+		if (imageCount > 0) parts.push(`${imageCount} image(s)`);
 		contentEl.createEl('p', {
-			text: `Found ${audioCount} audio file(s) and ${videoCount} video URL(s).`,
+			text: `Found ${parts.join(', ')}.`,
 		});
 
 		// Select all / none
@@ -38,30 +48,34 @@ export class NoteMediaModal extends Modal {
 				btn.setButtonText('Select All').onClick(() => {
 					this.selectedAudio = new Set(this.audioEmbeds.map(e => e.fileName));
 					this.selectedVideo = new Set(this.videoEmbeds.map(e => e.url));
-					this.renderCheckboxes(audioListEl, videoListEl);
+					this.selectedImage = new Set(this.imageEmbeds.map(e => e.fileName));
+					this.renderCheckboxes(audioListEl, videoListEl, imageListEl);
 				});
 			})
 			.addButton((btn) => {
 				btn.setButtonText('Select None').onClick(() => {
 					this.selectedAudio.clear();
 					this.selectedVideo.clear();
-					this.renderCheckboxes(audioListEl, videoListEl);
+					this.selectedImage.clear();
+					this.renderCheckboxes(audioListEl, videoListEl, imageListEl);
 				});
 			});
 
 		const audioListEl = contentEl.createDiv({ cls: 'synapse-audio-list' });
 		const videoListEl = contentEl.createDiv({ cls: 'synapse-video-list' });
-		this.renderCheckboxes(audioListEl, videoListEl);
+		const imageListEl = contentEl.createDiv({ cls: 'synapse-image-list' });
+		this.renderCheckboxes(audioListEl, videoListEl, imageListEl);
 
-		// Transcribe button
+		// Process button
 		new Setting(contentEl).addButton((btn) => {
-			btn.setButtonText('Transcribe Selected')
+			btn.setButtonText('Process Selected')
 				.setCta()
 				.onClick(async () => {
 					const chosenAudio = this.audioEmbeds.filter(e => this.selectedAudio.has(e.fileName));
 					const chosenVideo = this.videoEmbeds.filter(e => this.selectedVideo.has(e.url));
+					const chosenImage = this.imageEmbeds.filter(e => this.selectedImage.has(e.fileName));
 
-					if (chosenAudio.length === 0 && chosenVideo.length === 0) {
+					if (chosenAudio.length === 0 && chosenVideo.length === 0 && chosenImage.length === 0) {
 						new Notice('Please select at least one item');
 						return;
 					}
@@ -74,13 +88,21 @@ export class NoteMediaModal extends Modal {
 					if (chosenVideo.length > 0) {
 						await this.callbacks.onTranscribeVideo(chosenVideo);
 					}
+					if (chosenImage.length > 0) {
+						await this.callbacks.onExtractImages(chosenImage);
+					}
 				});
 		});
 	}
 
-	private renderCheckboxes(audioContainer: HTMLElement, videoContainer: HTMLElement): void {
+	private renderCheckboxes(
+		audioContainer: HTMLElement,
+		videoContainer: HTMLElement,
+		imageContainer: HTMLElement
+	): void {
 		audioContainer.empty();
 		videoContainer.empty();
+		imageContainer.empty();
 
 		if (this.audioEmbeds.length > 0) {
 			audioContainer.createEl('h4', { text: 'Audio Files' });
@@ -114,6 +136,25 @@ export class NoteMediaModal extends Modal {
 									this.selectedVideo.add(embed.url);
 								} else {
 									this.selectedVideo.delete(embed.url);
+								}
+							});
+					});
+			}
+		}
+
+		if (this.imageEmbeds.length > 0) {
+			imageContainer.createEl('h4', { text: 'Images (OCR)' });
+			for (const embed of this.imageEmbeds) {
+				new Setting(imageContainer)
+					.setName(embed.fileName)
+					.addToggle((toggle) => {
+						toggle
+							.setValue(this.selectedImage.has(embed.fileName))
+							.onChange((val) => {
+								if (val) {
+									this.selectedImage.add(embed.fileName);
+								} else {
+									this.selectedImage.delete(embed.fileName);
 								}
 							});
 					});


### PR DESCRIPTION
## Summary
- Extend `ChatMessage.content` to a union type (`string | ContentBlock[]`) supporting multi-modal content (text + images) with full backward compatibility
- Update all three AI provider methods (OpenAI, Anthropic, Ollama) to serialize image content blocks per provider-specific format
- Add `src/image/` module with note-scanner, extractor, types, and full checkpoint support following the existing audio module patterns
- Wire ImageModule into main.ts with enrichment/title callbacks, checkpoint resume, and updated NoteMediaModal for combined audio/video/image media processing
- Add `'synapse-ocr'` callout type and `'image'` checkpoint module
- Add `ImageSettings` (enabled, visionModel, language) to settings with defaults

closes #162

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (600 tests, 42 test files including 2 new image test files)
- [x] `node esbuild.config.mjs production` builds successfully
- [ ] Manual: embed an image in a note, run "Transcribe media from current note", verify OCR callout is inserted below the image embed
- [ ] Manual: verify existing audio/video transcription still works unchanged

Co-Authored-By: Claude <bot@wafflenet.io>