### PR TITLE
feat: add image analysis to elaboration proposals (#163)

### DIFF
--- a/src/elaboration/image-analyzer.test.ts
+++ b/src/elaboration/image-analyzer.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TFile } from '../__mocks__/obsidian';
+import { ImageAnalyzer, MAX_IMAGES_PER_NOTE } from './image-analyzer';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+
+const mockChat = vi.fn().mockResolvedValue(
+	'DESCRIPTION: A sunset over mountains\n\nLOCATION: Rocky Mountain range, Colorado\n\nMETADATA: Taken during golden hour, approximately 6pm'
+);
+
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		chat = mockChat;
+	},
+}));
+
+function makeSettings(overrides?: Partial<SynapseSettings>): SynapseSettings {
+	return { ...structuredClone(DEFAULT_SETTINGS), ...overrides };
+}
+
+function makeImageBuffer(): ArrayBuffer {
+	const data = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+	return data.buffer;
+}
+
+describe('ImageAnalyzer.findImageReferences', () => {
+	let analyzer: ImageAnalyzer;
+
+	beforeEach(() => {
+		const settings = makeSettings();
+		const mockApp = {
+			vault: { readBinary: vi.fn() },
+			metadataCache: { getFirstLinkpathDest: vi.fn() },
+		};
+		analyzer = new ImageAnalyzer(mockApp as any, () => settings);
+	});
+
+	it('finds wiki-link images', () => {
+		const content = 'Some text\n![[photo.png]]\nMore text';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(1);
+		expect(refs[0].reference).toBe('![[photo.png]]');
+		expect(refs[0].path).toBe('photo.png');
+		expect(refs[0].isInternal).toBe(true);
+	});
+
+	it('finds markdown images with local paths', () => {
+		const content = 'Some text\n![alt text](assets/photo.jpg)\nMore text';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(1);
+		expect(refs[0].reference).toBe('![alt text](assets/photo.jpg)');
+		expect(refs[0].path).toBe('assets/photo.jpg');
+		expect(refs[0].isInternal).toBe(true);
+	});
+
+	it('skips external URLs in markdown images', () => {
+		const content = '![photo](https://example.com/img.png)\n![local](local.png)';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(1);
+		expect(refs[0].path).toBe('local.png');
+	});
+
+	it('skips http external URLs', () => {
+		const content = '![photo](http://example.com/img.png)';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(0);
+	});
+
+	it('deduplicates same image referenced twice', () => {
+		const content = '![[photo.png]]\nSome text\n![[photo.png]]';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(1);
+	});
+
+	it('returns empty for content with no images', () => {
+		const content = '# Title\n\nJust plain text with no images.';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(0);
+	});
+
+	it('handles mixed wiki-link and markdown images', () => {
+		const content = '![[photo.png]]\n![alt](diagram.jpg)\n![[chart.gif]]';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(3);
+		// Wiki-link images are collected first, then markdown images
+		expect(refs[0].path).toBe('photo.png');
+		expect(refs[1].path).toBe('chart.gif');
+		expect(refs[2].path).toBe('diagram.jpg');
+	});
+
+	it('respects MAX_IMAGES_PER_NOTE limit', () => {
+		const images = Array.from({ length: 8 }, (_, i) => `![[img${i}.png]]`).join('\n');
+		const refs = analyzer.findImageReferences(images);
+
+		expect(refs).toHaveLength(MAX_IMAGES_PER_NOTE);
+	});
+
+	it('finds images with various supported extensions', () => {
+		const content = [
+			'![[photo.jpg]]',
+			'![[photo.jpeg]]',
+			'![[photo.gif]]',
+			'![[photo.webp]]',
+			'![[photo.bmp]]',
+		].join('\n');
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(5);
+	});
+
+	it('is case-insensitive for extensions in wiki-links', () => {
+		const content = '![[Photo.PNG]]\n![[image.JPG]]';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(2);
+	});
+
+	it('does not match non-image wiki-links', () => {
+		const content = '![[document.pdf]]\n![[note.md]]\n![[photo.png]]';
+		const refs = analyzer.findImageReferences(content);
+
+		expect(refs).toHaveLength(1);
+		expect(refs[0].path).toBe('photo.png');
+	});
+});
+
+describe('ImageAnalyzer.parseAnalysisResponse', () => {
+	let analyzer: ImageAnalyzer;
+
+	beforeEach(() => {
+		const settings = makeSettings();
+		const mockApp = {
+			vault: { readBinary: vi.fn() },
+			metadataCache: { getFirstLinkpathDest: vi.fn() },
+		};
+		analyzer = new ImageAnalyzer(mockApp as any, () => settings);
+	});
+
+	it('parses well-formed DESCRIPTION/LOCATION/METADATA response', () => {
+		const response = 'DESCRIPTION: A sunset over mountains\n\nLOCATION: Rocky Mountain range\n\nMETADATA: Golden hour lighting';
+		const result = analyzer.parseAnalysisResponse('![[photo.png]]', response);
+
+		expect(result.reference).toBe('![[photo.png]]');
+		expect(result.description).toBe('A sunset over mountains');
+		expect(result.locationHints).toBe('Rocky Mountain range');
+		expect(result.metadata).toBe('Golden hour lighting');
+	});
+
+	it('handles missing sections gracefully', () => {
+		const response = 'DESCRIPTION: A diagram showing architecture';
+		const result = analyzer.parseAnalysisResponse('![[diagram.png]]', response);
+
+		expect(result.description).toBe('A diagram showing architecture');
+		expect(result.locationHints).toBe('');
+		expect(result.metadata).toBe('');
+	});
+
+	it('uses full response as description when format does not match', () => {
+		const response = 'This is a photo of a cat sitting on a windowsill.';
+		const result = analyzer.parseAnalysisResponse('![[cat.jpg]]', response);
+
+		expect(result.description).toBe('This is a photo of a cat sitting on a windowsill.');
+		expect(result.locationHints).toBe('');
+		expect(result.metadata).toBe('');
+	});
+
+	it('handles multiline section content', () => {
+		const response = [
+			'DESCRIPTION: A complex diagram showing:',
+			'- System architecture',
+			'- Data flow between components',
+			'',
+			'LOCATION: No location clues detected.',
+			'',
+			'METADATA: High resolution, appears to be a screen capture',
+		].join('\n');
+		const result = analyzer.parseAnalysisResponse('![[arch.png]]', response);
+
+		expect(result.description).toContain('System architecture');
+		expect(result.description).toContain('Data flow between components');
+		expect(result.locationHints).toBe('No location clues detected.');
+		expect(result.metadata).toBe('High resolution, appears to be a screen capture');
+	});
+});
+
+describe('ImageAnalyzer.analyzeImagesInNote', () => {
+	let analyzer: ImageAnalyzer;
+	let settings: SynapseSettings;
+	let mockApp: any;
+
+	beforeEach(() => {
+		mockChat.mockClear();
+		mockChat.mockResolvedValue(
+			'DESCRIPTION: A sunset over mountains\n\nLOCATION: Rocky Mountain range\n\nMETADATA: Golden hour lighting'
+		);
+
+		settings = makeSettings();
+
+		const imageFile = new TFile('assets/photo.png');
+
+		mockApp = {
+			vault: {
+				readBinary: vi.fn().mockResolvedValue(makeImageBuffer()),
+			},
+			metadataCache: {
+				getFirstLinkpathDest: vi.fn().mockReturnValue(imageFile),
+			},
+		};
+
+		analyzer = new ImageAnalyzer(mockApp as any, () => settings);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns empty array when no images found', async () => {
+		const results = await analyzer.analyzeImagesInNote('notes/test.md', '# No images here');
+		expect(results).toHaveLength(0);
+	});
+
+	it('returns empty array when image module is disabled', async () => {
+		settings.image.enabled = false;
+		const results = await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'# Title\n![[photo.png]]'
+		);
+		expect(results).toHaveLength(0);
+	});
+
+	it('analyzes images and returns structured results', async () => {
+		const results = await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'# Trip Notes\n![[photo.png]]\nGreat view!'
+		);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].reference).toBe('![[photo.png]]');
+		expect(results[0].description).toBe('A sunset over mountains');
+		expect(results[0].locationHints).toBe('Rocky Mountain range');
+		expect(results[0].metadata).toBe('Golden hour lighting');
+	});
+
+	it('sends correct content blocks to AIClient', async () => {
+		await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'# Title\n![[photo.png]]'
+		);
+
+		expect(mockChat).toHaveBeenCalledOnce();
+		const messages = mockChat.mock.calls[0][0];
+
+		expect(messages).toHaveLength(2);
+		expect(messages[0].role).toBe('system');
+		expect(messages[0].content).toContain('image analysis assistant');
+
+		const content = messages[1].content;
+		expect(Array.isArray(content)).toBe(true);
+		expect(content).toHaveLength(2);
+		expect(content[0].type).toBe('image');
+		expect(content[0].mediaType).toBe('image/png');
+		expect(content[1].type).toBe('text');
+		expect(content[1].text).toContain('DESCRIPTION');
+		expect(content[1].text).toContain('LOCATION');
+		expect(content[1].text).toContain('METADATA');
+	});
+
+	it('skips images that cannot be resolved', async () => {
+		mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(null);
+
+		const results = await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'# Title\n![[missing.png]]'
+		);
+
+		expect(results).toHaveLength(0);
+		expect(mockChat).not.toHaveBeenCalled();
+	});
+
+	it('gracefully handles per-image failures', async () => {
+		const imageFile = new TFile('assets/photo.png');
+		const secondFile = new TFile('assets/second.jpg');
+
+		mockApp.metadataCache.getFirstLinkpathDest
+			.mockReturnValueOnce(imageFile)
+			.mockReturnValueOnce(secondFile);
+
+		mockApp.vault.readBinary
+			.mockRejectedValueOnce(new Error('File read error'))
+			.mockResolvedValueOnce(makeImageBuffer());
+
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const results = await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'![[photo.png]]\n![[second.jpg]]'
+		);
+
+		// First image failed, second succeeded
+		expect(results).toHaveLength(1);
+		expect(results[0].reference).toBe('![[second.jpg]]');
+		expect(warnSpy).toHaveBeenCalled();
+
+		warnSpy.mockRestore();
+	});
+
+	it('uses vision model when configured', async () => {
+		settings.image.visionModel = 'gpt-4o';
+		settings.ai.model = 'gpt-4o-mini';
+
+		await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'![[photo.png]]'
+		);
+
+		// Model should be restored after the call
+		expect(settings.ai.model).toBe('gpt-4o-mini');
+	});
+
+	it('restores model even if chat throws', async () => {
+		settings.image.visionModel = 'gpt-4o';
+		settings.ai.model = 'gpt-4o-mini';
+		mockChat.mockRejectedValue(new Error('API error'));
+
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		await analyzer.analyzeImagesInNote(
+			'notes/test.md',
+			'![[photo.png]]'
+		);
+
+		expect(settings.ai.model).toBe('gpt-4o-mini');
+		warnSpy.mockRestore();
+	});
+});

--- a/src/elaboration/image-analyzer.ts
+++ b/src/elaboration/image-analyzer.ts
@@ -1,0 +1,195 @@
+import { App, TFile } from 'obsidian';
+import { AIClient } from '../shared';
+import type { ContentBlock } from '../shared/types';
+import { SynapseSettings } from '../settings';
+
+export interface ImageAnalysis {
+	/** Original reference as it appears in the note */
+	reference: string;
+	/** AI-generated description of the image */
+	description: string;
+	/** Location hints from visual clues (landmarks, signs, etc.) */
+	locationHints: string;
+	/** Metadata observations (date clues, camera details from visible UI, etc.) */
+	metadata: string;
+}
+
+/** Maximum number of images to analyze per note to avoid token overflow */
+export const MAX_IMAGES_PER_NOTE = 5;
+
+/** Regex patterns for finding image references in notes */
+const WIKI_IMAGE_REGEX = /!\[\[([^\]]+\.(?:png|jpg|jpeg|gif|webp|bmp|tiff))\]\]/gi;
+const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g;
+
+export class ImageAnalyzer {
+	private aiClient: AIClient;
+
+	constructor(
+		private app: App,
+		private getSettings: () => SynapseSettings
+	) {
+		this.aiClient = new AIClient(getSettings);
+	}
+
+	/**
+	 * Find all image references in a note's content.
+	 * Returns both wiki-link (![[file]]) and markdown (![alt](url)) references.
+	 */
+	findImageReferences(content: string): Array<{ reference: string; path: string; isInternal: boolean }> {
+		const refs: Array<{ reference: string; path: string; isInternal: boolean }> = [];
+		const seen = new Set<string>();
+
+		// Find wiki-link images: ![[image.png]]
+		let match;
+		const wikiRegex = new RegExp(WIKI_IMAGE_REGEX.source, WIKI_IMAGE_REGEX.flags);
+		while ((match = wikiRegex.exec(content)) !== null) {
+			const path = match[1];
+			if (!seen.has(path)) {
+				seen.add(path);
+				refs.push({ reference: match[0], path, isInternal: true });
+			}
+		}
+
+		// Find markdown images: ![alt](url)
+		const mdRegex = new RegExp(MARKDOWN_IMAGE_REGEX.source, MARKDOWN_IMAGE_REGEX.flags);
+		while ((match = mdRegex.exec(content)) !== null) {
+			const url = match[2];
+			// Skip external URLs -- we can only analyze vault images
+			if (url.startsWith('http://') || url.startsWith('https://')) continue;
+			if (!seen.has(url)) {
+				seen.add(url);
+				refs.push({ reference: match[0], path: url, isInternal: true });
+			}
+		}
+
+		return refs.slice(0, MAX_IMAGES_PER_NOTE);
+	}
+
+	/**
+	 * Analyze all images found in a note.
+	 * Returns descriptions for each image that could be resolved and analyzed.
+	 */
+	async analyzeImagesInNote(notePath: string, content: string): Promise<ImageAnalysis[]> {
+		const refs = this.findImageReferences(content);
+		if (refs.length === 0) return [];
+
+		const settings = this.getSettings();
+		if (!settings.image.enabled) return [];
+
+		const results: ImageAnalysis[] = [];
+
+		for (const ref of refs) {
+			try {
+				const analysis = await this.analyzeImage(ref, notePath);
+				if (analysis) {
+					results.push(analysis);
+				}
+			} catch (error) {
+				console.warn(`[Synapse] Failed to analyze image ${ref.path}:`, error);
+				// Graceful degradation -- skip this image and continue
+			}
+		}
+
+		return results;
+	}
+
+	private async analyzeImage(
+		ref: { reference: string; path: string; isInternal: boolean },
+		notePath: string
+	): Promise<ImageAnalysis | null> {
+		// Resolve the vault file
+		const file = this.app.metadataCache.getFirstLinkpathDest(ref.path, notePath);
+		if (!(file instanceof TFile)) {
+			console.warn(`[Synapse] Could not resolve image: ${ref.path}`);
+			return null;
+		}
+
+		// Read binary data
+		const data = await this.app.vault.readBinary(file);
+		const base64 = this.arrayBufferToBase64(data);
+		const mediaType = this.getMediaType(file.name);
+
+		// Apply vision model override if configured
+		const settings = this.getSettings();
+		const visionModel = settings.image.visionModel || settings.ai.model;
+		const originalModel = settings.ai.model;
+		if (visionModel !== originalModel) {
+			settings.ai.model = visionModel;
+		}
+
+		try {
+			const contentBlocks: ContentBlock[] = [
+				{
+					type: 'image',
+					data: base64,
+					mediaType,
+				},
+				{
+					type: 'text',
+					text: `Analyze this image and provide a structured response with exactly these three sections:
+
+DESCRIPTION: A concise description of what the image shows (objects, people, scenes, text, diagrams, etc.)
+
+LOCATION: Any location hints visible in the image (landmarks, signs, GPS overlays, language on signs, architectural style, vegetation). If no location clues are visible, write "No location clues detected."
+
+METADATA: Any observable metadata clues (timestamps visible in the image, camera UI elements, watermarks, image quality observations, apparent time of day from lighting). If nothing notable, write "No metadata observations."`,
+				},
+			];
+
+			const response = await this.aiClient.chat([
+				{
+					role: 'system',
+					content: 'You are an image analysis assistant. Analyze images and provide structured descriptions. Be concise but thorough. Focus on factual observations.',
+				},
+				{ role: 'user', content: contentBlocks },
+			]);
+
+			return this.parseAnalysisResponse(ref.reference, response);
+		} finally {
+			if (visionModel !== originalModel) {
+				settings.ai.model = originalModel;
+			}
+		}
+	}
+
+	/**
+	 * Parse a structured AI response into an ImageAnalysis object.
+	 * Exported for testability.
+	 */
+	parseAnalysisResponse(reference: string, response: string): ImageAnalysis {
+		// Parse the structured response into sections
+		const descMatch = response.match(/DESCRIPTION:\s*([\s\S]*?)(?=LOCATION:|$)/i);
+		const locMatch = response.match(/LOCATION:\s*([\s\S]*?)(?=METADATA:|$)/i);
+		const metaMatch = response.match(/METADATA:\s*([\s\S]*?)$/i);
+
+		return {
+			reference,
+			description: descMatch?.[1]?.trim() || response.trim(),
+			locationHints: locMatch?.[1]?.trim() || '',
+			metadata: metaMatch?.[1]?.trim() || '',
+		};
+	}
+
+	private arrayBufferToBase64(buffer: ArrayBuffer): string {
+		const bytes = new Uint8Array(buffer);
+		let binary = '';
+		for (let i = 0; i < bytes.length; i++) {
+			binary += String.fromCharCode(bytes[i]);
+		}
+		return btoa(binary);
+	}
+
+	private getMediaType(fileName: string): string {
+		const ext = fileName.split('.').pop()?.toLowerCase() || '';
+		const mimeMap: Record<string, string> = {
+			png: 'image/png',
+			jpg: 'image/jpeg',
+			jpeg: 'image/jpeg',
+			gif: 'image/gif',
+			webp: 'image/webp',
+			bmp: 'image/bmp',
+			tiff: 'image/tiff',
+		};
+		return mimeMap[ext] || 'image/png';
+	}
+}

--- a/src/elaboration/proposer.test.ts
+++ b/src/elaboration/proposer.test.ts
@@ -1,21 +1,31 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TFile } from '../__mocks__/obsidian';
 import { ProposalGenerator } from './proposer';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { DetectionResult } from './types';
 
 const mockComplete = vi.fn().mockResolvedValue('Expanded content here.');
+const mockChat = vi.fn().mockResolvedValue(
+	'DESCRIPTION: A photo of mountains\n\nLOCATION: Rocky Mountains\n\nMETADATA: No metadata observations.'
+);
 
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {
 		complete = mockComplete;
+		chat = mockChat;
 	},
 }));
 
-describe('ProposalGenerator — image embed preservation', () => {
+function makeSettings(): SynapseSettings {
+	return structuredClone(DEFAULT_SETTINGS);
+}
+
+describe('ProposalGenerator -- image embed preservation (no images)', () => {
 	let generator: ProposalGenerator;
 
 	beforeEach(() => {
 		mockComplete.mockClear();
+		mockChat.mockClear();
 		mockComplete.mockResolvedValue('Expanded content here.');
 
 		const mockApp = {
@@ -24,6 +34,7 @@ describe('ProposalGenerator — image embed preservation', () => {
 					read: vi.fn().mockResolvedValue('# Note\n\nSome content with ![photo](https://example.com/img.png)'),
 				},
 				read: vi.fn(),
+				readBinary: vi.fn(),
 			},
 			metadataCache: {
 				getCache: vi.fn().mockReturnValue(null),
@@ -31,8 +42,10 @@ describe('ProposalGenerator — image embed preservation', () => {
 			},
 		};
 
-		const settings = structuredClone(DEFAULT_SETTINGS);
+		const settings = makeSettings();
 		settings.elaboration.proposal.includeSourceContext = false;
+		// Disable image analysis so these tests stay focused on original behavior
+		settings.image.enabled = false;
 		generator = new ProposalGenerator(mockApp as any, () => settings);
 	});
 
@@ -70,5 +83,168 @@ describe('ProposalGenerator — image embed preservation', () => {
 			'preserve them as markdown image embeds (![alt](url))'
 		);
 		expect(systemPrompt).toContain('embed them as ![[image.jpg]]');
+	});
+});
+
+describe('ProposalGenerator -- image analysis integration', () => {
+	let generator: ProposalGenerator;
+	let settings: SynapseSettings;
+
+	beforeEach(() => {
+		mockComplete.mockClear();
+		mockChat.mockClear();
+		mockComplete.mockResolvedValue('Expanded content referencing the mountain photo.');
+		mockChat.mockResolvedValue(
+			'DESCRIPTION: A photo of mountains at sunset\n\nLOCATION: Rocky Mountains, Colorado\n\nMETADATA: No metadata observations.'
+		);
+
+		const imageFile = new TFile('assets/photo.png');
+
+		const mockApp = {
+			vault: {
+				adapter: {
+					read: vi.fn().mockResolvedValue('# Trip Notes\n![[photo.png]]\nGreat view!'),
+				},
+				read: vi.fn(),
+				readBinary: vi.fn().mockResolvedValue(new Uint8Array([137, 80]).buffer),
+			},
+			metadataCache: {
+				getCache: vi.fn().mockReturnValue(null),
+				getFirstLinkpathDest: vi.fn().mockReturnValue(imageFile),
+			},
+		};
+
+		settings = makeSettings();
+		settings.elaboration.proposal.includeSourceContext = false;
+		settings.image.enabled = true;
+		generator = new ProposalGenerator(mockApp as any, () => settings);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('uses image-aware system prompt when image analysis is available', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/trip.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		await generator.generate(detection);
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain('Image analysis has been provided');
+		expect(systemPrompt).toContain('Preserve all image embeds in their original format');
+		// Should NOT contain the generic image preservation instruction
+		expect(systemPrompt).not.toContain('preserve them as markdown image embeds');
+	});
+
+	it('includes image analysis in prompt', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/trip.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		await generator.generate(detection);
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [prompt] = mockComplete.mock.calls[0];
+		expect(prompt).toContain('Image analysis from this note:');
+		expect(prompt).toContain('A photo of mountains at sunset');
+		expect(prompt).toContain('Rocky Mountains, Colorado');
+	});
+
+	it('stores image analysis results in proposal', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/trip.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		const proposal = await generator.generate(detection);
+
+		expect(proposal.imageAnalysis).toBeDefined();
+		expect(proposal.imageAnalysis).toHaveLength(1);
+		expect(proposal.imageAnalysis![0].description).toBe('A photo of mountains at sunset');
+	});
+
+	it('omits imageAnalysis field when no images found', async () => {
+		const mockApp = {
+			vault: {
+				adapter: {
+					read: vi.fn().mockResolvedValue('# Plain Note\nNo images here'),
+				},
+				read: vi.fn(),
+				readBinary: vi.fn(),
+			},
+			metadataCache: {
+				getCache: vi.fn().mockReturnValue(null),
+				getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+			},
+		};
+
+		const noImageGenerator = new ProposalGenerator(mockApp as any, () => settings);
+
+		const detection: DetectionResult = {
+			notePath: 'notes/plain.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		const proposal = await noImageGenerator.generate(detection);
+
+		expect(proposal.imageAnalysis).toBeUndefined();
+	});
+
+	it('falls back to generic prompt when image analysis fails', async () => {
+		mockChat.mockRejectedValue(new Error('API error'));
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const detection: DetectionResult = {
+			notePath: 'notes/trip.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		const proposal = await generator.generate(detection);
+
+		// Should still generate a proposal
+		expect(proposal.proposedAdditions).toBeDefined();
+		expect(proposal.imageAnalysis).toBeUndefined();
+
+		// Should use the non-image system prompt
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain('preserve them as markdown image embeds');
+
+		warnSpy.mockRestore();
+	});
+
+	it('skips image analysis when image module is disabled', async () => {
+		settings.image.enabled = false;
+
+		const detection: DetectionResult = {
+			notePath: 'notes/trip.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		await generator.generate(detection);
+
+		// Image AI should not be called
+		expect(mockChat).not.toHaveBeenCalled();
+
+		// Should use generic system prompt
+		const [, systemPrompt] = mockComplete.mock.calls[0];
+		expect(systemPrompt).toContain('preserve them as markdown image embeds');
+	});
+
+	it('excludes "No metadata observations" from image context', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/trip.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		await generator.generate(detection);
+
+		const [prompt] = mockComplete.mock.calls[0];
+		// "No metadata observations." should be filtered from the context
+		expect(prompt).not.toContain('No metadata observations.');
 	});
 });

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -1,29 +1,43 @@
 import { App } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { AIClient, sanitizeAIResponse, stripCodeFences } from '../shared';
+import { ImageAnalyzer, ImageAnalysis } from './image-analyzer';
 import { DetectionResult, Proposal } from './types';
 
 export class ProposalGenerator {
 	private aiClient: AIClient;
+	private imageAnalyzer: ImageAnalyzer;
 
 	constructor(
 		private app: App,
 		private getSettings: () => SynapseSettings
 	) {
 		this.aiClient = new AIClient(getSettings);
+		this.imageAnalyzer = new ImageAnalyzer(app, getSettings);
 	}
 
 	async generate(detection: DetectionResult): Promise<Proposal> {
 		const content = await this.app.vault.adapter.read(detection.notePath);
-		const settings = this.getSettings().elaboration;
+		const settings = this.getSettings();
 
 		let contextNotes = '';
-		if (settings.proposal.includeSourceContext) {
+		if (settings.elaboration.proposal.includeSourceContext) {
 			contextNotes = await this.gatherContext(detection.notePath);
 		}
 
-		const prompt = this.buildPrompt(content, detection, contextNotes);
-		const systemPrompt = `You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. If the source content contains image URLs, preserve them as markdown image embeds (![alt](url)) rather than describing the image in text. For internal images referenced as [[image.jpg]], embed them as ![[image.jpg]].`;
+		// Gather image context if image module is enabled
+		let imageContext = '';
+		let analyses: ImageAnalysis[] = [];
+		if (settings.image.enabled) {
+			const result = await this.gatherImageContext(detection.notePath, content);
+			imageContext = result.context;
+			analyses = result.analyses;
+		}
+
+		const prompt = this.buildPrompt(content, detection, contextNotes, imageContext);
+		const systemPrompt = imageContext
+			? 'You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. Image analysis has been provided -- use the descriptions to write contextually aware content that references what the images actually show. Preserve all image embeds in their original format.'
+			: 'You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. If the source content contains image URLs, preserve them as markdown image embeds (![alt](url)) rather than describing the image in text. For internal images referenced as [[image.jpg]], embed them as ![[image.jpg]].';
 
 		const rawAdditions = await this.aiClient.complete(prompt, systemPrompt);
 		const proposedAdditions = stripCodeFences(sanitizeAIResponse(rawAdditions));
@@ -37,13 +51,15 @@ export class ProposalGenerator {
 			proposedAdditions,
 			insertionPoint: 'append',
 			status: 'pending',
+			imageAnalysis: analyses.length > 0 ? analyses : undefined,
 		};
 	}
 
 	private buildPrompt(
 		content: string,
 		detection: DetectionResult,
-		contextNotes: string
+		contextNotes: string,
+		imageContext: string
 	): string {
 		const reasonDescriptions = detection.reasons.map(r => {
 			switch (r.type) {
@@ -74,6 +90,10 @@ export class ProposalGenerator {
 			prompt += `\n\nContext from related notes:\n${contextNotes}`;
 		}
 
+		if (imageContext) {
+			prompt += `\n\nImage analysis from this note:\n${imageContext}`;
+		}
+
 		return prompt;
 	}
 
@@ -95,6 +115,31 @@ export class ProposalGenerator {
 			}
 		}
 		return contextParts.join('\n\n');
+	}
+
+	private async gatherImageContext(
+		notePath: string,
+		content: string
+	): Promise<{ context: string; analyses: ImageAnalysis[] }> {
+		try {
+			const analyses = await this.imageAnalyzer.analyzeImagesInNote(notePath, content);
+			if (analyses.length === 0) return { context: '', analyses: [] };
+
+			const parts = analyses.map(a => {
+				let section = `**Image: ${a.reference}**\n- Description: ${a.description}`;
+				if (a.locationHints && a.locationHints !== 'No location clues detected.') {
+					section += `\n- Location: ${a.locationHints}`;
+				}
+				if (a.metadata && a.metadata !== 'No metadata observations.') {
+					section += `\n- Metadata: ${a.metadata}`;
+				}
+				return section;
+			});
+			return { context: parts.join('\n\n'), analyses };
+		} catch (error) {
+			console.warn('[Synapse] Failed to gather image context:', error);
+			return { context: '', analyses: [] };
+		}
 	}
 
 	private generateId(): string {

--- a/src/elaboration/types.ts
+++ b/src/elaboration/types.ts
@@ -1,3 +1,5 @@
+import type { ImageAnalysis } from './image-analyzer';
+
 export type DetectionReason =
 	| { type: 'short-note'; wordCount: number }
 	| { type: 'todo-marker'; markers: string[] }
@@ -20,4 +22,6 @@ export interface Proposal {
 	insertionPoint: 'append' | 'after-heading' | 'replace-section';
 	insertionTarget?: string;
 	status: 'pending' | 'accepted' | 'rejected';
+	/** Image analysis results used during proposal generation, if any */
+	imageAnalysis?: ImageAnalysis[];
 }


### PR DESCRIPTION
## Summary
- Adds `ImageAnalyzer` class to the elaboration module that parses notes for embedded images (both `![[wiki-link]]` and `![markdown](path)` formats), resolves vault files, and sends them to the vision AI for structured analysis (description, location hints, metadata observations)
- Integrates image analysis into `ProposalGenerator` so elaboration proposals are contextually aware of what embedded images actually show
- Switches system prompt to an image-aware variant when image analysis is available, improving the quality of generated proposals for image-rich notes
- Stores `ImageAnalysis[]` on the `Proposal` interface for downstream consumers (review UI, etc.)
- Enforces a max of 5 images per note to prevent token overflow, with graceful per-image error handling

## Test plan
- [x] 23 new tests for `ImageAnalyzer`: reference parsing (wiki-link, markdown, dedup, external URL skipping, max limit, extension variants), response parsing (well-formed, missing sections, unformatted fallback, multiline), and full `analyzeImagesInNote` flow (disabled module, resolved images, unresolvable images, per-image failure recovery, vision model override/restore)
- [x] 8 new tests for `ProposalGenerator` image integration: image-aware system prompt, image context in prompt, analysis stored on proposal, omitted when no images, fallback on failure, disabled module path, metadata filtering
- [x] Existing 4 proposer tests updated and passing (backward compatibility)
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (630 tests)
- [x] `node esbuild.config.mjs production` builds successfully

closes #163

Co-Authored-By: Claude <bot@wafflenet.io>