### PR TITLE
fix: clean up setTimeout handles and injected styles on unload

### DIFF
--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -17,6 +17,7 @@ export class ElaborationModule {
 	private proposer: ProposalGenerator;
 	private store: ProposalStore;
 	private scanInterval: number | null = null;
+	private startupTimeout: number | null = null;
 
 	/** Optional callback invoked after a proposal is accepted. Wired by main.ts for enrichment. */
 	onProposalAccepted: ((filePath: string) => void) | null = null;
@@ -69,7 +70,7 @@ export class ElaborationModule {
 
 		const settings = this.getSettings().elaboration;
 		if (settings.scanOnStartup) {
-			setTimeout(() => this.scanVault(), 5000);
+			this.startupTimeout = window.setTimeout(() => this.scanVault(), 5000);
 		}
 
 		if (settings.autoScanInterval > 0) {
@@ -81,6 +82,10 @@ export class ElaborationModule {
 	}
 
 	onunload(): void {
+		if (this.startupTimeout !== null) {
+			window.clearTimeout(this.startupTimeout);
+			this.startupTimeout = null;
+		}
 		if (this.scanInterval !== null) {
 			window.clearInterval(this.scanInterval);
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { TidyModule } from './tidy';
 import { OrganizeModule } from './organize';
 import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
-import { NotificationManager, CheckpointManager } from './shared';
+import { NotificationManager, CheckpointManager, removeNotificationStyles } from './shared';
 import type { DeferredTask, Checkpoint } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
@@ -38,6 +38,7 @@ export default class SynapsePlugin extends Plugin {
 	private organize!: OrganizeModule;
 	private deepDive!: DeepDiveModule;
 	private title!: TitleModule;
+	private startupTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -249,7 +250,7 @@ export default class SynapsePlugin extends Plugin {
 		});
 
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
-		setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
+		this.startupTimeout = setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
 
 		// Unified transcription commands (audio on any platform, video on desktop only, image OCR)
 		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
@@ -273,6 +274,10 @@ export default class SynapsePlugin extends Plugin {
 	}
 
 	onunload(): void {
+		if (this.startupTimeout !== null) {
+			clearTimeout(this.startupTimeout);
+			this.startupTimeout = null;
+		}
 		this.elaboration?.onunload();
 		this.audio?.onunload();
 		this.video?.onunload();
@@ -283,6 +288,8 @@ export default class SynapsePlugin extends Plugin {
 		this.organize?.onunload();
 		this.deepDive?.onunload();
 		this.title?.onunload();
+		removeNotificationStyles();
+		UnifiedProposalView.removeStyles();
 	}
 
 	async loadSettings(): Promise<void> {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -8,7 +8,7 @@ export {
 	getMarkdownFiles,
 	wordCount,
 } from './file-utils';
-export { NotificationManager } from './notifications';
+export { NotificationManager, removeNotificationStyles } from './notifications';
 export type { OperationHandle } from './notifications';
 export { FolderPickerModal } from './folder-picker-modal';
 export {

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -116,6 +116,12 @@ function injectStyles(): void {
 	document.head.appendChild(style);
 }
 
+export function removeNotificationStyles(): void {
+	if (!stylesInjected) return;
+	document.getElementById('synapse-notification-styles')?.remove();
+	stylesInjected = false;
+}
+
 /** Get the underlying DOM element from a Notice */
 function getNoticeEl(notice: Notice): HTMLElement {
 	return (notice as unknown as { noticeEl: HTMLElement }).noticeEl;

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -1059,6 +1059,10 @@ export class UnifiedProposalView extends ItemView {
 		}
 	}
 
+	static removeStyles(): void {
+		document.getElementById('synapse-unified-view-styles')?.remove();
+	}
+
 	// ── Styles ─────────────────────────────────────────────────
 
 	private injectStyles(): void {


### PR DESCRIPTION
## Summary
- Store and clear `setTimeout` handles in `main.ts` and `elaboration/index.ts` on plugin unload
- Add `removeNotificationStyles()` to clean up injected notification CSS
- Add `UnifiedProposalView.removeStyles()` static method to clean up injected view CSS
- Call both style cleanup functions from `main.ts` `onunload()`

Closes #132

## Test plan
- [x] Verify TypeScript compiles without errors (`npx tsc --noEmit --skipLibCheck`)
- [x] Verify all 630 tests pass (`npm test`)
- [x] Verify production build succeeds (`node esbuild.config.mjs production`)
- [ ] Enable/disable plugin in Obsidian and verify no style elements remain in DOM after disable

Co-Authored-By: Wafflebot <bot@wafflenet.io>