### PR TITLE
feat: display plugin version in settings header

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -13,6 +13,8 @@ export class SynapseSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
+		new Setting(containerEl).setHeading().setName(`Synapse v${this.plugin.manifest.version}`);
+
 		// ── AI Configuration ──
 		new Setting(containerEl).setHeading().setName('AI Configuration');
 


### PR DESCRIPTION
## Summary
- Adds "Synapse vX.Y.Z" heading at the top of the settings tab
- Version reads dynamically from manifest.json via `this.plugin.manifest.version`
- Follows existing `Setting.setHeading().setName()` pattern

## Test plan
- [ ] Open Synapse settings tab → version heading appears at top
- [ ] Version matches manifest.json
- [ ] TypeScript compiles cleanly
- [ ] All tests pass
- [ ] Production build succeeds

closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)