### PR TITLE
fix: auto-tag version bumps via GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag name (e.g. v0.3.1) passed from tag-on-version-bump'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -13,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -20,6 +28,15 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Determine tag version
+        id: tag
+        run: |
+          # inputs.tag is like "v0.3.1", github.ref_name is like "v0.3.1"
+          RAW_TAG="${{ inputs.tag || github.ref_name }}"
+          TAG_VERSION="${RAW_TAG#v}"
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "name=$RAW_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Verify versions
         run: |
@@ -30,7 +47,7 @@ jobs:
             echo "ERROR: versions.json minAppVersion ($VERSIONS_MIN) does not match manifest.json minAppVersion ($MANIFEST_MIN) for version $MANIFEST_VERSION"
             exit 1
           fi
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION="${{ steps.tag.outputs.version }}"
           if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
             echo "ERROR: manifest.json version ($MANIFEST_VERSION) does not match tag version ($TAG_VERSION)"
             exit 1
@@ -42,6 +59,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.name }}
           files: |
             main.js
             manifest.json

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -1,0 +1,45 @@
+name: Tag on version bump
+
+on:
+  push:
+    branches: [main]
+    paths: ['manifest.json']
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.check.outputs.tag }}
+      created: ${{ steps.check.outputs.created }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from manifest
+        id: version
+        run: |
+          VERSION=$(jq -r .version manifest.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Created and pushed tag $TAG"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: tag
+    if: needs.tag.outputs.created == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag.outputs.tag }}

--- a/scripts/version-bump.mjs
+++ b/scripts/version-bump.mjs
@@ -9,17 +9,18 @@
  *   - versions.json
  *   - src/__mocks__/obsidian.ts
  *
+ * Git tags are created automatically by CI when manifest.json changes
+ * land on main (see .github/workflows/tag-on-version-bump.yml).
+ *
  * Usage:
  *   node scripts/version-bump.mjs patch          # 0.1.0 → 0.1.1
  *   node scripts/version-bump.mjs minor          # 0.1.0 → 0.2.0
  *   node scripts/version-bump.mjs major          # 0.1.0 → 1.0.0
  *   node scripts/version-bump.mjs 2.0.0          # explicit version
- *   node scripts/version-bump.mjs patch --tag    # also creates git tag
  *   node scripts/version-bump.mjs --check        # validate consistency only
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -108,7 +109,6 @@ function checkConsistency() {
 // --- Main -------------------------------------------------------------------
 
 const args = process.argv.slice(2);
-const doTag = args.includes('--tag');
 const doCheck = args.includes('--check');
 const positional = args.filter(a => !a.startsWith('--'));
 
@@ -117,7 +117,7 @@ if (doCheck) {
 }
 
 if (positional.length === 0) {
-  console.error('Usage: version-bump.mjs <patch|minor|major|x.y.z> [--tag] [--check]');
+  console.error('Usage: version-bump.mjs <patch|minor|major|x.y.z> [--check]');
   process.exit(1);
 }
 
@@ -169,10 +169,3 @@ if (!checkConsistency()) {
 }
 
 console.log(`Bumped ${currentVersion} → ${newVersion}`);
-
-// Optional git tag
-if (doTag) {
-  const tag = `v${newVersion}`;
-  execFileSync('git', ['tag', tag], { cwd: root, stdio: 'inherit' });
-  console.log(`Created git tag: ${tag}`);
-}


### PR DESCRIPTION
## Summary

- Remove unused `--tag` flag from `scripts/version-bump.mjs` (and its `execFileSync` import)
- Add `tag-on-version-bump.yml` workflow that creates a git tag when `manifest.json` changes land on `main`
- Update `release.yml` to accept `workflow_call` with a `tag` input, since `GITHUB_TOKEN` tag pushes don't trigger other workflows
- The tagging workflow calls `release.yml` directly via `workflow_call` to ensure releases fire

closes #186

## Test plan

- [ ] `node scripts/version-bump.mjs --check` passes
- [ ] `node scripts/version-bump.mjs patch` still bumps without `--tag` flag
- [ ] After merge: push a version bump PR → merge to main → verify tag auto-created → verify release workflow triggered
- [ ] Verify idempotency: re-running on an already-tagged version skips tag creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)