### PR TITLE
fix: broaden URL detection for YouTube/TikTok edge cases

### DIFF
--- a/src/video/note-scanner.test.ts
+++ b/src/video/note-scanner.test.ts
@@ -53,6 +53,34 @@ describe('findVideoUrls', () => {
 		expect(result).toHaveLength(2);
 	});
 
+	it('finds YouTube URL with v= not as first query param', () => {
+		const content = 'https://youtube.com/watch?feature=share&v=dQw4w9WgXcQ';
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(1);
+		expect(result[0].platform).toBe('youtube');
+	});
+
+	it('finds YouTube embed URL', () => {
+		const content = 'https://youtube.com/embed/dQw4w9WgXcQ';
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(1);
+		expect(result[0].platform).toBe('youtube');
+	});
+
+	it('finds YouTube live URL', () => {
+		const content = 'https://youtube.com/live/dQw4w9WgXcQ';
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(1);
+		expect(result[0].platform).toBe('youtube');
+	});
+
+	it('finds TikTok URL with locale prefix', () => {
+		const content = 'https://www.tiktok.com/en/@user/video/1234567890';
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(1);
+		expect(result[0].platform).toBe('tiktok');
+	});
+
 	it('ignores non-video URLs', () => {
 		const content = 'https://example.com\nhttps://google.com\nhttps://vimeo.com/123';
 		const result = findVideoUrls(content);

--- a/src/video/url-detector.test.ts
+++ b/src/video/url-detector.test.ts
@@ -33,6 +33,36 @@ describe('detectPlatform', () => {
 			const result = detectPlatform('https://youtube.com/watch?v=abc_DEF-123');
 			expect(result?.videoId).toBe('abc_DEF-123');
 		});
+
+		it('matches when v= is not the first query param', () => {
+			const result = detectPlatform('https://youtube.com/watch?feature=share&v=dQw4w9WgXcQ');
+			expect(result?.platform).toBe('youtube');
+			expect(result?.videoId).toBe('dQw4w9WgXcQ');
+		});
+
+		it('matches when v= is after multiple query params', () => {
+			const result = detectPlatform('https://youtube.com/watch?list=PLxxx&index=3&v=abc123');
+			expect(result?.platform).toBe('youtube');
+			expect(result?.videoId).toBe('abc123');
+		});
+
+		it('matches embed URL', () => {
+			const result = detectPlatform('https://youtube.com/embed/dQw4w9WgXcQ');
+			expect(result?.platform).toBe('youtube');
+			expect(result?.videoId).toBe('dQw4w9WgXcQ');
+		});
+
+		it('matches live URL', () => {
+			const result = detectPlatform('https://youtube.com/live/dQw4w9WgXcQ');
+			expect(result?.platform).toBe('youtube');
+			expect(result?.videoId).toBe('dQw4w9WgXcQ');
+		});
+
+		it('matches www.youtube.com embed URL', () => {
+			const result = detectPlatform('https://www.youtube.com/embed/abc_DEF-123');
+			expect(result?.platform).toBe('youtube');
+			expect(result?.videoId).toBe('abc_DEF-123');
+		});
 	});
 
 	describe('TikTok URLs', () => {
@@ -94,6 +124,18 @@ describe('detectPlatform', () => {
 				'https://vm.tiktok.com/ZMxxxxxxx/?sender_device=mobile'
 			);
 			expect(result?.url).toBe('https://vm.tiktok.com/ZMxxxxxxx/');
+		});
+
+		it('matches URL with locale prefix', () => {
+			const result = detectPlatform('https://www.tiktok.com/en/@user/video/1234567890');
+			expect(result?.platform).toBe('tiktok');
+			expect(result?.videoId).toBe('1234567890');
+		});
+
+		it('matches URL with locale-country prefix', () => {
+			const result = detectPlatform('https://www.tiktok.com/es-MX/@user/video/1234567890');
+			expect(result?.platform).toBe('tiktok');
+			expect(result?.videoId).toBe('1234567890');
 		});
 	});
 

--- a/src/video/url-detector.ts
+++ b/src/video/url-detector.ts
@@ -1,10 +1,10 @@
 import { UrlDetectionResult } from './types';
 
 const YOUTUBE_REGEX =
-	/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/shorts\/)([a-zA-Z0-9_-]+)/;
-// Full TikTok URL: tiktok.com/@user/video/123
+	/(?:youtube\.com\/watch\?(?:[^#\s]*?&)?v=|youtu\.be\/|youtube\.com\/(?:shorts|embed|live)\/)([a-zA-Z0-9_-]+)/;
+// Full TikTok URL: tiktok.com/@user/video/123 (with optional locale prefix like /en/)
 const TIKTOK_VIDEO_REGEX =
-	/tiktok\.com\/@[\w.-]+\/video\/(\d+)/;
+	/tiktok\.com\/(?:[a-z]{2}(?:-[A-Za-z]{2,4})?\/)?@[\w.-]+\/video\/(\d+)/;
 // Short/share TikTok URLs: tiktok.com/t/..., vm.tiktok.com/..., vt.tiktok.com/...
 const TIKTOK_SHORT_REGEX =
 	/(?:vm\.|vt\.)?tiktok\.com\/(?:t\/)?[\w.-]+/;


### PR DESCRIPTION
## Summary
- **YouTube**: `detectPlatform()` now handles `v=` appearing anywhere in query params (e.g. `?feature=share&v=ID`), plus `/embed/ID` and `/live/ID` URL formats
- **TikTok**: `detectPlatform()` now handles locale-prefixed paths (e.g. `/en/@user/video/ID`, `/es-MX/@user/video/ID`)
- Added 10 new tests covering all previously-failing URL variants

closes #190

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — type check passes
- [x] `npm test` — all 641 tests pass (including 10 new tests)
- [x] `node esbuild.config.mjs production` — production build succeeds
- [ ] Manual: paste a YouTube URL with `?feature=share&v=ID` into a note, run "Transcribe media from current note" — should detect the URL
- [ ] Manual: paste a YouTube `/embed/` URL — should detect
- [ ] Manual: paste a TikTok URL with locale prefix — should detect

🤖 Generated with [Claude Code](https://claude.com/claude-code)