### PR TITLE
feat: add time-range clipping for audio/video transcription

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -2,14 +2,15 @@ import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import {
 	NotificationManager, buildCallout, CALLOUT_TYPES, sanitizeAIResponse,
-	CheckpointManager, generateId,
+	CheckpointManager, generateId, formatTimeRange,
 } from '../shared';
-import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
+import type { Checkpoint, CheckpointWorkItem, DeferredTask, TimeRange } from '../shared';
 import { findAudioEmbeds } from './note-scanner';
 import { AudioEmbed } from './types';
 import { PostProcessor } from './post-processor';
 import { Transcriber } from './transcriber';
 import { TranscribeOptions, TranscriptionResult } from './types';
+import type { AudioExtractor } from '../video/audio-extractor';
 
 export { findAudioEmbeds, AUDIO_EXTENSIONS, AUDIO_EMBED_REGEX } from './note-scanner';
 export type { AudioEmbed, TranscribeOptions, TranscriptionResult, TimestampEntry } from './types';
@@ -25,7 +26,8 @@ export class AudioModule {
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private extractor?: AudioExtractor
 	) {
 		this.transcriber = new Transcriber(getSettings);
 		this.postProcessor = new PostProcessor(getSettings);
@@ -57,7 +59,7 @@ export class AudioModule {
 		return result;
 	}
 
-	async transcribeFileToActiveNote(file: TFile): Promise<void> {
+	async transcribeFileToActiveNote(file: TFile, timeRange?: TimeRange): Promise<void> {
 		const activeFile = this.plugin.app.workspace.getActiveFile();
 		if (!activeFile) {
 			this.notifications.info('Open a note first to insert the transcription');
@@ -69,13 +71,39 @@ export class AudioModule {
 			`audio-${file.path}`
 		);
 		try {
-			const data = await this.plugin.app.vault.readBinary(file);
+			let data = await this.plugin.app.vault.readBinary(file);
+
+			// Clip audio to time range if specified (requires ffmpeg via AudioExtractor)
+			if (timeRange && this.extractor) {
+				const os = require('os') as typeof import('os');
+				const path = require('path') as typeof import('path');
+				const fs = require('fs') as typeof import('fs');
+
+				const tempPath = path.join(os.tmpdir(), `synapse-clip-src-${Date.now()}.mp3`);
+				fs.writeFileSync(tempPath, Buffer.from(data));
+
+				const clippedPath = await this.extractor.clipAudio(
+					tempPath, timeRange.startSeconds, timeRange.endSeconds
+				);
+
+				data = fs.readFileSync(clippedPath).buffer as ArrayBuffer;
+
+				// Clean up temp files
+				try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
+				try { fs.unlinkSync(clippedPath); } catch { /* ignore */ }
+			} else if (timeRange && !this.extractor) {
+				this.notifications.info('Time-range clipping requires ffmpeg (desktop only). Transcribing full file.');
+			}
+
 			const result = await this.transcribe(data, file.name);
 			const text = result.processed || result.raw;
 
+			const title = timeRange && this.extractor
+				? `Transcription of ${file.name} ${formatTimeRange(timeRange)}`
+				: `Transcription of ${file.name}`;
 			const transcriptionBlock = buildCallout(
 				CALLOUT_TYPES.transcription,
-				`Transcription of ${file.name}`,
+				title,
 				text,
 				true
 			);

--- a/src/audio/types.ts
+++ b/src/audio/types.ts
@@ -1,4 +1,5 @@
 import { TFile } from 'obsidian';
+import { TimeRange } from '../shared/validation';
 
 export interface TranscriptionResult {
 	raw: string;
@@ -19,6 +20,7 @@ export interface TranscribeOptions {
 	language?: string;
 	postProcess?: boolean;
 	sourceName?: string;
+	timeRange?: TimeRange;
 }
 
 export interface AudioEmbed {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { SynapseSettings, DEFAULT_SETTINGS } from './settings';
 import { SynapseSettingTab } from './settings-tab';
 import { ElaborationModule } from './elaboration';
 import { AudioModule } from './audio';
-import { VideoModule } from './video';
+import { VideoModule, AudioExtractor } from './video';
 import { ImageModule } from './image';
 import { EnrichmentModule } from './enrichment';
 import { SummarizeModule } from './summarize';
@@ -62,7 +62,9 @@ export default class SynapsePlugin extends Plugin {
 		// Initialize modules (Audio before Video since Video depends on Audio)
 		// Pass checkpointManager to each module instead of letting them create their own
 		this.elaboration = new ElaborationModule(this, getSettings, this.notifications, this.checkpointManager);
-		this.audio = new AudioModule(this, getSettings, this.notifications, this.checkpointManager);
+		// Create a shared AudioExtractor on desktop for clipping support
+		const audioExtractor = Platform.isDesktop ? new AudioExtractor(getSettings) : undefined;
+		this.audio = new AudioModule(this, getSettings, this.notifications, this.checkpointManager, audioExtractor);
 		if (Platform.isDesktop) {
 			this.video = new VideoModule(this, getSettings, this.audio, this.notifications, this.checkpointManager);
 		}
@@ -312,9 +314,9 @@ export default class SynapsePlugin extends Plugin {
 				video: this.settings.video.enabled && this.video !== null,
 			},
 			{
-				onTranscribeFile: (file) => this.audio.transcribeFileToActiveNote(file),
+				onTranscribeFile: (file, timeRange) => this.audio.transcribeFileToActiveNote(file, timeRange),
 				onTranscribeUrl: this.video
-					? (url) => this.video!.transcribeUrlToActiveNote(url)
+					? (url, timeRange) => this.video!.transcribeUrlToActiveNote(url, timeRange)
 					: async () => { /* unreachable: video hidden on mobile */ },
 			}
 		).open();

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -18,7 +18,11 @@ export {
 	sanitizeAIResponse,
 	stripCodeFences,
 	blockquoteOriginal,
+	parseTimestamp,
+	validateTimeRange,
+	formatTimeRange,
 } from './validation';
+export type { TimeRange } from './validation';
 export { CALLOUT_TYPES, buildCallout, ENRICHMENT_START, ENRICHMENT_END } from './callouts';
 export type { CalloutType } from './callouts';
 export {

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { blockquoteOriginal, ensureWithinVault, stripCodeFences } from './validation';
+import {
+	blockquoteOriginal, ensureWithinVault, stripCodeFences,
+	parseTimestamp, validateTimeRange, formatTimeRange,
+} from './validation';
 
 describe('blockquoteOriginal', () => {
 	it('converts plain text to a blockquote with attribution', () => {
@@ -106,6 +109,90 @@ describe('ensureWithinVault', () => {
 		expect(() => ensureWithinVault('/other/path', '/vault')).toThrow(
 			'Path escapes vault boundary'
 		);
+	});
+});
+
+describe('parseTimestamp', () => {
+	it('parses HH:MM:SS format', () => {
+		expect(parseTimestamp('01:30:00')).toBe(5400);
+	});
+
+	it('parses MM:SS format', () => {
+		expect(parseTimestamp('05:30')).toBe(330);
+	});
+
+	it('parses raw seconds', () => {
+		expect(parseTimestamp('90')).toBe(90);
+	});
+
+	it('parses zero timestamp', () => {
+		expect(parseTimestamp('0:00')).toBe(0);
+	});
+
+	it('parses 00:00:00', () => {
+		expect(parseTimestamp('00:00:00')).toBe(0);
+	});
+
+	it('rejects non-numeric input', () => {
+		expect(() => parseTimestamp('abc')).toThrow('Invalid timestamp format');
+	});
+
+	it('rejects negative-looking input', () => {
+		expect(() => parseTimestamp('-1:00')).toThrow('Invalid timestamp format');
+	});
+
+	it('rejects empty string', () => {
+		expect(() => parseTimestamp('')).toThrow('Timestamp cannot be empty');
+	});
+
+	it('trims whitespace', () => {
+		expect(parseTimestamp('  05:30  ')).toBe(330);
+	});
+});
+
+describe('validateTimeRange', () => {
+	it('returns a valid TimeRange', () => {
+		const range = validateTimeRange('01:00', '05:00');
+		expect(range).toEqual({ startSeconds: 60, endSeconds: 300 });
+	});
+
+	it('rejects end <= start', () => {
+		expect(() => validateTimeRange('05:00', '01:00')).toThrow('End time must be after start time');
+	});
+
+	it('rejects equal start and end', () => {
+		expect(() => validateTimeRange('01:00', '01:00')).toThrow('End time must be after start time');
+	});
+
+	it('rejects end > duration', () => {
+		expect(() => validateTimeRange('00:00', '02:00', 60)).toThrow('exceeds media duration');
+	});
+
+	it('allows end = duration exactly', () => {
+		const range = validateTimeRange('00:00', '01:00', 60);
+		expect(range).toEqual({ startSeconds: 0, endSeconds: 60 });
+	});
+});
+
+describe('formatTimeRange', () => {
+	it('formats MM:SS when under an hour', () => {
+		expect(formatTimeRange({ startSeconds: 60, endSeconds: 300 }))
+			.toBe('[01:00 – 05:00]');
+	});
+
+	it('formats HH:MM:SS when hours > 0', () => {
+		expect(formatTimeRange({ startSeconds: 0, endSeconds: 5400 }))
+			.toBe('[00:00:00 – 01:30:00]');
+	});
+
+	it('uses HH:MM:SS when start has hours', () => {
+		expect(formatTimeRange({ startSeconds: 3600, endSeconds: 3660 }))
+			.toBe('[01:00:00 – 01:01:00]');
+	});
+
+	it('formats zero-start correctly', () => {
+		expect(formatTimeRange({ startSeconds: 0, endSeconds: 90 }))
+			.toBe('[00:00 – 01:30]');
 	});
 });
 

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -129,6 +129,95 @@ export function sanitizeAIResponse(text: string): string {
 }
 
 /**
+ * A validated time range in seconds, used for clipping audio/video before transcription.
+ */
+export interface TimeRange {
+	startSeconds: number;
+	endSeconds: number;
+}
+
+/**
+ * Parses a timestamp string into total seconds.
+ * Accepts `HH:MM:SS`, `MM:SS`, or raw seconds (e.g. `"90"`).
+ * @throws Error on malformed input.
+ */
+export function parseTimestamp(input: string): number {
+	if (!input || input.trim().length === 0) {
+		throw new Error('Timestamp cannot be empty');
+	}
+	const trimmed = input.trim();
+
+	// Raw seconds (integer or decimal, no colons)
+	if (/^\d+(\.\d+)?$/.test(trimmed)) {
+		return parseFloat(trimmed);
+	}
+
+	// MM:SS or HH:MM:SS
+	const parts = trimmed.split(':');
+	if (parts.length < 2 || parts.length > 3) {
+		throw new Error(`Invalid timestamp format: "${input}"`);
+	}
+
+	for (const part of parts) {
+		if (!/^\d+$/.test(part)) {
+			throw new Error(`Invalid timestamp format: "${input}"`);
+		}
+	}
+
+	const nums = parts.map(Number);
+
+	if (parts.length === 2) {
+		// MM:SS
+		const [minutes, seconds] = nums;
+		if (seconds >= 60) throw new Error(`Invalid timestamp: seconds must be < 60 in "${input}"`);
+		return minutes * 60 + seconds;
+	}
+
+	// HH:MM:SS
+	const [hours, minutes, seconds] = nums;
+	if (minutes >= 60) throw new Error(`Invalid timestamp: minutes must be < 60 in "${input}"`);
+	if (seconds >= 60) throw new Error(`Invalid timestamp: seconds must be < 60 in "${input}"`);
+	return hours * 3600 + minutes * 60 + seconds;
+}
+
+/**
+ * Validates that start < end and (if duration is known) end <= duration.
+ * @throws Error on invalid range.
+ */
+export function validateTimeRange(start: string, end: string, duration?: number): TimeRange {
+	const startSeconds = parseTimestamp(start);
+	const endSeconds = parseTimestamp(end);
+
+	if (endSeconds <= startSeconds) {
+		throw new Error('End time must be after start time');
+	}
+
+	if (duration !== undefined && endSeconds > duration) {
+		throw new Error(`End time (${endSeconds}s) exceeds media duration (${duration}s)`);
+	}
+
+	return { startSeconds, endSeconds };
+}
+
+/**
+ * Formats a TimeRange for display in callout titles.
+ * Returns `[MM:SS – MM:SS]` or `[HH:MM:SS – HH:MM:SS]` when hours > 0.
+ */
+export function formatTimeRange(range: TimeRange): string {
+	const needsHours = range.startSeconds >= 3600 || range.endSeconds >= 3600;
+	const fmt = (s: number): string => {
+		const h = Math.floor(s / 3600);
+		const m = Math.floor((s % 3600) / 60);
+		const sec = Math.floor(s % 60);
+		if (needsHours) {
+			return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+		}
+		return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+	};
+	return `[${fmt(range.startSeconds)} – ${fmt(range.endSeconds)}]`;
+}
+
+/**
  * Removes wrapping code fences that LLMs sometimes add despite instructions.
  * Only strips when the entire text is wrapped in a single code fence block.
  */

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -2,18 +2,22 @@ import { App, Modal, Notice, Platform, Setting, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { AUDIO_EXTENSIONS } from '../audio';
 import { detectPlatform } from '../video';
+import { validateTimeRange } from '../shared/validation';
+import type { TimeRange } from '../shared/validation';
 
 export class UnifiedTranscriptionModal extends Modal {
 	private selectedFile: TFile | null = null;
 	private url = '';
+	private startTime = '';
+	private endTime = '';
 
 	constructor(
 		app: App,
 		private getSettings: () => SynapseSettings,
 		private enabledModules: { audio: boolean; video: boolean },
 		private callbacks: {
-			onTranscribeFile: (file: TFile) => Promise<void>;
-			onTranscribeUrl: (url: string) => Promise<void>;
+			onTranscribeFile: (file: TFile, timeRange?: TimeRange) => Promise<void>;
+			onTranscribeUrl: (url: string, timeRange?: TimeRange) => Promise<void>;
 		}
 	) {
 		super(app);
@@ -85,21 +89,56 @@ export class UnifiedTranscriptionModal extends Modal {
 				});
 		}
 
+		// Time Range section (desktop only — requires ffmpeg)
+		if (Platform.isDesktop) {
+			contentEl.createEl('h3', { text: 'Time Range (optional)' });
+
+			new Setting(contentEl)
+				.setName('Start time')
+				.setDesc('Format: HH:MM:SS or MM:SS. Leave blank for full file.')
+				.addText((text) => {
+					text.setPlaceholder('00:00:00');
+					text.onChange((value) => { this.startTime = value; });
+				});
+
+			new Setting(contentEl)
+				.setName('End time')
+				.addText((text) => {
+					text.setPlaceholder('00:00:00');
+					text.onChange((value) => { this.endTime = value; });
+				});
+		}
+
 		// Transcribe button
 		new Setting(contentEl).addButton((btn) => {
 			btn.setButtonText('Transcribe')
 				.setCta()
 				.onClick(async () => {
+					// Validate time range if provided
+					let timeRange: TimeRange | undefined;
+					if (this.startTime || this.endTime) {
+						if (!this.startTime || !this.endTime) {
+							new Notice('Both start and end times are required');
+							return;
+						}
+						try {
+							timeRange = validateTimeRange(this.startTime, this.endTime);
+						} catch (error) {
+							new Notice(error instanceof Error ? error.message : String(error));
+							return;
+						}
+					}
+
 					if (this.selectedFile) {
 						this.close();
-						await this.callbacks.onTranscribeFile(this.selectedFile);
+						await this.callbacks.onTranscribeFile(this.selectedFile, timeRange);
 					} else if (this.url) {
 						if (!detectPlatform(this.url)) {
 							new Notice('Unsupported URL. Please use YouTube or TikTok.');
 							return;
 						}
 						this.close();
-						await this.callbacks.onTranscribeUrl(this.url);
+						await this.callbacks.onTranscribeUrl(this.url, timeRange);
 					} else {
 						new Notice('Please select a file or enter a URL');
 					}

--- a/src/video/audio-extractor.ts
+++ b/src/video/audio-extractor.ts
@@ -91,6 +91,23 @@ export class AudioExtractor {
 		return outputPath;
 	}
 
+	/**
+	 * Clip an audio file to a specific time range using ffmpeg.
+	 * Returns the path to the clipped temp file. Caller is responsible for cleanup.
+	 */
+	async clipAudio(inputPath: string, startSeconds: number, endSeconds: number): Promise<string> {
+		const settings = this.getSettings().video;
+		const outputPath = path.join(os.tmpdir(), `synapse-clipped-${Date.now()}.mp3`);
+		await this.runCommand(sanitizePath(settings.ffmpegPath), [
+			'-i', sanitizePath(inputPath),
+			'-ss', String(startSeconds),
+			'-to', String(endSeconds),
+			'-vn', '-acodec', 'libmp3lame',
+			outputPath,
+		]);
+		return outputPath;
+	}
+
 	async checkDependencies(): Promise<{
 		ytDlp: boolean;
 		ffmpeg: boolean;

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -3,8 +3,9 @@ import { SynapseSettings } from '../settings';
 import { AudioModule, TranscriptionResult } from '../audio';
 import {
 	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, CALLOUT_TYPES,
-	CheckpointManager, generateId,
+	CheckpointManager, generateId, formatTimeRange,
 } from '../shared';
+import type { TimeRange } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { AudioExtractor } from './audio-extractor';
 import { findVideoUrls } from './note-scanner';
@@ -20,6 +21,7 @@ export type {
 	VideoSource,
 	VideoUrlEmbed,
 } from './types';
+export { AudioExtractor } from './audio-extractor';
 export { detectPlatform, isSupportedUrl } from './url-detector';
 export { findVideoUrls } from './note-scanner';
 
@@ -92,7 +94,25 @@ export class VideoModule {
 
 		update('Extracting audio...');
 		const fs = require('fs') as typeof import('fs');
-		const audioData = fs.readFileSync(extraction.audioPath);
+
+		let audioPath = extraction.audioPath;
+
+		// Clip audio to time range if specified
+		if (options?.timeRange) {
+			const { startSeconds, endSeconds } = options.timeRange;
+			if (extraction.metadata.duration && endSeconds > extraction.metadata.duration) {
+				throw new Error(
+					`End time (${endSeconds}s) exceeds video duration (${extraction.metadata.duration}s)`
+				);
+			}
+			update('Clipping audio to time range...');
+			const clippedPath = await this.extractor.clipAudio(audioPath, startSeconds, endSeconds);
+			// Clean up the original unclipped audio
+			try { fs.unlinkSync(audioPath); } catch { /* ignore */ }
+			audioPath = clippedPath;
+		}
+
+		const audioData = fs.readFileSync(audioPath);
 
 		update('Transcribing...');
 		const result = await this.audioModule.transcribe(
@@ -103,7 +123,7 @@ export class VideoModule {
 
 		// Clean up temp audio file
 		try {
-			fs.unlinkSync(extraction.audioPath);
+			fs.unlinkSync(audioPath);
 		} catch {
 			// Ignore cleanup errors
 		}
@@ -111,7 +131,7 @@ export class VideoModule {
 		return { ...result, videoVaultPath };
 	}
 
-	async transcribeUrlToActiveNote(url: string): Promise<void> {
+	async transcribeUrlToActiveNote(url: string, timeRange?: TimeRange): Promise<void> {
 		const activeFile = this.plugin.app.workspace.getActiveFile();
 		if (!activeFile) {
 			this.notifications.info('Open a note first to insert the transcription');
@@ -123,7 +143,7 @@ export class VideoModule {
 			`video-url-${Date.now()}`
 		);
 		try {
-			const result = await this.processUrl(url, { insertMode: true }, op);
+			const result = await this.processUrl(url, { insertMode: true, timeRange }, op);
 			const text = result.processed || result.raw;
 
 			const blockLines: string[] = [''];
@@ -134,9 +154,12 @@ export class VideoModule {
 				blockLines.push('');
 			}
 
+			const title = timeRange
+				? `Transcription of ${url} ${formatTimeRange(timeRange)}`
+				: `Transcription of ${url}`;
 			const callout = buildCallout(
 				CALLOUT_TYPES.transcription,
-				`Transcription of ${url}`,
+				title,
 				text,
 				true
 			);

--- a/src/video/types.ts
+++ b/src/video/types.ts
@@ -16,11 +16,14 @@ export interface VideoSource {
 	duration?: number;
 }
 
+import { TimeRange } from '../shared/validation';
+
 export interface VideoProcessOptions {
 	postProcess?: boolean;
 	extractFrames?: boolean;
 	outputPath?: string;
 	insertMode?: boolean;
+	timeRange?: TimeRange;
 }
 
 export interface ExtractionResult {


### PR DESCRIPTION
## Summary

- Adds optional start/end timestamp inputs to the unified transcription modal (desktop only) that clip media via ffmpeg before sending to the transcription API
- Introduces `TimeRange` type with `parseTimestamp`, `validateTimeRange`, and `formatTimeRange` validators in `src/shared/validation.ts`
- Threads `timeRange` through both audio and video pipelines — `AudioModule.transcribeFileToActiveNote` and `VideoModule.transcribeUrlToActiveNote` — with graceful fallback on mobile
- Callout titles display the clipped range (e.g. `[01:30 – 05:00]`) when a time range is used

Closes #192

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — type-check passes
- [x] `npm test` — all 659 tests pass (14 new validation tests)
- [x] `node esbuild.config.mjs production` — production build succeeds
- [ ] Open unified modal → time range inputs visible on desktop
- [ ] Transcribe local audio with range → clipped output, callout shows `[MM:SS – MM:SS]`
- [ ] Transcribe YouTube URL with range → clipped output
- [ ] Transcribe without range → full file (backward compatible)
- [ ] Batch transcription via note media modal → no time range inputs (expected)
- [ ] Invalid time range (end < start) → error notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)