### PR TITLE
feat: duration-aware time-range slider for transcription clipping

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -216,6 +216,33 @@ export function stringifyYaml(obj: any): string {
 	return lines.join('\n') + '\n';
 }
 
+// --- Platform detection (mock defaults to desktop) ---
+
+export const Platform = {
+	isDesktop: true,
+	isDesktopApp: true,
+	isMobile: false,
+	isMobileApp: false,
+	isIosApp: false,
+	isAndroidApp: false,
+	isPhone: false,
+	isTablet: false,
+	isMacOS: true,
+	isWin: false,
+	isLinux: false,
+	isSafari: false,
+};
+
+// --- SliderComponent (stub for slider-helper.ts) ---
+
+export class SliderComponent {
+	sliderEl: any = createStubEl();
+	setLimits = vi.fn().mockReturnThis();
+	setValue = vi.fn().mockReturnThis();
+	setDynamicTooltip = vi.fn().mockReturnThis();
+	onChange = vi.fn().mockReturnThis();
+}
+
 // --- Utility functions ---
 
 export function normalizePath(path: string): string {

--- a/src/transcription/duration-detector.test.ts
+++ b/src/transcription/duration-detector.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { formatTimestamp, MIN_SLIDER_DURATION } from './duration-detector';
+
+describe('formatTimestamp', () => {
+	it('formats 0 seconds as 00:00', () => {
+		expect(formatTimestamp(0)).toBe('00:00');
+	});
+
+	it('formats seconds under a minute', () => {
+		expect(formatTimestamp(45)).toBe('00:45');
+	});
+
+	it('formats exactly one minute', () => {
+		expect(formatTimestamp(60)).toBe('01:00');
+	});
+
+	it('formats minutes and seconds', () => {
+		expect(formatTimestamp(90)).toBe('01:30');
+	});
+
+	it('formats exactly one hour', () => {
+		expect(formatTimestamp(3600)).toBe('01:00:00');
+	});
+
+	it('formats hours, minutes, and seconds', () => {
+		expect(formatTimestamp(5400)).toBe('01:30:00');
+	});
+
+	it('formats large durations with hours', () => {
+		expect(formatTimestamp(7261)).toBe('02:01:01');
+	});
+
+	it('pads single-digit values', () => {
+		expect(formatTimestamp(61)).toBe('01:01');
+	});
+
+	it('handles durations just under an hour as MM:SS', () => {
+		expect(formatTimestamp(3599)).toBe('59:59');
+	});
+
+	it('clamps negative values to 00:00', () => {
+		expect(formatTimestamp(-5)).toBe('00:00');
+	});
+
+	it('floors fractional seconds', () => {
+		expect(formatTimestamp(90.7)).toBe('01:30');
+	});
+});
+
+describe('MIN_SLIDER_DURATION', () => {
+	it('is 10 seconds', () => {
+		expect(MIN_SLIDER_DURATION).toBe(10);
+	});
+});

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -1,0 +1,148 @@
+import { Platform, TFile } from 'obsidian';
+import type { SynapseSettings } from '../settings';
+import { sanitizePath } from '../shared/validation';
+
+/**
+ * Result of a duration detection attempt.
+ * `durationSeconds` is undefined when detection fails (e.g. missing ffprobe).
+ */
+export interface DurationResult {
+	durationSeconds: number | undefined;
+	title: string;
+}
+
+/**
+ * Detect the duration of a local audio file using ffprobe.
+ * Returns undefined duration on failure (mobile, missing ffprobe, corrupt file).
+ */
+export async function detectLocalFileDuration(
+	file: TFile,
+	readBinary: (file: TFile) => Promise<ArrayBuffer>,
+	getSettings: () => SynapseSettings
+): Promise<DurationResult> {
+	const title = file.basename;
+
+	if (!Platform.isDesktop) {
+		return { durationSeconds: undefined, title };
+	}
+
+	try {
+		const os = require('os') as typeof import('os');
+		const path = require('path') as typeof import('path');
+		const fs = require('fs') as typeof import('fs');
+		const { execFile } = require('child_process') as typeof import('child_process');
+
+		const data = await readBinary(file);
+		const tempPath = path.join(os.tmpdir(), `synapse-probe-${Date.now()}-${file.name}`);
+		fs.writeFileSync(tempPath, Buffer.from(data));
+
+		const ffmpegPath = sanitizePath(getSettings().video.ffmpegPath);
+		// Derive ffprobe path from ffmpeg path: replace "ffmpeg" with "ffprobe"
+		const ffprobePath = ffmpegPath.replace(/ffmpeg$/, 'ffprobe');
+
+		const duration = await new Promise<number | undefined>((resolve) => {
+			execFile(
+				ffprobePath,
+				[
+					'-v', 'error',
+					'-show_entries', 'format=duration',
+					'-of', 'csv=p=0',
+					tempPath,
+				],
+				{ env: shellEnv(), timeout: 15_000 },
+				(error, stdout) => {
+					try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
+					if (error) {
+						resolve(undefined);
+						return;
+					}
+					const seconds = parseFloat(stdout.trim());
+					resolve(isNaN(seconds) ? undefined : seconds);
+				}
+			);
+		});
+
+		return { durationSeconds: duration, title };
+	} catch {
+		return { durationSeconds: undefined, title };
+	}
+}
+
+/**
+ * Detect the duration of a video URL using yt-dlp metadata.
+ * Returns undefined duration on failure.
+ */
+export async function detectUrlDuration(
+	url: string,
+	getSettings: () => SynapseSettings
+): Promise<DurationResult> {
+	if (!Platform.isDesktop) {
+		return { durationSeconds: undefined, title: url };
+	}
+
+	try {
+		const { execFile } = require('child_process') as typeof import('child_process');
+		const ytDlpPath = sanitizePath(getSettings().video.ytDlpPath);
+
+		const output = await new Promise<string>((resolve, reject) => {
+			execFile(
+				ytDlpPath,
+				['--dump-json', '--no-download', url],
+				{ env: shellEnv(), maxBuffer: 10 * 1024 * 1024, timeout: 30_000 },
+				(error, stdout) => {
+					if (error) reject(error);
+					else resolve(stdout);
+				}
+			);
+		});
+
+		const data = JSON.parse(output);
+		return {
+			durationSeconds: typeof data.duration === 'number' ? data.duration : undefined,
+			title: data.title || url,
+		};
+	} catch {
+		return { durationSeconds: undefined, title: url };
+	}
+}
+
+/**
+ * Minimum duration (in seconds) below which the slider is skipped.
+ * For very short media, a slider adds friction without value.
+ */
+export const MIN_SLIDER_DURATION = 10;
+
+/**
+ * Format a number of seconds into a display timestamp.
+ * Returns MM:SS for durations under an hour, HH:MM:SS otherwise.
+ */
+export function formatTimestamp(totalSeconds: number): string {
+	const s = Math.max(0, Math.floor(totalSeconds));
+	const hours = Math.floor(s / 3600);
+	const minutes = Math.floor((s % 3600) / 60);
+	const seconds = s % 60;
+
+	if (hours > 0) {
+		return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+	}
+	return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+/**
+ * Obsidian's Electron process has a minimal PATH that often excludes
+ * user-installed tools. Append common install locations.
+ */
+function shellEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	const extra = [
+		'/usr/local/bin',
+		'/opt/homebrew/bin',
+		`${process.env.HOME}/.local/bin`,
+	];
+	const current = env.PATH || '';
+	const missing = extra.filter(p => !current.includes(p));
+	if (missing.length) {
+		env.PATH = missing.join(':') + ':' + current;
+	}
+	return env;
+}

--- a/src/transcription/index.ts
+++ b/src/transcription/index.ts
@@ -1,2 +1,13 @@
 export { UnifiedTranscriptionModal } from './unified-modal';
 export { NoteMediaModal } from './note-media-modal';
+export { TimeRangeSlider } from './time-range-slider';
+export type { TimeRangeSliderOptions } from './time-range-slider';
+export { showTimeRangeToast } from './time-range-toast';
+export type { TimeRangeToastOptions } from './time-range-toast';
+export {
+	detectLocalFileDuration,
+	detectUrlDuration,
+	formatTimestamp,
+	MIN_SLIDER_DURATION,
+} from './duration-detector';
+export type { DurationResult } from './duration-detector';

--- a/src/transcription/time-range-slider.ts
+++ b/src/transcription/time-range-slider.ts
@@ -1,0 +1,156 @@
+import { formatTimestamp } from './duration-detector';
+
+/** CSS class prefix for the time-range slider */
+const CLS = 'synapse-time-range';
+
+/**
+ * Options for creating a TimeRangeSlider.
+ */
+export interface TimeRangeSliderOptions {
+	/** Total media duration in seconds. */
+	duration: number;
+	/** Initial start position in seconds. Defaults to 0. */
+	initialStart?: number;
+	/** Initial end position in seconds. Defaults to duration. */
+	initialEnd?: number;
+	/** Callback fired whenever the selected range changes. */
+	onChange?: (start: number, end: number) => void;
+}
+
+/**
+ * A dual-handle range slider for selecting a time range within a known duration.
+ *
+ * Uses two native HTML range inputs overlaid on a shared track. The track's
+ * selected region is visually highlighted. Timestamp labels update live as
+ * handles move.
+ *
+ * This is a pure DOM component with no Obsidian dependencies beyond the
+ * Obsidian-provided `createEl`/`createDiv` helpers on HTMLElement.
+ */
+export class TimeRangeSlider {
+	/** The root container element. */
+	readonly containerEl: HTMLElement;
+
+	private startInput: HTMLInputElement;
+	private endInput: HTMLInputElement;
+	private trackHighlight: HTMLElement;
+	private startLabel: HTMLElement;
+	private endLabel: HTMLElement;
+	private rangeLabel: HTMLElement;
+
+	private _start: number;
+	private _end: number;
+	private readonly duration: number;
+	private readonly onChange?: (start: number, end: number) => void;
+
+	constructor(parentEl: HTMLElement, options: TimeRangeSliderOptions) {
+		this.duration = options.duration;
+		this._start = options.initialStart ?? 0;
+		this._end = options.initialEnd ?? options.duration;
+		this.onChange = options.onChange;
+
+		// Step size: 1 second for media under 10 minutes, 5 seconds otherwise
+		const step = this.duration <= 600 ? 1 : 5;
+
+		// Root container
+		this.containerEl = parentEl.createDiv({ cls: `${CLS}-container` });
+
+		// Range display label (e.g. "01:30 - 05:00")
+		this.rangeLabel = this.containerEl.createDiv({ cls: `${CLS}-range-label` });
+
+		// Track wrapper for overlapping range inputs
+		const trackWrapper = this.containerEl.createDiv({ cls: `${CLS}-track-wrapper` });
+
+		// Highlighted region on the track
+		this.trackHighlight = trackWrapper.createDiv({ cls: `${CLS}-track-highlight` });
+
+		// Start handle (lower range input)
+		this.startInput = trackWrapper.createEl('input', {
+			cls: `${CLS}-input ${CLS}-input-start`,
+			attr: {
+				type: 'range',
+				min: '0',
+				max: String(this.duration),
+				step: String(step),
+				value: String(this._start),
+				'aria-label': 'Start time',
+			},
+		});
+
+		// End handle (upper range input)
+		this.endInput = trackWrapper.createEl('input', {
+			cls: `${CLS}-input ${CLS}-input-end`,
+			attr: {
+				type: 'range',
+				min: '0',
+				max: String(this.duration),
+				step: String(step),
+				value: String(this._end),
+				'aria-label': 'End time',
+			},
+		});
+
+		// Labels row (start timestamp, duration, end timestamp)
+		const labelsRow = this.containerEl.createDiv({ cls: `${CLS}-labels` });
+		this.startLabel = labelsRow.createSpan({ cls: `${CLS}-label-start` });
+		labelsRow.createSpan({
+			cls: `${CLS}-label-duration`,
+			text: `Duration: ${formatTimestamp(this.duration)}`,
+		});
+		this.endLabel = labelsRow.createSpan({ cls: `${CLS}-label-end` });
+
+		// Wire up event handlers
+		this.startInput.addEventListener('input', () => this.onStartChange());
+		this.endInput.addEventListener('input', () => this.onEndChange());
+
+		// Initial render
+		this.updateDisplay();
+	}
+
+	/** Get the current start position in seconds. */
+	get start(): number {
+		return this._start;
+	}
+
+	/** Get the current end position in seconds. */
+	get end(): number {
+		return this._end;
+	}
+
+	private onStartChange(): void {
+		let val = parseInt(this.startInput.value, 10);
+		// Prevent start from crossing past end
+		if (val >= this._end) {
+			val = Math.max(0, this._end - 1);
+			this.startInput.value = String(val);
+		}
+		this._start = val;
+		this.updateDisplay();
+		this.onChange?.(this._start, this._end);
+	}
+
+	private onEndChange(): void {
+		let val = parseInt(this.endInput.value, 10);
+		// Prevent end from crossing before start
+		if (val <= this._start) {
+			val = Math.min(this.duration, this._start + 1);
+			this.endInput.value = String(val);
+		}
+		this._end = val;
+		this.updateDisplay();
+		this.onChange?.(this._start, this._end);
+	}
+
+	private updateDisplay(): void {
+		// Update timestamp labels
+		this.startLabel.textContent = formatTimestamp(this._start);
+		this.endLabel.textContent = formatTimestamp(this._end);
+		this.rangeLabel.textContent = `${formatTimestamp(this._start)} \u2013 ${formatTimestamp(this._end)}`;
+
+		// Update track highlight position (percentage-based)
+		const startPct = (this._start / this.duration) * 100;
+		const endPct = (this._end / this.duration) * 100;
+		this.trackHighlight.style.left = `${startPct}%`;
+		this.trackHighlight.style.width = `${endPct - startPct}%`;
+	}
+}

--- a/src/transcription/time-range-toast.ts
+++ b/src/transcription/time-range-toast.ts
@@ -1,0 +1,125 @@
+import { Notice } from 'obsidian';
+import type { TimeRange } from '../shared/validation';
+import { TimeRangeSlider } from './time-range-slider';
+
+/** CSS class prefix */
+const CLS = 'synapse-notice';
+
+/**
+ * Options for the time-range confirmation toast.
+ */
+export interface TimeRangeToastOptions {
+	/** Media title or filename to display. */
+	title: string;
+	/** Total media duration in seconds. */
+	duration: number;
+}
+
+/**
+ * Get the underlying DOM element from a Notice (Obsidian internal).
+ */
+function getNoticeEl(notice: Notice): HTMLElement {
+	return (notice as unknown as { noticeEl: HTMLElement }).noticeEl;
+}
+
+/**
+ * Prevent Obsidian's default click-to-dismiss on a Notice.
+ * Blocks clicks on the notice background but allows clicks on
+ * interactive elements (buttons, inputs) to pass through normally.
+ */
+function preventDismiss(notice: Notice): void {
+	const el = getNoticeEl(notice);
+	if (!el) return;
+	el.classList.add(`${CLS}--no-dismiss`);
+	el.addEventListener('click', (e) => {
+		const target = e.target as HTMLElement;
+		if (target.closest('button') || target.closest('input')) return;
+		e.preventDefault();
+		e.stopPropagation();
+	}, true);
+}
+
+/**
+ * Show a confirmation toast with a dual-handle time-range slider.
+ *
+ * The toast presents:
+ * - The media title
+ * - A TimeRangeSlider spanning the full duration
+ * - "Transcribe Selection" and "Full File" buttons
+ *
+ * Returns a Promise that resolves to:
+ * - A TimeRange if the user selects a sub-range and clicks "Transcribe Selection"
+ * - undefined if the user clicks "Full File" or closes the toast
+ */
+export function showTimeRangeToast(
+	options: TimeRangeToastOptions
+): Promise<TimeRange | undefined> {
+	return new Promise((resolve) => {
+		let resolved = false;
+
+		const notice = new Notice('', 0);
+		const el = getNoticeEl(notice);
+		if (!el) {
+			resolve(undefined);
+			return;
+		}
+
+		// Style as an info-level notice
+		el.classList.add(CLS, `${CLS}--info`, `${CLS}--time-range`);
+		preventDismiss(notice);
+		el.empty();
+
+		// Title
+		el.createDiv({
+			cls: `${CLS}-time-range-title`,
+			text: `Synapse: ${options.title}`,
+		});
+
+		// Slider container
+		const sliderContainer = el.createDiv({ cls: `${CLS}-time-range-slider` });
+
+		let selectedStart = 0;
+		let selectedEnd = options.duration;
+
+		const slider = new TimeRangeSlider(sliderContainer, {
+			duration: options.duration,
+			onChange: (start, end) => {
+				selectedStart = start;
+				selectedEnd = end;
+			},
+		});
+
+		// Buttons row
+		const actions = el.createDiv({ cls: `${CLS}-actions` });
+
+		const selectionBtn = actions.createEl('button', {
+			text: 'Transcribe Selection',
+			cls: 'mod-cta',
+		});
+		selectionBtn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			if (resolved) return;
+			resolved = true;
+			notice.hide();
+			// Only return a range if the user actually adjusted the selection
+			// (not the full file)
+			if (selectedStart === 0 && selectedEnd === options.duration) {
+				resolve(undefined);
+			} else {
+				resolve({ startSeconds: selectedStart, endSeconds: selectedEnd });
+			}
+		});
+
+		const fullBtn = actions.createEl('button', {
+			text: 'Full File',
+			cls: 'mod-cancel',
+		});
+		fullBtn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			if (resolved) return;
+			resolved = true;
+			notice.hide();
+			resolve(undefined);
+		});
+	});
+}

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -4,12 +4,16 @@ import { AUDIO_EXTENSIONS } from '../audio';
 import { detectPlatform } from '../video';
 import { validateTimeRange } from '../shared/validation';
 import type { TimeRange } from '../shared/validation';
+import {
+	detectLocalFileDuration,
+	detectUrlDuration,
+	MIN_SLIDER_DURATION,
+} from './duration-detector';
+import { showTimeRangeToast } from './time-range-toast';
 
 export class UnifiedTranscriptionModal extends Modal {
 	private selectedFile: TFile | null = null;
 	private url = '';
-	private startTime = '';
-	private endTime = '';
 
 	constructor(
 		app: App,
@@ -60,7 +64,7 @@ export class UnifiedTranscriptionModal extends Modal {
 				.setDesc(ppStatus);
 		}
 
-		// URL section (desktop only — video transcription requires yt-dlp + ffmpeg)
+		// URL section (desktop only -- video transcription requires yt-dlp + ffmpeg)
 		if (this.enabledModules.video && Platform.isDesktop) {
 			const platformBadge = contentEl.createDiv({
 				cls: 'synapse-platform-badge',
@@ -89,60 +93,188 @@ export class UnifiedTranscriptionModal extends Modal {
 				});
 		}
 
-		// Time Range section (desktop only — requires ffmpeg)
-		if (Platform.isDesktop) {
-			contentEl.createEl('h3', { text: 'Time Range (optional)' });
-
-			new Setting(contentEl)
-				.setName('Start time')
-				.setDesc('Format: HH:MM:SS or MM:SS. Leave blank for full file.')
-				.addText((text) => {
-					text.setPlaceholder('00:00:00');
-					text.onChange((value) => { this.startTime = value; });
-				});
-
-			new Setting(contentEl)
-				.setName('End time')
-				.addText((text) => {
-					text.setPlaceholder('00:00:00');
-					text.onChange((value) => { this.endTime = value; });
-				});
-		}
-
 		// Transcribe button
 		new Setting(contentEl).addButton((btn) => {
 			btn.setButtonText('Transcribe')
 				.setCta()
 				.onClick(async () => {
-					// Validate time range if provided
-					let timeRange: TimeRange | undefined;
-					if (this.startTime || this.endTime) {
-						if (!this.startTime || !this.endTime) {
-							new Notice('Both start and end times are required');
-							return;
-						}
-						try {
-							timeRange = validateTimeRange(this.startTime, this.endTime);
-						} catch (error) {
-							new Notice(error instanceof Error ? error.message : String(error));
-							return;
-						}
-					}
-
-					if (this.selectedFile) {
-						this.close();
-						await this.callbacks.onTranscribeFile(this.selectedFile, timeRange);
-					} else if (this.url) {
-						if (!detectPlatform(this.url)) {
-							new Notice('Unsupported URL. Please use YouTube or TikTok.');
-							return;
-						}
-						this.close();
-						await this.callbacks.onTranscribeUrl(this.url, timeRange);
-					} else {
-						new Notice('Please select a file or enter a URL');
-					}
+					await this.handleTranscribe();
 				});
+		});
+	}
+
+	/**
+	 * Handle the transcribe action. On desktop, attempts to detect media
+	 * duration and show a time-range slider toast. Falls back to text
+	 * inputs if duration detection fails, or transcribes the full file
+	 * if the media is too short for clipping.
+	 */
+	private async handleTranscribe(): Promise<void> {
+		if (this.selectedFile) {
+			await this.handleFileTranscribe(this.selectedFile);
+		} else if (this.url) {
+			if (!detectPlatform(this.url)) {
+				new Notice('Unsupported URL. Please use YouTube or TikTok.');
+				return;
+			}
+			await this.handleUrlTranscribe(this.url);
+		} else {
+			new Notice('Please select a file or enter a URL');
+		}
+	}
+
+	private async handleFileTranscribe(file: TFile): Promise<void> {
+		if (!Platform.isDesktop) {
+			// No clipping on mobile -- transcribe full file
+			this.close();
+			await this.callbacks.onTranscribeFile(file);
+			return;
+		}
+
+		// Attempt duration detection
+		this.close();
+		const durationResult = await detectLocalFileDuration(
+			file,
+			(f) => this.app.vault.readBinary(f),
+			this.getSettings
+		);
+
+		if (
+			durationResult.durationSeconds !== undefined &&
+			durationResult.durationSeconds >= MIN_SLIDER_DURATION
+		) {
+			const timeRange = await showTimeRangeToast({
+				title: durationResult.title,
+				duration: durationResult.durationSeconds,
+			});
+			await this.callbacks.onTranscribeFile(file, timeRange);
+		} else if (durationResult.durationSeconds !== undefined) {
+			// Too short for slider -- transcribe full file
+			await this.callbacks.onTranscribeFile(file);
+		} else {
+			// Duration unknown -- show fallback text input toast
+			const timeRange = await this.showFallbackTextInputToast(
+				durationResult.title
+			);
+			await this.callbacks.onTranscribeFile(file, timeRange);
+		}
+	}
+
+	private async handleUrlTranscribe(url: string): Promise<void> {
+		if (!Platform.isDesktop) {
+			this.close();
+			await this.callbacks.onTranscribeUrl(url);
+			return;
+		}
+
+		this.close();
+		const durationResult = await detectUrlDuration(url, this.getSettings);
+
+		if (
+			durationResult.durationSeconds !== undefined &&
+			durationResult.durationSeconds >= MIN_SLIDER_DURATION
+		) {
+			const timeRange = await showTimeRangeToast({
+				title: durationResult.title,
+				duration: durationResult.durationSeconds,
+			});
+			await this.callbacks.onTranscribeUrl(url, timeRange);
+		} else if (durationResult.durationSeconds !== undefined) {
+			// Too short for slider -- transcribe full file
+			await this.callbacks.onTranscribeUrl(url);
+		} else {
+			// Duration unknown -- show fallback text input toast
+			const timeRange = await this.showFallbackTextInputToast(
+				durationResult.title
+			);
+			await this.callbacks.onTranscribeUrl(url, timeRange);
+		}
+	}
+
+	/**
+	 * Show a fallback Notice-based toast with text inputs for start/end times.
+	 * Used when duration detection fails (e.g. missing ffprobe, corrupt file).
+	 */
+	private showFallbackTextInputToast(
+		title: string
+	): Promise<TimeRange | undefined> {
+		return new Promise((resolve) => {
+			let resolved = false;
+			let startValue = '';
+			let endValue = '';
+
+			const notice = new Notice('', 0);
+			const el = (notice as unknown as { noticeEl: HTMLElement }).noticeEl;
+			if (!el) {
+				resolve(undefined);
+				return;
+			}
+
+			el.classList.add('synapse-notice', 'synapse-notice--info', 'synapse-notice--no-dismiss');
+			el.addEventListener('click', (e) => {
+				const target = e.target as HTMLElement;
+				if (target.closest('button') || target.closest('input')) return;
+				e.preventDefault();
+				e.stopPropagation();
+			}, true);
+			el.empty();
+
+			el.createDiv({
+				cls: 'synapse-notice-time-range-title',
+				text: `Synapse: Clip "${title}" (optional)`,
+			});
+
+			const desc = el.createDiv({ cls: 'synapse-notice-time-range-desc' });
+			desc.textContent = 'Duration unknown. Enter timestamps manually (HH:MM:SS or MM:SS):';
+
+			const inputRow = el.createDiv({ cls: 'synapse-notice-time-range-inputs' });
+			const startInput = inputRow.createEl('input', {
+				attr: { type: 'text', placeholder: 'Start (00:00)', 'aria-label': 'Start time' },
+				cls: 'synapse-notice-time-input',
+			});
+			inputRow.createSpan({ text: ' \u2013 ' });
+			const endInput = inputRow.createEl('input', {
+				attr: { type: 'text', placeholder: 'End (00:00)', 'aria-label': 'End time' },
+				cls: 'synapse-notice-time-input',
+			});
+
+			startInput.addEventListener('input', () => { startValue = startInput.value; });
+			endInput.addEventListener('input', () => { endValue = endInput.value; });
+
+			const actions = el.createDiv({ cls: 'synapse-notice-actions' });
+
+			const clipBtn = actions.createEl('button', {
+				text: 'Transcribe Selection',
+				cls: 'mod-cta',
+			});
+			clipBtn.addEventListener('click', (e) => {
+				e.stopPropagation();
+				if (resolved) return;
+				if (!startValue || !endValue) {
+					new Notice('Both start and end times are required');
+					return;
+				}
+				try {
+					const range = validateTimeRange(startValue, endValue);
+					resolved = true;
+					notice.hide();
+					resolve(range);
+				} catch (err) {
+					new Notice(err instanceof Error ? err.message : String(err));
+				}
+			});
+
+			const fullBtn = actions.createEl('button', {
+				text: 'Full File',
+				cls: 'mod-cancel',
+			});
+			fullBtn.addEventListener('click', (e) => {
+				e.stopPropagation();
+				if (resolved) return;
+				resolved = true;
+				notice.hide();
+				resolve(undefined);
+			});
 		});
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -107,6 +107,156 @@
   resize: vertical;
 }
 
+/* ── Dual-handle time-range slider ── */
+
+.synapse-time-range-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  padding: 4px 0;
+}
+
+.synapse-time-range-range-label {
+  text-align: center;
+  font-size: var(--font-ui-small);
+  font-weight: var(--font-semibold);
+  color: var(--text-accent);
+}
+
+.synapse-time-range-track-wrapper {
+  position: relative;
+  height: 28px;
+  width: 100%;
+}
+
+.synapse-time-range-track-highlight {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 6px;
+  background-color: var(--interactive-accent);
+  opacity: 0.4;
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.synapse-time-range-input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background: none;
+  pointer-events: none;
+  -webkit-appearance: none;
+  appearance: none;
+  z-index: 1;
+}
+
+/* Allow thumb interaction while keeping track transparent */
+.synapse-time-range-input::-webkit-slider-thumb {
+  pointer-events: auto;
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--interactive-accent);
+  border: 2px solid var(--background-primary);
+  cursor: grab;
+  position: relative;
+  z-index: 2;
+}
+
+.synapse-time-range-input::-moz-range-thumb {
+  pointer-events: auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--interactive-accent);
+  border: 2px solid var(--background-primary);
+  cursor: grab;
+}
+
+.synapse-time-range-input::-webkit-slider-runnable-track {
+  height: 4px;
+  background: var(--background-modifier-border);
+  border-radius: 2px;
+}
+
+.synapse-time-range-input::-moz-range-track {
+  height: 4px;
+  background: var(--background-modifier-border);
+  border-radius: 2px;
+}
+
+/* Only show track on the bottom (start) input */
+.synapse-time-range-input-end::-webkit-slider-runnable-track {
+  background: transparent;
+}
+.synapse-time-range-input-end::-moz-range-track {
+  background: transparent;
+}
+
+.synapse-time-range-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  padding: 0 2px;
+}
+
+.synapse-time-range-label-duration {
+  color: var(--text-faint);
+  font-size: var(--font-ui-smaller);
+}
+
+/* ── Time-range toast ── */
+
+.synapse-notice--time-range {
+  min-width: 340px;
+  max-width: 480px;
+}
+
+.synapse-notice-time-range-title,
+.synapse-notice--time-range .synapse-notice-time-range-title {
+  font-weight: var(--font-semibold);
+  margin-bottom: 8px;
+}
+
+.synapse-notice-time-range-slider {
+  margin: 8px 0;
+}
+
+/* ── Fallback text input toast ── */
+
+.synapse-notice-time-range-desc {
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.synapse-notice-time-range-inputs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.synapse-notice-time-input {
+  width: 80px;
+  padding: 4px 6px;
+  font-size: var(--font-ui-small);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+}
+
 /* ── Mobile-responsive overrides ── */
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Replace static start/end text inputs in `UnifiedTranscriptionModal` with a duration-aware dual-handle range slider shown in a confirmation toast after the media duration is resolved
- Add `duration-detector.ts` module that detects local audio file duration via `ffprobe` and URL duration via `yt-dlp --dump-json` metadata
- Add `TimeRangeSlider` component: dual-handle range slider with live-updating timestamp labels and highlighted track region, styled with Obsidian CSS variables
- Add `showTimeRangeToast()`: confirmation toast embedding the slider with "Transcribe Selection" and "Full File" buttons
- Edge case handling: media < 10s skips slider entirely, unknown duration falls back to manual text inputs in a fallback toast, mobile skips clipping
- Add `Platform` and `SliderComponent` to the obsidian test mock
- Add unit tests for `formatTimestamp` and `MIN_SLIDER_DURATION`

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (671 tests, including 12 new)
- [x] `node esbuild.config.mjs production` builds successfully
- [ ] Manual: open the Transcribe Media modal, select a local audio file or enter a URL, click Transcribe -- verify the slider toast appears with correct duration
- [ ] Manual: adjust slider handles -- verify timestamp labels update live and the highlighted track region reflects the selection
- [ ] Manual: click "Transcribe Selection" with an adjusted range -- verify the transcription only covers the selected segment
- [ ] Manual: click "Full File" -- verify the entire media is transcribed
- [ ] Manual: test with a very short audio file (< 10s) -- verify the slider is skipped and full transcription starts immediately
- [ ] Manual: test on mobile -- verify clipping is skipped gracefully

closes #195

Co-Authored-By: Claude <bot@wafflenet.io>