### PR TITLE
feat: add Instagram Reels URL detection for transcription (closes #193)

### DIFF
--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -3,6 +3,7 @@ import { SummarizeTarget } from './types';
 
 const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;
 const TIKTOK_HOST_RE = /(?:vm\.|vt\.)?tiktok\.com/;
+const INSTAGRAM_HOST_RE = /instagram\.com/;
 const TRANSCRIPTION_HEADER = /^>\s*\*\*Transcription of (.+?)\*\*$/;
 const CALLOUT_TRANSCRIPTION_HEADER = new RegExp(
 	`^>\\s*\\[!${CALLOUT_TYPES.transcription}\\][-+]?\\s+Transcription of (.+)$`
@@ -132,11 +133,11 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
 }
 
 /**
- * Strip query parameters and fragment from TikTok URLs for comparison.
- * Non-TikTok URLs are returned unchanged.
+ * Strip query parameters and fragment from TikTok / Instagram URLs for comparison.
+ * Other URLs are returned unchanged.
  */
-function normalizeTikTokUrl(url: string): string {
-	if (TIKTOK_HOST_RE.test(url)) {
+function normalizeSocialUrl(url: string): string {
+	if (TIKTOK_HOST_RE.test(url) || INSTAGRAM_HOST_RE.test(url)) {
 		return url.replace(/[?#].*$/, '');
 	}
 	return url;
@@ -147,7 +148,7 @@ function normalizeTikTokUrl(url: string): string {
  * Looks within 3 lines below, allowing blank lines and blockquotes.
  */
 export function hasSummaryBelow(lines: string[], startLine: number, source: string): boolean {
-	const normalized = normalizeTikTokUrl(source);
+	const normalized = normalizeSocialUrl(source);
 	for (let j = startLine + 1; j < lines.length && j <= startLine + 3; j++) {
 		const line = lines[j];
 		// Legacy format: > **Summary of <source>**
@@ -170,7 +171,7 @@ export function hasSummaryBelow(lines: string[], startLine: number, source: stri
  * Check if a transcription block exists below a URL line.
  */
 function hasTranscriptionBelow(lines: string[], urlLine: number, url: string): boolean {
-	const normalized = normalizeTikTokUrl(url);
+	const normalized = normalizeSocialUrl(url);
 	for (let j = urlLine + 1; j < lines.length && j <= urlLine + 5; j++) {
 		const line = lines[j];
 		// Legacy format: > **Transcription of <url>**

--- a/src/video/types.ts
+++ b/src/video/types.ts
@@ -1,4 +1,4 @@
-export type Platform = 'youtube' | 'tiktok' | 'unknown';
+export type Platform = 'youtube' | 'tiktok' | 'instagram' | 'unknown';
 
 export interface UrlDetectionResult {
 	platform: Platform;

--- a/src/video/url-detector.test.ts
+++ b/src/video/url-detector.test.ts
@@ -139,6 +139,79 @@ describe('detectPlatform', () => {
 		});
 	});
 
+	describe('Instagram URLs', () => {
+		it('matches /reel/ URL with www', () => {
+			const result = detectPlatform('https://www.instagram.com/reel/DAFnBq_xSHw/');
+			expect(result).toEqual({
+				platform: 'instagram',
+				videoId: 'DAFnBq_xSHw',
+				url: 'https://www.instagram.com/reel/DAFnBq_xSHw/',
+			});
+		});
+
+		it('matches /reel/ URL without www', () => {
+			const result = detectPlatform('https://instagram.com/reel/DAFnBq_xSHw/');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('DAFnBq_xSHw');
+		});
+
+		it('matches /reels/ URL', () => {
+			const result = detectPlatform('https://www.instagram.com/reels/DAFnBq_xSHw/');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('DAFnBq_xSHw');
+		});
+
+		it('matches /p/ post URL', () => {
+			const result = detectPlatform('https://www.instagram.com/p/CxYzAbCdEfG/');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('CxYzAbCdEfG');
+		});
+
+		it('matches without trailing slash', () => {
+			const result = detectPlatform('https://www.instagram.com/reel/DAFnBq_xSHw');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('DAFnBq_xSHw');
+		});
+
+		it('matches with query params', () => {
+			const result = detectPlatform('https://www.instagram.com/reel/DAFnBq_xSHw/?igsh=abc123');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('DAFnBq_xSHw');
+		});
+
+		it('matches with fragment', () => {
+			const result = detectPlatform('https://www.instagram.com/reel/DAFnBq_xSHw/#comments');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('DAFnBq_xSHw');
+		});
+
+		it('matches shortcode with hyphens', () => {
+			const result = detectPlatform('https://www.instagram.com/reel/abc-DEF-123/');
+			expect(result?.platform).toBe('instagram');
+			expect(result?.videoId).toBe('abc-DEF-123');
+		});
+
+		it('does not match profile URLs', () => {
+			expect(detectPlatform('https://www.instagram.com/username/')).toBeNull();
+		});
+
+		it('does not match story URLs', () => {
+			expect(detectPlatform('https://www.instagram.com/stories/username/123456789/')).toBeNull();
+		});
+
+		it('does not match explore URLs', () => {
+			expect(detectPlatform('https://www.instagram.com/explore/')).toBeNull();
+		});
+
+		it('does not match bare instagram.com', () => {
+			expect(detectPlatform('https://www.instagram.com/')).toBeNull();
+		});
+
+		it('does not match IGTV URL', () => {
+			expect(detectPlatform('https://www.instagram.com/tv/CxYzAbCdEfG/')).toBeNull();
+		});
+	});
+
 	describe('unsupported URLs', () => {
 		it('returns null for vimeo', () => {
 			expect(detectPlatform('https://vimeo.com/123456')).toBeNull();
@@ -166,10 +239,12 @@ describe('isSupportedUrl', () => {
 	it('returns true for supported URLs', () => {
 		expect(isSupportedUrl('https://youtube.com/watch?v=abc123')).toBe(true);
 		expect(isSupportedUrl('https://tiktok.com/t/ZTxxxxx/')).toBe(true);
+		expect(isSupportedUrl('https://www.instagram.com/reel/DAFnBq_xSHw/')).toBe(true);
 	});
 
 	it('returns false for unsupported URLs', () => {
 		expect(isSupportedUrl('https://example.com')).toBe(false);
 		expect(isSupportedUrl('')).toBe(false);
+		expect(isSupportedUrl('https://www.instagram.com/username/')).toBe(false);
 	});
 });

--- a/src/video/url-detector.ts
+++ b/src/video/url-detector.ts
@@ -8,6 +8,9 @@ const TIKTOK_VIDEO_REGEX =
 // Short/share TikTok URLs: tiktok.com/t/..., vm.tiktok.com/..., vt.tiktok.com/...
 const TIKTOK_SHORT_REGEX =
 	/(?:vm\.|vt\.)?tiktok\.com\/(?:t\/)?[\w.-]+/;
+// Instagram Reels / posts: instagram.com/reel/CODE, /reels/CODE, /p/CODE
+const INSTAGRAM_REGEX =
+	/instagram\.com\/(?:reel|reels|p)\/([\w-]+)/;
 
 /**
  * Strip query parameters and fragment from TikTok URLs so the canonical
@@ -32,6 +35,11 @@ export function detectPlatform(url: string): UrlDetectionResult | null {
 	const ttShortMatch = url.match(TIKTOK_SHORT_REGEX);
 	if (ttShortMatch) {
 		return { platform: 'tiktok', videoId: 'short-url', url: stripTikTokParams(url) };
+	}
+
+	const igMatch = url.match(INSTAGRAM_REGEX);
+	if (igMatch) {
+		return { platform: 'instagram', videoId: igMatch[1], url };
 	}
 
 	return null;


### PR DESCRIPTION
## Summary
- Add `'instagram'` to the `Platform` union type in `src/video/types.ts`
- Add regex pattern matching for `instagram.com/reel/`, `/reels/`, and `/p/` URLs in `src/video/url-detector.ts`
- Extend `normalizeSocialUrl` in `src/summarize/note-scanner.ts` to strip query params from Instagram URLs (same treatment as TikTok)
- No changes to `audio-extractor.ts` -- yt-dlp already supports Instagram extraction natively

closes #193

## Test plan
- [x] All 684 existing tests pass (`npm test`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit --skipLibCheck`)
- [x] Production build succeeds (`node esbuild.config.mjs production`)
- [x] New Instagram URL tests cover:
  - `/reel/`, `/reels/`, `/p/` path variants
  - With and without `www.`
  - With and without trailing slashes
  - With query params (`?igsh=...`) and fragments
  - Shortcodes containing hyphens
  - Non-matching Instagram URLs (profiles, stories, explore, IGTV)
  - `isSupportedUrl` returns correct results for Instagram URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)