### PR TITLE
feat: mobile-compatible build with lazy Node.js requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit --skipLibCheck
 
+      - name: Check for top-level Node.js requires
+        run: node scripts/check-top-level-requires.mjs
+
       - name: Test
         run: npm test
 

--- a/scripts/check-top-level-requires.mjs
+++ b/scripts/check-top-level-requires.mjs
@@ -1,0 +1,69 @@
+/**
+ * CI guard: ensure no top-level require() calls exist in source files.
+ * Top-level require() for Node.js builtins causes crashes on Obsidian mobile
+ * because esbuild marks them as external and the literal require() executes
+ * at module load time — before any Platform.isDesktop guard can run.
+ *
+ * Usage: node scripts/check-top-level-requires.mjs
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = resolve(__dirname, '..');
+
+function collectTsFiles(dir) {
+	let results = [];
+	for (const entry of readdirSync(dir)) {
+		const full = resolve(dir, entry);
+		if (statSync(full).isDirectory()) {
+			results = results.concat(collectTsFiles(full));
+		} else if (full.endsWith('.ts') && !full.endsWith('.test.ts') && !full.endsWith('.d.ts')) {
+			results.push(full);
+		}
+	}
+	return results;
+}
+
+const files = collectTsFiles(resolve(root, 'src'));
+const requireRe = /\brequire\s*\(/;
+const violations = [];
+
+for (const file of files) {
+	const source = readFileSync(file, 'utf8');
+	const lines = source.split('\n');
+	let braceDepth = 0;
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+
+		// Track brace depth (simplified — ignores braces in strings/comments,
+		// but sufficient for well-formatted TypeScript)
+		for (const ch of line) {
+			if (ch === '{') braceDepth++;
+			if (ch === '}') braceDepth = Math.max(0, braceDepth - 1);
+		}
+
+		if (braceDepth === 0 && requireRe.test(line)) {
+			const rel = file.replace(root + '/', '');
+			violations.push(`  ${rel}:${i + 1}: ${line.trim()}`);
+		}
+	}
+}
+
+if (violations.length > 0) {
+	console.error('ERROR: Top-level require() calls detected:\n');
+	for (const v of violations) {
+		console.error(v);
+	}
+	console.error(
+		'\nMove these into function/method bodies or use a lazy getter ' +
+		'to avoid crashes on Obsidian mobile.'
+	);
+	process.exit(1);
+} else {
+	console.log('No top-level require() calls found.');
+}

--- a/src/video/audio-extractor.ts
+++ b/src/video/audio-extractor.ts
@@ -2,15 +2,6 @@ import { SynapseSettings } from '../settings';
 import { ExtractionResult, VideoMetadata } from './types';
 import { sanitizePath, sanitizeUrl } from '../shared';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const os = require('os') as typeof import('os');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const path = require('path') as typeof import('path');
-
-// child_process is available in Obsidian's Electron environment
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { execFile } = require('child_process') as typeof import('child_process');
-
 /**
  * Obsidian's Electron process has a minimal PATH that often excludes
  * user-installed tools. Append common install locations so yt-dlp/ffmpeg
@@ -34,13 +25,31 @@ function shellEnv(): NodeJS.ProcessEnv {
 }
 
 export class AudioExtractor {
+	private _node: {
+		os: typeof import('os');
+		path: typeof import('path');
+		execFile: typeof import('child_process')['execFile'];
+	} | null = null;
+
+	private get node() {
+		if (!this._node) {
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			this._node = {
+				os: require('os'),
+				path: require('path'),
+				execFile: require('child_process').execFile,
+			};
+		}
+		return this._node;
+	}
+
 	constructor(private getSettings: () => SynapseSettings) {}
 
 	async extractFromUrl(url: string): Promise<ExtractionResult> {
 		const sanitizedUrl = sanitizeUrl(url);
 		const settings = this.getSettings().video;
 		// Use OS temp dir for absolute path — yt-dlp needs a real filesystem path
-		const outputPath = path.join(os.tmpdir(), `synapse-audio-${Date.now()}.mp3`);
+		const outputPath = this.node.path.join(this.node.os.tmpdir(), `synapse-audio-${Date.now()}.mp3`);
 
 		// Get metadata first
 		const metadata = await this.getMetadata(sanitizedUrl);
@@ -58,7 +67,7 @@ export class AudioExtractor {
 	async extractFromFile(filePath: string): Promise<ExtractionResult> {
 		const sanitizedPath = sanitizePath(filePath);
 		const settings = this.getSettings().video;
-		const outputPath = path.join(os.tmpdir(), `synapse-audio-${Date.now()}.mp3`);
+		const outputPath = this.node.path.join(this.node.os.tmpdir(), `synapse-audio-${Date.now()}.mp3`);
 
 		await this.runCommand(sanitizePath(settings.ffmpegPath), [
 			'-i', sanitizedPath,
@@ -80,7 +89,7 @@ export class AudioExtractor {
 	async downloadVideo(url: string): Promise<string> {
 		const sanitizedUrl = sanitizeUrl(url);
 		const settings = this.getSettings().video;
-		const outputPath = path.join(os.tmpdir(), `synapse-video-${Date.now()}.mp4`);
+		const outputPath = this.node.path.join(this.node.os.tmpdir(), `synapse-video-${Date.now()}.mp4`);
 
 		await this.runCommand(sanitizePath(settings.ytDlpPath), [
 			'-f', 'mp4/best',
@@ -97,7 +106,7 @@ export class AudioExtractor {
 	 */
 	async clipAudio(inputPath: string, startSeconds: number, endSeconds: number): Promise<string> {
 		const settings = this.getSettings().video;
-		const outputPath = path.join(os.tmpdir(), `synapse-clipped-${Date.now()}.mp3`);
+		const outputPath = this.node.path.join(this.node.os.tmpdir(), `synapse-clipped-${Date.now()}.mp3`);
 		await this.runCommand(sanitizePath(settings.ffmpegPath), [
 			'-i', sanitizePath(inputPath),
 			'-ss', String(startSeconds),
@@ -143,7 +152,7 @@ export class AudioExtractor {
 
 	private runCommand(cmd: string, args: string[]): Promise<string> {
 		return new Promise((resolve, reject) => {
-			execFile(cmd, args, {
+			this.node.execFile(cmd, args, {
 				env: shellEnv(),
 				maxBuffer: 10 * 1024 * 1024,
 				timeout: 300_000, // 5 minute timeout for long downloads/conversions

--- a/src/video/mobile-safety.test.ts
+++ b/src/video/mobile-safety.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('mobile safety — no top-level Node.js requires', () => {
+	const nodeBuiltins = ['os', 'path', 'child_process', 'fs'];
+	let originalRequire: NodeRequire;
+
+	beforeEach(() => {
+		originalRequire = globalThis.require;
+	});
+
+	afterEach(() => {
+		globalThis.require = originalRequire;
+		vi.resetModules();
+	});
+
+	it('importing the video barrel does not call require() for Node.js builtins at module load', async () => {
+		const trapped: string[] = [];
+
+		// Wrap require to detect Node.js builtin imports
+		const wrappedRequire = ((id: string) => {
+			if (nodeBuiltins.includes(id)) {
+				trapped.push(id);
+			}
+			return originalRequire(id);
+		}) as NodeRequire;
+		// Copy properties from original require
+		Object.assign(wrappedRequire, originalRequire);
+		globalThis.require = wrappedRequire;
+
+		// Dynamic import to trigger module evaluation after our trap is in place
+		await import('./index');
+
+		expect(trapped).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- Moves 3 top-level `require()` calls (`os`, `path`, `child_process`) in `audio-extractor.ts` into a lazy-cached class getter, preventing Obsidian mobile crash at load time
- Adds CI regression guard (`scripts/check-top-level-requires.mjs`) that fails on any top-level `require()` at brace depth 0
- Adds mobile-safety test verifying the video barrel import doesn't trigger Node.js builtin requires

closes #188

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — types pass
- [x] `npm test` — all 685 tests pass (including new mobile-safety test)
- [x] `node esbuild.config.mjs production` — build succeeds
- [x] `node scripts/check-top-level-requires.mjs` — no violations
- [x] Inspected bundled `main.js` — no top-level `require('os')`/`require('path')`/`require('child_process')`

Co-Authored-By: Claude <bot@wafflenet.io>