### PR TITLE
feat: add receipt content template for OCR text extraction (closes #169)

### DIFF
--- a/src/summarize/templates.test.ts
+++ b/src/summarize/templates.test.ts
@@ -3,6 +3,8 @@ import {
 	detectContentTemplate,
 	isRecipeContent,
 	scoreRecipeContent,
+	isReceiptContent,
+	scoreReceiptContent,
 	CONTENT_TEMPLATES,
 } from './templates';
 
@@ -271,5 +273,211 @@ describe('scoreRecipeContent with structured preamble', () => {
 	it('isRecipeContent returns true when structured preamble is present', () => {
 		const content = 'STRUCTURED RECIPE DATA (from page schema):\nRecipe: Simple';
 		expect(isRecipeContent(content)).toBe(true);
+	});
+});
+
+// ── Receipt Detection ────────────────────────────────────────────────
+
+describe('receipt content detection', () => {
+	describe('isReceiptContent', () => {
+		it('detects a receipt with store name, items, totals, and payment method', () => {
+			const content = [
+				'WALMART SUPERCENTER',
+				'Store #4523',
+				'123 Main St, Springfield IL',
+				'03/15/2026 14:32',
+				'',
+				'Cashier: JANE',
+				'Register: 07',
+				'',
+				'GREAT VALUE MILK      $3.48',
+				'BANANAS 2x$0.59       $1.18',
+				'BREAD WHEAT           $2.98',
+				'CHEERIOS              $4.29',
+				'',
+				'Subtotal              $11.93',
+				'Tax                   $0.72',
+				'Total                 $12.65',
+				'',
+				'VISA **** 4521',
+				'Payment               $12.65',
+				'',
+				'THANK YOU FOR SHOPPING AT WALMART',
+			].join('\n');
+
+			expect(isReceiptContent(content)).toBe(true);
+		});
+
+		it('does not detect an invoice as a receipt', () => {
+			const content = [
+				'INVOICE #INV-2026-0042',
+				'',
+				'Bill To: Acme Corporation',
+				'1234 Business Park Drive',
+				'',
+				'Services Rendered:',
+				'- Web Development (40 hours @ $150/hr): $6,000.00',
+				'- Design Consultation (8 hours @ $120/hr): $960.00',
+				'',
+				'Due Date: April 15, 2026',
+				'Net 30 terms apply.',
+				'',
+				'Please remit payment to the address above.',
+			].join('\n');
+
+			expect(isReceiptContent(content)).toBe(false);
+		});
+
+		it('does not detect a restaurant menu as a receipt', () => {
+			const content = [
+				'THE GOLDEN FORK - LUNCH MENU',
+				'',
+				'APPETIZERS',
+				'Bruschetta .......................... $8.95',
+				'Calamari ........................... $10.95',
+				'Soup of the Day .................... $6.50',
+				'',
+				'ENTREES',
+				'Grilled Salmon ..................... $24.95',
+				'Filet Mignon ....................... $32.95',
+				'Pasta Primavera .................... $16.95',
+				'',
+				'DESSERTS',
+				'Tiramisu ........................... $9.50',
+				'Cheesecake ......................... $8.50',
+			].join('\n');
+
+			expect(isReceiptContent(content)).toBe(false);
+		});
+
+		it('does not detect a product catalog as a receipt', () => {
+			const content = [
+				'SPRING 2026 PRODUCT CATALOG',
+				'',
+				'Garden Tools Collection:',
+				'- Premium Pruning Shears: $24.99',
+				'- Ergonomic Trowel Set: $18.99',
+				'- 50ft Expandable Hose: $34.99',
+				'',
+				'All items available online and in-store.',
+				'Free shipping on orders over $75.',
+				'Visit our website for more selections.',
+			].join('\n');
+
+			expect(isReceiptContent(content)).toBe(false);
+		});
+
+		it('does not detect a bank statement as a receipt', () => {
+			const content = [
+				'FIRST NATIONAL BANK',
+				'Monthly Statement - March 2026',
+				'Account: ****7890',
+				'',
+				'Beginning Balance: $4,523.18',
+				'',
+				'03/01 Direct Deposit - Employer      +$3,200.00',
+				'03/05 Electric Company               -$142.50',
+				'03/10 Grocery Store                   -$87.32',
+				'03/15 ATM Withdrawal                  -$200.00',
+				'03/20 Online Transfer                 -$500.00',
+				'',
+				'Ending Balance: $6,793.36',
+			].join('\n');
+
+			expect(isReceiptContent(content)).toBe(false);
+		});
+	});
+
+	describe('scoreReceiptContent', () => {
+		it('returns 0 for content with no receipt signals', () => {
+			const content = 'This is a plain paragraph about the weather today.';
+			expect(scoreReceiptContent(content)).toBe(0);
+		});
+
+		it('gives 2 points for currency patterns', () => {
+			const content = 'Item costs $5.99 in the store.';
+			const score = scoreReceiptContent(content);
+			// currency pattern = 2 pts, also matches LINE_ITEM_DOLLAR = +1
+			expect(score).toBeGreaterThanOrEqual(2);
+		});
+
+		it('gives 2 points for total/subtotal/tax headers', () => {
+			const content = 'Subtotal for all items listed above.';
+			const score = scoreReceiptContent(content);
+			expect(score).toBeGreaterThanOrEqual(2);
+		});
+
+		it('gives points for payment terms', () => {
+			const content = 'Paid with Visa credit card. Cash back available.';
+			const score = scoreReceiptContent(content);
+			// visa + credit + cash = 3 points
+			expect(score).toBeGreaterThanOrEqual(3);
+		});
+
+		it('gives points for receipt identifiers', () => {
+			const content = 'Store #123  Cashier: Tom  Register: 4  Receipt copy';
+			const score = scoreReceiptContent(content);
+			// store # + cashier + register + receipt = 4 points
+			expect(score).toBeGreaterThanOrEqual(4);
+		});
+
+		it('gives 1 point for date/time patterns', () => {
+			const content = 'Transaction on 03/15/2026 14:32 completed.';
+			const score = scoreReceiptContent(content);
+			expect(score).toBeGreaterThanOrEqual(1);
+		});
+
+		it('scores below threshold for borderline content', () => {
+			// Only a single dollar amount — not enough on its own
+			const content = 'The price was $5.99 for one item.';
+			expect(scoreReceiptContent(content)).toBeLessThan(5);
+		});
+	});
+
+	describe('receipt template shape', () => {
+		it('receipt template has valid id, name, detect function, and prompt', () => {
+			const receipt = CONTENT_TEMPLATES.find(t => t.id === 'receipt');
+			expect(receipt).toBeDefined();
+			expect(receipt!.id).toBe('receipt');
+			expect(receipt!.name).toBe('Receipt');
+			expect(typeof receipt!.detect).toBe('function');
+			expect(typeof receipt!.prompt).toBe('string');
+			expect(receipt!.prompt.length).toBeGreaterThan(0);
+		});
+
+		it('receipt template prompt includes structured output sections', () => {
+			const receipt = CONTENT_TEMPLATES.find(t => t.id === 'receipt');
+			expect(receipt).toBeDefined();
+			expect(receipt!.prompt).toContain('Items');
+			expect(receipt!.prompt).toContain('Totals');
+			expect(receipt!.prompt).toContain('Notes');
+			expect(receipt!.prompt).toContain('Store/Location');
+		});
+	});
+
+	describe('detectContentTemplate for receipts', () => {
+		it('returns the receipt template for receipt content', () => {
+			const content = [
+				'TARGET',
+				'Store #1234',
+				'Cashier: Mike',
+				'01/20/2026 10:15',
+				'',
+				'PAPER TOWELS          $8.99',
+				'DISH SOAP             $3.49',
+				'',
+				'Subtotal              $12.48',
+				'Tax                   $1.00',
+				'Total                 $13.48',
+				'',
+				'Debit **** 9876',
+				'Payment               $13.48',
+			].join('\n');
+
+			const template = detectContentTemplate(content);
+			expect(template).not.toBeNull();
+			expect(template!.id).toBe('receipt');
+			expect(template!.name).toBe('Receipt');
+		});
 	});
 });

--- a/src/summarize/templates.ts
+++ b/src/summarize/templates.ts
@@ -103,6 +103,103 @@ const RECIPE_PROMPT =
 	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +
 	'Do not invent information that is not in the original text.';
 
+// ── Receipt Detection ─────────────────────────────────────────────────
+
+const CURRENCY_PATTERN = /(?:\$\d+\.\d{2}|[€£]\d+(?:\.\d{2})?)/;
+const TOTAL_HEADERS = /\b(?:total|subtotal|sub-total|tax|grand\s*total)\b/i;
+const LINE_ITEM_QTY_PRICE = /\d+\s*[x×]\s*\$?\d+/i;
+const LINE_ITEM_DOLLAR = /.+\$\d+\.\d{2}/;
+const PAYMENT_TERMS = /\b(?:cash|credit|debit|visa|mastercard|amex|payment|change\s*due|amount\s*tendered)\b/i;
+const RECEIPT_IDENTIFIERS = /\b(?:store\s*#|register|cashier|receipt|transaction\s*#?|order\s*#?)\b/i;
+const RECEIPT_DATETIME = /\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}\s+\d{1,2}:\d{2}/;
+
+/**
+ * Compute a numeric receipt score for content. Exported for testing.
+ *
+ * Scoring:
+ *   - Structural signals (2 pts each): currency patterns, "total"/"subtotal"/"tax" headers
+ *   - Line-item patterns (1 pt each): quantity x price, item + dollar amount
+ *   - Payment terms (1 pt each match)
+ *   - Receipt identifiers (1 pt each match)
+ *   - Date/time patterns (1 pt)
+ */
+export function scoreReceiptContent(content: string): number {
+	let score = 0;
+
+	// Structural signals — 2 points each
+	if (CURRENCY_PATTERN.test(content)) {
+		score += 2;
+	}
+	if (TOTAL_HEADERS.test(content)) {
+		score += 2;
+	}
+
+	// Line-item patterns — 1 point each
+	if (LINE_ITEM_QTY_PRICE.test(content)) {
+		score += 1;
+	}
+	if (LINE_ITEM_DOLLAR.test(content)) {
+		score += 1;
+	}
+
+	// Payment terms — 1 point each unique match
+	const paymentKeywords = [
+		'cash', 'credit', 'debit', 'visa', 'mastercard', 'amex', 'payment',
+		'change due', 'amount tendered',
+	];
+	for (const keyword of paymentKeywords) {
+		const pattern = new RegExp(`\\b${keyword}\\b`, 'i');
+		if (pattern.test(content)) {
+			score += 1;
+		}
+	}
+
+	// Receipt identifiers — 1 point each unique match
+	const identifierKeywords = ['store #', 'register', 'cashier', 'receipt', 'transaction', 'order #'];
+	for (const keyword of identifierKeywords) {
+		const escaped = keyword.replace('#', '#?');
+		const pattern = new RegExp(`\\b${escaped}\\b`, 'i');
+		if (pattern.test(content)) {
+			score += 1;
+		}
+	}
+
+	// Date/time pattern — 1 point
+	if (RECEIPT_DATETIME.test(content)) {
+		score += 1;
+	}
+
+	return score;
+}
+
+/**
+ * Score content for receipt-like characteristics.
+ * Returns true if the score meets or exceeds the threshold (5).
+ */
+export function isReceiptContent(content: string): boolean {
+	return scoreReceiptContent(content) >= 5;
+}
+
+const RECEIPT_PROMPT =
+	'You are summarizing receipt/transaction content from OCR text extraction. Produce a structured receipt summary using the following format:\n\n' +
+	'## [Store Name]\n\n' +
+	'**Date:** [date or "Not specified"]\n' +
+	'**Store/Location:** [address or store number or "Not specified"]\n\n' +
+	'### Items\n' +
+	'| Item | Qty | Price |\n' +
+	'|------|-----|-------|\n' +
+	'| [item name] | [quantity] | [price] |\n\n' +
+	'List each purchased item with its quantity and price. Preserve the original prices from the source.\n\n' +
+	'### Totals\n' +
+	'- **Subtotal:** [amount or "Not specified"]\n' +
+	'- **Tax:** [amount or "Not specified"]\n' +
+	'- **Total:** [amount]\n' +
+	'- **Payment method:** [method or "Not specified"]\n\n' +
+	'### Notes\n' +
+	'- Any return policy, warranty information, loyalty points, or other relevant details from the receipt\n\n' +
+	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +
+	'Do not invent information that is not in the original text.';
+
 // ── Template Registry ─────────────────────────────────────────────────
 
 export const CONTENT_TEMPLATES: ContentTemplate[] = [
@@ -111,6 +208,12 @@ export const CONTENT_TEMPLATES: ContentTemplate[] = [
 		name: 'Recipe',
 		detect: isRecipeContent,
 		prompt: RECIPE_PROMPT,
+	},
+	{
+		id: 'receipt',
+		name: 'Receipt',
+		detect: isReceiptContent,
+		prompt: RECEIPT_PROMPT,
 	},
 ];
 


### PR DESCRIPTION
## Summary
- Add `scoreReceiptContent()` scoring heuristic detecting currency, totals, line items, payment terms, and receipt identifiers
- Add `isReceiptContent()` wrapper with threshold-based detection
- Add receipt-specific structured prompt for store/items/totals/notes output
- Register receipt template in `CONTENT_TEMPLATES` array

closes #169

## Test plan
- [ ] Positive detection: receipt text with store, items, totals, payment
- [ ] Negative detection: invoices, menus, catalogs, bank statements
- [ ] Scoring: individual signal verification, threshold check  
- [ ] Template shape: valid id, name, detect, prompt
- [ ] TypeScript compiles without errors
- [ ] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)