### PR TITLE
chore: codebase audit — fix imports, harden URL validation, update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Output: `main.js` (single bundle, Obsidian loads this)
 | audio | `src/audio/` | Audio transcription (Whisper, Deepgram, local), post-processing | `AudioModule`, `findAudioEmbeds`, types |
 | video | `src/video/` | Video download (YouTube/TikTok), audio extraction, transcription | `VideoModule`, `findVideoUrls`, `detectPlatform`, `isSupportedUrl`, types |
 | image | `src/image/` | Image OCR via multi-modal AI (vision models), batch extraction with checkpoints | `ImageModule`, `findImageEmbeds`, `ImageExtractor`, types |
-| transcription | `src/transcription/` | Unified transcription/OCR UI modals | `UnifiedTranscriptionModal`, `NoteMediaModal` |
+| transcription | `src/transcription/` | Unified transcription/OCR UI modals, duration detection, time-range clipping UI | `UnifiedTranscriptionModal`, `NoteMediaModal`, `TimeRangeSlider`, `showTimeRangeToast`, `detectLocalFileDuration`, `detectUrlDuration`, `formatTimestamp` |
 | enrichment | `src/enrichment/` | Metadata classification, topic extraction, link resolution, external refs, frontmatter | `EnrichmentModule`, types |
 | summarize | `src/summarize/` | URL and transcription summarization, standalone summary notes, audio-embed summarization | `SummarizeModule`, types |
 | tidy | `src/tidy/` | Spelling correction and markdown formatting via AI | `TidyModule`, `TidySnapshot` |
@@ -52,7 +52,7 @@ main.ts
   |-- audio/ --> shared/ (CheckpointManager)
   |-- video/ --> shared/ (CheckpointManager), audio/ (reuses transcription pipeline)
   |-- image/ --> shared/ (CheckpointManager, AIClient, callouts, validation)
-  |-- transcription/ --> audio/ (types), video/ (detectPlatform), image/ (types)
+  |-- transcription/ --> audio/ (types), video/ (detectPlatform), image/ (types), shared/ (TimeRange, validation)
   |-- enrichment/ --> shared/ (CheckpointManager)
   |-- summarize/ --> shared/ (CheckpointManager), video/ (transcribeUrl injection), audio/ (findAudioEmbeds)
   |-- tidy/ --> shared/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,8 +100,11 @@ src/
 │   └── index.ts            #   ImageModule orchestrator (batch + checkpoint)
 │
 ├── transcription/          # Unified transcription UI (issue #20)
-│   ├── unified-modal.ts    #   File picker + URL input in a single modal
+│   ├── unified-modal.ts    #   File picker + URL input with duration + time-range
 │   ├── note-media-modal.ts #   Selection modal for media in current note
+│   ├── time-range-slider.ts#   Dual-handle range slider (pure DOM component)
+│   ├── time-range-toast.ts #   Confirmation toast with embedded slider
+│   ├── duration-detector.ts#   Media duration via ffprobe (local) / yt-dlp (URL)
 │   └── index.ts            #   Barrel export
 │
 ├── enrichment/             # Tags, links, refs, frontmatter
@@ -330,6 +333,25 @@ graph TB
 
 The transcription module replaced 4 modal files across audio/ and video/ with 2 unified modals. The `NoteMediaModal` also handles image OCR extraction. All callbacks are wired in `main.ts`.
 
+### Time-Range Clipping (v0.3.2)
+
+When a user selects an audio file or enters a video URL, the modal auto-detects media duration via ffprobe (local) or yt-dlp (URLs). If duration >= 10 seconds, a dual-handle `TimeRangeSlider` appears allowing sub-range selection. Clipping uses ffmpeg on the extracted audio (desktop only; mobile falls back to full-file transcription).
+
+```
+File/URL selected --> detectDuration() --> duration >= 10s?
+  |-- Yes --> Show TimeRangeSlider (dual handles, live timestamps)
+  |           User adjusts range --> TimeRange { start, end }
+  |           Transcribe button --> clip audio via ffmpeg --> transcribe clip
+  |-- No  --> Full file transcription (no slider shown)
+```
+
+### Supported Platforms
+
+URL detection (`video/url-detector.ts`) recognizes:
+- **YouTube**: `youtube.com/watch`, `youtu.be`, `youtube.com/shorts`, `music.youtube.com`
+- **TikTok**: `tiktok.com/@user/video/id`, `tiktok.com/t/...`, `vm.tiktok.com`, `vt.tiktok.com`
+- **Instagram**: `instagram.com/reel/{id}`, `instagram.com/p/{id}` (Reels)
+
 ---
 
 ## Cross-Module Communication
@@ -476,7 +498,7 @@ graph TB
 
 ## Summarize: Content-Aware Templates
 
-The summarize module detects content type (e.g., recipe pages via JSON-LD schema data) and applies specialized templates:
+The summarize module detects content type and applies specialized templates. Supports recipe pages (via JSON-LD schema data) and receipt images (via OCR keyword scoring):
 
 ```
 Note with URL --> content-fetcher.ts

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,115 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-03-19: Receipt content template for OCR text extraction (Issue #200)
+
+**Context**: The OCR module extracts raw text from images, but receipt images contain structured data (store name, items, prices, totals) that benefits from a specialized extraction format rather than raw text dump.
+
+**Decision**: Add a `receipt` content template to the OCR pipeline that detects receipt-like content and applies a structured extraction prompt. The template formats OCR output with store info, line items with prices, subtotals, and totals.
+
+**Alternatives considered**:
+- Raw OCR only (loses structured financial data)
+- Separate receipt scanning command (fragments UX)
+- Post-processing step after OCR (doubles AI cost)
+
+**Rationale**: Receipt detection is cheap (keyword scoring on OCR output) and the structured template produces dramatically more useful output for expense tracking and bookkeeping workflows. Follows the same template pattern established for recipe summarization.
+
+**Impact**: Receipt images produce structured extractions with itemized data. Non-receipt images are unaffected.
+
+---
+
+## 2026-03-19: Lazy Node.js requires for mobile safety (Issue #198)
+
+**Context**: Obsidian mobile crashes on top-level `require('child_process')` / `require('fs')` even if the code path is never executed. The plugin had `isDesktopOnly: false` but still imported Node.js built-ins at module scope.
+
+**Decision**: Wrap all Node.js built-in requires (`child_process`, `fs`, `os`, `path`) in lazy getter functions that only resolve on first access. Desktop-only features (yt-dlp, ffmpeg, ffprobe) gracefully degrade on mobile.
+
+**Alternatives considered**:
+- Separate mobile/desktop builds — doubles build complexity
+- Dynamic `import()` — not supported in Obsidian's module system
+- Gate entire modules behind `Platform.isDesktop` — loses mobile access to non-CLI features within those modules
+
+**Rationale**: Lazy getters are minimal code change, zero runtime cost on mobile, and keep a single build artifact. The pattern is applied to `video/audio-extractor.ts` and `transcription/duration-detector.ts`.
+
+**Impact**: Plugin no longer crashes on mobile load. Video/audio clipping features silently fall back to full-file processing on mobile.
+
+---
+
+## 2026-03-19: Instagram Reels URL detection for transcription pipeline (Issue #197)
+
+**Context**: Users share Instagram Reels URLs in their notes. The transcription pipeline only recognized YouTube and TikTok URLs, leaving Instagram content unsupported.
+
+**Decision**: Add Instagram Reels detection to `url-detector.ts`. Recognizes `instagram.com/reel/{id}` and `instagram.com/p/{id}` URL patterns. Platform type extended to `'youtube' | 'tiktok' | 'instagram' | 'unknown'`.
+
+**Alternatives considered**:
+- Only support YouTube and TikTok (misses growing Instagram Reels usage)
+- Generic "any URL" support (yt-dlp supports many sites but detection UX needs platform-specific badges)
+
+**Rationale**: Instagram Reels are increasingly common in note-taking workflows. yt-dlp already supports Instagram extraction, so the only change needed is URL detection and badge display in the transcription modal.
+
+**Impact**: Instagram Reels URLs show platform badge in transcription modal and are processed through the existing yt-dlp pipeline. `UnifiedTranscriptionModal` displays Instagram badge alongside YouTube and TikTok.
+
+---
+
+## 2026-03-19: Duration-aware time-range slider for transcription clipping (Issues #192, #194, #196)
+
+**Context**: Users wanted to transcribe specific segments of audio/video rather than entire files. This required (1) knowing media duration before presenting a UI, and (2) a visual way to select the time range.
+
+**Decision**: Three-part implementation:
+
+1. **Duration detection** (`transcription/duration-detector.ts`): Probes media length via ffprobe (local files) or yt-dlp (URLs). Returns `DurationResult` with duration and title. Falls back gracefully on mobile or when tools are unavailable.
+
+2. **Time-range slider** (`transcription/time-range-slider.ts`): Pure DOM component with dual-handle range inputs on a shared track. Visual highlight for selected region, live timestamp labels (MM:SS or HH:MM:SS), step size adapts to media length (1s for <= 10min, 5s otherwise).
+
+3. **Time-range toast** (`transcription/time-range-toast.ts`): Non-dismissible Obsidian Notice with embedded slider. "Transcribe Selection" button returns `TimeRange`; "Full File" button returns `undefined`.
+
+The slider appears in `UnifiedTranscriptionModal` when detected duration >= 10 seconds (`MIN_SLIDER_DURATION`). Audio clipping uses ffmpeg; video clipping uses ffmpeg on extracted audio. Both are desktop-only with full-file fallback on mobile.
+
+**Alternatives considered**:
+- Text input for start/end times — error-prone, poor UX
+- Always show slider with unknown duration — misleading
+- Waveform visualization — complex, large dependency, marginal benefit
+
+**Rationale**: Duration detection is fast (metadata-only, no download). Dual-handle slider provides intuitive visual feedback. The toast pattern reuses Obsidian's Notice system without a full modal. Falls back gracefully when detection fails.
+
+**Impact**: New files in `transcription/`: `duration-detector.ts`, `time-range-slider.ts`, `time-range-toast.ts`. Callout titles include time range when clipped: "Transcription of file.mp3 [01:30 - 05:00]". Desktop-only for clipping (mobile gets full-file fallback).
+
+---
+
+## 2026-03-19: Broaden URL detection for YouTube and TikTok edge cases (Issue #190, #191)
+
+**Context**: Users encountered YouTube and TikTok URL variants that the existing regex patterns did not match: YouTube Shorts with query params, YouTube Music URLs, TikTok mobile share links with tracking parameters.
+
+**Decision**: Expand URL detection regexes in `url-detector.ts` to handle additional patterns:
+- YouTube: `music.youtube.com`, shorts with query params, embedded URLs
+- TikTok: `vm.tiktok.com`, `vt.tiktok.com` short links, URLs with tracking query params
+
+**Alternatives considered**:
+- Parse URLs with the `URL` API and match by hostname (cleaner but loses line-number tracking from regex scan)
+- Only support canonical URL forms (too restrictive for real-world note content)
+
+**Rationale**: Users paste URLs directly from mobile share sheets, which produce non-canonical forms. Broader regex coverage prevents false negatives without increasing false positives.
+
+**Impact**: More YouTube and TikTok URLs are correctly detected in notes. No behavior change for already-matched URLs.
+
+---
+
+## 2026-03-19: Display plugin version in settings header (Issue #178)
+
+**Context**: Users had no easy way to check which version of Synapse they were running, especially when reporting bugs.
+
+**Decision**: Display the plugin version from `manifest.json` in the settings tab header, next to the plugin name.
+
+**Alternatives considered**:
+- Separate "About" section in settings (over-engineered)
+- Console log on load (not discoverable)
+
+**Rationale**: Minimal change, high discoverability. Users see the version every time they open settings.
+
+**Impact**: Settings header shows "Synapse v0.3.2" (or current version).
+
+---
+
 ## 2026-03-19: Revised hybrid strategy -- caption-first with extraction fallback (Issue #166, follow-up)
 
 **Context**: After the initial hybrid extraction decision (below), a key insight emerged: Synapse's actual need is transcription (URL to text), not video downloading. The user does not need the video file itself -- they need the transcript, and optionally a summary. This reframes the problem: if we can get text from a URL without ever downloading audio or video, the entire yt-dlp/ffmpeg dependency becomes unnecessary for the most common use case.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,9 @@
 # Project Status
 
 **Last updated**: 2026-03-19
-**Version**: 0.2.2
+**Version**: 0.3.2
 **Branch**: `main`
-**Phase**: 11 modules (10 feature + 1 UI-only transcription); image OCR, multi-modal AI, and image-aware elaboration recently shipped
+**Phase**: 11 modules (10 feature + 1 UI-only transcription); time-range clipping, Instagram Reels, receipt OCR templates, and mobile safety recently shipped
 
 ---
 
@@ -18,7 +18,7 @@
 | **Audio** -- Deepgram transcription | Yes | Yes | No | **Working** |
 | **Audio** -- local Whisper | -- | -- | No | Not started (throws) |
 | **Audio** -- note scanning for embeds | Yes | -- | Yes | **Working** |
-| **Video** -- URL detection (YT + TikTok) | Yes | -- | Yes | **Working** |
+| **Video** -- URL detection (YT + TikTok + Instagram) | Yes | -- | Yes | **Working** |
 | **Video** -- yt-dlp download + transcribe | Yes | Yes | No | **Working** |
 | **Video** -- TikTok URL normalization | Yes | -- | Yes | **Working** |
 | **Video** -- note scanning for URLs | Yes | -- | Yes | **Working** |
@@ -29,6 +29,9 @@
 | **Image** -- note scanning for embeds | Yes | -- | Yes | **Working** |
 | **Transcription** -- unified modal (file + URL) | Yes | Yes | No | **Working** |
 | **Transcription** -- note media modal (scan + select) | Yes | Yes | No | **Working** |
+| **Transcription** -- duration detection (ffprobe/yt-dlp) | Yes | -- | Yes | **Working** |
+| **Transcription** -- time-range slider (dual-handle) | Yes | Yes | No | **Working** |
+| **Transcription** -- time-range clipping (audio/video) | Yes | Yes | No | **Working** (desktop only) |
 | **Enrichment** -- metadata classification (vocabulary-based) | Yes | Yes | Yes | **Working** |
 | **Enrichment** -- topic extraction (AI topics to links) | Yes | Yes | Yes | **Working** |
 | **Enrichment** -- link resolution (graph + topic merge) | Yes | Yes | Yes | **Working** |
@@ -39,6 +42,7 @@
 | **Summarize** -- transcription summarization | Yes | Yes | No | **Working** |
 | **Summarize** -- enrichment link -> standalone note | Yes | -- | Yes | **Working** |
 | **Summarize** -- content-aware templates (recipe detection) | Yes | -- | Yes | **Working** |
+| **Summarize** -- receipt content template for OCR | Yes | -- | No | **Working** |
 | **Summarize** -- vault-wide scan | Yes | Yes | No | **Working** |
 | **Tidy** -- spelling/formatting | Yes | -- | Yes | **Working** |
 | **Tidy** -- undo | Yes | -- | Yes | **Working** |
@@ -84,21 +88,37 @@
 
 - **Documentation audit**: Updating AGENTS.md, DECISIONS.md, STATUS.md, ARCHITECTURE.md
 - **Security pass**: Ongoing audit for input validation and credential handling
+- **Hybrid extraction strategy**: Research complete (Issue #166); implementation planned for v0.7.0
 
-## Recent Changes (2026-03-19)
+## Recent Changes (v0.3.2 — 2026-03-19)
 
-- Added image OCR module with multi-modal AIClient and vision model support (#162, #165)
-- Added image analysis to elaboration proposals for context-aware content generation (#163, #167)
-- Added image embed preservation in AI-generated content (#161)
-- Fixed resource cleanup: setTimeout handles and injected styles properly cleared on unload (#170)
-- Migrated settings headings from `createEl` to `setHeading()` API (#171)
-- Bumped version to 0.2.2 (#159)
+- Added receipt content template for OCR text extraction (#200)
+- Moved top-level Node.js requires into lazy getters for mobile safety (#198)
+- Added Instagram Reels URL detection for transcription pipeline (#197)
+- Added duration-aware time-range slider for transcription clipping (#196)
+- Added optional time-range clipping for audio/video transcription (#194)
+- Broadened URL detection for YouTube and TikTok edge cases (#191)
+- Bumped version to 0.3.2 (#199)
 
-## Previous Milestone (2026-03-18)
+## Previous Milestones
 
+### v0.3.1 (2026-03-19)
+- Research: hybrid extraction strategy for cross-platform media support (#183)
+- Display plugin version in settings header (#178)
+
+### v0.3.0 (2026-03-19)
+- Full codebase audit — fix imports, update docs (#173)
+- Migrated settings headings from `createEl` to `setHeading()` (#171)
+- Fixed resource cleanup: setTimeout handles and injected styles on unload (#170)
+
+### v0.2.2 (2026-03-18)
+- Image OCR module with multi-modal AIClient and vision model support (#162, #165)
+- Image analysis in elaboration proposals (#163, #167)
+- Image embed preservation in AI content (#161)
+
+### v0.2.1 (2026-03-18)
 - Title proposal module (#150, #157)
 - TikTok URL normalization (#155, #156)
-- JSON-LD recipe data extraction (#153, #154)
 - Content-aware summary templates with recipe detection (#145, #148)
 - Reject All button for proposals (#141)
 

--- a/src/audio/AGENTS.md
+++ b/src/audio/AGENTS.md
@@ -12,12 +12,12 @@ Exported from `index.ts`:
 
 ```ts
 class AudioModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager)
+  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager, extractor?: AudioExtractor)
   onload(): Promise<void>
   onunload(): void
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   transcribe(audioData: ArrayBuffer, fileName: string, options?: TranscribeOptions): Promise<TranscriptionResult>
-  transcribeFileToActiveNote(file: TFile): Promise<void>
+  transcribeFileToActiveNote(file: TFile, timeRange?: TimeRange): Promise<void>
   transcribeAndInsert(noteFile: TFile, embeds: AudioEmbed[]): Promise<void>
   onTranscriptionComplete: ((filePath: string) => void) | null
 }
@@ -37,7 +37,7 @@ interface TranscriptionResult {
 }
 
 interface TimestampEntry { start: number; end: number; text: string }
-interface TranscribeOptions { language?: string; postProcess?: boolean; sourceName?: string }
+interface TranscribeOptions { language?: string; postProcess?: boolean; sourceName?: string; timeRange?: TimeRange }
 interface AudioEmbed { fileName: string; file: TFile; line: number }
 ```
 
@@ -57,8 +57,9 @@ interface AudioEmbed { fileName: string; file: TFile; line: number }
 ```
 1. User triggers via UnifiedTranscriptionModal or NoteMediaModal (in transcription/)
    |
-2a. transcribeFileToActiveNote(file) -- single file to active note
-   |  Reads binary, calls transcribe(), builds callout, appends to active note
+2a. transcribeFileToActiveNote(file, timeRange?) -- single file to active note
+   |  Reads binary, clips audio via AudioExtractor if timeRange provided (desktop only)
+   |  Calls transcribe(), builds callout with time-range label, appends to active note
    |
 2b. transcribeAndInsert(noteFile, embeds) -- batch from note scan
    |  Processes embeds in reverse line order, 2s delay between API calls
@@ -101,9 +102,18 @@ All under `settings.audio`:
 | `language` | Language hint |
 | `postProcessing.*` | AI cleanup flags |
 
+## Time-Range Clipping
+
+When `timeRange` is provided to `transcribeFileToActiveNote()`:
+1. Audio file written to temp directory
+2. `AudioExtractor.clipAudio(tempPath, start, end)` clips via ffmpeg (desktop only)
+3. Clipped audio data passed to `transcribe()`
+4. Callout title includes time range: "Transcription of file.mp3 [01:30 - 05:00]"
+5. Falls back to full-file transcription on mobile (no AudioExtractor)
+
 ## Video Module Integration
 
-`AudioModule.transcribe()` is called by `VideoModule.processUrl()` at `video/index.ts:L93`. Video passes extracted audio as `ArrayBuffer` with `sourceName` set to video title.
+`AudioModule.transcribe()` is called by `VideoModule.processUrl()` at `video/index.ts:L118`. Video passes extracted audio as `ArrayBuffer` with `sourceName` set to video title.
 
 ## Commands
 

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -10,7 +10,7 @@ import { AudioEmbed } from './types';
 import { PostProcessor } from './post-processor';
 import { Transcriber } from './transcriber';
 import { TranscribeOptions, TranscriptionResult } from './types';
-import type { AudioExtractor } from '../video/audio-extractor';
+import type { AudioExtractor } from '../video';
 
 export { findAudioEmbeds, AUDIO_EXTENSIONS, AUDIO_EMBED_REGEX } from './note-scanner';
 export type { AudioEmbed, TranscribeOptions, TranscriptionResult, TimestampEntry } from './types';

--- a/src/audio/types.ts
+++ b/src/audio/types.ts
@@ -1,5 +1,5 @@
 import { TFile } from 'obsidian';
-import { TimeRange } from '../shared/validation';
+import { TimeRange } from '../shared';
 
 export interface TranscriptionResult {
 	raw: string;

--- a/src/transcription/AGENTS.md
+++ b/src/transcription/AGENTS.md
@@ -4,7 +4,7 @@ last-updated: 2026-03-19
 
 # Transcription Module
 
-Unified transcription and OCR UI modals. Replaces the former separate modals in audio/ and video/ modules. Now also handles image OCR selection.
+Unified transcription and OCR UI modals with duration-aware time-range clipping. Replaces the former separate modals in audio/ and video/ modules. Also handles image OCR selection.
 
 ## Public API
 
@@ -17,8 +17,8 @@ class UnifiedTranscriptionModal extends Modal {
     getSettings: () => SynapseSettings,
     enabledModules: { audio: boolean; video: boolean },
     callbacks: {
-      onTranscribeFile: (file: TFile) => Promise<void>;
-      onTranscribeUrl: (url: string) => Promise<void>;
+      onTranscribeFile: (file: TFile, timeRange?: TimeRange) => Promise<void>;
+      onTranscribeUrl: (url: string, timeRange?: TimeRange) => Promise<void>;
     }
   )
 }
@@ -36,24 +36,63 @@ class NoteMediaModal extends Modal {
     }
   )
 }
+
+class TimeRangeSlider {
+  readonly containerEl: HTMLElement
+  get start(): number
+  get end(): number
+  constructor(parentEl: HTMLElement, options: TimeRangeSliderOptions)
+}
+
+interface TimeRangeSliderOptions {
+  duration: number
+  initialStart?: number
+  initialEnd?: number
+  onChange?: (start: number, end: number) => void
+}
+
+function showTimeRangeToast(options: TimeRangeToastOptions): Promise<TimeRange | undefined>
+
+interface TimeRangeToastOptions {
+  title: string
+  duration: number
+}
+
+function detectLocalFileDuration(file: TFile, readBinary: (file: TFile) => Promise<ArrayBuffer>, getSettings: () => SynapseSettings): Promise<DurationResult>
+function detectUrlDuration(url: string, getSettings: () => SynapseSettings): Promise<DurationResult>
+function formatTimestamp(totalSeconds: number): string
+
+const MIN_SLIDER_DURATION: number  // 10 seconds
+
+interface DurationResult {
+  durationSeconds: number | undefined
+  title: string
+}
 ```
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `unified-modal.ts` | `UnifiedTranscriptionModal` | File picker + URL input modal for ad-hoc transcription |
+| `unified-modal.ts` | `UnifiedTranscriptionModal` | File picker + URL input modal with duration detection and time-range slider |
 | `note-media-modal.ts` | `NoteMediaModal` | Selection modal for media found in current note |
+| `time-range-slider.ts` | `TimeRangeSlider`, `TimeRangeSliderOptions` | Dual-handle range slider for time selection (pure DOM component) |
+| `time-range-toast.ts` | `showTimeRangeToast`, `TimeRangeToastOptions` | Confirmation toast with embedded time-range slider |
+| `duration-detector.ts` | `detectLocalFileDuration`, `detectUrlDuration`, `formatTimestamp`, `MIN_SLIDER_DURATION`, `DurationResult` | Duration detection via ffprobe (local) and yt-dlp (URL) |
+| `duration-detector.test.ts` | Tests | Duration detector tests |
 | `index.ts` | Re-exports | Barrel file |
 
 ## UnifiedTranscriptionModal
 
 Single modal combining audio file selection and video URL input:
 - Dropdown lists all audio files in vault (filtered by `AUDIO_EXTENSIONS`)
-- URL text field with platform detection badge (YouTube/TikTok)
+- URL text field with platform detection badge (YouTube/TikTok/Instagram)
 - Post-processing status display
+- Duration detection: auto-detects media length when file selected or URL entered
+- Time-range slider: shown when duration >= `MIN_SLIDER_DURATION` (10s)
 - Validates URL via `detectPlatform()` before allowing transcription
 - File selection and URL input are mutually exclusive
+- Callbacks pass `timeRange` when user selects a sub-range
 
 Opened via:
 - Ribbon icon (`mic`)
@@ -70,6 +109,40 @@ Selection modal for media embedded in the current note:
 Opened via:
 - Command `synapse:transcribe-note-media`
 
+## Duration Detection
+
+`duration-detector.ts` provides two detection strategies:
+
+### Local Files (`detectLocalFileDuration`)
+1. Writes audio binary to temp file
+2. Runs ffprobe (derived from `video.ffmpegPath` setting)
+3. Parses `-show_entries format=duration` output
+4. Returns `DurationResult` (undefined duration on failure/mobile)
+
+### URLs (`detectUrlDuration`)
+1. Runs `yt-dlp --dump-json --no-download` on validated URL
+2. Parses `duration` and `title` from JSON metadata
+3. Returns `DurationResult` (undefined duration on failure/mobile)
+
+Both use `shellEnv()` to append common tool paths (`/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin`).
+
+## Time-Range Slider
+
+`TimeRangeSlider` is a pure DOM component (no Obsidian dependencies beyond `createEl`):
+- Two overlapping HTML range inputs on a shared track
+- Visual highlight for the selected region
+- Timestamp labels update live (MM:SS or HH:MM:SS)
+- Step size: 1s for media <= 10min, 5s otherwise
+- Handles cannot cross each other (enforced via input handlers)
+
+## Time-Range Toast
+
+`showTimeRangeToast()` shows a non-dismissible Obsidian Notice with:
+- Media title
+- Embedded `TimeRangeSlider`
+- "Transcribe Selection" button (returns `TimeRange` if range adjusted)
+- "Full File" button (returns `undefined`)
+
 ## Dependencies
 
 | Import | From |
@@ -79,14 +152,17 @@ Opened via:
 | `detectPlatform` | `../video` (function) |
 | `VideoUrlEmbed` | `../video` (type) |
 | `ImageEmbed` | `../image` (type) |
+| `TimeRange` | `../shared` (type) |
+| `sanitizePath`, `sanitizeUrl` | `../shared` (validation) |
+| `SynapseSettings` | `../settings` |
 
 ## Wiring (in main.ts)
 
 ```ts
 // UnifiedTranscriptionModal
 new UnifiedTranscriptionModal(app, getSettings, enabledModules, {
-  onTranscribeFile: (file) => audio.transcribeFileToActiveNote(file),
-  onTranscribeUrl: (url) => video.transcribeUrlToActiveNote(url),
+  onTranscribeFile: (file, timeRange) => audio.transcribeFileToActiveNote(file, timeRange),
+  onTranscribeUrl: (url, timeRange) => video.transcribeUrlToActiveNote(url, timeRange),
 })
 
 // NoteMediaModal (after scanning note content)

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -1,6 +1,6 @@
 import { Platform, TFile } from 'obsidian';
 import type { SynapseSettings } from '../settings';
-import { sanitizePath } from '../shared/validation';
+import { sanitizePath, sanitizeUrl } from '../shared';
 
 /**
  * Result of a duration detection attempt.
@@ -81,13 +81,14 @@ export async function detectUrlDuration(
 	}
 
 	try {
+		const validatedUrl = sanitizeUrl(url);
 		const { execFile } = require('child_process') as typeof import('child_process');
 		const ytDlpPath = sanitizePath(getSettings().video.ytDlpPath);
 
 		const output = await new Promise<string>((resolve, reject) => {
 			execFile(
 				ytDlpPath,
-				['--dump-json', '--no-download', url],
+				['--dump-json', '--no-download', validatedUrl],
 				{ env: shellEnv(), maxBuffer: 10 * 1024 * 1024, timeout: 30_000 },
 				(error, stdout) => {
 					if (error) reject(error);

--- a/src/transcription/time-range-toast.ts
+++ b/src/transcription/time-range-toast.ts
@@ -1,5 +1,5 @@
 import { Notice } from 'obsidian';
-import type { TimeRange } from '../shared/validation';
+import type { TimeRange } from '../shared';
 import { TimeRangeSlider } from './time-range-slider';
 
 /** CSS class prefix */

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -2,8 +2,8 @@ import { App, Modal, Notice, Platform, Setting, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { AUDIO_EXTENSIONS } from '../audio';
 import { detectPlatform } from '../video';
-import { validateTimeRange } from '../shared/validation';
-import type { TimeRange } from '../shared/validation';
+import { validateTimeRange } from '../shared';
+import type { TimeRange } from '../shared';
 import {
 	detectLocalFileDuration,
 	detectUrlDuration,

--- a/src/video/AGENTS.md
+++ b/src/video/AGENTS.md
@@ -18,7 +18,7 @@ class VideoModule {
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   transcribeUrl(url: string, parentOp?: { update: (msg: string) => void }): Promise<string>
   processUrl(url: string, options?: VideoProcessOptions, parentOp?: { update: (msg: string) => void }): Promise<TranscriptionResult & { videoVaultPath?: string }>
-  transcribeUrlToActiveNote(url: string): Promise<void>
+  transcribeUrlToActiveNote(url: string, timeRange?: TimeRange): Promise<void>
   transcribeAndInsert(noteFile: TFile, embeds: VideoUrlEmbed[]): Promise<void>
   onTranscriptionComplete: ((filePath: string) => void) | null
 }
@@ -29,7 +29,7 @@ function findVideoUrls(content: string): VideoUrlEmbed[]
 
 type Platform = 'youtube' | 'tiktok' | 'unknown'
 interface UrlDetectionResult { platform: Platform; videoId: string; url: string }
-interface VideoProcessOptions { postProcess?: boolean; extractFrames?: boolean; outputPath?: string; insertMode?: boolean }
+interface VideoProcessOptions { postProcess?: boolean; extractFrames?: boolean; outputPath?: string; insertMode?: boolean; timeRange?: TimeRange }
 interface ExtractionResult { audioPath: string; metadata: VideoMetadata }
 interface VideoMetadata { title: string; channel?: string; duration?: number; uploadDate?: string; description?: string; platform?: string; url?: string }
 interface VideoUrlEmbed { url: string; platform: Platform; line: number }
@@ -53,8 +53,9 @@ interface VideoUrlEmbed { url: string; platform: Platform; line: number }
 ```
 1. User triggers via UnifiedTranscriptionModal or NoteMediaModal (in transcription/)
    |
-2a. transcribeUrlToActiveNote(url) -- single URL to active note
-   |  Calls processUrl(), builds callout + optional video embed, appends to active note
+2a. transcribeUrlToActiveNote(url, timeRange?) -- single URL to active note
+   |  Calls processUrl(url, {insertMode:true, timeRange}), clips audio if timeRange provided
+   |  Builds callout with time-range label + optional video embed, appends to active note
    |
 2b. transcribeAndInsert(noteFile, embeds) -- batch from note scan
    |  Processes embeds in reverse line order, 2s delay between API calls
@@ -73,6 +74,10 @@ interface VideoUrlEmbed { url: string; platform: Platform; line: number }
    |  getMetadata() --> yt-dlp --dump-json --no-download
    |  Download audio --> yt-dlp -x --audio-format mp3
    |  Tool paths via sanitizePath(), env via shellEnv()
+   |
+5a. [if timeRange] AudioExtractor.clipAudio(audioPath, start, end)
+   |  Clips extracted audio via ffmpeg -ss/-to, validates end < duration
+   |  Cleans up original unclipped audio
    |
 6. downloadVideoToVault() [if downloadFolder configured]
    |  yt-dlp -f mp4/best, writes to vault via adapter.writeBinary

--- a/src/video/types.ts
+++ b/src/video/types.ts
@@ -16,7 +16,7 @@ export interface VideoSource {
 	duration?: number;
 }
 
-import { TimeRange } from '../shared/validation';
+import { TimeRange } from '../shared';
 
 export interface VideoProcessOptions {
 	postProcess?: boolean;


### PR DESCRIPTION
## Summary
- **Architect** (6 fixes): Fix import path violations bypassing `shared/index.ts` barrel in `audio/types.ts`, `video/types.ts`, `transcription/unified-modal.ts`, `transcription/time-range-toast.ts`, `transcription/duration-detector.ts`, `audio/index.ts`
- **Security** (1 fix): Add `sanitizeUrl()` defense-in-depth call in `detectUrlDuration` before `execFile`
- **Docs-agent** (4 files): Update root `AGENTS.md` + 3 per-feature `AGENTS.md` (audio, video, transcription) with time-range clipping APIs
- **Docs-human** (3 files): Update `DECISIONS.md` (+7 entries), `STATUS.md` (v0.3.2), `ARCHITECTURE.md` (time-range clipping flow)
- **Security pass 2**: Clean — zero issues, all fixes intact, no sensitive data in docs

## Audit Results

| # | Agent | Findings | Fixes Applied |
|---|-------|----------|---------------|
| 1 | architect | 9 issues (6 fixable) | 6 import path violations fixed |
| 2 | security (pass 1) | 1 medium | sanitizeUrl() added to detectUrlDuration |
| 3 | docs-agent | 4 files updated | AGENTS.md (root + audio, video, transcription) |
| 4 | docs-human | 3 files updated | DECISIONS.md, STATUS.md, ARCHITECTURE.md |
| 5 | security (pass 2) | 0 issues | clean |

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — passes
- [x] `npm test` — 700/700 tests pass
- [x] `node esbuild.config.mjs production` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)