### PR TITLE
feat: add Twitter/X.com link support

### DIFF
--- a/src/summarize/content-fetcher.test.ts
+++ b/src/summarize/content-fetcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { extractReadableText, fetchPageContent, extractJsonLdRecipes, formatRecipeStructuredData } from './content-fetcher';
+import { extractReadableText, fetchPageContent, fetchTweetContent, extractJsonLdRecipes, formatRecipeStructuredData } from './content-fetcher';
 import { isSupportedUrl } from '../video';
 
 /**
@@ -50,6 +50,12 @@ describe('isSupportedUrl integration with summarize', () => {
 
 	it('does not flag empty strings', () => {
 		expect(isSupportedUrl('')).toBe(false);
+	});
+
+	it('does not flag Twitter/X.com URLs as video (text content)', () => {
+		expect(isSupportedUrl('https://twitter.com/user/status/123456789')).toBe(false);
+		expect(isSupportedUrl('https://x.com/user/status/123456789')).toBe(false);
+		expect(isSupportedUrl('https://mobile.twitter.com/user/status/123456789')).toBe(false);
 	});
 });
 
@@ -321,5 +327,81 @@ describe('fetchPageContent with JSON-LD', () => {
 		const result = await fetchPageContent('https://example.com/blog', 10000);
 		expect(result).not.toContain('STRUCTURED RECIPE DATA');
 		expect(result).toContain('Just a blog post');
+	});
+});
+
+// ── fetchTweetContent ─────────────────────────────────────────────────
+
+describe('fetchTweetContent', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('extracts tweet text from oEmbed response', async () => {
+		const { requestUrl } = await import('obsidian');
+		const oembedResponse = {
+			text: JSON.stringify({
+				html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hello world, this is a tweet!</p>&mdash; Test User (@testuser)</blockquote>',
+				author_name: 'testuser',
+				url: 'https://twitter.com/testuser/status/123',
+			}),
+		};
+		vi.mocked(requestUrl).mockResolvedValue(oembedResponse as never);
+
+		const result = await fetchTweetContent('https://twitter.com/testuser/status/123', 10000);
+		expect(result).toContain('@testuser');
+		expect(result).toContain('Hello world, this is a tweet!');
+		expect(result).toContain('Source: https://twitter.com/testuser/status/123');
+	});
+
+	it('handles tweet with HTML entities', async () => {
+		const { requestUrl } = await import('obsidian');
+		const oembedResponse = {
+			text: JSON.stringify({
+				html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Tom &amp; Jerry &lt;3</p>&mdash; User (@user)</blockquote>',
+				author_name: 'user',
+			}),
+		};
+		vi.mocked(requestUrl).mockResolvedValue(oembedResponse as never);
+
+		const result = await fetchTweetContent('https://x.com/user/status/456', 10000);
+		expect(result).toContain('Tom & Jerry <3');
+	});
+
+	it('handles tweet with links (strips anchor tags, keeps text)', async () => {
+		const { requestUrl } = await import('obsidian');
+		const oembedResponse = {
+			text: JSON.stringify({
+				html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Check out <a href="https://t.co/abc">https://example.com</a></p>&mdash; User (@user)</blockquote>',
+				author_name: 'user',
+			}),
+		};
+		vi.mocked(requestUrl).mockResolvedValue(oembedResponse as never);
+
+		const result = await fetchTweetContent('https://x.com/user/status/789', 10000);
+		expect(result).toContain('Check out https://example.com');
+		expect(result).not.toContain('<a');
+	});
+
+	it('truncates to maxLength', async () => {
+		const { requestUrl } = await import('obsidian');
+		const oembedResponse = {
+			text: JSON.stringify({
+				html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">A very long tweet content here</p>&mdash; User (@user)</blockquote>',
+				author_name: 'user',
+			}),
+		};
+		vi.mocked(requestUrl).mockResolvedValue(oembedResponse as never);
+
+		const result = await fetchTweetContent('https://x.com/user/status/999', 20);
+		expect(result.length).toBeLessThanOrEqual(20);
+	});
+
+	it('throws on network error', async () => {
+		const { requestUrl } = await import('obsidian');
+		vi.mocked(requestUrl).mockRejectedValue(new Error('Network error'));
+
+		await expect(fetchTweetContent('https://x.com/user/status/000', 10000))
+			.rejects.toThrow('Network error');
 	});
 });

--- a/src/summarize/content-fetcher.ts
+++ b/src/summarize/content-fetcher.ts
@@ -135,6 +135,45 @@ export function formatRecipeStructuredData(recipes: RecipeJsonLd[]): string {
 	return sections.join('\n');
 }
 
+/**
+ * Fetch tweet text via Twitter's oEmbed API (no auth required).
+ * Extracts the tweet body from the HTML field in the oEmbed response.
+ */
+export async function fetchTweetContent(url: string, maxLength: number): Promise<string> {
+	const validatedUrl = sanitizeUrl(url);
+	const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(validatedUrl)}`;
+
+	const timeout = new Promise<never>((_, reject) =>
+		setTimeout(() => reject(new Error('Tweet fetch timed out')), FETCH_TIMEOUT_MS)
+	);
+
+	const response = await Promise.race([
+		requestUrl({ url: oembedUrl, method: 'GET' }),
+		timeout,
+	]);
+
+	const data = JSON.parse(response.text);
+
+	// Extract tweet text from the blockquote in the HTML field
+	const blockquoteMatch = (data.html as string).match(/<blockquote[^>]*><p[^>]*>([\s\S]*?)<\/p>/);
+	const tweetText = blockquoteMatch
+		? blockquoteMatch[1]
+			.replace(/<br\s*\/?>/g, '\n')
+			.replace(/<a[^>]*>([\s\S]*?)<\/a>/g, '$1')
+			.replace(/<[^>]+>/g, '')
+			.replace(/&amp;/g, '&')
+			.replace(/&lt;/g, '<')
+			.replace(/&gt;/g, '>')
+			.replace(/&quot;/g, '"')
+			.replace(/&#39;/g, "'")
+			.trim()
+		: '';
+
+	const author = data.author_name ? `@${data.author_name}` : 'Unknown';
+	const formatted = `${author}: ${tweetText}\n\nSource: ${validatedUrl}`;
+	return formatted.slice(0, maxLength);
+}
+
 export async function fetchPageContent(url: string, maxLength: number): Promise<string> {
 	const validatedUrl = sanitizeUrl(url);
 

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -6,9 +6,9 @@ import {
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { OperationHandle } from '../shared';
-import { isSupportedUrl } from '../video';
+import { isSupportedUrl, detectPlatform } from '../video';
 import { findAudioEmbeds } from '../audio';
-import { fetchPageContent } from './content-fetcher';
+import { fetchPageContent, fetchTweetContent } from './content-fetcher';
 import { findSummarizeTargets } from './note-scanner';
 import { hasSummaryBelow } from './note-scanner';
 import { SummarizeSelectionModal } from './summarize-modal';
@@ -468,6 +468,10 @@ export class SummarizeModule {
 				const msg = error instanceof Error ? error.message : String(error);
 				throw new Error(`Video transcription failed for ${url}: ${msg}`);
 			}
+		}
+
+		if (detectPlatform(url)?.platform === 'twitter') {
+			return fetchTweetContent(url, maxLength);
 		}
 
 		return fetchPageContent(url, maxLength);

--- a/src/summarize/note-scanner.test.ts
+++ b/src/summarize/note-scanner.test.ts
@@ -413,6 +413,29 @@ describe('findSummarizeTargets', () => {
 		expect(targets[0].type).toBe('transcription');
 	});
 
+	it('matches summary for Twitter/X.com URL with query params stripped', () => {
+		const content = [
+			'https://x.com/user/status/123?s=20&t=abc',
+			'',
+			'> [!synapse-summary] Summary of https://x.com/user/status/123',
+			'> Tweet summary text.',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
+	it('matches summary for twitter.com URL with params stripped', () => {
+		const content = [
+			'https://twitter.com/user/status/456?ref_src=twsrc',
+			'',
+			'> **Summary of https://twitter.com/user/status/456**',
+			'>',
+			'> Summary here.',
+		].join('\n');
+		const targets = findSummarizeTargets(content);
+		expect(targets).toHaveLength(0);
+	});
+
 	it('enrichment targets survive idempotent re-scan after note creation', () => {
 		// After processing, the external links become wikilinks.
 		// Re-scanning should find no enrichment targets.

--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -4,6 +4,7 @@ import { SummarizeTarget } from './types';
 const URL_REGEX = /https?:\/\/[^\s)\]>]+/g;
 const TIKTOK_HOST_RE = /(?:vm\.|vt\.)?tiktok\.com/;
 const INSTAGRAM_HOST_RE = /instagram\.com/;
+const TWITTER_HOST_RE = /(?:mobile\.)?(?:twitter\.com|x\.com)/;
 const TRANSCRIPTION_HEADER = /^>\s*\*\*Transcription of (.+?)\*\*$/;
 const CALLOUT_TRANSCRIPTION_HEADER = new RegExp(
 	`^>\\s*\\[!${CALLOUT_TYPES.transcription}\\][-+]?\\s+Transcription of (.+)$`
@@ -137,7 +138,7 @@ export function findSummarizeTargets(content: string): SummarizeTarget[] {
  * Other URLs are returned unchanged.
  */
 function normalizeSocialUrl(url: string): string {
-	if (TIKTOK_HOST_RE.test(url) || INSTAGRAM_HOST_RE.test(url)) {
+	if (TIKTOK_HOST_RE.test(url) || INSTAGRAM_HOST_RE.test(url) || TWITTER_HOST_RE.test(url)) {
 		return url.replace(/[?#].*$/, '');
 	}
 	return url;

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -8,6 +8,7 @@ import { fetchPageContent } from './content-fetcher';
 // Mock the content fetcher to avoid real network calls
 vi.mock('./content-fetcher', () => ({
 	fetchPageContent: vi.fn().mockResolvedValue('Some fetched content for testing.'),
+	fetchTweetContent: vi.fn().mockResolvedValue('Tweet content for testing.'),
 }));
 
 // Mock the summarizer to return a canned summary.
@@ -33,6 +34,7 @@ vi.mock('./note-scanner', () => ({
 // Mock the video module
 vi.mock('../video', () => ({
 	isSupportedUrl: vi.fn().mockReturnValue(false),
+	detectPlatform: vi.fn().mockReturnValue(null),
 }));
 
 // Mock the shared module to avoid folder picker / getMarkdownFiles issues

--- a/src/video/note-scanner.test.ts
+++ b/src/video/note-scanner.test.ts
@@ -81,6 +81,27 @@ describe('findVideoUrls', () => {
 		expect(result[0].platform).toBe('tiktok');
 	});
 
+	it('excludes Twitter/X.com URLs', () => {
+		const content = [
+			'https://twitter.com/user/status/1234567890',
+			'https://x.com/other/status/9876543210',
+		].join('\n');
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(0);
+	});
+
+	it('finds video URLs but excludes Twitter URLs in mixed content', () => {
+		const content = [
+			'https://youtube.com/watch?v=abc123',
+			'https://x.com/user/status/1234567890',
+			'https://www.tiktok.com/@user/video/9876543210',
+		].join('\n');
+		const result = findVideoUrls(content);
+		expect(result).toHaveLength(2);
+		expect(result[0].platform).toBe('youtube');
+		expect(result[1].platform).toBe('tiktok');
+	});
+
 	it('ignores non-video URLs', () => {
 		const content = 'https://example.com\nhttps://google.com\nhttps://vimeo.com/123';
 		const result = findVideoUrls(content);

--- a/src/video/note-scanner.ts
+++ b/src/video/note-scanner.ts
@@ -17,7 +17,7 @@ export function findVideoUrls(content: string): VideoUrlEmbed[] {
 		for (const match of matches) {
 			const url = match[0];
 			const detected = detectPlatform(url);
-			if (!detected) continue;
+			if (!detected || detected.platform === 'twitter') continue;
 
 			if (hasTranscriptionBelow(lines, i, url)) {
 				continue;

--- a/src/video/types.ts
+++ b/src/video/types.ts
@@ -1,4 +1,4 @@
-export type Platform = 'youtube' | 'tiktok' | 'instagram' | 'unknown';
+export type Platform = 'youtube' | 'tiktok' | 'instagram' | 'twitter' | 'unknown';
 
 export interface UrlDetectionResult {
 	platform: Platform;

--- a/src/video/url-detector.test.ts
+++ b/src/video/url-detector.test.ts
@@ -212,6 +212,73 @@ describe('detectPlatform', () => {
 		});
 	});
 
+	describe('Twitter/X.com URLs', () => {
+		it('matches twitter.com status URL', () => {
+			const result = detectPlatform('https://twitter.com/user/status/1234567890');
+			expect(result).toEqual({
+				platform: 'twitter',
+				videoId: '1234567890',
+				url: 'https://twitter.com/user/status/1234567890',
+			});
+		});
+
+		it('matches x.com status URL', () => {
+			const result = detectPlatform('https://x.com/user/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+			expect(result?.videoId).toBe('1234567890');
+		});
+
+		it('matches www.twitter.com', () => {
+			const result = detectPlatform('https://www.twitter.com/user/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+		});
+
+		it('matches www.x.com', () => {
+			const result = detectPlatform('https://www.x.com/user/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+		});
+
+		it('matches mobile.twitter.com', () => {
+			const result = detectPlatform('https://mobile.twitter.com/user/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+		});
+
+		it('matches mobile.x.com', () => {
+			const result = detectPlatform('https://mobile.x.com/user/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+		});
+
+		it('matches twitter.com/i/web/status/ share redirect', () => {
+			const result = detectPlatform('https://twitter.com/i/web/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+			expect(result?.videoId).toBe('1234567890');
+		});
+
+		it('matches x.com/i/web/status/ share redirect', () => {
+			const result = detectPlatform('https://x.com/i/web/status/1234567890');
+			expect(result?.platform).toBe('twitter');
+			expect(result?.videoId).toBe('1234567890');
+		});
+
+		it('strips query params', () => {
+			const result = detectPlatform('https://x.com/user/status/1234567890?s=20&t=abc');
+			expect(result?.url).toBe('https://x.com/user/status/1234567890');
+		});
+
+		it('strips fragment', () => {
+			const result = detectPlatform('https://twitter.com/user/status/1234567890#m');
+			expect(result?.url).toBe('https://twitter.com/user/status/1234567890');
+		});
+
+		it('does not match profile URLs', () => {
+			expect(detectPlatform('https://twitter.com/username')).toBeNull();
+		});
+
+		it('does not match bare twitter.com', () => {
+			expect(detectPlatform('https://twitter.com/')).toBeNull();
+		});
+	});
+
 	describe('unsupported URLs', () => {
 		it('returns null for vimeo', () => {
 			expect(detectPlatform('https://vimeo.com/123456')).toBeNull();
@@ -246,5 +313,10 @@ describe('isSupportedUrl', () => {
 		expect(isSupportedUrl('https://example.com')).toBe(false);
 		expect(isSupportedUrl('')).toBe(false);
 		expect(isSupportedUrl('https://www.instagram.com/username/')).toBe(false);
+	});
+
+	it('returns false for Twitter URLs (text content, not video)', () => {
+		expect(isSupportedUrl('https://twitter.com/user/status/123')).toBe(false);
+		expect(isSupportedUrl('https://x.com/user/status/123')).toBe(false);
 	});
 });

--- a/src/video/url-detector.ts
+++ b/src/video/url-detector.ts
@@ -11,12 +11,24 @@ const TIKTOK_SHORT_REGEX =
 // Instagram Reels / posts: instagram.com/reel/CODE, /reels/CODE, /p/CODE
 const INSTAGRAM_REGEX =
 	/instagram\.com\/(?:reel|reels|p)\/([\w-]+)/;
+// Twitter/X.com status URLs: twitter.com/<user>/status/<id>, x.com/<user>/status/<id>,
+// twitter.com/i/web/status/<id>, with optional www./mobile. prefix
+const TWITTER_REGEX =
+	/(?:mobile\.)?(?:twitter\.com|x\.com)\/(?:[\w]+\/status|i\/web\/status)\/(\d+)/;
 
 /**
  * Strip query parameters and fragment from TikTok URLs so the canonical
  * form is the bare path (e.g. `https://www.tiktok.com/@user/video/123`).
  */
 function stripTikTokParams(url: string): string {
+	return url.replace(/[?#].*$/, '');
+}
+
+/**
+ * Strip query parameters and fragment from Twitter/X.com URLs so the canonical
+ * form is the bare path (e.g. `https://x.com/user/status/123`).
+ */
+function stripTwitterParams(url: string): string {
 	return url.replace(/[?#].*$/, '');
 }
 
@@ -42,9 +54,15 @@ export function detectPlatform(url: string): UrlDetectionResult | null {
 		return { platform: 'instagram', videoId: igMatch[1], url };
 	}
 
+	const twMatch = url.match(TWITTER_REGEX);
+	if (twMatch) {
+		return { platform: 'twitter', videoId: twMatch[1], url: stripTwitterParams(url) };
+	}
+
 	return null;
 }
 
 export function isSupportedUrl(url: string): boolean {
-	return detectPlatform(url) !== null;
+	const result = detectPlatform(url);
+	return result !== null && result.platform !== 'twitter';
 }


### PR DESCRIPTION
## Summary
- Adds Twitter/X.com URL detection (`twitter.com`, `x.com`, `mobile.*`, `i/web/status/` variants) as a new `'twitter'` platform type
- Fetches tweet content via the oEmbed API (`publish.twitter.com/oembed`) — no API key required
- Routes Twitter URLs through the summarize pipeline (not video transcription), so tweets are summarized/elaborated/enriched like any text content
- Guards `isSupportedUrl()` and `findVideoUrls()` to exclude Twitter from the transcription modal

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — type check passes
- [x] `npm test` — all 723 tests pass (23 new tests added)
- [x] `node esbuild.config.mjs production` — production build succeeds
- [ ] Manual: paste a Twitter/X.com URL in a note, run "Summarize current note" — tweet is summarized (not transcribed)
- [ ] Manual: Twitter URLs do not appear in the "Transcribe media" modal

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)