### PR TITLE
feat: add REM batch link discovery module

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { TidyModule } from './tidy';
 import { OrganizeModule } from './organize';
 import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
+import { RemModule } from './rem';
 import { NotificationManager, CheckpointManager, removeNotificationStyles } from './shared';
 import type { DeferredTask, Checkpoint } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
@@ -38,6 +39,7 @@ export default class SynapsePlugin extends Plugin {
 	private organize!: OrganizeModule;
 	private deepDive!: DeepDiveModule;
 	private title!: TitleModule;
+	private rem!: RemModule;
 	private startupTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	async onload(): Promise<void> {
@@ -85,6 +87,7 @@ export default class SynapsePlugin extends Plugin {
 		this.organize = new OrganizeModule(this, getSettings, this.notifications, this.checkpointManager);
 		this.deepDive = new DeepDiveModule(this, getSettings, this.notifications, this.checkpointManager);
 		this.title = new TitleModule(this, getSettings, this.notifications);
+		this.rem = new RemModule(this, getSettings, this.notifications, this.checkpointManager);
 
 		// Register the unified proposal view
 		this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {
@@ -99,6 +102,8 @@ export default class SynapsePlugin extends Plugin {
 				onDeepDiveReject: (id) => this.deepDive.rejectProposal(id),
 				onTitleAccept: (id) => this.title.acceptProposal(id),
 				onTitleReject: (id) => this.title.rejectProposal(id),
+				onRemAcceptSelected: (id, texts) => this.rem.acceptProposal(id, texts),
+				onRemReject: (id) => this.rem.rejectProposal(id),
 				onCheckpointDiscard: (id) => this.discardCheckpoint(id),
 				onCheckpointResume: (id) => this.resumeCheckpoint(id),
 			});
@@ -111,6 +116,7 @@ export default class SynapsePlugin extends Plugin {
 		this.organize.onViewRefreshNeeded = refreshView;
 		this.deepDive.onViewRefreshNeeded = refreshView;
 		this.title.onViewRefreshNeeded = refreshView;
+		this.rem.onViewRefreshNeeded = refreshView;
 
 		// Load enabled modules
 		if (this.settings.elaboration.enabled) {
@@ -142,6 +148,9 @@ export default class SynapsePlugin extends Plugin {
 		}
 		if (this.settings.title.enabled) {
 			await this.title.onload();
+		}
+		if (this.settings.rem.enabled) {
+			await this.rem.onload();
 		}
 
 		// Wire enrichment callbacks -- triggers after other processes complete
@@ -290,6 +299,7 @@ export default class SynapsePlugin extends Plugin {
 		this.organize?.onunload();
 		this.deepDive?.onunload();
 		this.title?.onunload();
+		this.rem?.onunload();
 		removeNotificationStyles();
 		UnifiedProposalView.removeStyles();
 	}
@@ -421,6 +431,9 @@ export default class SynapsePlugin extends Plugin {
 			case 'deep-dive':
 				await this.deepDive.resumeFromCheckpoint(checkpoint);
 				break;
+			case 'rem':
+				await this.rem.resumeFromCheckpoint(checkpoint);
+				break;
 			default:
 				this.notifications.info(`Unknown module: ${checkpoint.module}`);
 		}
@@ -458,6 +471,11 @@ export default class SynapsePlugin extends Plugin {
 		const titleProposals = await this.title.getPendingProposals();
 		for (const p of titleProposals) {
 			items.push({ kind: 'title', data: p });
+		}
+
+		const remProposals = await this.rem.getPendingProposals();
+		for (const p of remProposals) {
+			items.push({ kind: 'rem', data: p });
 		}
 
 		// Gather incomplete checkpoints for the sidebar banner

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -1,0 +1,439 @@
+import type { Plugin, TFile } from 'obsidian';
+import type { SynapseSettings } from '../settings';
+import type { NotificationManager, CheckpointManager } from '../shared';
+import type { DeferredTask, CheckpointWorkItem } from '../shared';
+import type { RemProposal, RemLinkCandidate } from './types';
+import { generateId, getMarkdownFiles, FolderPickerModal } from '../shared';
+import { MentionScanner } from './mention-scanner';
+import { SemanticMatcher } from './semantic-matcher';
+import { RemApplier } from './rem-applier';
+import { RemStore } from './rem-store';
+
+export type { RemProposal, RemLinkCandidate, RemOccurrence, RemSettings } from './types';
+
+/**
+ * REM (Re-link & Enrich Mappings) module.
+ * Discovers linkable references in note text and proposes in-place [[wikilink]] insertions.
+ */
+export class RemModule {
+	private store!: RemStore;
+	private scanner!: MentionScanner;
+	private semanticMatcher!: SemanticMatcher;
+	private applier!: RemApplier;
+
+	/** Optional callback to refresh the unified proposal view. */
+	onViewRefreshNeeded: (() => Promise<void>) | null = null;
+
+	constructor(
+		private plugin: Plugin,
+		private getSettings: () => SynapseSettings,
+		private notifications: NotificationManager,
+		private checkpointManager: CheckpointManager
+	) {}
+
+	async onload(): Promise<void> {
+		this.store = new RemStore(this.plugin.app, this.getSettings);
+		this.scanner = new MentionScanner(this.plugin.app);
+		this.semanticMatcher = new SemanticMatcher(this.plugin.app, this.getSettings);
+		this.applier = new RemApplier();
+
+		await this.store.init();
+
+		// Command: scan current note
+		this.plugin.addCommand({
+			id: 'synapse:rem-current-note',
+			name: 'REM: Discover links in current note',
+			editorCallback: async (_editor, ctx) => {
+				if (ctx.file) {
+					await this.remScanNote(ctx.file.path);
+				}
+			},
+		});
+
+		// Command: scan directory
+		this.plugin.addCommand({
+			id: 'synapse:rem-directory',
+			name: 'REM: Discover links in directory',
+			callback: () => {
+				new FolderPickerModal(
+					this.plugin.app,
+					(folder) => {
+						const path = folder.isRoot() ? undefined : folder.path;
+						this.remScanDirectory(path);
+					}
+				).open();
+			},
+		});
+	}
+
+	onunload(): void {
+		// No timers or events to clean up
+	}
+
+	/**
+	 * Scan a single note for linkable mentions.
+	 */
+	async remScanNote(filePath: string): Promise<RemProposal | null> {
+		const settings = this.getSettings().rem;
+		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
+		if (!file || !('extension' in file)) {
+			this.notifications.info('File not found');
+			return null;
+		}
+
+		const tFile = file as TFile;
+		if (this.isExcluded(tFile)) {
+			this.notifications.info('Note is excluded from REM scanning');
+			return null;
+		}
+
+		const content = await this.plugin.app.vault.read(tFile);
+
+		// Phase 1: literal mention scanning
+		const literalCandidates = this.scanner.scan(tFile, content, settings.maxLinksPerNote);
+
+		// Phase 2: optional semantic matching
+		let semanticCandidates: RemLinkCandidate[] = [];
+		if (settings.semanticMatching) {
+			const alreadyMatched = new Set(literalCandidates.map(c => c.targetPath));
+			const remaining = settings.maxLinksPerNote - literalCandidates.length;
+			if (remaining > 0) {
+				semanticCandidates = await this.semanticMatcher.match(
+					tFile, content, alreadyMatched, remaining
+				);
+				// Filter by confidence threshold
+				semanticCandidates = semanticCandidates.filter(
+					c => c.confidence >= settings.confidenceThreshold
+				);
+			}
+		}
+
+		const allCandidates = [...literalCandidates, ...semanticCandidates];
+
+		if (allCandidates.length === 0) {
+			this.notifications.info('No linkable mentions found');
+			return null;
+		}
+
+		const proposal: RemProposal = {
+			id: generateId(),
+			sourceNotePath: filePath,
+			createdAt: new Date().toISOString(),
+			candidates: allCandidates,
+			status: 'pending',
+		};
+
+		await this.store.save(proposal);
+		this.notifications.success(
+			`Found ${allCandidates.length} linkable mention${allCandidates.length === 1 ? '' : 's'}`
+		);
+
+		await this.refreshView();
+		return proposal;
+	}
+
+	/**
+	 * Scan all markdown files in a directory (or vault root) with checkpoint support.
+	 */
+	async remScanDirectory(folderPath?: string): Promise<number> {
+		const settings = this.getSettings().rem;
+		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+
+		// Filter out excluded files
+		const eligible = allFiles.filter(f => !this.isExcluded(f));
+
+		if (eligible.length === 0) {
+			this.notifications.info('No eligible files found');
+			return 0;
+		}
+
+		const op = this.notifications.startOperation(
+			`REM scanning ${eligible.length} notes`,
+			'rem-directory-scan'
+		);
+
+		// Create checkpoint
+		const checkpointItems: CheckpointWorkItem[] = eligible.map((f, i) => ({
+			id: `rem-${i}-${f.path}`,
+			label: f.path,
+			payload: { filePath: f.path } as Record<string, unknown>,
+		}));
+
+		const checkpoint = await this.checkpointManager.create({
+			module: 'rem',
+			operationLabel: `REM scan: ${folderPath || 'vault'}`,
+			items: checkpointItems,
+			metadata: {},
+		});
+
+		await this.checkpointManager.addDeferredTask(checkpoint.id, {
+			id: generateId(),
+			type: 'refresh-sidebar-view',
+			data: {},
+		});
+
+		let created = 0;
+		const createdProposalIds: string[] = [];
+
+		try {
+			for (let i = 0; i < eligible.length; i++) {
+				if (op.cancelled) break;
+
+				const file = eligible[i];
+				op.progress(i + 1, eligible.length, `Scanning ${file.basename}`);
+
+				const content = await this.plugin.app.vault.read(file);
+				const candidates = this.scanner.scan(file, content, settings.maxLinksPerNote);
+
+				// Optional semantic matching
+				let semanticCandidates: RemLinkCandidate[] = [];
+				if (settings.semanticMatching) {
+					const alreadyMatched = new Set(candidates.map(c => c.targetPath));
+					const remaining = settings.maxLinksPerNote - candidates.length;
+					if (remaining > 0) {
+						semanticCandidates = await this.semanticMatcher.match(
+							file, content, alreadyMatched, remaining
+						);
+						semanticCandidates = semanticCandidates.filter(
+							c => c.confidence >= settings.confidenceThreshold
+						);
+					}
+				}
+
+				const allCandidates = [...candidates, ...semanticCandidates];
+
+				if (allCandidates.length > 0) {
+					const proposal: RemProposal = {
+						id: generateId(),
+						sourceNotePath: file.path,
+						createdAt: new Date().toISOString(),
+						candidates: allCandidates,
+						status: 'pending',
+					};
+					await this.store.save(proposal);
+					created++;
+					createdProposalIds.push(proposal.id);
+				}
+
+				await this.checkpointManager.completeItem(checkpoint.id, checkpointItems[i].id);
+			}
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			op.error(`REM scan failed -- ${msg}`);
+			await this.rejectProposalBatch(createdProposalIds);
+			return 0;
+		}
+
+		if (op.cancelled) {
+			await this.checkpointManager.discard(checkpoint.id);
+			await this.rejectProposalBatch(createdProposalIds);
+			op.finish('REM scan cancelled');
+		} else {
+			const tasks = await this.checkpointManager.complete(checkpoint.id);
+			this.dispatchDeferredTasks(tasks);
+			op.finish(`REM scan complete -- ${created} note${created === 1 ? '' : 's'} with linkable mentions`);
+		}
+
+		return created;
+	}
+
+	/**
+	 * Resume a REM scan from a checkpoint.
+	 */
+	async resumeFromCheckpoint(checkpoint: import('../shared').Checkpoint): Promise<void> {
+		const settings = this.getSettings().rem;
+		const op = this.notifications.startOperation(
+			'Resuming REM scan',
+			'rem-resume'
+		);
+
+		const createdProposalIds: string[] = [];
+
+		try {
+			for (let i = 0; i < checkpoint.remainingItems.length; i++) {
+				if (op.cancelled) break;
+
+				const item = checkpoint.remainingItems[i];
+				op.progress(i + 1, checkpoint.remainingItems.length, 'Resuming');
+
+				const filePath = item.payload.filePath as string;
+				const file = this.plugin.app.vault.getAbstractFileByPath(filePath) as TFile | null;
+
+				if (!file) {
+					await this.checkpointManager.completeItem(checkpoint.id, item.id);
+					continue;
+				}
+
+				const content = await this.plugin.app.vault.read(file);
+				const candidates = this.scanner.scan(file, content, settings.maxLinksPerNote);
+
+				if (candidates.length > 0) {
+					const proposal: RemProposal = {
+						id: generateId(),
+						sourceNotePath: filePath,
+						createdAt: new Date().toISOString(),
+						candidates,
+						status: 'pending',
+					};
+					await this.store.save(proposal);
+					createdProposalIds.push(proposal.id);
+				}
+
+				await this.checkpointManager.completeItem(checkpoint.id, item.id);
+			}
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			op.error(`Resume failed -- ${msg}`);
+			await this.rejectProposalBatch(createdProposalIds);
+			return;
+		}
+
+		if (op.cancelled) {
+			await this.checkpointManager.discard(checkpoint.id);
+			await this.rejectProposalBatch(createdProposalIds);
+		} else {
+			const tasks = await this.checkpointManager.complete(checkpoint.id);
+			this.dispatchDeferredTasks(tasks);
+			op.finish(`Resumed -- generated ${createdProposalIds.length} proposals`);
+		}
+
+		await this.refreshView();
+	}
+
+	/**
+	 * Accept a REM proposal: apply selected links to the note.
+	 */
+	async acceptProposal(id: string, acceptedMatchTexts: string[]): Promise<void> {
+		const proposal = await this.store.load(id);
+		if (!proposal) return;
+
+		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
+		if (!file) {
+			this.notifications.info('Source note no longer exists');
+			return;
+		}
+
+		const tFile = file as TFile;
+		const originalContent = await this.plugin.app.vault.read(tFile);
+
+		// Filter candidates to only accepted ones
+		const accepted = proposal.candidates.filter(
+			c => acceptedMatchTexts.includes(c.matchedText)
+		);
+
+		if (accepted.length === 0) {
+			await this.store.updateStatus(id, 'rejected');
+			await this.refreshView();
+			return;
+		}
+
+		// Apply the links
+		const modifiedContent = this.applier.apply(originalContent, accepted);
+		await this.plugin.app.vault.modify(tFile, modifiedContent);
+
+		// Update proposal status with undo data
+		const status = accepted.length === proposal.candidates.length
+			? 'accepted' as const
+			: 'partially-accepted' as const;
+		await this.store.updateStatus(
+			id,
+			status,
+			acceptedMatchTexts,
+			originalContent
+		);
+
+		this.notifications.success(
+			`Inserted ${accepted.length} wikilink${accepted.length === 1 ? '' : 's'}`
+		);
+
+		await this.refreshView();
+	}
+
+	/**
+	 * Reject a REM proposal.
+	 */
+	async rejectProposal(id: string): Promise<void> {
+		await this.store.updateStatus(id, 'rejected');
+		await this.refreshView();
+	}
+
+	/**
+	 * Undo a previously accepted proposal by restoring the original content.
+	 */
+	async undoProposal(id: string): Promise<void> {
+		const proposal = await this.store.load(id);
+		if (!proposal || !proposal.originalContent) {
+			this.notifications.info('Cannot undo — no original content snapshot');
+			return;
+		}
+
+		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
+		if (!file) {
+			this.notifications.info('Source note no longer exists');
+			return;
+		}
+
+		const tFile = file as TFile;
+		await this.plugin.app.vault.modify(tFile, proposal.originalContent);
+
+		// Reset proposal to pending
+		await this.store.updateStatus(id, 'pending', undefined, undefined);
+		this.notifications.success('Wikilinks reverted — proposal reset to pending');
+
+		await this.refreshView();
+	}
+
+	/**
+	 * Get all pending proposals (for unified view).
+	 */
+	async getPendingProposals(): Promise<RemProposal[]> {
+		return this.store.loadPending();
+	}
+
+	/**
+	 * Check if a file is excluded from REM scanning.
+	 * Reuses enrichment exclude-folder and exclude-tag settings.
+	 */
+	private isExcluded(file: TFile): boolean {
+		const enrichmentSettings = this.getSettings().enrichment;
+
+		for (const folder of enrichmentSettings.excludeFolders) {
+			if (file.path.startsWith(folder + '/') || file.path === folder) return true;
+		}
+
+		const cache = this.plugin.app.metadataCache.getFileCache(file);
+		if (cache?.frontmatter?.tags) {
+			const tags: string[] = Array.isArray(cache.frontmatter.tags)
+				? cache.frontmatter.tags
+				: [cache.frontmatter.tags];
+			for (const excludeTag of enrichmentSettings.excludeTags) {
+				const normalized = excludeTag.replace(/^#/, '');
+				if (tags.some(t => t.replace(/^#/, '') === normalized)) return true;
+			}
+		}
+
+		return false;
+	}
+
+	private async refreshView(): Promise<void> {
+		await this.onViewRefreshNeeded?.();
+	}
+
+	private dispatchDeferredTasks(tasks: DeferredTask[]): void {
+		for (const task of tasks) {
+			switch (task.type) {
+				case 'refresh-sidebar-view':
+					this.onViewRefreshNeeded?.();
+					break;
+				default:
+					console.warn(`[Synapse REM] Unknown deferred task type: ${task.type}`);
+			}
+		}
+	}
+
+	private async rejectProposalBatch(ids: string[]): Promise<void> {
+		for (const id of ids) {
+			await this.store.updateStatus(id, 'rejected');
+		}
+	}
+}

--- a/src/rem/mention-scanner.test.ts
+++ b/src/rem/mention-scanner.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MentionScanner } from './mention-scanner';
+import type { TFile, CachedMetadata } from 'obsidian';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeFile(path: string, basename?: string): TFile {
+	return {
+		path,
+		basename: basename ?? path.replace(/\.md$/, '').split('/').pop()!,
+		extension: 'md',
+		name: path.split('/').pop()!,
+	} as unknown as TFile;
+}
+
+function makeApp(files: TFile[], cacheMap: Map<string, Partial<CachedMetadata>> = new Map()) {
+	return {
+		vault: {
+			getMarkdownFiles: () => files,
+		},
+		metadataCache: {
+			getFileCache: (file: TFile) => cacheMap.get(file.path) ?? null,
+		},
+	} as any;
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('MentionScanner', () => {
+	let scanner: MentionScanner;
+
+	describe('exact title match', () => {
+		beforeEach(() => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Machine Learning.md', 'Machine Learning'),
+				makeFile('Data Science.md', 'Data Science'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+		});
+
+		it('should find exact title mentions', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'I am studying machine learning and data science today.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(2);
+			expect(results.map(r => r.targetDisplayName).sort()).toEqual(
+				['Data Science', 'Machine Learning']
+			);
+		});
+
+		it('should return correct occurrence positions', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'I love machine learning.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].occurrences).toHaveLength(1);
+			expect(results[0].occurrences[0].startOffset).toBe(7);
+			expect(results[0].occurrences[0].endOffset).toBe(23);
+			expect(results[0].occurrences[0].lineNumber).toBe(0);
+		});
+
+		it('should find multiple occurrences of the same term', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'Machine learning is great.\nI love machine learning.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].occurrences).toHaveLength(2);
+			expect(results[0].occurrences[0].lineNumber).toBe(0);
+			expect(results[0].occurrences[1].lineNumber).toBe(1);
+		});
+	});
+
+	describe('alias match', () => {
+		beforeEach(() => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('ML Fundamentals.md', 'ML Fundamentals'),
+			];
+			const cache = new Map<string, Partial<CachedMetadata>>();
+			cache.set('ML Fundamentals.md', {
+				frontmatter: {
+					aliases: ['machine learning', 'ML'],
+					position: { start: { line: 0, col: 0, offset: 0 }, end: { line: 0, col: 0, offset: 0 } },
+				},
+			});
+			scanner = new MentionScanner(makeApp(files, cache));
+		});
+
+		it('should match aliases', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'This note is about machine learning techniques.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].targetDisplayName).toBe('ML Fundamentals');
+			expect(results[0].matchType).toBe('alias');
+			expect(results[0].matchedText).toBe('machine learning');
+		});
+
+		it('should skip aliases shorter than 3 chars', () => {
+			const source = makeFile('source.md', 'source');
+			// "ML" alias is only 2 chars, should be skipped
+			const content = 'ML is a broad field.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+	});
+
+	describe('case-insensitive matching', () => {
+		beforeEach(() => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Machine Learning.md', 'Machine Learning'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+		});
+
+		it('should match regardless of case', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'MACHINE LEARNING is interesting. Also machine learning.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].occurrences).toHaveLength(2);
+		});
+	});
+
+	describe('word boundary enforcement', () => {
+		beforeEach(() => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Data.md', 'Data'),
+				makeFile('Art.md', 'Art'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+		});
+
+		it('should not match partial words', () => {
+			const source = makeFile('source.md', 'source');
+			// "data" should match standalone but not inside "database"
+			// "art" is only 3 chars but should not match inside "start"
+			const content = 'database is not data. starting is not art.';
+			const results = scanner.scan(source, content, 20);
+
+			const dataResult = results.find(r => r.targetDisplayName === 'Data');
+			const artResult = results.find(r => r.targetDisplayName === 'Art');
+
+			expect(dataResult).toBeDefined();
+			expect(dataResult!.occurrences).toHaveLength(1);
+			// 'database is not data. starting is not art.'
+			//  0123456789...    ^16                  ^38
+			expect(dataResult!.occurrences[0].startOffset).toBe(16);
+
+			expect(artResult).toBeDefined();
+			expect(artResult!.occurrences).toHaveLength(1);
+			expect(artResult!.occurrences[0].startOffset).toBe(38);
+		});
+
+		it('should match at line boundaries', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'data\nmore data';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].occurrences).toHaveLength(2);
+		});
+	});
+
+	describe('skip regions', () => {
+		beforeEach(() => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Machine Learning.md', 'Machine Learning'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+		});
+
+		it('should skip frontmatter', () => {
+			const source = makeFile('source.md', 'source');
+			const content = '---\ntitle: Machine Learning\n---\nSome other text.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('should skip fenced code blocks', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'Before\n```\nmachine learning code\n```\nAfter';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('should skip inline code', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'Use `machine learning` as a variable name.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('should skip existing wikilinks', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'Already linked: [[Machine Learning]].';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('should skip embeds', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'Embedded: ![[Machine Learning]].';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+
+		it('should match text outside skip regions', () => {
+			const source = makeFile('source.md', 'source');
+			const content = '---\ntitle: test\n---\nmachine learning is great. Also `code here`.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].occurrences[0].lineNumber).toBe(3);
+		});
+	});
+
+	describe('overlapping matches (longest wins)', () => {
+		beforeEach(() => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Machine.md', 'Machine'),
+				makeFile('Machine Learning.md', 'Machine Learning'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+		});
+
+		it('should prefer longest match when candidates overlap', () => {
+			const source = makeFile('source.md', 'source');
+			const content = 'I study machine learning every day.';
+			const results = scanner.scan(source, content, 20);
+
+			// "Machine Learning" (16 chars) should win over "Machine" (7 chars)
+			const mlResult = results.find(r => r.targetDisplayName === 'Machine Learning');
+			const machineResult = results.find(r => r.targetDisplayName === 'Machine');
+
+			expect(mlResult).toBeDefined();
+			expect(mlResult!.occurrences).toHaveLength(1);
+
+			// "Machine" alone should NOT match at the same position
+			// (it could match elsewhere if "machine" appears standalone)
+			if (machineResult) {
+				// If it matched, it should NOT overlap with the ML match
+				for (const occ of machineResult.occurrences) {
+					expect(occ.startOffset).not.toBe(mlResult!.occurrences[0].startOffset);
+				}
+			}
+		});
+	});
+
+	describe('self-reference exclusion', () => {
+		it('should not match the source note itself', () => {
+			const files = [
+				makeFile('Machine Learning.md', 'Machine Learning'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+
+			const source = makeFile('Machine Learning.md', 'Machine Learning');
+			const content = 'This note is about machine learning.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(0);
+		});
+	});
+
+	describe('max links limit', () => {
+		it('should respect maxLinks parameter', () => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Alpha.md', 'Alpha'),
+				makeFile('Beta.md', 'Beta'),
+				makeFile('Gamma.md', 'Gamma'),
+				makeFile('Delta.md', 'Delta'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+
+			const source = makeFile('source.md', 'source');
+			const content = 'alpha beta gamma delta';
+			const results = scanner.scan(source, content, 2);
+
+			expect(results).toHaveLength(2);
+		});
+	});
+
+	describe('unicode/special characters', () => {
+		it('should handle unicode titles', () => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Résumé.md', 'Résumé'),
+			];
+			scanner = new MentionScanner(makeApp(files));
+
+			const source = makeFile('source.md', 'source');
+			const content = 'Update your résumé today.';
+			const results = scanner.scan(source, content, 20);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].targetDisplayName).toBe('Résumé');
+		});
+	});
+});

--- a/src/rem/mention-scanner.ts
+++ b/src/rem/mention-scanner.ts
@@ -1,0 +1,299 @@
+import type { App, CachedMetadata, TFile } from 'obsidian';
+import type { RemLinkCandidate, RemOccurrence } from './types';
+
+/** Entry in the lookup table: a term and the note it maps to. */
+interface LookupEntry {
+	/** The term to search for (lowercased) */
+	term: string;
+	/** Original-case term for display */
+	originalTerm: string;
+	/** Path to the target note */
+	targetPath: string;
+	/** Display name for the target note */
+	targetDisplayName: string;
+	/** Whether this entry came from an alias */
+	isAlias: boolean;
+}
+
+/** Region of text to skip during scanning. */
+interface SkipRegion {
+	start: number;
+	end: number;
+}
+
+/**
+ * Scans note content for literal mentions of other vault note titles and aliases.
+ * Returns link candidates with precise occurrence positions.
+ */
+export class MentionScanner {
+	constructor(private app: App) {}
+
+	/**
+	 * Scan a note's content for mentions of other vault notes.
+	 *
+	 * @param sourceFile - The note being scanned
+	 * @param content - The raw text of the note
+	 * @param maxLinks - Maximum number of link candidates to return
+	 * @returns Array of link candidates, sorted by number of occurrences (descending)
+	 */
+	scan(sourceFile: TFile, content: string, maxLinks: number): RemLinkCandidate[] {
+		const lookup = this.buildLookupTable(sourceFile.path);
+		if (lookup.length === 0) return [];
+
+		const skipRegions = this.buildSkipRegions(content);
+		const lines = content.split('\n');
+
+		// Track matches: key = targetPath + matchedText
+		const matchMap = new Map<string, {
+			entry: LookupEntry;
+			occurrences: RemOccurrence[];
+		}>();
+
+		let lineOffset = 0;
+		for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+			const line = lines[lineNum];
+			this.scanLine(line, lineNum, lineOffset, lookup, skipRegions, matchMap);
+			lineOffset += line.length + 1; // +1 for the newline
+		}
+
+		// Convert to candidates
+		const candidates: RemLinkCandidate[] = [];
+		for (const { entry, occurrences } of matchMap.values()) {
+			if (occurrences.length === 0) continue;
+			candidates.push({
+				targetPath: entry.targetPath,
+				targetDisplayName: entry.targetDisplayName,
+				matchedText: entry.originalTerm,
+				matchType: entry.isAlias ? 'alias' : 'title',
+				occurrences,
+				confidence: 1.0,
+			});
+		}
+
+		// Sort by occurrence count (most references first), then by earliest position
+		candidates.sort((a, b) => {
+			const countDiff = b.occurrences.length - a.occurrences.length;
+			if (countDiff !== 0) return countDiff;
+			return a.occurrences[0].lineNumber - b.occurrences[0].lineNumber;
+		});
+
+		return candidates.slice(0, maxLinks);
+	}
+
+	/**
+	 * Build a lookup table of all vault note titles and aliases,
+	 * sorted by term length descending (longest-match-first).
+	 */
+	private buildLookupTable(sourceFilePath: string): LookupEntry[] {
+		const entries: LookupEntry[] = [];
+		const files = this.app.vault.getMarkdownFiles();
+
+		for (const file of files) {
+			// Skip self-references
+			if (file.path === sourceFilePath) continue;
+
+			const displayName = file.basename;
+
+			// Skip very short names (1-2 chars) — too noisy
+			if (displayName.length < 3) continue;
+
+			// Add title entry
+			entries.push({
+				term: displayName.toLowerCase(),
+				originalTerm: displayName,
+				targetPath: file.path,
+				targetDisplayName: displayName,
+				isAlias: false,
+			});
+
+			// Add alias entries
+			const cache: CachedMetadata | null = this.app.metadataCache.getFileCache(file);
+			if (cache?.frontmatter?.aliases) {
+				const aliases: string[] = Array.isArray(cache.frontmatter.aliases)
+					? cache.frontmatter.aliases
+					: [cache.frontmatter.aliases];
+
+				for (const alias of aliases) {
+					if (typeof alias !== 'string' || alias.length < 3) continue;
+					entries.push({
+						term: alias.toLowerCase(),
+						originalTerm: alias,
+						targetPath: file.path,
+						targetDisplayName: displayName,
+						isAlias: true,
+					});
+				}
+			}
+		}
+
+		// Sort by term length descending — longest match first
+		entries.sort((a, b) => b.term.length - a.term.length);
+
+		return entries;
+	}
+
+	/**
+	 * Build a list of character ranges to skip during scanning:
+	 * - YAML frontmatter (--- delimited)
+	 * - Fenced code blocks
+	 * - Inline code
+	 * - Existing wikilinks
+	 * - Image/file embeds
+	 * - Markdown links
+	 */
+	private buildSkipRegions(content: string): SkipRegion[] {
+		const regions: SkipRegion[] = [];
+
+		// Frontmatter: starts at position 0 with ---
+		if (content.startsWith('---')) {
+			const endIdx = content.indexOf('\n---', 3);
+			if (endIdx !== -1) {
+				regions.push({ start: 0, end: endIdx + 4 });
+			}
+		}
+
+		// Fenced code blocks (``` or ~~~)
+		const fencedCodeRegex = /^(```|~~~).*\n[\s\S]*?\n\1/gm;
+		let match: RegExpExecArray | null;
+		while ((match = fencedCodeRegex.exec(content)) !== null) {
+			regions.push({ start: match.index, end: match.index + match[0].length });
+		}
+
+		// Inline code
+		const inlineCodeRegex = /`[^`\n]+`/g;
+		while ((match = inlineCodeRegex.exec(content)) !== null) {
+			regions.push({ start: match.index, end: match.index + match[0].length });
+		}
+
+		// Existing wikilinks and embeds: [[...]] and ![[...]]
+		const wikilinkRegex = /!?\[\[[^\]]+\]\]/g;
+		while ((match = wikilinkRegex.exec(content)) !== null) {
+			regions.push({ start: match.index, end: match.index + match[0].length });
+		}
+
+		// Markdown links: [text](url)
+		const mdLinkRegex = /\[[^\]]*\]\([^)]*\)/g;
+		while ((match = mdLinkRegex.exec(content)) !== null) {
+			regions.push({ start: match.index, end: match.index + match[0].length });
+		}
+
+		// Sort by start position
+		regions.sort((a, b) => a.start - b.start);
+
+		return regions;
+	}
+
+	/**
+	 * Check if a position falls within any skip region.
+	 */
+	private isInSkipRegion(absStart: number, absEnd: number, regions: SkipRegion[]): boolean {
+		for (const region of regions) {
+			if (region.start > absEnd) break; // Regions are sorted
+			if (absStart >= region.start && absEnd <= region.end) return true;
+			if (absStart < region.end && absEnd > region.start) return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Scan a single line for term matches.
+	 */
+	private scanLine(
+		line: string,
+		lineNumber: number,
+		lineOffset: number,
+		lookup: LookupEntry[],
+		skipRegions: SkipRegion[],
+		matchMap: Map<string, { entry: LookupEntry; occurrences: RemOccurrence[] }>
+	): void {
+		const lineLower = line.toLowerCase();
+		// Track which character positions in this line have already been claimed
+		const claimed = new Set<number>();
+
+		for (const entry of lookup) {
+			let searchFrom = 0;
+			while (searchFrom <= lineLower.length - entry.term.length) {
+				const idx = lineLower.indexOf(entry.term, searchFrom);
+				if (idx === -1) break;
+
+				const end = idx + entry.term.length;
+
+				// Check word boundaries
+				if (!this.isWordBoundary(lineLower, idx, end)) {
+					searchFrom = idx + 1;
+					continue;
+				}
+
+				// Check if any character in this range is already claimed (longest-match-first)
+				let overlap = false;
+				for (let c = idx; c < end; c++) {
+					if (claimed.has(c)) {
+						overlap = true;
+						break;
+					}
+				}
+				if (overlap) {
+					searchFrom = idx + 1;
+					continue;
+				}
+
+				// Check skip regions
+				const absStart = lineOffset + idx;
+				const absEnd = lineOffset + end;
+				if (this.isInSkipRegion(absStart, absEnd, skipRegions)) {
+					searchFrom = idx + 1;
+					continue;
+				}
+
+				// Record the match
+				const key = `${entry.targetPath}::${entry.term}`;
+				if (!matchMap.has(key)) {
+					matchMap.set(key, { entry, occurrences: [] });
+				}
+				matchMap.get(key)!.occurrences.push({
+					lineNumber,
+					lineText: line,
+					startOffset: idx,
+					endOffset: end,
+				});
+
+				// Claim these positions
+				for (let c = idx; c < end; c++) {
+					claimed.add(c);
+				}
+
+				searchFrom = end;
+			}
+		}
+	}
+
+	/**
+	 * Check if a match at the given position has word boundaries on both sides.
+	 * A word boundary exists when the character before/after is not a word character.
+	 */
+	private isWordBoundary(text: string, start: number, end: number): boolean {
+		// Check left boundary
+		if (start > 0) {
+			const charBefore = text[start - 1];
+			if (this.isWordChar(charBefore)) return false;
+		}
+		// Check right boundary
+		if (end < text.length) {
+			const charAfter = text[end];
+			if (this.isWordChar(charAfter)) return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Determine if a character is a "word character" for boundary checking.
+	 * Includes letters, digits, and underscore.
+	 */
+	private isWordChar(ch: string): boolean {
+		// Fast path for ASCII
+		if (/[a-zA-Z0-9_]/.test(ch)) return true;
+		// Unicode letters and marks
+		if (/[\p{L}\p{M}\p{N}]/u.test(ch)) return true;
+		return false;
+	}
+}

--- a/src/rem/rem-applier.ts
+++ b/src/rem/rem-applier.ts
@@ -1,0 +1,75 @@
+import type { RemLinkCandidate, RemOccurrence } from './types';
+
+/**
+ * Applies accepted wikilink insertions to note content.
+ * Replaces matched text with `[[target|matchedText]]` (or `[[target]]`
+ * if the matched text equals the display name).
+ *
+ * Processes replacements in reverse document order (bottom-up, right-to-left)
+ * so that earlier offsets remain valid as content is modified.
+ */
+export class RemApplier {
+	/**
+	 * Apply accepted link candidates to the note content.
+	 *
+	 * @param content - Original note content
+	 * @param candidates - The accepted link candidates to apply
+	 * @returns Modified content with wikilinks inserted
+	 */
+	apply(content: string, candidates: RemLinkCandidate[]): string {
+		// Collect all individual replacements
+		const replacements: Array<{
+			lineNumber: number;
+			startOffset: number;
+			endOffset: number;
+			replacement: string;
+		}> = [];
+
+		for (const candidate of candidates) {
+			const wikilink = this.buildWikilink(candidate);
+
+			for (const occ of candidate.occurrences) {
+				replacements.push({
+					lineNumber: occ.lineNumber,
+					startOffset: occ.startOffset,
+					endOffset: occ.endOffset,
+					replacement: wikilink,
+				});
+			}
+		}
+
+		// Sort in reverse document order: higher line numbers first,
+		// then higher start offsets first within the same line
+		replacements.sort((a, b) => {
+			const lineDiff = b.lineNumber - a.lineNumber;
+			if (lineDiff !== 0) return lineDiff;
+			return b.startOffset - a.startOffset;
+		});
+
+		// Apply replacements
+		const lines = content.split('\n');
+
+		for (const rep of replacements) {
+			if (rep.lineNumber >= lines.length) continue;
+			const line = lines[rep.lineNumber];
+			lines[rep.lineNumber] =
+				line.slice(0, rep.startOffset) +
+				rep.replacement +
+				line.slice(rep.endOffset);
+		}
+
+		return lines.join('\n');
+	}
+
+	/**
+	 * Build the wikilink string for a candidate.
+	 * Uses `[[displayName]]` when the matched text equals the display name,
+	 * otherwise uses `[[displayName|matchedText]]` to preserve the original phrasing.
+	 */
+	private buildWikilink(candidate: RemLinkCandidate): string {
+		if (candidate.matchedText.toLowerCase() === candidate.targetDisplayName.toLowerCase()) {
+			return `[[${candidate.targetDisplayName}]]`;
+		}
+		return `[[${candidate.targetDisplayName}|${candidate.matchedText}]]`;
+	}
+}

--- a/src/rem/rem-store.ts
+++ b/src/rem/rem-store.ts
@@ -1,0 +1,117 @@
+import { App, normalizePath } from 'obsidian';
+import type { SynapseSettings } from '../settings';
+import { ensureFolder } from '../shared';
+import type { RemProposal, RemProposalStatus } from './types';
+
+/**
+ * Persists REM proposals as JSON files.
+ * Follows the same pattern as EnrichmentStore.
+ */
+export class RemStore {
+	constructor(
+		private app: App,
+		private getSettings: () => SynapseSettings
+	) {}
+
+	private get folderPath(): string {
+		return this.getSettings().rem.remFolderPath;
+	}
+
+	async init(): Promise<void> {
+		await ensureFolder(this.app, this.folderPath);
+	}
+
+	async save(proposal: RemProposal): Promise<void> {
+		await ensureFolder(this.app, this.folderPath);
+		const fileName = this.proposalFileName(proposal);
+		const path = normalizePath(`${this.folderPath}/${fileName}`);
+		const content = JSON.stringify(proposal, null, 2);
+		await this.app.vault.adapter.write(path, content);
+	}
+
+	async load(id: string): Promise<RemProposal | null> {
+		const files = await this.listFiles();
+		for (const filePath of files) {
+			const content = await this.app.vault.adapter.read(filePath);
+			const proposal: RemProposal = JSON.parse(content);
+			if (proposal.id === id) return proposal;
+		}
+		return null;
+	}
+
+	async loadAll(): Promise<RemProposal[]> {
+		const files = await this.listFiles();
+		const proposals: RemProposal[] = [];
+		for (const filePath of files) {
+			try {
+				const content = await this.app.vault.adapter.read(filePath);
+				proposals.push(JSON.parse(content));
+			} catch {
+				// Skip invalid files
+			}
+		}
+		return proposals;
+	}
+
+	async loadPending(): Promise<RemProposal[]> {
+		const all = await this.loadAll();
+		return all.filter(p => p.status === 'pending');
+	}
+
+	async loadForNote(notePath: string): Promise<RemProposal[]> {
+		const all = await this.loadAll();
+		return all.filter(p => p.sourceNotePath === notePath);
+	}
+
+	async updateStatus(
+		id: string,
+		status: RemProposalStatus,
+		acceptedLinks?: string[],
+		originalContent?: string
+	): Promise<void> {
+		const proposal = await this.load(id);
+		if (!proposal) return;
+		proposal.status = status;
+		if (acceptedLinks) {
+			proposal.acceptedLinks = acceptedLinks;
+		}
+		if (originalContent !== undefined) {
+			proposal.originalContent = originalContent;
+		}
+		await this.save(proposal);
+	}
+
+	async delete(id: string): Promise<void> {
+		const files = await this.listFiles();
+		for (const filePath of files) {
+			try {
+				const content = await this.app.vault.adapter.read(filePath);
+				const proposal: RemProposal = JSON.parse(content);
+				if (proposal.id === id) {
+					await this.app.vault.adapter.remove(filePath);
+					return;
+				}
+			} catch {
+				// Skip
+			}
+		}
+	}
+
+	private proposalFileName(proposal: RemProposal): string {
+		const baseName = proposal.sourceNotePath
+			.replace(/\.md$/, '')
+			.replace(/\//g, '-')
+			.replace(/[\0]/g, '')
+			.replace(/\.\./g, '_');
+		const shortId = proposal.id.slice(0, 8).replace(/[^a-zA-Z0-9]/g, '');
+		return `${baseName}-rem-${shortId}.json`;
+	}
+
+	private async listFiles(): Promise<string[]> {
+		const normalized = normalizePath(this.folderPath);
+		const exists = await this.app.vault.adapter.exists(normalized);
+		if (!exists) return [];
+		const files = await this.app.vault.adapter.list(normalized);
+		return files.files.filter(f => f.endsWith('.json'));
+	}
+}

--- a/src/rem/semantic-matcher.ts
+++ b/src/rem/semantic-matcher.ts
@@ -1,0 +1,150 @@
+import type { App, TFile } from 'obsidian';
+import type { SynapseSettings } from '../settings';
+import type { RemLinkCandidate, RemOccurrence } from './types';
+import { AIClient } from '../shared';
+
+/**
+ * Uses AI to discover conceptual matches between a note's content
+ * and other vault note titles, beyond literal text matching.
+ *
+ * Example: text mentions "machine learning" → AI identifies
+ * [[ML Fundamentals]] as a conceptual match even if the exact
+ * title never appears in the text.
+ */
+export class SemanticMatcher {
+	private aiClient: AIClient;
+
+	constructor(
+		private app: App,
+		private getSettings: () => SynapseSettings
+	) {
+		this.aiClient = new AIClient(getSettings);
+	}
+
+	/**
+	 * Find conceptual matches between a note's content and vault note titles.
+	 *
+	 * @param sourceFile - The note being scanned
+	 * @param content - The raw text of the note
+	 * @param existingMatches - Titles already matched literally (to avoid duplicates)
+	 * @param maxLinks - Maximum candidates to return
+	 * @returns Semantic link candidates with confidence scores
+	 */
+	async match(
+		sourceFile: TFile,
+		content: string,
+		existingMatches: Set<string>,
+		maxLinks: number
+	): Promise<RemLinkCandidate[]> {
+		const settings = this.getSettings().rem;
+
+		// Gather vault note titles (excluding self and already-matched)
+		const noteTitles: { path: string; title: string }[] = [];
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			if (file.path === sourceFile.path) continue;
+			if (existingMatches.has(file.path)) continue;
+			noteTitles.push({ path: file.path, title: file.basename });
+		}
+
+		if (noteTitles.length === 0) return [];
+
+		// Truncate content to avoid token limits
+		const truncatedContent = content.slice(0, 4000);
+		const titleList = noteTitles.map(n => n.title).join('\n');
+
+		const systemPrompt =
+			'You are a knowledge graph assistant. Given a note\'s content and a list of ' +
+			'other note titles in the vault, identify which titles are conceptually related ' +
+			'to topics discussed in the note content. Only suggest strong conceptual matches, ' +
+			'not tangential ones.';
+
+		const userPrompt =
+			`Note content:\n---\n${truncatedContent}\n---\n\n` +
+			`Vault note titles:\n${titleList}\n\n` +
+			'Respond with a JSON array of objects, each with:\n' +
+			'- "title": the exact note title from the list\n' +
+			'- "matchedConcept": the phrase or concept in the note content that relates to this title\n' +
+			'- "confidence": a number 0-1 indicating how strong the conceptual match is\n\n' +
+			'Only include matches with confidence >= 0.5. Return an empty array if no strong matches exist.\n' +
+			'Respond ONLY with the JSON array, no other text.';
+
+		let rawResponse: string;
+		try {
+			rawResponse = await this.aiClient.complete(userPrompt, systemPrompt);
+		} catch (error) {
+			console.warn('[Synapse REM] Semantic matching failed:', error);
+			return [];
+		}
+
+		// Parse AI response
+		let parsed: Array<{ title: string; matchedConcept: string; confidence: number }>;
+		try {
+			// Strip code fences if present
+			const cleaned = rawResponse.replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '');
+			parsed = JSON.parse(cleaned);
+			if (!Array.isArray(parsed)) return [];
+		} catch {
+			console.warn('[Synapse REM] Failed to parse semantic match response');
+			return [];
+		}
+
+		// Build candidates by locating matched concepts in the text
+		const candidates: RemLinkCandidate[] = [];
+		const lines = content.split('\n');
+
+		for (const item of parsed) {
+			if (item.confidence < settings.confidenceThreshold) continue;
+
+			// Find the target note
+			const target = noteTitles.find(n => n.title === item.title);
+			if (!target) continue;
+
+			// Locate the matched concept in the text
+			const occurrences = this.findConcept(item.matchedConcept, lines);
+
+			candidates.push({
+				targetPath: target.path,
+				targetDisplayName: target.title,
+				matchedText: item.matchedConcept,
+				matchType: 'semantic',
+				occurrences,
+				confidence: item.confidence,
+			});
+		}
+
+		// Sort by confidence descending
+		candidates.sort((a, b) => b.confidence - a.confidence);
+
+		return candidates.slice(0, maxLinks);
+	}
+
+	/**
+	 * Find occurrences of a concept phrase in the note lines.
+	 * Case-insensitive search.
+	 */
+	private findConcept(concept: string, lines: string[]): RemOccurrence[] {
+		const occurrences: RemOccurrence[] = [];
+		const conceptLower = concept.toLowerCase();
+
+		for (let i = 0; i < lines.length; i++) {
+			const lineLower = lines[i].toLowerCase();
+			let searchFrom = 0;
+
+			while (searchFrom <= lineLower.length - conceptLower.length) {
+				const idx = lineLower.indexOf(conceptLower, searchFrom);
+				if (idx === -1) break;
+
+				occurrences.push({
+					lineNumber: i,
+					lineText: lines[i],
+					startOffset: idx,
+					endOffset: idx + conceptLower.length,
+				});
+
+				searchFrom = idx + conceptLower.length;
+			}
+		}
+
+		return occurrences;
+	}
+}

--- a/src/rem/types.ts
+++ b/src/rem/types.ts
@@ -1,0 +1,57 @@
+/** A single occurrence of a matched term in the source note. */
+export interface RemOccurrence {
+	/** Zero-based line number in the source note */
+	lineNumber: number;
+	/** Full text of the line containing the match */
+	lineText: string;
+	/** Start offset within the line */
+	startOffset: number;
+	/** End offset within the line (exclusive) */
+	endOffset: number;
+}
+
+/** How the match was discovered. */
+export type RemMatchType = 'title' | 'alias' | 'semantic';
+
+/** A single link candidate grouping all occurrences of the same target note. */
+export interface RemLinkCandidate {
+	/** Path to the target note in the vault */
+	targetPath: string;
+	/** Display name for the target note (basename without extension) */
+	targetDisplayName: string;
+	/** The text in the source note that was matched */
+	matchedText: string;
+	/** How the match was found */
+	matchType: RemMatchType;
+	/** All positions where this match appears */
+	occurrences: RemOccurrence[];
+	/** Match confidence (0-1). Always 1.0 for title/alias; AI-assigned for semantic. */
+	confidence: number;
+}
+
+export type RemProposalStatus = 'pending' | 'accepted' | 'partially-accepted' | 'rejected';
+
+/** A proposal to insert wikilinks into a single source note. */
+export interface RemProposal {
+	id: string;
+	sourceNotePath: string;
+	createdAt: string;
+	candidates: RemLinkCandidate[];
+	status: RemProposalStatus;
+	/** Which candidate matchedTexts were accepted (set on accept). */
+	acceptedLinks?: string[];
+	/** Snapshot of the note content before links were applied (set on accept for undo). */
+	originalContent?: string;
+}
+
+export interface RemSettings {
+	enabled: boolean;
+	/** Use AI to find conceptual matches beyond literal title/alias matching. */
+	semanticMatching: boolean;
+	/** Minimum confidence for semantic matches (0-1). */
+	confidenceThreshold: number;
+	/** Maximum link candidates per scanned note. */
+	maxLinksPerNote: number;
+	/** Storage folder for REM proposals. */
+	remFolderPath: string;
+}

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -877,5 +877,64 @@ export class SynapseSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		// ── REM (Link Discovery) ──
+		new Setting(containerEl).setHeading().setName('REM (Link Discovery)');
+
+		new Setting(containerEl)
+			.setName('Enable REM')
+			.setDesc('Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.rem.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.rem.enabled = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Semantic matching')
+			.setDesc('Use AI to find conceptual matches beyond literal title/alias matching')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.rem.semanticMatching)
+					.onChange(async (value) => {
+						this.plugin.settings.rem.semanticMatching = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		addEnhancedSlider(
+			new Setting(containerEl)
+				.setName('Confidence threshold')
+				.setDesc('Minimum confidence for semantic matches (0-1)'),
+			{
+				min: 0,
+				max: 1,
+				step: 0.05,
+				value: this.plugin.settings.rem.confidenceThreshold,
+				showTicks: true,
+				onChange: async (value) => {
+					this.plugin.settings.rem.confidenceThreshold = value;
+					await this.plugin.saveSettings();
+				},
+			},
+		);
+
+		new Setting(containerEl)
+			.setName('Max links per note')
+			.setDesc('Maximum number of link candidates to suggest per scanned note')
+			.addText((text) =>
+				text
+					.setValue(String(this.plugin.settings.rem.maxLinksPerNote))
+					.onChange(async (value) => {
+						const num = parseInt(value);
+						if (!isNaN(num) && num > 0) {
+							this.plugin.settings.rem.maxLinksPerNote = num;
+							await this.plugin.saveSettings();
+						}
+					})
+			);
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -178,6 +178,18 @@ export interface DeepDiveSettings {
 	autoOrganizeOnAccept: boolean;
 }
 
+export interface RemSettings {
+	enabled: boolean;
+	/** Use AI to find conceptual matches beyond literal title/alias matching. */
+	semanticMatching: boolean;
+	/** Minimum confidence for semantic matches (0-1). */
+	confidenceThreshold: number;
+	/** Maximum link candidates per scanned note. */
+	maxLinksPerNote: number;
+	/** Storage folder for REM proposals. */
+	remFolderPath: string;
+}
+
 export interface TitleSettings {
 	enabled: boolean;
 	proposalFolderPath: string;
@@ -196,6 +208,7 @@ export interface SynapseSettings {
 	organize: OrganizeSettings;
 	deepDive: DeepDiveSettings;
 	title: TitleSettings;
+	rem: RemSettings;
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
@@ -332,5 +345,12 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		enabled: true,
 		proposalFolderPath: '.synapse/title-proposals',
 		checkAfterOperations: true,
+	},
+	rem: {
+		enabled: true,
+		semanticMatching: false,
+		confidenceThreshold: 0.5,
+		maxLinksPerNote: 20,
+		remFolderPath: '.synapse/rem',
 	},
 };

--- a/src/shared/checkpoint-types.ts
+++ b/src/shared/checkpoint-types.ts
@@ -15,7 +15,8 @@ export type CheckpointModule =
 	| 'video'
 	| 'image'
 	| 'summarize'
-	| 'organize';
+	| 'organize'
+	| 'rem';
 
 /** Status of a checkpoint lifecycle. */
 export type CheckpointStatus = 'active' | 'completed' | 'discarded';

--- a/src/views/types.ts
+++ b/src/views/types.ts
@@ -3,14 +3,16 @@ import type { AcceptedItems, EnrichmentProposal } from '../enrichment';
 import type { OrganizeProposal } from '../organize';
 import type { DeepDiveProposal } from '../deep-dive';
 import type { TitleProposal } from '../title';
+import type { RemProposal } from '../rem';
 
-/** Wrapper to unify elaboration, enrichment, organize, deep-dive, and title proposals in one list. */
+/** Wrapper to unify elaboration, enrichment, organize, deep-dive, title, and REM proposals in one list. */
 export type UnifiedItem =
 	| { kind: 'elaboration'; data: Proposal }
 	| { kind: 'enrichment'; data: EnrichmentProposal }
 	| { kind: 'organize'; data: OrganizeProposal }
 	| { kind: 'deep-dive'; data: DeepDiveProposal }
-	| { kind: 'title'; data: TitleProposal };
+	| { kind: 'title'; data: TitleProposal }
+	| { kind: 'rem'; data: RemProposal };
 
 export interface UnifiedViewCallbacks {
 	// Elaboration
@@ -28,6 +30,9 @@ export interface UnifiedViewCallbacks {
 	// Title
 	onTitleAccept: (id: string) => Promise<void>;
 	onTitleReject: (id: string) => Promise<void>;
+	// REM
+	onRemAcceptSelected: (id: string, acceptedMatchTexts: string[]) => Promise<void>;
+	onRemReject: (id: string) => Promise<void>;
 	// Checkpoints
 	onCheckpointDiscard: (id: string) => Promise<void>;
 	onCheckpointResume: (id: string) => Promise<void>;

--- a/src/views/unified-proposal-view.test.ts
+++ b/src/views/unified-proposal-view.test.ts
@@ -25,6 +25,8 @@ function mockCallbacks(): UnifiedViewCallbacks {
 		onDeepDiveReject: vi.fn().mockResolvedValue(undefined),
 		onTitleAccept: vi.fn().mockResolvedValue(undefined),
 		onTitleReject: vi.fn().mockResolvedValue(undefined),
+		onRemAcceptSelected: vi.fn().mockResolvedValue(undefined),
+		onRemReject: vi.fn().mockResolvedValue(undefined),
 		onCheckpointDiscard: vi.fn().mockResolvedValue(undefined),
 		onCheckpointResume: vi.fn().mockResolvedValue(undefined),
 	};

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -4,6 +4,7 @@ import type { AcceptedItems, EnrichmentProposal } from '../enrichment';
 import type { OrganizeProposal } from '../organize';
 import type { DeepDiveProposal } from '../deep-dive';
 import type { TitleProposal } from '../title';
+import type { RemProposal } from '../rem';
 import type { Checkpoint } from '../shared';
 import type { UnifiedItem, UnifiedViewCallbacks } from './types';
 
@@ -28,6 +29,10 @@ export class UnifiedProposalView extends ItemView {
 	private reviewingOrganize: OrganizeProposal | null = null;
 	private reviewingDeepDive: DeepDiveProposal | null = null;
 	private reviewingTitle: TitleProposal | null = null;
+	private reviewingRem: RemProposal | null = null;
+
+	// REM review selection state
+	private selectedRemLinks = new Set<string>();
 
 	private acceptAllInProgress = false;
 	private rejectAllInProgress = false;
@@ -102,6 +107,12 @@ export class UnifiedProposalView extends ItemView {
 			);
 			if (!exists) this.reviewingTitle = null;
 		}
+		if (this.reviewingRem) {
+			const exists = items.some(
+				i => i.kind === 'rem' && i.data.id === this.reviewingRem!.id
+			);
+			if (!exists) this.reviewingRem = null;
+		}
 		this.render();
 	}
 
@@ -116,6 +127,8 @@ export class UnifiedProposalView extends ItemView {
 			this.renderDeepDiveReview(this.reviewingDeepDive);
 		} else if (this.reviewingTitle) {
 			this.renderTitleReview(this.reviewingTitle);
+		} else if (this.reviewingRem) {
+			this.renderRemReview(this.reviewingRem);
 		} else {
 			this.renderList();
 		}
@@ -136,6 +149,7 @@ export class UnifiedProposalView extends ItemView {
 		this.reviewingOrganize = null;
 		this.reviewingDeepDive = null;
 		this.reviewingTitle = null;
+		this.reviewingRem = null;
 		this.render();
 	}
 
@@ -214,6 +228,11 @@ export class UnifiedProposalView extends ItemView {
 			case 'title':
 				await this.callbacks.onTitleAccept(item.data.id);
 				break;
+			case 'rem': {
+				const allTexts = item.data.candidates.map(c => c.matchedText);
+				await this.callbacks.onRemAcceptSelected(item.data.id, allTexts);
+				break;
+			}
 		}
 	}
 
@@ -230,6 +249,8 @@ export class UnifiedProposalView extends ItemView {
 				return `Deep Dive: ${(item.data as DeepDiveProposal).topic.title}`;
 			case 'title':
 				return `Title: ${item.data.sourceNotePath}`;
+			case 'rem':
+				return `REM: ${item.data.sourceNotePath}`;
 		}
 	}
 
@@ -297,6 +318,9 @@ export class UnifiedProposalView extends ItemView {
 				break;
 			case 'title':
 				await this.callbacks.onTitleReject(item.data.id);
+				break;
+			case 'rem':
+				await this.callbacks.onRemReject(item.data.id);
 				break;
 		}
 	}
@@ -402,6 +426,8 @@ export class UnifiedProposalView extends ItemView {
 					this.renderDeepDiveCard(section, item.data);
 				} else if (item.kind === 'title') {
 					this.renderTitleCard(section, item.data);
+				} else if (item.kind === 'rem') {
+					this.renderRemCard(section, item.data);
 				}
 			}
 		}
@@ -985,6 +1011,168 @@ export class UnifiedProposalView extends ItemView {
 		});
 	}
 
+	// ── REM Card ─────────────────────────────────────────────
+
+	private renderRemCard(container: HTMLElement, proposal: RemProposal): void {
+		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--rem' });
+
+		card.createEl('span', { text: 'REM', cls: 'synapse-badge synapse-badge--rem' });
+
+		const { candidates } = proposal;
+		const parts: string[] = [];
+		const titleCount = candidates.filter(c => c.matchType === 'title').length;
+		const aliasCount = candidates.filter(c => c.matchType === 'alias').length;
+		const semanticCount = candidates.filter(c => c.matchType === 'semantic').length;
+		if (titleCount > 0) parts.push(`${titleCount} title`);
+		if (aliasCount > 0) parts.push(`${aliasCount} alias`);
+		if (semanticCount > 0) parts.push(`${semanticCount} semantic`);
+
+		card.createEl('small', {
+			text: `${candidates.length} link${candidates.length === 1 ? '' : 's'} | ${parts.join(', ')}`,
+			cls: 'synapse-reasons',
+		});
+
+		// Preview: show first few candidates
+		const previewItems = candidates.slice(0, 3);
+		const previewText = previewItems
+			.map(c => `${c.matchedText} → [[${c.targetDisplayName}]]`)
+			.join('; ');
+		card.createEl('p', {
+			text: previewText + (candidates.length > 3 ? '...' : ''),
+			cls: 'synapse-preview',
+		});
+
+		const actions = card.createDiv({ cls: 'synapse-actions' });
+
+		const viewBtn = actions.createEl('button', { text: 'Review' });
+		viewBtn.addEventListener('click', () => {
+			this.enterRemReview(proposal);
+		});
+
+		const acceptBtn = actions.createEl('button', { text: 'Accept All' });
+		acceptBtn.addEventListener('click', () => {
+			const allTexts = candidates.map(c => c.matchedText);
+			this.callbacks.onRemAcceptSelected(proposal.id, allTexts);
+		});
+
+		const rejectBtn = actions.createEl('button', { text: 'Reject' });
+		rejectBtn.addEventListener('click', () =>
+			this.callbacks.onRemReject(proposal.id)
+		);
+	}
+
+	// ── REM Review ───────────────────────────────────────────
+
+	private enterRemReview(proposal: RemProposal): void {
+		this.reviewingRem = proposal;
+		this.selectedRemLinks = new Set(proposal.candidates.map(c => c.matchedText));
+		this.render();
+	}
+
+	private renderRemReview(proposal: RemProposal): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('synapse-view-root');
+
+		// Header
+		const header = contentEl.createDiv({ cls: 'synapse-review-header' });
+		const backBtn = header.createEl('button', { text: 'Back', cls: 'synapse-review-back' });
+		backBtn.addEventListener('click', () => this.exitReview());
+
+		const titleLink = header.createEl('span', {
+			text: proposal.sourceNotePath,
+			cls: 'synapse-review-title synapse-note-link',
+		});
+		titleLink.addEventListener('click', () => this.openNote(proposal.sourceNotePath));
+
+		contentEl.createEl('small', {
+			text: `${proposal.candidates.length} linkable mention${proposal.candidates.length === 1 ? '' : 's'} | ${proposal.createdAt.split('T')[0]}`,
+			cls: 'synapse-review-reasons',
+		});
+
+		// Scrollable checklist of candidates
+		const checklist = contentEl.createDiv({ cls: 'synapse-enrichment-checklist' });
+
+		for (const candidate of proposal.candidates) {
+			const section = checklist.createDiv({ cls: 'synapse-checklist-section' });
+
+			// Header: target name + match type badge
+			const headingRow = section.createDiv({ cls: 'synapse-rem-candidate-header' });
+			headingRow.createEl('span', {
+				text: `[[${candidate.targetDisplayName}]]`,
+				cls: 'synapse-rem-target',
+			});
+			headingRow.createEl('span', {
+				text: candidate.matchType,
+				cls: `synapse-badge synapse-badge--rem-${candidate.matchType}`,
+			});
+			if (candidate.matchType === 'semantic') {
+				headingRow.createEl('span', {
+					text: `${Math.round(candidate.confidence * 100)}%`,
+					cls: 'synapse-quality-badge',
+				});
+			}
+
+			// Checkbox row for this candidate
+			const row = section.createEl('label', { cls: 'synapse-checklist-row' });
+			const checkbox = row.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+			checkbox.checked = this.selectedRemLinks.has(candidate.matchedText);
+			checkbox.addEventListener('change', () => {
+				if (checkbox.checked) {
+					this.selectedRemLinks.add(candidate.matchedText);
+				} else {
+					this.selectedRemLinks.delete(candidate.matchedText);
+				}
+			});
+
+			const label = row.createEl('span');
+			label.createEl('strong', { text: `"${candidate.matchedText}"` });
+			label.createEl('span', {
+				text: ` (${candidate.occurrences.length} occurrence${candidate.occurrences.length === 1 ? '' : 's'})`,
+			});
+
+			// Show context for first occurrence
+			if (candidate.occurrences.length > 0) {
+				const occ = candidate.occurrences[0];
+				const contextEl = section.createEl('div', { cls: 'synapse-rem-context' });
+				const before = occ.lineText.slice(Math.max(0, occ.startOffset - 30), occ.startOffset);
+				const matched = occ.lineText.slice(occ.startOffset, occ.endOffset);
+				const after = occ.lineText.slice(occ.endOffset, occ.endOffset + 30);
+				contextEl.createEl('span', { text: `...${before}` });
+				contextEl.createEl('mark', { text: matched });
+				contextEl.createEl('span', { text: `${after}...` });
+			}
+		}
+
+		// Action bar
+		const actionBar = contentEl.createDiv({ cls: 'synapse-review-actions' });
+
+		const acceptBtn = actionBar.createEl('button', { text: 'Accept Selected', cls: 'mod-cta' });
+		acceptBtn.addEventListener('click', () => {
+			const accepted = [...this.selectedRemLinks];
+			this.reviewingRem = null;
+			this.callbacks.onRemAcceptSelected(proposal.id, accepted);
+		});
+
+		const selectAllBtn = actionBar.createEl('button', { text: 'All' });
+		selectAllBtn.addEventListener('click', () => {
+			this.selectedRemLinks = new Set(proposal.candidates.map(c => c.matchedText));
+			this.render();
+		});
+
+		const noneBtn = actionBar.createEl('button', { text: 'None' });
+		noneBtn.addEventListener('click', () => {
+			this.selectedRemLinks.clear();
+			this.render();
+		});
+
+		const rejectBtn = actionBar.createEl('button', { text: 'Reject' });
+		rejectBtn.addEventListener('click', () => {
+			this.reviewingRem = null;
+			this.callbacks.onRemReject(proposal.id);
+		});
+	}
+
 	// ── Checkpoint Banner ─────────────────────────────────────
 
 	private renderCheckpointBanner(container: HTMLElement): void {
@@ -1386,6 +1574,64 @@ export class UnifiedProposalView extends ItemView {
 			.synapse-review-pane-label--title {
 				background: var(--color-cyan);
 				color: var(--text-on-accent);
+			}
+
+			/* ── REM ── */
+			.synapse-card--rem {
+				border-left-color: var(--color-pink);
+			}
+			.synapse-badge--rem {
+				background: var(--color-pink);
+				color: var(--text-on-accent);
+			}
+			.synapse-badge--rem-title {
+				background: var(--interactive-accent);
+				color: var(--text-on-accent);
+				font-size: 9px;
+				padding: 0 4px;
+				border-radius: 2px;
+			}
+			.synapse-badge--rem-alias {
+				background: var(--color-green);
+				color: var(--text-on-accent);
+				font-size: 9px;
+				padding: 0 4px;
+				border-radius: 2px;
+			}
+			.synapse-badge--rem-semantic {
+				background: var(--color-purple);
+				color: var(--text-on-accent);
+				font-size: 9px;
+				padding: 0 4px;
+				border-radius: 2px;
+			}
+			.synapse-rem-candidate-header {
+				display: flex;
+				align-items: center;
+				gap: 6px;
+				padding: 4px 8px;
+				margin-bottom: 2px;
+			}
+			.synapse-rem-target {
+				font-weight: 600;
+				font-size: 13px;
+				color: var(--text-accent);
+			}
+			.synapse-rem-context {
+				font-size: 12px;
+				color: var(--text-muted);
+				padding: 2px 8px 4px 32px;
+				font-family: var(--font-monospace);
+				line-height: 1.4;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.synapse-rem-context mark {
+				background: var(--text-highlight-bg);
+				color: var(--text-normal);
+				padding: 0 2px;
+				border-radius: 2px;
 			}
 
 			/* ── Organize Review ── */


### PR DESCRIPTION
## Summary

- **New `src/rem/` module** — scans note text for literal mentions of vault note titles/aliases and proposes in-place `[[wikilink]]` insertions
- **MentionScanner** — core text-matching engine with word-boundary enforcement, longest-match-first, case-insensitive, Unicode-aware, skips frontmatter/code blocks/existing wikilinks
- **SemanticMatcher** — optional AI-powered conceptual matching (gated by setting)
- **RemApplier** — reverse document order in-place text replacement to preserve offsets
- **RemStore** — JSON proposal persistence following the `EnrichmentStore` pattern
- **RemModule** — orchestration with checkpoint-based batch scanning, accept/reject/undo, resume support
- **Unified sidebar integration** — REM cards with per-candidate review, highlighted context preview, match-type badges (title/alias/semantic)
- **Settings** — enable toggle, semantic matching toggle, confidence threshold slider, max links per note
- **18 unit tests** for mention scanner edge cases (boundaries, skip regions, overlaps, unicode, self-exclusion)

### Commands
- `REM: Discover links in current note` — single-note scan via editor callback
- `REM: Discover links in directory` — folder picker → checkpoint-based batch scan

### Design decisions
- **New module vs enrichment sub-command** — REM uses in-place text replacement (not appended callout sections), requires position/offset data that `EnrichmentProposal` doesn't carry
- **Reuses enrichment exclude-folders/exclude-tags** — no duplicate settings
- **Undo support** — stores `originalContent` snapshot at accept time for full revert

closes #179

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — passes
- [x] `npm test` — 750/750 tests passing (18 new)
- [x] `node esbuild.config.mjs production` — builds cleanly
- [ ] Manual: create vault with notes "Machine Learning", "ML Fundamentals" (alias: "machine learning"), write a note mentioning "machine learning" in plain text, run "REM: Discover links in current note", verify proposal in sidebar, accept a link, verify `[[ML Fundamentals|machine learning]]` inserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)