### PR TITLE
chore: verify native fetch CSP compliance in audio transcriber

### DIFF
--- a/src/audio/transcriber.test.ts
+++ b/src/audio/transcriber.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { requestUrl } from '../__mocks__/obsidian';
+import { Transcriber, buildMultipartBody } from './transcriber';
+import { SynapseSettings, DEFAULT_SETTINGS } from '../settings';
+
+function makeSettings(overrides?: Partial<SynapseSettings>): SynapseSettings {
+	return { ...structuredClone(DEFAULT_SETTINGS), ...overrides };
+}
+
+const mockRequestUrl = vi.mocked(requestUrl);
+
+describe('buildMultipartBody', () => {
+	it('produces valid multipart body with text fields and a file', () => {
+		const fields = [
+			{ name: 'model', value: 'whisper-1' },
+			{ name: 'response_format', value: 'verbose_json' },
+		];
+		const fileData = new TextEncoder().encode('fake audio content').buffer as ArrayBuffer;
+		const result = buildMultipartBody(fields, {
+			name: 'test.mp3',
+			fieldName: 'file',
+			data: fileData,
+		});
+
+		expect(result.contentType).toMatch(/^multipart\/form-data; boundary=----SynapseFormBoundary/);
+		expect(result.body).toBeInstanceOf(ArrayBuffer);
+
+		// Decode the body to verify structure
+		const decoded = new TextDecoder().decode(result.body);
+		const boundary = result.contentType.split('boundary=')[1];
+
+		// Verify boundary markers
+		expect(decoded).toContain(`--${boundary}`);
+		expect(decoded).toContain(`--${boundary}--`);
+
+		// Verify text fields
+		expect(decoded).toContain('Content-Disposition: form-data; name="model"');
+		expect(decoded).toContain('whisper-1');
+		expect(decoded).toContain('Content-Disposition: form-data; name="response_format"');
+		expect(decoded).toContain('verbose_json');
+
+		// Verify file field
+		expect(decoded).toContain('Content-Disposition: form-data; name="file"; filename="test.mp3"');
+		expect(decoded).toContain('Content-Type: application/octet-stream');
+		expect(decoded).toContain('fake audio content');
+	});
+
+	it('handles empty fields array', () => {
+		const fileData = new Uint8Array([0x01, 0x02]).buffer as ArrayBuffer;
+		const result = buildMultipartBody([], {
+			name: 'audio.wav',
+			fieldName: 'file',
+			data: fileData,
+		});
+
+		const decoded = new TextDecoder().decode(result.body);
+		expect(decoded).toContain('Content-Disposition: form-data; name="file"; filename="audio.wav"');
+		// Should only have file part and closing boundary
+		expect(decoded).not.toContain('name="model"');
+	});
+
+	it('generates unique boundaries per call', () => {
+		const fileData = new Uint8Array([0x00]).buffer as ArrayBuffer;
+		const r1 = buildMultipartBody([], { name: 'a.mp3', fieldName: 'file', data: fileData });
+		const r2 = buildMultipartBody([], { name: 'b.mp3', fieldName: 'file', data: fileData });
+
+		const b1 = r1.contentType.split('boundary=')[1];
+		const b2 = r2.contentType.split('boundary=')[1];
+		expect(b1).not.toBe(b2);
+	});
+});
+
+describe('Transcriber', () => {
+	let settings: SynapseSettings;
+	let transcriber: Transcriber;
+
+	beforeEach(() => {
+		settings = makeSettings({
+			ai: { ...DEFAULT_SETTINGS.ai, apiKey: 'sk-test-key' },
+			audio: {
+				...DEFAULT_SETTINGS.audio,
+				whisperApiKey: 'sk-whisper-key',
+				deepgramApiKey: 'dg-test-key',
+			},
+		});
+		transcriber = new Transcriber(() => settings);
+		mockRequestUrl.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('provider dispatch', () => {
+		it('throws for unsupported provider', async () => {
+			settings.audio.transcriptionProvider = 'unknown' as any;
+			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+				.rejects.toThrow('Unsupported transcription provider: unknown');
+		});
+
+		it('throws for local-whisper (not yet implemented)', async () => {
+			settings.audio.transcriptionProvider = 'local-whisper';
+			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+				.rejects.toThrow('Local Whisper transcription not yet implemented');
+		});
+	});
+
+	describe('Whisper API (requestUrl)', () => {
+		it('throws when no API key is configured', async () => {
+			settings.audio.whisperApiKey = '';
+			settings.ai.apiKey = '';
+			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+				.rejects.toThrow('No OpenAI API key configured for Whisper');
+		});
+
+		it('falls back to shared AI key when whisperApiKey is empty', async () => {
+			settings.audio.whisperApiKey = '';
+			settings.ai.apiKey = 'sk-shared-key';
+
+			mockRequestUrl.mockResolvedValue({
+				status: 200,
+				json: { text: 'hello', language: 'en', duration: 1.5, segments: [] },
+				text: '',
+				headers: {},
+			});
+
+			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+
+			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			expect(callArgs.headers.Authorization).toBe('Bearer sk-shared-key');
+		});
+
+		it('sends multipart request to Whisper API via requestUrl', async () => {
+			mockRequestUrl.mockResolvedValue({
+				status: 200,
+				json: {
+					text: 'Hello world',
+					language: 'en',
+					duration: 2.5,
+					segments: [{ start: 0, end: 2.5, text: 'Hello world' }],
+				},
+				text: '',
+				headers: {},
+			});
+
+			const audioData = new Uint8Array([0xff, 0xfb, 0x90]).buffer as ArrayBuffer;
+			const result = await transcriber.transcribe(audioData, 'recording.mp3');
+
+			// Verify requestUrl was called (not native fetch)
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+
+			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			expect(callArgs.url).toBe('https://api.openai.com/v1/audio/transcriptions');
+			expect(callArgs.method).toBe('POST');
+			expect(callArgs.headers.Authorization).toBe('Bearer sk-whisper-key');
+			expect(callArgs.headers['Content-Type']).toMatch(/^multipart\/form-data; boundary=/);
+			expect(callArgs.body).toBeInstanceOf(ArrayBuffer);
+			expect(callArgs.throw).toBe(false);
+
+			// Verify response mapping
+			expect(result.raw).toBe('Hello world');
+			expect(result.language).toBe('en');
+			expect(result.duration).toBe(2.5);
+			expect(result.sourceName).toBe('recording.mp3');
+			expect(result.timestamps).toEqual([{ start: 0, end: 2.5, text: 'Hello world' }]);
+		});
+
+		it('includes language field when configured', async () => {
+			settings.audio.language = 'fr';
+
+			mockRequestUrl.mockResolvedValue({
+				status: 200,
+				json: { text: 'Bonjour', language: 'fr', duration: 1 },
+				text: '',
+				headers: {},
+			});
+
+			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+
+			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			const body = new TextDecoder().decode(callArgs.body);
+			expect(body).toContain('name="language"');
+			expect(body).toContain('fr');
+		});
+
+		it('throws on HTTP error status', async () => {
+			mockRequestUrl.mockResolvedValue({
+				status: 429,
+				json: { error: { message: 'Rate limited' } },
+				text: '',
+				headers: {},
+			});
+
+			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+				.rejects.toThrow('Whisper API request failed (status 429)');
+		});
+
+		it('handles segments being absent in response', async () => {
+			mockRequestUrl.mockResolvedValue({
+				status: 200,
+				json: { text: 'No segments', language: 'en', duration: 1 },
+				text: '',
+				headers: {},
+			});
+
+			const result = await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+			expect(result.timestamps).toBeUndefined();
+		});
+	});
+
+	describe('Deepgram API (requestUrl)', () => {
+		beforeEach(() => {
+			settings.audio.transcriptionProvider = 'deepgram';
+		});
+
+		it('throws when no API key is configured', async () => {
+			settings.audio.deepgramApiKey = '';
+			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+				.rejects.toThrow('No Deepgram API key configured');
+		});
+
+		it('sends ArrayBuffer body to Deepgram via requestUrl', async () => {
+			mockRequestUrl.mockResolvedValue({
+				status: 200,
+				json: {
+					results: {
+						channels: [{
+							alternatives: [{ transcript: 'transcribed text' }],
+							detected_language: 'en',
+						}],
+					},
+				},
+				text: '',
+				headers: {},
+			});
+
+			const audioData = new Uint8Array([0x01, 0x02, 0x03]).buffer as ArrayBuffer;
+			const result = await transcriber.transcribe(audioData, 'audio.wav');
+
+			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+
+			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			expect(callArgs.url).toContain('https://api.deepgram.com/v1/listen');
+			expect(callArgs.url).toContain('punctuate=true');
+			expect(callArgs.url).toContain('paragraphs=true');
+			expect(callArgs.method).toBe('POST');
+			expect(callArgs.headers.Authorization).toBe('Token dg-test-key');
+			expect(callArgs.headers['Content-Type']).toBe('audio/*');
+			expect(callArgs.body).toBe(audioData);
+			expect(callArgs.throw).toBe(false);
+
+			expect(result.raw).toBe('transcribed text');
+			expect(result.language).toBe('en');
+			expect(result.sourceName).toBe('audio.wav');
+		});
+
+		it('includes language parameter when configured', async () => {
+			settings.audio.language = 'de';
+
+			mockRequestUrl.mockResolvedValue({
+				status: 200,
+				json: {
+					results: {
+						channels: [{
+							alternatives: [{ transcript: 'Hallo' }],
+							detected_language: 'de',
+						}],
+					},
+				},
+				text: '',
+				headers: {},
+			});
+
+			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+
+			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			expect(callArgs.url).toContain('language=de');
+		});
+
+		it('throws on HTTP error status', async () => {
+			mockRequestUrl.mockResolvedValue({
+				status: 401,
+				json: { error: 'Unauthorized' },
+				text: '',
+				headers: {},
+			});
+
+			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+				.rejects.toThrow('Deepgram API request failed (status 401)');
+		});
+	});
+});

--- a/src/audio/transcriber.ts
+++ b/src/audio/transcriber.ts
@@ -1,5 +1,85 @@
+// CSP Compliance Note:
+//
+// This module previously used native fetch() + FormData for Whisper API calls
+// and native fetch() with raw ArrayBuffer body for Deepgram API calls. While
+// native fetch works in Obsidian's desktop Electron environment (Electron does
+// not strictly enforce CSP connect-src on renderer-process fetch), it fails on
+// mobile platforms (iOS/Android) where Capacitor's WebView enforces stricter
+// CSP and CORS policies.
+//
+// Obsidian's requestUrl() API routes requests through the platform's native
+// HTTP layer (Electron main process on desktop, native HTTP on mobile),
+// bypassing CSP entirely. This is the officially recommended approach for
+// Obsidian plugins and is already used by every other HTTP-calling module in
+// this codebase (ai-client.ts, content-fetcher.ts, tweet-fetcher.ts).
+//
+// Key challenge: requestUrl accepts body as string | ArrayBuffer, not FormData.
+// The Whisper API requires multipart/form-data with a binary file field, so we
+// manually construct the multipart body with a random boundary. The Deepgram
+// API accepts raw ArrayBuffer directly, which requestUrl handles natively.
+//
+// Migration: native fetch -> requestUrl (completed in issue #88)
+
+import { requestUrl } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { TranscriptionResult } from './types';
+
+/** Timeout for transcription API requests (5 minutes for large audio files). */
+const TRANSCRIPTION_TIMEOUT_MS = 300_000;
+
+/**
+ * Build a multipart/form-data body manually from field definitions.
+ *
+ * Obsidian's requestUrl does not support FormData, so we construct the
+ * multipart body as an ArrayBuffer with a random boundary string.
+ *
+ * @returns An object with the Content-Type header (including boundary) and the body ArrayBuffer.
+ */
+export function buildMultipartBody(
+	fields: { name: string; value: string }[],
+	file: { name: string; fieldName: string; data: ArrayBuffer }
+): { contentType: string; body: ArrayBuffer } {
+	const boundary = '----SynapseFormBoundary' + Math.random().toString(36).slice(2);
+	const encoder = new TextEncoder();
+	const crlf = '\r\n';
+
+	const parts: Uint8Array[] = [];
+
+	// Add text fields
+	for (const field of fields) {
+		const header =
+			`--${boundary}${crlf}` +
+			`Content-Disposition: form-data; name="${field.name}"${crlf}${crlf}` +
+			`${field.value}${crlf}`;
+		parts.push(encoder.encode(header));
+	}
+
+	// Add file field
+	const fileHeader =
+		`--${boundary}${crlf}` +
+		`Content-Disposition: form-data; name="${file.fieldName}"; filename="${file.name}"${crlf}` +
+		`Content-Type: application/octet-stream${crlf}${crlf}`;
+	parts.push(encoder.encode(fileHeader));
+	parts.push(new Uint8Array(file.data));
+	parts.push(encoder.encode(crlf));
+
+	// Closing boundary
+	parts.push(encoder.encode(`--${boundary}--${crlf}`));
+
+	// Concatenate all parts into a single ArrayBuffer
+	const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+	const body = new Uint8Array(totalLength);
+	let offset = 0;
+	for (const part of parts) {
+		body.set(part, offset);
+		offset += part.byteLength;
+	}
+
+	return {
+		contentType: `multipart/form-data; boundary=${boundary}`,
+		body: body.buffer as ArrayBuffer,
+	};
+}
 
 export class Transcriber {
 	constructor(private getSettings: () => SynapseSettings) {}
@@ -43,56 +123,59 @@ export class Transcriber {
 			);
 		}
 
-		const formData = new FormData();
-		formData.append(
-			'file',
-			new Blob([audioData]),
-			fileName
-		);
-		formData.append('model', settings.audio.whisperModel);
+		// Build multipart body manually since requestUrl does not support FormData
+		const fields: { name: string; value: string }[] = [
+			{ name: 'model', value: settings.audio.whisperModel },
+			{ name: 'response_format', value: 'verbose_json' },
+		];
 		if (settings.audio.language) {
-			formData.append('language', settings.audio.language);
+			fields.push({ name: 'language', value: settings.audio.language });
 		}
-		formData.append('response_format', 'verbose_json');
 
-		// Use AbortController for request timeout (5 minutes for large audio files)
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 300_000);
+		const { contentType, body } = buildMultipartBody(fields, {
+			name: fileName,
+			fieldName: 'file',
+			data: audioData,
+		});
 
-		try {
-			const response = await fetch(
-				'https://api.openai.com/v1/audio/transcriptions',
-				{
-					method: 'POST',
-					headers: {
-						Authorization: `Bearer ${apiKey}`,
-					},
-					body: formData,
-					signal: controller.signal,
-				}
-			);
+		const timeout = new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error('Whisper API request timed out')), TRANSCRIPTION_TIMEOUT_MS)
+		);
 
-			if (!response.ok) {
-				throw new Error(`Whisper API request failed (status ${response.status})`);
-			}
+		const response = await Promise.race([
+			requestUrl({
+				url: 'https://api.openai.com/v1/audio/transcriptions',
+				method: 'POST',
+				headers: {
+					'Authorization': `Bearer ${apiKey}`,
+					'Content-Type': contentType,
+				},
+				body,
+				throw: false,
+			}),
+			timeout,
+		]);
 
-			const data = await response.json();
-			return {
-				raw: data.text,
-				language: data.language,
-				duration: data.duration,
-				sourceName: fileName,
-				timestamps: data.segments?.map(
-					(s: { start: number; end: number; text: string }) => ({
-						start: s.start,
-						end: s.end,
-						text: s.text,
-					})
-				),
-			};
-		} finally {
-			clearTimeout(timeoutId);
+		if (response.status >= 400) {
+			throw new Error(`Whisper API request failed (status ${response.status})`);
 		}
+
+		const data = typeof response.json === 'string'
+			? JSON.parse(response.json)
+			: response.json;
+		return {
+			raw: data.text,
+			language: data.language,
+			duration: data.duration,
+			sourceName: fileName,
+			timestamps: data.segments?.map(
+				(s: { start: number; end: number; text: string }) => ({
+					start: s.start,
+					end: s.end,
+					text: s.text,
+				})
+			),
+		};
 	}
 
 	private async transcribeDeepgram(
@@ -114,37 +197,37 @@ export class Transcriber {
 			params.set('language', settings.language);
 		}
 
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 300_000);
+		const timeout = new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error('Deepgram API request timed out')), TRANSCRIPTION_TIMEOUT_MS)
+		);
 
-		try {
-			const response = await fetch(
-				`https://api.deepgram.com/v1/listen?${params}`,
-				{
-					method: 'POST',
-					headers: {
-						Authorization: `Token ${settings.deepgramApiKey}`,
-						'Content-Type': 'audio/*',
-					},
-					body: audioData,
-					signal: controller.signal,
-				}
-			);
+		const response = await Promise.race([
+			requestUrl({
+				url: `https://api.deepgram.com/v1/listen?${params}`,
+				method: 'POST',
+				headers: {
+					'Authorization': `Token ${settings.deepgramApiKey}`,
+					'Content-Type': 'audio/*',
+				},
+				body: audioData,
+				throw: false,
+			}),
+			timeout,
+		]);
 
-			if (!response.ok) {
-				throw new Error(`Deepgram API request failed (status ${response.status})`);
-			}
-
-			const data = await response.json();
-			const result = data.results.channels[0].alternatives[0];
-			return {
-				raw: result.transcript,
-				language: data.results.channels[0].detected_language,
-				sourceName: fileName,
-			};
-		} finally {
-			clearTimeout(timeoutId);
+		if (response.status >= 400) {
+			throw new Error(`Deepgram API request failed (status ${response.status})`);
 		}
+
+		const data = typeof response.json === 'string'
+			? JSON.parse(response.json)
+			: response.json;
+		const result = data.results.channels[0].alternatives[0];
+		return {
+			raw: result.transcript,
+			language: data.results.channels[0].detected_language,
+			sourceName: fileName,
+		};
 	}
 
 	private async transcribeLocalWhisper(


### PR DESCRIPTION
## Summary

- Migrated `src/audio/transcriber.ts` from native `fetch()` to Obsidian's `requestUrl()` API
- Added manual multipart/form-data body construction (`buildMultipartBody`) for Whisper API since `requestUrl` does not support `FormData`
- Added 15 new tests covering multipart body construction, provider dispatch, request format, error handling, and response mapping

## Findings

**Native `fetch` is problematic in Obsidian's runtime:**

| Platform | Native `fetch` | `requestUrl` |
|----------|---------------|-------------|
| Desktop (Electron) | Works (Electron relaxes CSP for renderer `fetch`) | Works (routes through main process) |
| iOS (Capacitor) | Blocked by WebView CSP/CORS | Works (native HTTP layer) |
| Android (Capacitor) | Blocked by WebView CSP/CORS | Works (native HTTP layer) |

`requestUrl` is the officially recommended approach and is already used by every other HTTP-calling module in this codebase (`ai-client.ts`, `content-fetcher.ts`, `tweet-fetcher.ts`). The audio transcriber was the sole holdout.

**Key implementation detail:** The Whisper API requires `multipart/form-data` with a binary file field. Since `requestUrl` accepts `body: string | ArrayBuffer` (not `FormData`), we manually construct the multipart body with a random boundary string via the new `buildMultipartBody()` utility. The Deepgram API sends raw `ArrayBuffer`, which `requestUrl` handles natively.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` -- types pass
- [x] `npm test` -- 765 tests pass (15 new)
- [x] `node esbuild.config.mjs production` -- build succeeds

Closes #88

Co-Authored-By: Claude <bot@wafflenet.io>