### PR TITLE
feat: expose maxTokens setting in AI Configuration UI

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -115,6 +115,23 @@ export class SynapseSettingTab extends PluginSettingTab {
 			},
 		);
 
+		addEnhancedSlider(
+			new Setting(containerEl)
+				.setName('Max tokens')
+				.setDesc('Maximum tokens in AI responses (256-8192)'),
+			{
+				min: 256,
+				max: 8192,
+				step: 256,
+				value: this.plugin.settings.ai.maxTokens,
+				showTicks: true,
+				onChange: async (value) => {
+					this.plugin.settings.ai.maxTokens = value;
+					await this.plugin.saveSettings();
+				},
+			},
+		);
+
 		// ── Note Elaboration ──
 		new Setting(containerEl).setHeading().setName('Note Elaboration');
 


### PR DESCRIPTION
## Summary
- Adds an enhanced slider for `maxTokens` (256–8192, step 256) in the AI Configuration settings section, placed after the temperature slider
- Wired to `settings.ai.maxTokens`, following the existing `addEnhancedSlider()` pattern

## Test plan
- [ ] Open Synapse settings → AI Configuration section
- [ ] Verify "Max tokens" slider appears after Temperature
- [ ] Confirm range is 256–8192 with step 256
- [ ] Change value, reload, verify persistence

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)