### PR TITLE
feat: expose audio language setting in transcription UI

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -265,6 +265,37 @@ export class SynapseSettingTab extends PluginSettingTab {
 		}
 
 		new Setting(containerEl)
+			.setName('Language')
+			.setDesc('Audio language for transcription (auto-detect if empty)')
+			.addDropdown((dd) =>
+				dd
+					.addOptions({
+						'': 'Auto-detect',
+						en: 'English',
+						es: 'Spanish',
+						fr: 'French',
+						de: 'German',
+						ja: 'Japanese',
+						zh: 'Chinese',
+						ko: 'Korean',
+						pt: 'Portuguese',
+						ru: 'Russian',
+						ar: 'Arabic',
+						hi: 'Hindi',
+						it: 'Italian',
+						nl: 'Dutch',
+						pl: 'Polish',
+						sv: 'Swedish',
+						tr: 'Turkish',
+					})
+					.setValue(this.plugin.settings.audio.language)
+					.onChange(async (value) => {
+						this.plugin.settings.audio.language = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
 			.setName('Post-processing')
 			.setDesc('Clean up and structure transcriptions with AI')
 			.addToggle((toggle) =>


### PR DESCRIPTION
## Summary
- Adds a language dropdown in the Audio Transcription settings section with 16 common ISO 639-1 codes plus "Auto-detect" default
- Wired to `settings.audio.language`, follows the existing dropdown pattern (provider selection)

## Test plan
- [ ] Open Synapse settings → Audio Transcription section
- [ ] Verify "Language" dropdown appears after provider-specific API key fields
- [ ] Confirm "Auto-detect" is the default selection
- [ ] Select a language, reload, verify persistence
- [ ] Verify all 16 language codes render correctly in dropdown

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)