### PR TITLE
fix: remove unused supportedPlatforms toggles from video settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -88,10 +88,6 @@ export interface VideoSettings {
 	tempFolder: string;
 	downloadFolder: string;
 	embedInNote: boolean;
-	supportedPlatforms: {
-		youtube: boolean;
-		tiktok: boolean;
-	};
 	frameExtraction: FrameExtractionSettings;
 }
 
@@ -262,10 +258,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		tempFolder: '.synapse/temp',
 		downloadFolder: 'Media',
 		embedInNote: true,
-		supportedPlatforms: {
-			youtube: true,
-			tiktok: true,
-		},
 		frameExtraction: {
 			enabled: false,
 			intervalSeconds: 30,


### PR DESCRIPTION
## Summary
- Removes `supportedPlatforms` (`youtube`/`tiktok` booleans) from `VideoSettings` interface and `DEFAULT_SETTINGS`
- These were defined but never enforced — the video pipeline processes all supported URLs regardless of toggle state
- No video module changes needed since it never checked these values

## Test plan
- [ ] Verify type check passes (`npx tsc --noEmit`)
- [ ] Verify all 750 tests pass (`npm test`)
- [ ] Verify production build succeeds
- [ ] Open settings, confirm no regressions in Video Transcription section

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)