### PR TITLE
feat: add Fire Synapse command (#36)

### DIFF
--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -157,7 +157,7 @@ export class ElaborationModule {
 	 * 2. Confirmation snackbar -- user decides whether to generate proposals
 	 * 3. Heavy proposal generation with cancellation support
 	 */
-	async scanVault(folderPath?: string): Promise<number> {
+	async scanVault(folderPath?: string, skipConfirmation = false): Promise<number> {
 		// --- Phase 1: Detection (lightweight, local-only) ---
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(scopeLabel, 'vault-scan');
@@ -184,15 +184,17 @@ export class ElaborationModule {
 			return 0;
 		}
 
-		// --- Phase 2: Confirmation ---
-		const proceed = await this.notifications.confirm(
-			`Found ${detected.length} stub note${detected.length === 1 ? '' : 's'}. Generate proposals?`,
-			{ proceedLabel: 'Generate', cancelLabel: 'Skip' }
-		);
+		// --- Phase 2: Confirmation (skipped when called from Fire Synapse) ---
+		if (!skipConfirmation) {
+			const proceed = await this.notifications.confirm(
+				`Found ${detected.length} stub note${detected.length === 1 ? '' : 's'}. Generate proposals?`,
+				{ proceedLabel: 'Generate', cancelLabel: 'Skip' }
+			);
 
-		if (!proceed) {
-			this.notifications.info('Scan skipped');
-			return 0;
+			if (!proceed) {
+				this.notifications.info('Scan skipped');
+				return 0;
+			}
 		}
 
 		// --- Phase 3: Proposal generation (heavy, cancellable, checkpointed) ---

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -172,7 +172,7 @@ export class EnrichmentModule {
 	 * 4. Resolve cross-note new-note candidates -- only topics referenced
 	 *    by 2+ notes become new-note link suggestions
 	 */
-	async scanVault(folderPath?: string): Promise<number> {
+	async scanVault(folderPath?: string, skipConfirmation = false): Promise<number> {
 		// -- Phase 1: Collect eligible files & warm caches --
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(
@@ -207,15 +207,17 @@ export class EnrichmentModule {
 			return 0;
 		}
 
-		// -- Phase 2: User confirmation --
-		const proceed = await this.notifications.confirm(
-			`Found ${eligible.length} note${eligible.length === 1 ? '' : 's'} to enrich. Generate proposals?`,
-			{ proceedLabel: 'Generate', cancelLabel: 'Skip' }
-		);
+		// -- Phase 2: User confirmation (skipped when called from Fire Synapse) --
+		if (!skipConfirmation) {
+			const proceed = await this.notifications.confirm(
+				`Found ${eligible.length} note${eligible.length === 1 ? '' : 's'} to enrich. Generate proposals?`,
+				{ proceedLabel: 'Generate', cancelLabel: 'Skip' }
+			);
 
-		if (!proceed) {
-			this.notifications.info('Enrichment scan skipped');
-			return 0;
+			if (!proceed) {
+				this.notifications.info('Enrichment scan skipped');
+				return 0;
+			}
 		}
 
 		// -- Phase 3: Generate proposals (heavy, cancellable, checkpointed) --

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,9 @@ import { OrganizeModule } from './organize';
 import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
 import { RemModule } from './rem';
-import { NotificationManager, CheckpointManager, removeNotificationStyles } from './shared';
+import { SynapseRunner } from './pipeline';
+import type { PipelineModuleMap } from './pipeline';
+import { FolderPickerModal, NotificationManager, CheckpointManager, removeNotificationStyles } from './shared';
 import type { DeferredTask, Checkpoint } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
@@ -282,6 +284,30 @@ export default class SynapsePlugin extends Plugin {
 				},
 			});
 		}
+
+		// Fire Synapse: run all enabled features on a directory
+		const moduleMap: PipelineModuleMap = {
+			elaboration: (fp, sc) => this.elaboration.scanVault(fp, sc),
+			summarize: (fp, sc) => this.summarize.scanVault(fp, sc),
+			enrichment: (fp, sc) => this.enrichment.scanVault(fp, sc),
+			rem: (fp) => this.rem.remScanDirectory(fp),
+			tidy: (fp, sc) => this.tidy.scanVault(fp, sc),
+			organize: (fp, sc) => this.organize.scanDirectory(fp, sc),
+		};
+		const synapseRunner = new SynapseRunner(moduleMap, getSettings, this.notifications);
+
+		this.addCommand({
+			id: 'synapse:fire',
+			name: 'Fire Synapse: run all features on a directory',
+			callback: () => {
+				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
+				new FolderPickerModal(
+					this.app,
+					(folder) => synapseRunner.fire(folder.isRoot() ? undefined : folder.path),
+					defaultPath,
+				).open();
+			},
+		});
 	}
 
 	onunload(): void {

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -215,7 +215,7 @@ export class OrganizeModule {
 	 * 2. User confirmation
 	 * 3. Analyze and organize each file (cancellable)
 	 */
-	async scanDirectory(folderPath?: string): Promise<number> {
+	async scanDirectory(folderPath?: string, skipConfirmation = false): Promise<number> {
 		// Phase 1: Collect eligible files
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(
@@ -245,15 +245,17 @@ export class OrganizeModule {
 			return 0;
 		}
 
-		// Phase 2: User confirmation
-		const proceed = await this.notifications.confirm(
-			`Found ${eligible.length} note${eligible.length === 1 ? '' : 's'} to analyze. Organize?`,
-			{ proceedLabel: 'Organize', cancelLabel: 'Skip' }
-		);
+		// Phase 2: User confirmation (skipped when called from Fire Synapse)
+		if (!skipConfirmation) {
+			const proceed = await this.notifications.confirm(
+				`Found ${eligible.length} note${eligible.length === 1 ? '' : 's'} to analyze. Organize?`,
+				{ proceedLabel: 'Organize', cancelLabel: 'Skip' }
+			);
 
-		if (!proceed) {
-			this.notifications.info('Organization scan skipped');
-			return 0;
+			if (!proceed) {
+				this.notifications.info('Organization scan skipped');
+				return 0;
+			}
 		}
 
 		// Phase 3: Analyze and organize (checkpointed)

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,0 +1,8 @@
+export { SynapseRunner } from './synapse-runner';
+export { SYNAPSE_PIPELINE } from './types';
+export type {
+	PipelineModuleKey,
+	PipelineModuleMap,
+	PipelinePhase,
+	PipelineScanFn,
+} from './types';

--- a/src/pipeline/synapse-runner.test.ts
+++ b/src/pipeline/synapse-runner.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SynapseRunner } from './synapse-runner';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { PipelineModuleMap } from './types';
+
+function createMockNotifications() {
+	const handle = {
+		update: vi.fn(),
+		progress: vi.fn(),
+		finish: vi.fn(),
+		error: vi.fn(),
+		cancelled: false,
+	};
+	return {
+		startOperation: vi.fn().mockReturnValue(handle),
+		info: vi.fn(),
+		success: vi.fn(),
+		notifyError: vi.fn(),
+		_handle: handle,
+	};
+}
+
+function createMockModules(): PipelineModuleMap {
+	return {
+		elaboration: vi.fn().mockResolvedValue(3),
+		summarize: vi.fn().mockResolvedValue(undefined),
+		enrichment: vi.fn().mockResolvedValue(5),
+		rem: vi.fn().mockResolvedValue(2),
+		tidy: vi.fn().mockResolvedValue(4),
+		organize: vi.fn().mockResolvedValue(1),
+	};
+}
+
+describe('SynapseRunner', () => {
+	let runner: SynapseRunner;
+	let mockModules: PipelineModuleMap;
+	let mockNotifications: ReturnType<typeof createMockNotifications>;
+	let settings: typeof DEFAULT_SETTINGS;
+
+	beforeEach(() => {
+		settings = structuredClone(DEFAULT_SETTINGS);
+		settings.elaboration.enabled = true;
+		settings.summarize.enabled = true;
+		settings.enrichment.enabled = true;
+		settings.rem.enabled = true;
+		settings.tidy.enabled = true;
+		settings.organize.enabled = true;
+
+		mockModules = createMockModules();
+		mockNotifications = createMockNotifications();
+
+		runner = new SynapseRunner(
+			mockModules,
+			() => settings,
+			mockNotifications as any,
+		);
+	});
+
+	it('runs all enabled phases in correct order', async () => {
+		const callOrder: string[] = [];
+		(mockModules.elaboration as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			callOrder.push('elaboration');
+			return Promise.resolve(0);
+		});
+		(mockModules.summarize as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			callOrder.push('summarize');
+			return Promise.resolve();
+		});
+		(mockModules.enrichment as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			callOrder.push('enrichment');
+			return Promise.resolve(0);
+		});
+		(mockModules.rem as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			callOrder.push('rem');
+			return Promise.resolve(0);
+		});
+		(mockModules.tidy as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			callOrder.push('tidy');
+			return Promise.resolve(0);
+		});
+		(mockModules.organize as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			callOrder.push('organize');
+			return Promise.resolve(0);
+		});
+
+		await runner.fire('/test/folder');
+
+		expect(callOrder).toEqual([
+			'elaboration',
+			'summarize',
+			'enrichment',
+			'rem',
+			'tidy',
+			'organize',
+		]);
+	});
+
+	it('skips disabled modules', async () => {
+		settings.summarize.enabled = false;
+		settings.rem.enabled = false;
+		settings.tidy.enabled = false;
+
+		await runner.fire();
+
+		expect(mockModules.elaboration).toHaveBeenCalled();
+		expect(mockModules.summarize).not.toHaveBeenCalled();
+		expect(mockModules.enrichment).toHaveBeenCalled();
+		expect(mockModules.rem).not.toHaveBeenCalled();
+		expect(mockModules.tidy).not.toHaveBeenCalled();
+		expect(mockModules.organize).toHaveBeenCalled();
+	});
+
+	it('handles zero enabled modules', async () => {
+		settings.elaboration.enabled = false;
+		settings.summarize.enabled = false;
+		settings.enrichment.enabled = false;
+		settings.rem.enabled = false;
+		settings.tidy.enabled = false;
+		settings.organize.enabled = false;
+
+		await runner.fire();
+
+		expect(mockNotifications.info).toHaveBeenCalledWith('No features are enabled');
+		expect(mockNotifications.startOperation).not.toHaveBeenCalled();
+	});
+
+	it('passes folderPath to each module', async () => {
+		await runner.fire('/my/folder');
+
+		expect(mockModules.elaboration).toHaveBeenCalledWith('/my/folder', true);
+		expect(mockModules.summarize).toHaveBeenCalledWith('/my/folder', true);
+		expect(mockModules.enrichment).toHaveBeenCalledWith('/my/folder', true);
+		expect(mockModules.rem).toHaveBeenCalledWith('/my/folder', true);
+		expect(mockModules.tidy).toHaveBeenCalledWith('/my/folder', true);
+		expect(mockModules.organize).toHaveBeenCalledWith('/my/folder', true);
+	});
+
+	it('passes skipConfirmation=true to each module', async () => {
+		await runner.fire();
+
+		for (const key of Object.keys(mockModules) as (keyof PipelineModuleMap)[]) {
+			expect(mockModules[key]).toHaveBeenCalledWith(undefined, true);
+		}
+	});
+
+	it('pipeline cancellation stops at next phase boundary', async () => {
+		let phaseCount = 0;
+		(mockModules.elaboration as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			phaseCount++;
+			return Promise.resolve(0);
+		});
+		(mockModules.summarize as ReturnType<typeof vi.fn>).mockImplementation(() => {
+			phaseCount++;
+			// Simulate cancellation after summarize completes
+			mockNotifications._handle.cancelled = true;
+			return Promise.resolve();
+		});
+
+		await runner.fire();
+
+		expect(phaseCount).toBe(2);
+		expect(mockModules.enrichment).not.toHaveBeenCalled();
+		expect(mockModules.rem).not.toHaveBeenCalled();
+		expect(mockModules.tidy).not.toHaveBeenCalled();
+		expect(mockModules.organize).not.toHaveBeenCalled();
+		// Should not call finish when cancelled
+		expect(mockNotifications._handle.finish).not.toHaveBeenCalled();
+	});
+
+	it('phase error does not abort pipeline', async () => {
+		(mockModules.enrichment as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error('Enrichment exploded'),
+		);
+
+		await runner.fire();
+
+		// Phases after the error still run
+		expect(mockModules.rem).toHaveBeenCalled();
+		expect(mockModules.tidy).toHaveBeenCalled();
+		expect(mockModules.organize).toHaveBeenCalled();
+		expect(mockNotifications._handle.finish).toHaveBeenCalledWith(
+			expect.stringContaining('6 phases run'),
+		);
+	});
+
+	it('progress reporting shows correct phase counts', async () => {
+		settings.summarize.enabled = false;
+		settings.rem.enabled = false;
+
+		await runner.fire();
+
+		// 4 enabled phases: elaboration, enrichment, tidy, organize
+		expect(mockNotifications._handle.progress).toHaveBeenCalledWith(
+			1, 4, 'Phase 1/4: Elaboration',
+		);
+		expect(mockNotifications._handle.progress).toHaveBeenCalledWith(
+			2, 4, 'Phase 2/4: Enrichment',
+		);
+		expect(mockNotifications._handle.progress).toHaveBeenCalledWith(
+			3, 4, 'Phase 3/4: Tidy',
+		);
+		expect(mockNotifications._handle.progress).toHaveBeenCalledWith(
+			4, 4, 'Phase 4/4: Organize',
+		);
+		expect(mockNotifications._handle.finish).toHaveBeenCalledWith(
+			'Fire Synapse complete — 4 phases run',
+		);
+	});
+});

--- a/src/pipeline/synapse-runner.ts
+++ b/src/pipeline/synapse-runner.ts
@@ -1,0 +1,52 @@
+import type { NotificationManager } from '../shared';
+import type { SynapseSettings } from '../settings';
+import { SYNAPSE_PIPELINE, PipelineModuleMap } from './types';
+
+export class SynapseRunner {
+	constructor(
+		private modules: PipelineModuleMap,
+		private getSettings: () => SynapseSettings,
+		private notifications: NotificationManager,
+	) {}
+
+	async fire(folderPath?: string): Promise<void> {
+		const settings = this.getSettings();
+		const activePhases = SYNAPSE_PIPELINE.filter(phase => {
+			const section = settings[phase.key] as { enabled: boolean };
+			return section.enabled;
+		});
+
+		if (activePhases.length === 0) {
+			this.notifications.info('No features are enabled');
+			return;
+		}
+
+		const op = this.notifications.startOperation(
+			`Fire Synapse (0/${activePhases.length})`,
+			'synapse-fire',
+		);
+
+		let completed = 0;
+		for (const phase of activePhases) {
+			if (op.cancelled) break;
+
+			completed++;
+			op.progress(
+				completed,
+				activePhases.length,
+				`Phase ${completed}/${activePhases.length}: ${phase.label}`,
+			);
+
+			try {
+				await this.modules[phase.key](folderPath, true);
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				console.warn(`[Synapse] Phase ${phase.label} failed: ${msg}`);
+			}
+		}
+
+		if (!op.cancelled) {
+			op.finish(`Fire Synapse complete — ${completed} phases run`);
+		}
+	}
+}

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Scan function contract that each pipeline module must satisfy.
+ * folderPath scopes the scan; skipConfirmation bypasses the
+ * user-confirmation dialog (always true when called from Fire Synapse).
+ */
+export type PipelineScanFn = (
+	folderPath?: string,
+	skipConfirmation?: boolean,
+) => Promise<number | void>;
+
+export type PipelineModuleKey =
+	| 'elaboration'
+	| 'summarize'
+	| 'enrichment'
+	| 'rem'
+	| 'tidy'
+	| 'organize';
+
+export interface PipelinePhase {
+	key: PipelineModuleKey;
+	label: string;
+}
+
+export type PipelineModuleMap = Record<PipelineModuleKey, PipelineScanFn>;
+
+/**
+ * Ordered pipeline phases for Fire Synapse.
+ * Elaboration → Summarize → Enrichment → REM → Tidy → Organize
+ */
+export const SYNAPSE_PIPELINE: PipelinePhase[] = [
+	{ key: 'elaboration', label: 'Elaboration' },
+	{ key: 'summarize', label: 'Summarize' },
+	{ key: 'enrichment', label: 'Enrichment' },
+	{ key: 'rem', label: 'REM' },
+	{ key: 'tidy', label: 'Tidy' },
+	{ key: 'organize', label: 'Organize' },
+];

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -513,7 +513,7 @@ export class SummarizeModule {
 		return `${folderPrefix}${safeName}.md`;
 	}
 
-	private async scanVault(folderPath?: string): Promise<void> {
+	async scanVault(folderPath?: string, skipConfirmation = false): Promise<void> {
 		const settings = this.getSettings().summarize;
 
 		// Phase 1: Scan for files with targets
@@ -555,15 +555,17 @@ export class SummarizeModule {
 			return;
 		}
 
-		// Phase 2: Confirm with user
-		const proceed = await this.notifications.confirm(
-			`Found ${totalTargets} item(s) to summarize across ${filesWithTargets.length} note(s). Proceed?`,
-			{ proceedLabel: 'Summarize', cancelLabel: 'Cancel' }
-		);
+		// Phase 2: Confirm with user (skipped when called from Fire Synapse)
+		if (!skipConfirmation) {
+			const proceed = await this.notifications.confirm(
+				`Found ${totalTargets} item(s) to summarize across ${filesWithTargets.length} note(s). Proceed?`,
+				{ proceedLabel: 'Summarize', cancelLabel: 'Cancel' }
+			);
 
-		if (!proceed) {
-			this.notifications.info('Vault summarization cancelled');
-			return;
+			if (!proceed) {
+				this.notifications.info('Vault summarization cancelled');
+				return;
+			}
 		}
 
 		// Phase 3: Process files (checkpointed)

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, NotificationManager, parseFrontmatter, sanitizeAIResponse, stripCodeFences, serializeFrontmatter, withRetry, generateId } from '../shared';
+import { AIClient, NotificationManager, getMarkdownFiles, parseFrontmatter, sanitizeAIResponse, stripCodeFences, serializeFrontmatter, withRetry, generateId } from '../shared';
 import { TidyStore } from './tidy-store';
 import { TidySnapshot } from './types';
 
@@ -66,6 +66,50 @@ export class TidyModule {
 	}
 
 	onunload(): void {}
+
+	async scanVault(folderPath?: string, skipConfirmation = false): Promise<number> {
+		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+
+		if (allFiles.length === 0) {
+			return 0;
+		}
+
+		if (!skipConfirmation) {
+			const proceed = await this.notifications.confirm(
+				`Found ${allFiles.length} note${allFiles.length === 1 ? '' : 's'} to tidy. Proceed?`,
+				{ proceedLabel: 'Tidy', cancelLabel: 'Cancel' }
+			);
+			if (!proceed) {
+				this.notifications.info('Tidy scan skipped');
+				return 0;
+			}
+		}
+
+		const op = this.notifications.startOperation(
+			'Tidying notes',
+			'tidy-vault'
+		);
+
+		let tidied = 0;
+		for (let i = 0; i < allFiles.length; i++) {
+			if (op.cancelled) break;
+			op.progress(i + 1, allFiles.length, 'Tidying notes');
+
+			try {
+				await this.tidy(allFiles[i]);
+				tidied++;
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				console.warn(`[Synapse] Failed to tidy ${allFiles[i].path}: ${msg}`);
+			}
+		}
+
+		if (!op.cancelled) {
+			op.finish(`Tidied ${tidied} note${tidied === 1 ? '' : 's'}`);
+		}
+
+		return tidied;
+	}
 
 	async tidy(file: TFile): Promise<void> {
 		const op = this.notifications.startOperation(


### PR DESCRIPTION
## Summary

- Adds `synapse:fire` command that runs all enabled feature modules in dependency order (Elaboration → Summarize → Enrichment → REM → Tidy → Organize) against a user-chosen folder
- New `src/pipeline/` module with `SynapseRunner` orchestrator, pipeline types, and 8 unit tests
- Adds `skipConfirmation` parameter to elaboration, summarize, enrichment, and organize scan methods so Fire Synapse bypasses per-module confirmation dialogs
- Adds batch `scanVault()` to `TidyModule` and makes `SummarizeModule.scanVault` public
- Pipeline-level cancellation between phases; per-phase error isolation (one failure doesn't abort the rest)

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — type check passes
- [x] `npm test` — 773 tests pass (including 8 new pipeline tests)
- [x] `node esbuild.config.mjs production` — production build succeeds
- [ ] Manual: Cmd+P → "Fire Synapse" → pick folder → verify phases run in order with progress
- [ ] Manual: Disable some modules in settings → verify skipped phases
- [ ] Manual: Cancel mid-pipeline → verify it stops at next phase boundary

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)