### PR TITLE
feat: add central command registry (source of truth + master control)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-05
 ---
 
 # Synapse — Agent Reference
@@ -26,6 +26,7 @@ Output: `main.js` (single bundle, Obsidian loads this)
 | main | `src/main.ts` | Plugin entry, module orchestration, command/view registration, checkpoint dispatch | `SynapsePlugin` (default) |
 | settings | `src/settings.ts` | Settings interfaces, defaults, model options | `SynapseSettings`, `DEFAULT_SETTINGS`, `AIProvider`, `MODEL_OPTIONS` |
 | settings-tab | `src/settings-tab.ts` | Obsidian settings UI | `SynapseSettingTab` |
+| commands | `src/commands/` | Command registry: developer source of truth + master control (status/flow gating), central registrar, drift audit | `CommandRegistrar`, `COMMAND_REGISTRY`, `isInFlow`, `isPipelineKeyInFlow`, `auditCommands` |
 | elaboration | `src/elaboration/` | Stub note detection, AI proposal generation, image analysis for proposals | `ElaborationModule`, `ImageAnalyzer`, types |
 | audio | `src/audio/` | Audio transcription (Whisper, Deepgram, local), post-processing | `AudioModule`, `findAudioEmbeds`, types |
 | video | `src/video/` | Video download (YouTube/TikTok), audio extraction, transcription | `VideoModule`, `findVideoUrls`, `detectPlatform`, `isSupportedUrl`, types |
@@ -73,28 +74,35 @@ Key constraints:
 
 ## Command Registry
 
-| ID | Name | Type | Module |
-|----|------|------|--------|
-| `synapse:review-proposals` | Open proposal review sidebar | callback | main |
-| `synapse:manage-checkpoints` | Manage interrupted operations | callback | main |
-| `synapse:transcribe-media` | Transcribe media | callback | main |
-| `synapse:transcribe-note-media` | Transcribe media from current note | editorCallback | main |
-| `synapse:scan-vault` | Scan vault for stub notes | callback | elaboration |
-| `synapse:scan-current-note` | Scan current note for elaboration | editorCallback | elaboration |
-| `synapse:clear-proposals` | Clear all pending proposals | callback | elaboration |
-| `synapse:check-dependencies` | Check external tool availability | callback | video |
-| `synapse:enrich-current-note` | Enrich current note | editorCallback | enrichment |
-| `synapse:scan-vault-enrichment` | Scan vault for enrichment | callback | enrichment |
-| `synapse:undo-enrichment` | Undo last enrichment on current note | editorCallback | enrichment |
-| `synapse:summarize-current-note` | Summarize current note | editorCallback | summarize |
-| `synapse:scan-vault-summarize` | Scan vault for notes to summarize | callback | summarize |
-| `synapse:tidy-current-note` | Tidy current note | editorCallback | tidy |
-| `synapse:undo-tidy` | Undo last tidy on current note | editorCallback | tidy |
-| `synapse:organize-current-note` | Organize current note | editorCallback | organize |
-| `synapse:scan-directory-organize` | Scan directory for organization | callback | organize |
-| `synapse:undo-organize` | Undo last organize on current note | editorCallback | organize |
-| `synapse:deep-dive` | Deep dive into current note | editorCallback | deep-dive |
-| `synapse:clear-deep-dive` | Clear deep dive proposals | callback | deep-dive |
+Source of truth: `src/commands/registry.ts` (mirrored here). 23 user-invocable commands, all `active` on first ship. Flows: `p`=palette, `f`=fire-synapse, `s`=startup. Full detail in `docs/agent/command-registry.md`.
+
+| ID | Name | Type | Module | Flows | Status |
+|----|------|------|--------|-------|--------|
+| `synapse:review-proposals` | Open proposal review sidebar | callback | main | p | active |
+| `synapse:manage-checkpoints` | Manage interrupted operations | callback | main | p | active |
+| `synapse:transcribe-media` | Transcribe media | callback | main | p | active |
+| `synapse:transcribe-note-media` | Transcribe media from current note | editorCallback | main | p | active |
+| `synapse:fire` | Fire Synapse: run all features on a directory | callback | main | p | active |
+| `synapse:scan-vault` | Scan vault for stub notes | callback | elaboration | p, f, s | active |
+| `synapse:scan-current-note` | Scan current note for elaboration | editorCallback | elaboration | p | active |
+| `synapse:clear-proposals` | Clear all pending proposals | callback | elaboration | p | active |
+| `synapse:enrich-current-note` | Enrich current note | editorCallback | enrichment | p | active |
+| `synapse:scan-vault-enrichment` | Scan vault for enrichment | callback | enrichment | p, f | active |
+| `synapse:undo-enrichment` | Undo last enrichment on current note | editorCallback | enrichment | p | active |
+| `synapse:organize-current-note` | Organize current note | editorCallback | organize | p | active |
+| `synapse:scan-directory-organize` | Scan directory for organization | callback | organize | p, f | active |
+| `synapse:undo-organize` | Undo last organize on current note | editorCallback | organize | p | active |
+| `synapse:deep-dive` | Deep dive into current note | editorCallback | deep-dive | p | active |
+| `synapse:clear-deep-dive` | Clear deep dive proposals | callback | deep-dive | p | active |
+| `synapse:summarize-current-note` | Summarize current note | editorCallback | summarize | p | active |
+| `synapse:scan-vault-summarize` | Scan vault for notes to summarize | callback | summarize | p, f | active |
+| `synapse:tidy-current-note` | Tidy current note | editorCallback | tidy | p | active |
+| `synapse:undo-tidy` | Undo last tidy on current note | editorCallback | tidy | p | active |
+| `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | rem | p | active |
+| `synapse:rem-directory` | REM: Discover links in directory | callback | rem | p, f | active |
+| `synapse:check-dependencies` | Check external tool availability | callback | video | p | active |
+
+Plus a synthetic pipeline-only entry `synapse:tidy-vault` (`pipelineKey: tidy`, flows `f`) that gates the tidy Fire Synapse phase independently of any palette command.
 
 ## Ribbon Icons
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,24 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-06-05: Central command registry (Issue #215)
+
+**Context**: Synapse registered 23 commands via scattered `addCommand()` calls across 9 files. The only gate was each feature's user-facing `enabled` setting — all-or-nothing per feature — and there was no single place to audit commands or to deprecate/disable one or remove it from a specific flow (palette, Fire Synapse, startup) without hunting through modules. The drift was already real: `AGENTS.md`'s command table was missing 3 of the 23 commands.
+
+**Decision**: Add a developer-facing command registry under `src/commands/` (`types.ts`, `registry.ts`, `registrar.ts`, `audit.ts`, `index.ts`) that sits *above* user settings. `COMMAND_REGISTRY` is the source of truth (id, name, feature, `status`, `flows`, optional `pipelineKey`). Modules keep handlers co-located but call `registrar.register(id, userEnabled, spec)` instead of `plugin.addCommand(...)`; the registrar registers only when `status === 'active' && flows.includes('palette') && userEnabled`. Fire Synapse (`synapse-runner.ts`) and the elaboration startup scan AND-in `isPipelineKeyInFlow`/`isInFlow`. An end-of-onload audit (also a Vitest test) flags drift in both directions. Ships behavior-preserving: all entries `active` with current flows.
+
+**Alternatives considered**:
+- Single centralized wiring file owning all `addCommand` calls (moves handlers away from their modules; loses module-local closures; bigger, riskier migration than a 1:1 call-site swap).
+- Settings-authoritative (extend per-feature settings) — rejected; this is a *developer* kill-switch that must override user settings, not another user toggle.
+- Hang `pipelineKey: 'tidy'` on the `tidy-current-note` palette command — rejected; the pipeline runs `tidy.scanVault()` (vault-wide) while that command runs `tidy()` on one note. Coupling them would let disabling the palette command silently drop tidy from Fire Synapse. Instead a synthetic, pipeline-only `tidy-vault` entry owns `pipelineKey: 'tidy'` (24 registry entries; 23 real commands).
+- Pass an explicit `loadedFeatures` set to the audit — rejected; re-creates the hand-maintained list the registry exists to kill. The audit derives "feature loaded" from the attempted set instead, which also makes the platform-gated `video` module correct for free.
+
+**Rationale**: A 1:1 call-site swap keeps the migration mechanical and low-risk while giving one authoritative control surface. `pipelineKey` is typed `string` (not `PipelineModuleKey`) so `commands/` imports nothing from `pipeline/` — `pipeline/` imports `commands/`, so a back-import would close a cycle; `registry.test.ts` cross-checks the keys against `SYNAPSE_PIPELINE` to recover the type safety. Fail-open choices (unknown id in `register`, unmapped key in `isPipelineKeyInFlow`) preserve behavior under drift and let the audit surface it rather than silently dropping a working command/phase.
+
+**Impact**: All 23 commands now flow through `CommandRegistrar`; 8 module constructors take a registrar (summarize at position 5, before its optional transcribe callbacks). Developers can deprecate/disable a command or remove it from a single flow by editing one registry entry. CI fails on registry↔handler drift. Known limitation: a fully disabled feature can't be drift-checked (its `onload()` never runs). See `docs/agent/command-registry.md`.
+
+---
+
 ## 2026-03-19: Receipt content template for OCR text extraction (Issue #200)
 
 **Context**: The OCR module extracts raw text from images, but receipt images contain structured data (store name, items, prices, totals) that benefits from a specialized extraction format rather than raw text dump.

--- a/docs/agent/command-registry.md
+++ b/docs/agent/command-registry.md
@@ -1,0 +1,152 @@
+---
+last-updated: 2026-06-05
+status: implemented
+module-path: src/commands/
+---
+
+# Command Registry
+
+Developer-facing source of truth and master control for every user-invocable command in Synapse. It sits **above** user settings as an authoritative kill-switch / deprecation / per-flow-removal layer. Modules keep their handlers co-located but register them through a central registrar gated by this registry.
+
+## Status
+
+Implemented (Issue #215). Ships behavior-preserving: every command is `active` with flows matching prior behavior, so first load is a no-op functionally.
+
+## File Structure
+
+```
+src/commands/
+  types.ts       # CommandStatus, CommandFlow, FeatureKey, CommandDefinition
+  registry.ts    # COMMAND_REGISTRY (24 entries) + derived maps + flow helpers
+  registrar.ts   # CommandRegistrar — gated register(), attempted/registered tracking
+  audit.ts       # auditCommands() — bidirectional drift detection
+  index.ts       # public barrel
+```
+
+## Types (types.ts)
+
+```ts
+type CommandStatus = 'active' | 'deprecated' | 'disabled';   // only 'active' registers/runs
+type CommandFlow   = 'palette' | 'fire-synapse' | 'startup';
+type FeatureKey =
+  | 'main' | 'elaboration' | 'enrichment' | 'organize' | 'deep-dive'
+  | 'summarize' | 'tidy' | 'rem' | 'video';
+
+interface CommandDefinition {
+  id: string;
+  name: string;
+  feature: FeatureKey;
+  status: CommandStatus;
+  flows: readonly CommandFlow[];
+  pipelineKey?: string;   // string (not PipelineModuleKey) on purpose — see Dependency Graph
+  note?: string;
+}
+```
+
+## Public API
+
+```ts
+// registry.ts
+const COMMAND_REGISTRY: readonly CommandDefinition[];
+const REGISTRY_BY_ID: ReadonlyMap<string, CommandDefinition>;
+const REGISTRY_BY_PIPELINE_KEY: ReadonlyMap<string, CommandDefinition>;   // 1:1; throws on dup
+function buildPipelineKeyMap(commands): Map<string, CommandDefinition>;   // exported for tests
+function isInFlow(id: string, flow: CommandFlow): boolean;                // active AND flows.includes(flow)
+function isPipelineKeyInFlow(pipelineKey: string, flow: CommandFlow): boolean;  // fail-open if unmapped
+
+// registrar.ts
+class CommandRegistrar {
+  constructor(host: { addCommand(c: Command): unknown });
+  register(id: string, userEnabled: boolean, spec: Omit<Command, 'id'>): void;
+  getAttempted(): ReadonlySet<string>;
+  getRegistered(): ReadonlySet<string>;
+}
+
+// audit.ts
+function auditCommands(attempted: ReadonlySet<string>): string[];   // [] when consistent
+```
+
+## Precedence
+
+All ANDed; the registry is authoritative:
+
+```
+status (dev) -> flow membership (dev) -> settings.[feature].enabled (user) -> hasTranscription (runtime)
+```
+
+`CommandRegistrar.register` calls `host.addCommand` only when
+`entry.status === 'active' && entry.flows.includes('palette') && userEnabled`.
+A `deprecated`/`disabled` entry never registers or runs in any flow, regardless of user settings.
+
+## Registry (24 entries)
+
+23 real palette commands + 1 synthetic pipeline-only entry (`tidy-vault`).
+
+| ID | Feature | Status | Flows | pipelineKey |
+|----|---------|--------|-------|-------------|
+| `synapse:review-proposals` | main | active | palette | — |
+| `synapse:manage-checkpoints` | main | active | palette | — |
+| `synapse:transcribe-media` | main | active | palette | — |
+| `synapse:transcribe-note-media` | main | active | palette | — |
+| `synapse:fire` | main | active | palette | — |
+| `synapse:scan-vault` | elaboration | active | palette, fire-synapse, startup | elaboration |
+| `synapse:scan-current-note` | elaboration | active | palette | — |
+| `synapse:clear-proposals` | elaboration | active | palette | — |
+| `synapse:enrich-current-note` | enrichment | active | palette | — |
+| `synapse:scan-vault-enrichment` | enrichment | active | palette, fire-synapse | enrichment |
+| `synapse:undo-enrichment` | enrichment | active | palette | — |
+| `synapse:organize-current-note` | organize | active | palette | — |
+| `synapse:scan-directory-organize` | organize | active | palette, fire-synapse | organize |
+| `synapse:undo-organize` | organize | active | palette | — |
+| `synapse:deep-dive` | deep-dive | active | palette | — |
+| `synapse:clear-deep-dive` | deep-dive | active | palette | — |
+| `synapse:summarize-current-note` | summarize | active | palette | — |
+| `synapse:scan-vault-summarize` | summarize | active | palette, fire-synapse | summarize |
+| `synapse:tidy-current-note` | tidy | active | palette | — |
+| `synapse:undo-tidy` | tidy | active | palette | — |
+| `synapse:rem-current-note` | rem | active | palette | — |
+| `synapse:rem-directory` | rem | active | palette, fire-synapse | rem |
+| `synapse:check-dependencies` | video | active | palette | — |
+| `synapse:tidy-vault` *(synthetic)* | tidy | active | fire-synapse | tidy |
+
+**Why the synthetic `tidy-vault` entry:** tidy is the only Fire Synapse phase with no matching palette command. The pipeline runs `tidy.scanVault()` (vault-wide); the `tidy-current-note` palette command runs `tidy()` on one note — a different operation. Giving the pipeline phase its own entry lets it be controlled independently of the palette command. It is never passed to `registrar.register()`, and the audit ignores it (no `palette` flow).
+
+## Flow integration
+
+- **palette** — `CommandRegistrar.register` gates `addCommand`. All 23 real commands participate.
+- **fire-synapse** — `SynapseRunner.fire()` (`src/pipeline/synapse-runner.ts`) ANDs `isPipelineKeyInFlow(phase.key, 'fire-synapse')` into its `settings[phase.key].enabled` filter. Matched via `pipelineKey` (the 6 pipeline entries).
+- **startup** — `ElaborationModule.onload()` (`src/elaboration/index.ts`) ANDs `isInFlow('synapse:scan-vault', 'startup')` into both the `scanOnStartup` and `autoScanInterval` conditions.
+
+## Drift detection (audit.ts)
+
+Run once at the end of `SynapsePlugin.onload()`; reused by `audit.test.ts` so CI fails on drift.
+
+- **(a)** an `active` palette entry whose feature loaded but was never registered → "no handler".
+- **(b)** a registered id with no `COMMAND_REGISTRY` entry → "missing from registry".
+
+"Feature loaded" is derived from the attempted set (a module's `onload()` is the only caller of `register()` for its commands, and runs iff the feature is enabled). This makes the platform-gated `video` module correct for free.
+
+**Known limitation:** a fully disabled feature (its `onload()` never runs) produces zero attempts and cannot be drift-checked — its handlers never got a chance to register.
+
+## Dependency Graph
+
+```
+src/commands/  (depends on nothing else in src/ — never in an import cycle)
+  index.ts -> types.ts, registry.ts, registrar.ts, audit.ts
+  registrar.ts -> registry.ts (REGISTRY_BY_ID), obsidian (Command type)
+  audit.ts -> registry.ts
+
+consumed by:
+  main.ts                       -> CommandRegistrar, auditCommands
+  elaboration|enrichment|organize|deep-dive|summarize|tidy|rem|video  -> CommandRegistrar (+ elaboration: isInFlow)
+  pipeline/synapse-runner.ts    -> isPipelineKeyInFlow
+```
+
+`CommandDefinition.pipelineKey` is typed `string` (not `PipelineModuleKey`) so `commands/` never imports `pipeline/` — `pipeline/synapse-runner.ts` imports `commands/`, so a back-import would close a cycle. `registry.test.ts` cross-checks the 6 `pipelineKey`s against `SYNAPSE_PIPELINE` to recover that type safety at test time.
+
+## How to change command behavior
+
+- **Deprecate / disable a command everywhere:** set `status` to `'deprecated'` or `'disabled'`.
+- **Remove from one flow only (keep the others):** drop that flow from `flows` (e.g. `['palette']` to keep it in the palette but out of Fire Synapse).
+- **Remove a phase from Fire Synapse:** edit the entry carrying that `pipelineKey` (for tidy, the synthetic `tidy-vault` entry).
+- After any edit, `npm test` runs the registry + audit tests that guard the invariants.

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Controlled registry: two elaboration palette commands, one video palette
+// command, one tidy palette command, and a synthetic pipeline-only tidy entry.
+vi.mock('./registry', () => {
+	const COMMAND_REGISTRY = [
+		{ id: 'el:1', name: 'El 1', feature: 'elaboration', status: 'active', flows: ['palette'] },
+		{ id: 'el:2', name: 'El 2', feature: 'elaboration', status: 'active', flows: ['palette'] },
+		{ id: 'vid:1', name: 'Vid 1', feature: 'video', status: 'active', flows: ['palette'] },
+		{ id: 'tidy:1', name: 'Tidy 1', feature: 'tidy', status: 'active', flows: ['palette'] },
+		{ id: 'tidy:vault', name: 'Tidy vault', feature: 'tidy', status: 'active', flows: ['fire-synapse'] },
+	];
+	return {
+		COMMAND_REGISTRY,
+		REGISTRY_BY_ID: new Map(COMMAND_REGISTRY.map(c => [c.id, c])),
+	};
+});
+
+import { auditCommands } from './audit';
+
+describe('auditCommands', () => {
+	it('warns when a loaded feature has an active palette command with no handler', () => {
+		const warnings = auditCommands(new Set(['el:1']));
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('el:2');
+		expect(warnings[0]).toContain('no handler');
+	});
+
+	it('warns when a registered id is missing from the registry', () => {
+		const warnings = auditCommands(new Set(['el:1', 'el:2', 'ghost:cmd']));
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('ghost:cmd');
+		expect(warnings[0]).toContain('missing from COMMAND_REGISTRY');
+	});
+
+	it('returns no warnings when the loaded feature is fully wired', () => {
+		expect(auditCommands(new Set(['el:1', 'el:2']))).toEqual([]);
+	});
+
+	it('never flags the synthetic pipeline-only entry (no palette flow)', () => {
+		const warnings = auditCommands(new Set(['tidy:1']));
+		expect(warnings).toEqual([]);
+		expect(warnings.some(w => w.includes('tidy:vault'))).toBe(false);
+	});
+
+	it('ignores features that never loaded (zero attempts)', () => {
+		const warnings = auditCommands(new Set(['el:1', 'el:2']));
+		expect(warnings.some(w => w.includes('vid:1'))).toBe(false);
+	});
+});

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,54 @@
+/**
+ * Drift detection between COMMAND_REGISTRY and the actually-wired handlers.
+ * Run once at the end of plugin onload() and reused by a Vitest test so CI fails
+ * on drift in either direction.
+ */
+
+import { COMMAND_REGISTRY, REGISTRY_BY_ID } from './registry';
+
+/**
+ * Returns a list of human-readable drift warnings (empty when consistent).
+ *
+ * (a) An `active` palette entry whose feature loaded but was never registered —
+ *     i.e. a registry entry with no handler behind it.
+ * (b) A registered id that has no COMMAND_REGISTRY entry — a command added in code
+ *     but missing from the registry.
+ *
+ * "Feature loaded" is derived from `attempted`: a module's onload() is the only
+ * caller of register() for its commands, and onload() runs iff the feature is
+ * enabled. So a feature is considered loaded when >=1 of its commands was
+ * attempted. This makes the check correct for the platform-gated video module for
+ * free, and needs nothing passed in from main.ts.
+ *
+ * Known, intentional limitation: a fully disabled feature (onload never runs)
+ * produces zero attempts and so cannot be drift-checked — its handlers never got
+ * a chance to register.
+ */
+export function auditCommands(attempted: ReadonlySet<string>): string[] {
+	const warnings: string[] = [];
+
+	const featuresWithAttempts = new Set(
+		[...attempted].map(id => REGISTRY_BY_ID.get(id)?.feature).filter(Boolean),
+	);
+
+	// (a) active palette entry for a loaded feature that was never registered
+	for (const entry of COMMAND_REGISTRY) {
+		if (
+			entry.status === 'active' &&
+			entry.flows.includes('palette') &&
+			featuresWithAttempts.has(entry.feature) &&
+			!attempted.has(entry.id)
+		) {
+			warnings.push(`Active command "${entry.id}" (${entry.feature}) has no handler`);
+		}
+	}
+
+	// (b) registered id missing from the registry
+	for (const id of attempted) {
+		if (!REGISTRY_BY_ID.has(id)) {
+			warnings.push(`Command "${id}" is registered but missing from COMMAND_REGISTRY`);
+		}
+	}
+
+	return warnings;
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Public surface of the command registry module.
+ *
+ * Consumers import from `../commands`:
+ *   - main.ts + all feature modules: `CommandRegistrar`
+ *   - pipeline/synapse-runner.ts: `isPipelineKeyInFlow`
+ *   - elaboration/index.ts: `isInFlow`
+ *   - main.ts (end of onload): `auditCommands`
+ *
+ * This module depends on nothing else in `src/`, so it never participates in an
+ * import cycle.
+ */
+
+export type {
+	CommandStatus,
+	CommandFlow,
+	FeatureKey,
+	CommandDefinition,
+} from './types';
+
+export {
+	COMMAND_REGISTRY,
+	REGISTRY_BY_ID,
+	REGISTRY_BY_PIPELINE_KEY,
+	isInFlow,
+	isPipelineKeyInFlow,
+} from './registry';
+
+export { CommandRegistrar } from './registrar';
+export { auditCommands } from './audit';

--- a/src/commands/registrar.test.ts
+++ b/src/commands/registrar.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the registry so we can exercise every status/flow combination
+// (the real registry ships everything active + palette).
+vi.mock('./registry', () => {
+	const entries = [
+		{ id: 'cmd:active-palette', name: 'Active', feature: 'main', status: 'active', flows: ['palette'] },
+		{ id: 'cmd:deprecated', name: 'Deprecated', feature: 'main', status: 'deprecated', flows: ['palette'] },
+		{ id: 'cmd:disabled', name: 'Disabled', feature: 'main', status: 'disabled', flows: ['palette'] },
+		{ id: 'cmd:no-palette', name: 'Pipeline only', feature: 'main', status: 'active', flows: ['fire-synapse'] },
+	];
+	return { REGISTRY_BY_ID: new Map(entries.map(e => [e.id, e])) };
+});
+
+import { CommandRegistrar } from './registrar';
+
+describe('CommandRegistrar', () => {
+	let host: { addCommand: ReturnType<typeof vi.fn> };
+	let registrar: CommandRegistrar;
+	const spec = { name: 'X', callback: () => {} };
+
+	beforeEach(() => {
+		host = { addCommand: vi.fn() };
+		registrar = new CommandRegistrar(host as any);
+	});
+
+	it('registers an active palette command when the user has it enabled', () => {
+		registrar.register('cmd:active-palette', true, spec);
+		expect(host.addCommand).toHaveBeenCalledTimes(1);
+		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:active-palette', ...spec });
+		expect(registrar.getRegistered().has('cmd:active-palette')).toBe(true);
+	});
+
+	it('skips registration when userEnabled is false (still records the attempt)', () => {
+		registrar.register('cmd:active-palette', false, spec);
+		expect(host.addCommand).not.toHaveBeenCalled();
+		expect(registrar.getAttempted().has('cmd:active-palette')).toBe(true);
+		expect(registrar.getRegistered().has('cmd:active-palette')).toBe(false);
+	});
+
+	it('skips a deprecated command even when enabled', () => {
+		registrar.register('cmd:deprecated', true, spec);
+		expect(host.addCommand).not.toHaveBeenCalled();
+		expect(registrar.getAttempted().has('cmd:deprecated')).toBe(true);
+	});
+
+	it('skips a disabled command even when enabled', () => {
+		registrar.register('cmd:disabled', true, spec);
+		expect(host.addCommand).not.toHaveBeenCalled();
+	});
+
+	it('skips a command that is not in the palette flow', () => {
+		registrar.register('cmd:no-palette', true, spec);
+		expect(host.addCommand).not.toHaveBeenCalled();
+		expect(registrar.getAttempted().has('cmd:no-palette')).toBe(true);
+	});
+
+	it('fails open for an unknown id (registers + tracks it) so the command keeps working', () => {
+		registrar.register('cmd:unknown', true, spec);
+		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:unknown', ...spec });
+		expect(registrar.getAttempted().has('cmd:unknown')).toBe(true);
+		expect(registrar.getRegistered().has('cmd:unknown')).toBe(true);
+	});
+
+	it('does not register an unknown id when userEnabled is false', () => {
+		registrar.register('cmd:unknown', false, spec);
+		expect(host.addCommand).not.toHaveBeenCalled();
+	});
+});

--- a/src/commands/registrar.ts
+++ b/src/commands/registrar.ts
@@ -1,0 +1,57 @@
+/**
+ * CommandRegistrar — the single wiring point between feature modules and
+ * Obsidian's `addCommand`. Modules keep their handlers co-located but call
+ * `registrar.register(id, userEnabled, spec)` instead of `plugin.addCommand(...)`.
+ *
+ * A command is actually registered only when the registry says it's `active` and
+ * in the `'palette'` flow AND the user has the owning feature enabled. The
+ * registrar also tracks every attempted/registered id for drift detection (audit.ts).
+ */
+
+import type { Command } from 'obsidian';
+import { REGISTRY_BY_ID } from './registry';
+
+/** Minimal structural shape we need from the plugin — keeps tests trivial. */
+interface AddCommandHost {
+	addCommand: (command: Command) => unknown;
+}
+
+export class CommandRegistrar {
+	private readonly attempted = new Set<string>();
+	private readonly registered = new Set<string>();
+
+	constructor(private readonly host: AddCommandHost) {}
+
+	/**
+	 * Register a palette command through the registry gate.
+	 *
+	 * @param id          command id (must match a COMMAND_REGISTRY entry)
+	 * @param userEnabled user-level enablement (the feature's `enabled` flag, or a
+	 *                    runtime predicate such as `hasTranscription`)
+	 * @param spec        the rest of the Obsidian command (name + a callback)
+	 */
+	register(id: string, userEnabled: boolean, spec: Omit<Command, 'id'>): void {
+		this.attempted.add(id);
+
+		const entry = REGISTRY_BY_ID.get(id);
+		// Fail-open on an unknown id: still register it so the command keeps working,
+		// and let auditCommands() surface the missing registry entry as drift.
+		const active = entry ? entry.status === 'active' : true;
+		const inPalette = entry ? entry.flows.includes('palette') : true;
+
+		if (active && inPalette && userEnabled) {
+			this.host.addCommand({ id, ...spec });
+			this.registered.add(id);
+		}
+	}
+
+	/** Ids passed to register(), regardless of whether they were gated out. */
+	getAttempted(): ReadonlySet<string> {
+		return this.attempted;
+	}
+
+	/** Ids that passed the gate and actually called addCommand. */
+	getRegistered(): ReadonlySet<string> {
+		return this.registered;
+	}
+}

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+	COMMAND_REGISTRY,
+	REGISTRY_BY_ID,
+	REGISTRY_BY_PIPELINE_KEY,
+	buildPipelineKeyMap,
+	isInFlow,
+	isPipelineKeyInFlow,
+} from './registry';
+import { SYNAPSE_PIPELINE } from '../pipeline/types';
+import type { CommandDefinition } from './types';
+
+/** The 23 real, user-invocable command ids (excludes the synthetic pipeline entry). */
+const EXPECTED_COMMAND_IDS = [
+	'synapse:review-proposals', 'synapse:manage-checkpoints', 'synapse:transcribe-media',
+	'synapse:transcribe-note-media', 'synapse:fire',
+	'synapse:scan-vault', 'synapse:scan-current-note', 'synapse:clear-proposals',
+	'synapse:enrich-current-note', 'synapse:scan-vault-enrichment', 'synapse:undo-enrichment',
+	'synapse:organize-current-note', 'synapse:scan-directory-organize', 'synapse:undo-organize',
+	'synapse:deep-dive', 'synapse:clear-deep-dive',
+	'synapse:summarize-current-note', 'synapse:scan-vault-summarize',
+	'synapse:tidy-current-note', 'synapse:undo-tidy',
+	'synapse:rem-current-note', 'synapse:rem-directory',
+	'synapse:check-dependencies',
+];
+
+describe('COMMAND_REGISTRY', () => {
+	it('contains all 23 real commands plus the synthetic tidy-vault entry', () => {
+		expect(COMMAND_REGISTRY).toHaveLength(EXPECTED_COMMAND_IDS.length + 1);
+		for (const id of EXPECTED_COMMAND_IDS) {
+			expect(REGISTRY_BY_ID.has(id)).toBe(true);
+		}
+		expect(REGISTRY_BY_ID.has('synapse:tidy-vault')).toBe(true);
+	});
+
+	it('has no duplicate ids', () => {
+		const ids = COMMAND_REGISTRY.map(c => c.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it('ships every entry as active (behavior preserving)', () => {
+		for (const entry of COMMAND_REGISTRY) {
+			expect(entry.status).toBe('active');
+		}
+	});
+
+	it('gives every real command the palette flow', () => {
+		for (const id of EXPECTED_COMMAND_IDS) {
+			expect(REGISTRY_BY_ID.get(id)!.flows).toContain('palette');
+		}
+	});
+
+	it('keeps the synthetic tidy-vault entry out of the palette', () => {
+		const tidyVault = REGISTRY_BY_ID.get('synapse:tidy-vault')!;
+		expect(tidyVault.flows).not.toContain('palette');
+		expect(tidyVault.flows).toContain('fire-synapse');
+	});
+
+	it('marks exactly scan-vault as a startup flow command', () => {
+		const startupCommands = COMMAND_REGISTRY.filter(c => c.flows.includes('startup'));
+		expect(startupCommands.map(c => c.id)).toEqual(['synapse:scan-vault']);
+	});
+
+	it('gives every entry a non-empty name', () => {
+		for (const entry of COMMAND_REGISTRY) {
+			expect(entry.name.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe('pipeline mapping', () => {
+	it('maps exactly one registry entry per Fire Synapse phase', () => {
+		const phaseKeys = SYNAPSE_PIPELINE.map(p => p.key).sort();
+		const mappedKeys = [...REGISTRY_BY_PIPELINE_KEY.keys()].sort();
+		expect(mappedKeys).toEqual(phaseKeys);
+	});
+
+	it('points each phase at an active fire-synapse command', () => {
+		for (const phase of SYNAPSE_PIPELINE) {
+			const entry = REGISTRY_BY_PIPELINE_KEY.get(phase.key);
+			expect(entry, `no registry entry for phase ${phase.key}`).toBeDefined();
+			expect(entry!.status).toBe('active');
+			expect(entry!.flows).toContain('fire-synapse');
+		}
+	});
+
+	it('throws when two entries share a pipelineKey', () => {
+		const dupes: CommandDefinition[] = [
+			{ id: 'a', name: 'A', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy' },
+			{ id: 'b', name: 'B', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy' },
+		];
+		expect(() => buildPipelineKeyMap(dupes)).toThrow(/Duplicate pipelineKey/);
+	});
+});
+
+describe('isInFlow', () => {
+	it('is true for an active command in the requested flow', () => {
+		expect(isInFlow('synapse:scan-vault', 'palette')).toBe(true);
+		expect(isInFlow('synapse:scan-vault', 'fire-synapse')).toBe(true);
+		expect(isInFlow('synapse:scan-vault', 'startup')).toBe(true);
+	});
+
+	it('is false for a flow the command does not participate in', () => {
+		expect(isInFlow('synapse:scan-current-note', 'fire-synapse')).toBe(false);
+		expect(isInFlow('synapse:scan-current-note', 'startup')).toBe(false);
+	});
+
+	it('is false for an unknown id', () => {
+		expect(isInFlow('synapse:does-not-exist', 'palette')).toBe(false);
+	});
+});
+
+describe('isPipelineKeyInFlow', () => {
+	it('is true for every shipped pipeline phase (behavior preserving)', () => {
+		for (const phase of SYNAPSE_PIPELINE) {
+			expect(isPipelineKeyInFlow(phase.key, 'fire-synapse')).toBe(true);
+		}
+	});
+
+	it('fails open (true) for an unmapped pipeline key', () => {
+		expect(isPipelineKeyInFlow('not-a-real-phase', 'fire-synapse')).toBe(true);
+	});
+});

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,0 +1,107 @@
+/**
+ * COMMAND_REGISTRY — the single declarative source of truth for every Synapse
+ * command, plus the helpers that gate flows against it.
+ *
+ * Every entry ships `status: 'active'` with flows that preserve current behavior
+ * exactly. To deprecate/disable a command or remove it from a flow, edit the
+ * entry here — no module hunting required.
+ *
+ * Precedence (all ANDed, registry authoritative):
+ *   status (dev) -> flow membership (dev) -> settings.[feature].enabled (user) -> hasTranscription (runtime)
+ */
+
+import { CommandDefinition, CommandFlow } from './types';
+
+export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
+	// --- main (src/main.ts) ---
+	{ id: 'synapse:review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:transcribe-media', name: 'Transcribe media', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:fire', name: 'Fire Synapse: run all features on a directory', feature: 'main', status: 'active', flows: ['palette'] },
+
+	// --- elaboration (src/elaboration/index.ts) ---
+	{ id: 'synapse:scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], pipelineKey: 'elaboration' },
+	{ id: 'synapse:scan-current-note', name: 'Scan current note for elaboration', feature: 'elaboration', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:clear-proposals', name: 'Clear all pending proposals', feature: 'elaboration', status: 'active', flows: ['palette'] },
+
+	// --- enrichment (src/enrichment/index.ts) ---
+	{ id: 'synapse:enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'enrichment' },
+	{ id: 'synapse:undo-enrichment', name: 'Undo last enrichment on current note', feature: 'enrichment', status: 'active', flows: ['palette'] },
+
+	// --- organize (src/organize/index.ts) ---
+	{ id: 'synapse:organize-current-note', name: 'Organize current note', feature: 'organize', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:scan-directory-organize', name: 'Scan directory for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'organize' },
+	{ id: 'synapse:undo-organize', name: 'Undo last organize on current note', feature: 'organize', status: 'active', flows: ['palette'] },
+
+	// --- deep-dive (src/deep-dive/index.ts) ---
+	{ id: 'synapse:deep-dive', name: 'Deep dive into current note', feature: 'deep-dive', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:clear-deep-dive', name: 'Clear deep dive proposals', feature: 'deep-dive', status: 'active', flows: ['palette'] },
+
+	// --- summarize (src/summarize/index.ts) ---
+	{ id: 'synapse:summarize-current-note', name: 'Summarize current note', feature: 'summarize', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:scan-vault-summarize', name: 'Scan vault for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'summarize' },
+
+	// --- tidy (src/tidy/index.ts) ---
+	{ id: 'synapse:tidy-current-note', name: 'Tidy current note', feature: 'tidy', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:undo-tidy', name: 'Undo last tidy on current note', feature: 'tidy', status: 'active', flows: ['palette'] },
+
+	// --- rem (src/rem/index.ts) ---
+	{ id: 'synapse:rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'] },
+	{ id: 'synapse:rem-directory', name: 'REM: Discover links in directory', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'rem' },
+
+	// --- video (src/video/index.ts) ---
+	{ id: 'synapse:check-dependencies', name: 'Check external tool availability', feature: 'video', status: 'active', flows: ['palette'] },
+
+	// --- synthetic, pipeline-only ---
+	// Tidy is the only Fire Synapse phase with no matching palette command: the
+	// pipeline runs `tidy.scanVault()` (vault-wide), whereas the `tidy-current-note`
+	// palette command runs `tidy()` on a single note — a different operation. This
+	// entry carries `pipelineKey: 'tidy'` so the tidy pipeline phase is controlled
+	// independently of the palette command. It is never passed to registrar.register().
+	{ id: 'synapse:tidy-vault', name: 'Tidy vault (Fire Synapse)', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
+];
+
+/** Lookup by command id. */
+export const REGISTRY_BY_ID: ReadonlyMap<string, CommandDefinition> = new Map(
+	COMMAND_REGISTRY.map(c => [c.id, c]),
+);
+
+/**
+ * Build a 1:1 `pipelineKey -> entry` map. Throws on a duplicate `pipelineKey` so
+ * a future copy-paste can't silently shadow an earlier mapping. Exported for tests.
+ */
+export function buildPipelineKeyMap(
+	commands: readonly CommandDefinition[],
+): Map<string, CommandDefinition> {
+	const map = new Map<string, CommandDefinition>();
+	for (const cmd of commands) {
+		if (!cmd.pipelineKey) continue;
+		if (map.has(cmd.pipelineKey)) {
+			throw new Error(`[Synapse] Duplicate pipelineKey in COMMAND_REGISTRY: ${cmd.pipelineKey}`);
+		}
+		map.set(cmd.pipelineKey, cmd);
+	}
+	return map;
+}
+
+/** Lookup by pipeline phase key (1:1). */
+export const REGISTRY_BY_PIPELINE_KEY: ReadonlyMap<string, CommandDefinition> =
+	buildPipelineKeyMap(COMMAND_REGISTRY);
+
+/** True when the command exists, is `active`, and participates in `flow`. */
+export function isInFlow(id: string, flow: CommandFlow): boolean {
+	const entry = REGISTRY_BY_ID.get(id);
+	return !!entry && entry.status === 'active' && entry.flows.includes(flow);
+}
+
+/**
+ * True when the command mapped to `pipelineKey` participates in `flow`.
+ * Fail-OPEN: an unmapped key returns `true` so any future pipeline phase without
+ * a registry mapping keeps running exactly as it does today (behavior preserving).
+ */
+export function isPipelineKeyInFlow(pipelineKey: string, flow: CommandFlow): boolean {
+	const entry = REGISTRY_BY_PIPELINE_KEY.get(pipelineKey);
+	return entry ? isInFlow(entry.id, flow) : true;
+}

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Command registry types — the developer-facing source of truth for every
+ * user-invocable command in Synapse.
+ *
+ * The registry sits ABOVE user settings as an authoritative master-control /
+ * deprecation layer. See `registry.ts` for the entries and `registrar.ts` for
+ * how handlers are wired through it.
+ */
+
+/** Developer-level master switch for a command. `active` is the only state that registers/runs. */
+export type CommandStatus = 'active' | 'deprecated' | 'disabled';
+
+/** The flows a command can participate in. */
+export type CommandFlow = 'palette' | 'fire-synapse' | 'startup';
+
+/** The feature module a command belongs to (modules without commands are omitted). */
+export type FeatureKey =
+	| 'main'
+	| 'elaboration'
+	| 'enrichment'
+	| 'organize'
+	| 'deep-dive'
+	| 'summarize'
+	| 'tidy'
+	| 'rem'
+	| 'video';
+
+/** A single declarative command entry. */
+export interface CommandDefinition {
+	/** Obsidian command id, e.g. `synapse:scan-vault`. */
+	id: string;
+	/** Display name shown in the command palette. */
+	name: string;
+	/** Owning feature module. */
+	feature: FeatureKey;
+	/** Master status. Only `active` commands register and run. */
+	status: CommandStatus;
+	/** Flows this command participates in. All palette commands include `'palette'`. */
+	flows: readonly CommandFlow[];
+	/**
+	 * Links a command to a Fire Synapse pipeline phase (matches a `PipelineModuleKey`).
+	 * Typed as `string` deliberately so `src/commands/` never imports from `src/pipeline/`
+	 * (which imports back from here) — avoids a module cycle. The registry test
+	 * cross-checks these values against `SYNAPSE_PIPELINE`.
+	 */
+	pipelineKey?: string;
+	/** Free-form developer note (e.g. why an entry is pipeline-only). */
+	note?: string;
+}

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings, DeepDiveNestingMode } from '../settings';
+import { CommandRegistrar } from '../commands';
 import {
 	NotificationManager, ensureFolder, readNote, writeNote, wordCount,
 	CheckpointManager, generateId,
@@ -61,7 +62,8 @@ export class DeepDiveModule {
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar
 	) {
 		this.analyzer = new TopicAnalyzer(plugin.app, getSettings);
 		this.generator = new NoteGenerator(getSettings);
@@ -73,8 +75,7 @@ export class DeepDiveModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.plugin.addCommand({
-			id: 'synapse:deep-dive',
+		this.registrar.register('synapse:deep-dive', this.getSettings().deepDive.enabled, {
 			name: 'Deep dive into current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -83,8 +84,7 @@ export class DeepDiveModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:clear-deep-dive',
+		this.registrar.register('synapse:clear-deep-dive', this.getSettings().deepDive.enabled, {
 			name: 'Clear deep dive proposals',
 			callback: async () => {
 				await this.clearProposals();

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { CommandRegistrar, isInFlow } from '../commands';
 import {
 	buildCallout, CALLOUT_TYPES, FolderPickerModal, getMarkdownFiles,
 	NotificationManager, sanitizeAIResponse, stripCodeFences, CheckpointManager, generateId,
@@ -29,7 +30,8 @@ export class ElaborationModule {
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar
 	) {
 		this.detector = new PlaceholderDetector(plugin.app, getSettings);
 		this.proposer = new ProposalGenerator(plugin.app, getSettings);
@@ -39,8 +41,7 @@ export class ElaborationModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.plugin.addCommand({
-			id: 'synapse:scan-vault',
+		this.registrar.register('synapse:scan-vault', this.getSettings().elaboration.enabled, {
 			name: 'Scan vault for stub notes',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
@@ -52,8 +53,7 @@ export class ElaborationModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:scan-current-note',
+		this.registrar.register('synapse:scan-current-note', this.getSettings().elaboration.enabled, {
 			name: 'Scan current note for elaboration',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -62,18 +62,17 @@ export class ElaborationModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:clear-proposals',
+		this.registrar.register('synapse:clear-proposals', this.getSettings().elaboration.enabled, {
 			name: 'Clear all pending proposals',
 			callback: () => this.clearProposals(),
 		});
 
 		const settings = this.getSettings().elaboration;
-		if (settings.scanOnStartup) {
+		if (settings.scanOnStartup && isInFlow('synapse:scan-vault', 'startup')) {
 			this.startupTimeout = window.setTimeout(() => this.scanVault(), 5000);
 		}
 
-		if (settings.autoScanInterval > 0) {
+		if (settings.autoScanInterval > 0 && isInFlow('synapse:scan-vault', 'startup')) {
 			this.scanInterval = window.setInterval(
 				() => this.scanVault(),
 				settings.autoScanInterval * 60 * 1000

--- a/src/elaboration/scan-note.test.ts
+++ b/src/elaboration/scan-note.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ElaborationModule } from './index';
+import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { NotificationManager } from '../shared';
 import { mockFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
@@ -86,7 +87,8 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 			mockPlugin as any,
 			() => settings,
 			notifications,
-			createMockCheckpointManager() as any
+			createMockCheckpointManager() as any,
+			new CommandRegistrar(mockPlugin as any)
 		);
 	});
 

--- a/src/elaboration/startup-flow.test.ts
+++ b/src/elaboration/startup-flow.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Control isInFlow so we can prove the registry gates the startup auto-scan.
+const isInFlowMock = vi.hoisted(() => vi.fn());
+vi.mock('../commands', () => ({
+	isInFlow: isInFlowMock,
+	CommandRegistrar: class {
+		register = vi.fn();
+		getAttempted = () => new Set<string>();
+		getRegistered = () => new Set<string>();
+	},
+}));
+
+// Stub the heavy collaborators so onload() reduces to: register commands + timers.
+vi.mock('./proposal-store', () => ({
+	ProposalStore: class { init = vi.fn().mockResolvedValue(undefined); },
+}));
+vi.mock('./detector', () => ({ PlaceholderDetector: class {} }));
+vi.mock('./proposer', () => ({ ProposalGenerator: class {} }));
+
+import { ElaborationModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS } from '../settings';
+
+describe('ElaborationModule — startup flow gate', () => {
+	let settings: typeof DEFAULT_SETTINGS;
+	let setTimeoutFn: ReturnType<typeof vi.fn>;
+	let setIntervalFn: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		settings = structuredClone(DEFAULT_SETTINGS);
+		settings.elaboration.scanOnStartup = true;
+		settings.elaboration.autoScanInterval = 10;
+
+		setTimeoutFn = vi.fn().mockReturnValue(1);
+		setIntervalFn = vi.fn().mockReturnValue(2);
+		isInFlowMock.mockReset();
+		vi.stubGlobal('window', {
+			setTimeout: setTimeoutFn,
+			setInterval: setIntervalFn,
+			clearTimeout: vi.fn(),
+			clearInterval: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function makeModule(): ElaborationModule {
+		const plugin = { app: {} } as any;
+		return new ElaborationModule(plugin, () => settings, {} as any, {} as any, new CommandRegistrar(plugin as any));
+	}
+
+	it('schedules the startup + interval scans when scan-vault is in the startup flow', async () => {
+		isInFlowMock.mockReturnValue(true);
+		await makeModule().onload();
+		expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+		expect(setIntervalFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips both auto-scans when scan-vault is removed from the startup flow', async () => {
+		isInFlowMock.mockReturnValue(false);
+		await makeModule().onload();
+		expect(setTimeoutFn).not.toHaveBeenCalled();
+		expect(setIntervalFn).not.toHaveBeenCalled();
+		expect(isInFlowMock).toHaveBeenCalledWith('synapse:scan-vault', 'startup');
+	});
+});

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, parseFrontmatter,
 	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent,
@@ -42,7 +43,8 @@ export class EnrichmentModule {
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar
 	) {
 		this.analyzer = new VaultAnalyzer(plugin.app);
 		this.classifier = new MetadataClassifier(getSettings);
@@ -63,8 +65,7 @@ export class EnrichmentModule {
 			})
 		);
 
-		this.plugin.addCommand({
-			id: 'synapse:enrich-current-note',
+		this.registrar.register('synapse:enrich-current-note', this.getSettings().enrichment.enabled, {
 			name: 'Enrich current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -73,8 +74,7 @@ export class EnrichmentModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:scan-vault-enrichment',
+		this.registrar.register('synapse:scan-vault-enrichment', this.getSettings().enrichment.enabled, {
 			name: 'Scan vault for enrichment',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
@@ -86,8 +86,7 @@ export class EnrichmentModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:undo-enrichment',
+		this.registrar.register('synapse:undo-enrichment', this.getSettings().enrichment.enabled, {
 			name: 'Undo last enrichment on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { OrganizeModule } from './organize';
 import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
 import { RemModule } from './rem';
+import { CommandRegistrar, auditCommands } from './commands';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
 import { FolderPickerModal, NotificationManager, CheckpointManager, removeNotificationStyles } from './shared';
@@ -63,19 +64,23 @@ export default class SynapsePlugin extends Plugin {
 
 		const getSettings = () => this.settings;
 
+		// Central command registrar — the single wiring point to addCommand, gated
+		// by the command registry (developer source of truth / master control).
+		const registrar = new CommandRegistrar(this);
+
 		// Initialize modules (Audio before Video since Video depends on Audio)
 		// Pass checkpointManager to each module instead of letting them create their own
-		this.elaboration = new ElaborationModule(this, getSettings, this.notifications, this.checkpointManager);
+		this.elaboration = new ElaborationModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
 		// Create a shared AudioExtractor on desktop for clipping support
 		const audioExtractor = Platform.isDesktop ? new AudioExtractor(getSettings) : undefined;
 		this.audio = new AudioModule(this, getSettings, this.notifications, this.checkpointManager, audioExtractor);
 		if (Platform.isDesktop) {
-			this.video = new VideoModule(this, getSettings, this.audio, this.notifications, this.checkpointManager);
+			this.video = new VideoModule(this, getSettings, this.audio, this.notifications, this.checkpointManager, registrar);
 		}
 		this.image = new ImageModule(this, getSettings, this.notifications, this.checkpointManager);
-		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications, this.checkpointManager);
+		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
 		this.summarize = new SummarizeModule(
-			this, getSettings, this.notifications, this.checkpointManager,
+			this, getSettings, this.notifications, this.checkpointManager, registrar,
 			this.video
 				? (url, parentOp) => this.video!.transcribeUrl(url, parentOp)
 				: async () => { throw new Error('Video transcription is not available on mobile'); },
@@ -85,11 +90,11 @@ export default class SynapsePlugin extends Plugin {
 				return result.processed || result.raw;
 			}
 		);
-		this.tidy = new TidyModule(this, getSettings, this.notifications);
-		this.organize = new OrganizeModule(this, getSettings, this.notifications, this.checkpointManager);
-		this.deepDive = new DeepDiveModule(this, getSettings, this.notifications, this.checkpointManager);
+		this.tidy = new TidyModule(this, getSettings, this.notifications, registrar);
+		this.organize = new OrganizeModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
+		this.deepDive = new DeepDiveModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
 		this.title = new TitleModule(this, getSettings, this.notifications);
-		this.rem = new RemModule(this, getSettings, this.notifications, this.checkpointManager);
+		this.rem = new RemModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
 
 		// Register the unified proposal view
 		this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {
@@ -250,14 +255,12 @@ export default class SynapsePlugin extends Plugin {
 			});
 		}
 
-		this.addCommand({
-			id: 'synapse:review-proposals',
+		registrar.register('synapse:review-proposals', true, {
 			name: 'Open proposal review sidebar',
 			callback: () => this.activateUnifiedView(),
 		});
 
-		this.addCommand({
-			id: 'synapse:manage-checkpoints',
+		registrar.register('synapse:manage-checkpoints', true, {
 			name: 'Manage interrupted operations',
 			callback: () => this.manageCheckpoints(),
 		});
@@ -265,25 +268,22 @@ export default class SynapsePlugin extends Plugin {
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
 		this.startupTimeout = setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
 
-		// Unified transcription commands (audio on any platform, video on desktop only, image OCR)
+		// Unified transcription commands (audio on any platform, video on desktop only, image OCR).
+		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
 		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
-		if (hasTranscription) {
-			this.addCommand({
-				id: 'synapse:transcribe-media',
-				name: 'Transcribe media',
-				callback: () => this.openUnifiedModal(),
-			});
+		registrar.register('synapse:transcribe-media', !!hasTranscription, {
+			name: 'Transcribe media',
+			callback: () => this.openUnifiedModal(),
+		});
 
-			this.addCommand({
-				id: 'synapse:transcribe-note-media',
-				name: 'Transcribe media from current note',
-				editorCallback: async (_editor, ctx) => {
-					if (ctx.file) {
-						await this.transcribeMediaFromNote(ctx.file);
-					}
-				},
-			});
-		}
+		registrar.register('synapse:transcribe-note-media', !!hasTranscription, {
+			name: 'Transcribe media from current note',
+			editorCallback: async (_editor, ctx) => {
+				if (ctx.file) {
+					await this.transcribeMediaFromNote(ctx.file);
+				}
+			},
+		});
 
 		// Fire Synapse: run all enabled features on a directory
 		const moduleMap: PipelineModuleMap = {
@@ -296,8 +296,7 @@ export default class SynapsePlugin extends Plugin {
 		};
 		const synapseRunner = new SynapseRunner(moduleMap, getSettings, this.notifications);
 
-		this.addCommand({
-			id: 'synapse:fire',
+		registrar.register('synapse:fire', true, {
 			name: 'Fire Synapse: run all features on a directory',
 			callback: () => {
 				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
@@ -308,6 +307,10 @@ export default class SynapsePlugin extends Plugin {
 				).open();
 			},
 		});
+
+		// Surface command-registry drift: active entries with no handler, or
+		// registered handlers missing from the registry. Asserted by a Vitest test too.
+		auditCommands(registrar.getAttempted()).forEach(w => console.warn('[Synapse] ' + w));
 	}
 
 	onunload(): void {

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder,
 	writeNote, generateOrganizeSummary, CheckpointManager, generateId,
@@ -35,7 +36,8 @@ export class OrganizeModule {
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar
 	) {
 		this.analyzer = new ContentAnalyzer(plugin.app, getSettings);
 		this.matcher = new DirectoryMatcher(plugin.app);
@@ -45,8 +47,7 @@ export class OrganizeModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.plugin.addCommand({
-			id: 'synapse:organize-current-note',
+		this.registrar.register('synapse:organize-current-note', this.getSettings().organize.enabled, {
 			name: 'Organize current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -55,8 +56,7 @@ export class OrganizeModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:scan-directory-organize',
+		this.registrar.register('synapse:scan-directory-organize', this.getSettings().organize.enabled, {
 			name: 'Scan directory for organization',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
@@ -68,8 +68,7 @@ export class OrganizeModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:undo-organize',
+		this.registrar.register('synapse:undo-organize', this.getSettings().organize.enabled, {
 			name: 'Undo last organize on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {

--- a/src/pipeline/fire-flow-gate.test.ts
+++ b/src/pipeline/fire-flow-gate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Force isPipelineKeyInFlow to a controllable mock so we can prove the registry
+// gates the Fire Synapse pipeline. (The main synapse-runner.test.ts uses the real
+// module, where every phase is active and runs — proving behavior preservation.)
+const isPipelineKeyInFlowMock = vi.hoisted(() => vi.fn());
+vi.mock('../commands', () => ({ isPipelineKeyInFlow: isPipelineKeyInFlowMock }));
+
+import { SynapseRunner } from './synapse-runner';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { PipelineModuleMap } from './types';
+
+function createMockNotifications() {
+	const handle = { update: vi.fn(), progress: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled: false };
+	return {
+		startOperation: vi.fn().mockReturnValue(handle),
+		info: vi.fn(), success: vi.fn(), notifyError: vi.fn(),
+		_handle: handle,
+	};
+}
+
+function createMockModules(): PipelineModuleMap {
+	return {
+		elaboration: vi.fn().mockResolvedValue(0),
+		summarize: vi.fn().mockResolvedValue(undefined),
+		enrichment: vi.fn().mockResolvedValue(0),
+		rem: vi.fn().mockResolvedValue(0),
+		tidy: vi.fn().mockResolvedValue(0),
+		organize: vi.fn().mockResolvedValue(0),
+	};
+}
+
+describe('SynapseRunner — registry fire-synapse gate', () => {
+	let runner: SynapseRunner;
+	let mockModules: PipelineModuleMap;
+	let settings: typeof DEFAULT_SETTINGS;
+
+	beforeEach(() => {
+		isPipelineKeyInFlowMock.mockReset();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		for (const key of ['elaboration', 'summarize', 'enrichment', 'rem', 'tidy', 'organize'] as const) {
+			(settings[key] as { enabled: boolean }).enabled = true;
+		}
+		mockModules = createMockModules();
+		runner = new SynapseRunner(mockModules, () => settings, createMockNotifications() as any);
+	});
+
+	it('runs every enabled phase when all are in the fire-synapse flow', async () => {
+		isPipelineKeyInFlowMock.mockReturnValue(true);
+		await runner.fire();
+		for (const key of Object.keys(mockModules) as (keyof PipelineModuleMap)[]) {
+			expect(mockModules[key]).toHaveBeenCalled();
+		}
+	});
+
+	it('skips a phase whose command was removed from the fire-synapse flow', async () => {
+		// tidy removed from the flow even though settings.tidy.enabled is true
+		isPipelineKeyInFlowMock.mockImplementation((key: string) => key !== 'tidy');
+		await runner.fire();
+
+		expect(mockModules.elaboration).toHaveBeenCalled();
+		expect(mockModules.organize).toHaveBeenCalled();
+		expect(mockModules.tidy).not.toHaveBeenCalled();
+		expect(isPipelineKeyInFlowMock).toHaveBeenCalledWith('tidy', 'fire-synapse');
+	});
+});

--- a/src/pipeline/synapse-runner.ts
+++ b/src/pipeline/synapse-runner.ts
@@ -1,5 +1,6 @@
 import type { NotificationManager } from '../shared';
 import type { SynapseSettings } from '../settings';
+import { isPipelineKeyInFlow } from '../commands';
 import { SYNAPSE_PIPELINE, PipelineModuleMap } from './types';
 
 export class SynapseRunner {
@@ -13,7 +14,7 @@ export class SynapseRunner {
 		const settings = this.getSettings();
 		const activePhases = SYNAPSE_PIPELINE.filter(phase => {
 			const section = settings[phase.key] as { enabled: boolean };
-			return section.enabled;
+			return section.enabled && isPipelineKeyInFlow(phase.key, 'fire-synapse');
 		});
 
 		if (activePhases.length === 0) {

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin, TFile } from 'obsidian';
 import type { SynapseSettings } from '../settings';
+import type { CommandRegistrar } from '../commands';
 import type { NotificationManager, CheckpointManager } from '../shared';
 import type { DeferredTask, CheckpointWorkItem } from '../shared';
 import type { RemProposal, RemLinkCandidate } from './types';
@@ -28,7 +29,8 @@ export class RemModule {
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar
 	) {}
 
 	async onload(): Promise<void> {
@@ -40,8 +42,7 @@ export class RemModule {
 		await this.store.init();
 
 		// Command: scan current note
-		this.plugin.addCommand({
-			id: 'synapse:rem-current-note',
+		this.registrar.register('synapse:rem-current-note', this.getSettings().rem.enabled, {
 			name: 'REM: Discover links in current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -51,8 +52,7 @@ export class RemModule {
 		});
 
 		// Command: scan directory
-		this.plugin.addCommand({
-			id: 'synapse:rem-directory',
+		this.registrar.register('synapse:rem-directory', this.getSettings().rem.enabled, {
 			name: 'REM: Discover links in directory',
 			callback: () => {
 				new FolderPickerModal(

--- a/src/summarize/audio-summarize.test.ts
+++ b/src/summarize/audio-summarize.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SummarizeModule, TranscribeAudioFn } from './index';
+import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
@@ -121,6 +122,7 @@ describe('SummarizeModule audio target detection', () => {
 			() => settings,
 			mockNotifications as any,
 			createMockCheckpointManager() as any,
+			new CommandRegistrar(mockPlugin as any),
 			undefined,
 			transcribeAudioFn
 		);
@@ -227,6 +229,7 @@ describe('SummarizeModule audio target detection', () => {
 			() => settings,
 			mockNotifications as any,
 			createMockCheckpointManager() as any,
+			new CommandRegistrar(mockPlugin as any),
 			undefined,
 			undefined
 		);

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout,
 	CALLOUT_TYPES, CheckpointManager, generateId,
@@ -72,6 +73,7 @@ export class SummarizeModule {
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar,
 		transcribeUrl?: TranscribeUrlFn,
 		transcribeAudio?: TranscribeAudioFn
 	) {
@@ -81,8 +83,7 @@ export class SummarizeModule {
 	}
 
 	async onload(): Promise<void> {
-		this.plugin.addCommand({
-			id: 'synapse:summarize-current-note',
+		this.registrar.register('synapse:summarize-current-note', this.getSettings().summarize.enabled, {
 			name: 'Summarize current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -91,8 +92,7 @@ export class SummarizeModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:scan-vault-summarize',
+		this.registrar.register('synapse:scan-vault-summarize', this.getSettings().summarize.enabled, {
 			name: 'Scan vault for notes to summarize',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SummarizeModule } from './index';
+import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
@@ -106,7 +107,8 @@ describe('SummarizeModule organize scope', () => {
 			mockPlugin as any,
 			() => settings,
 			mockNotifications as any,
-			createMockCheckpointManager() as any
+			createMockCheckpointManager() as any,
+			new CommandRegistrar(mockPlugin as any)
 		);
 	});
 
@@ -236,7 +238,8 @@ describe('SummarizeModule content-aware templates', () => {
 			mockPlugin as any,
 			() => settings,
 			mockNotifications as any,
-			createMockCheckpointManager() as any
+			createMockCheckpointManager() as any,
+			new CommandRegistrar(mockPlugin as any)
 		);
 	});
 

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { CommandRegistrar } from '../commands';
 import { AIClient, NotificationManager, getMarkdownFiles, parseFrontmatter, sanitizeAIResponse, stripCodeFences, serializeFrontmatter, withRetry, generateId } from '../shared';
 import { TidyStore } from './tidy-store';
 import { TidySnapshot } from './types';
@@ -35,7 +36,8 @@ export class TidyModule {
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
-		private notifications: NotificationManager
+		private notifications: NotificationManager,
+		private registrar: CommandRegistrar
 	) {
 		this.aiClient = new AIClient(getSettings);
 		this.store = new TidyStore(plugin.app, getSettings);
@@ -44,8 +46,7 @@ export class TidyModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.plugin.addCommand({
-			id: 'synapse:tidy-current-note',
+		this.registrar.register('synapse:tidy-current-note', this.getSettings().tidy.enabled, {
 			name: 'Tidy current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -54,8 +55,7 @@ export class TidyModule {
 			},
 		});
 
-		this.plugin.addCommand({
-			id: 'synapse:undo-tidy',
+		this.registrar.register('synapse:undo-tidy', this.getSettings().tidy.enabled, {
 			name: 'Undo last tidy on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {

--- a/src/tidy/tidy-module.test.ts
+++ b/src/tidy/tidy-module.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TidyModule } from './index';
+import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 
@@ -68,7 +69,8 @@ describe('TidyModule', () => {
 		module = new TidyModule(
 			mockPlugin as any,
 			() => settings,
-			mockNotifications as any
+			mockNotifications as any,
+			new CommandRegistrar(mockPlugin as any)
 		);
 	});
 

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { CommandRegistrar } from '../commands';
 import { AudioModule, TranscriptionResult } from '../audio';
 import {
 	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, CALLOUT_TYPES,
@@ -36,7 +37,8 @@ export class VideoModule {
 		private getSettings: () => SynapseSettings,
 		private audioModule: AudioModule,
 		private notifications: NotificationManager,
-		private checkpointManager: CheckpointManager
+		private checkpointManager: CheckpointManager,
+		private registrar: CommandRegistrar
 	) {
 		this.extractor = new AudioExtractor(getSettings);
 	}
@@ -47,8 +49,7 @@ export class VideoModule {
 			this.getSettings().video.tempFolder
 		);
 
-		this.plugin.addCommand({
-			id: 'synapse:check-dependencies',
+		this.registrar.register('synapse:check-dependencies', this.getSettings().video.enabled, {
 			name: 'Check external tool availability',
 			callback: () => this.checkDependencies(),
 		});


### PR DESCRIPTION
## Summary

Adds a developer-facing **command registry** under `src/commands/` that sits *above* user settings as an authoritative master-control / deprecation / per-flow-removal layer over all 23 user-invocable commands. Previously commands were registered via scattered `addCommand()` calls across 9 files, gated only by per-feature user `enabled` toggles, with no single place to audit them or remove one from a specific flow.

**Ships behavior-preserving:** every command is `active` with its current flows, so first load is a functional no-op.

## What changed

- **`src/commands/`** (new): `types.ts`, `registry.ts` (24 entries — 23 commands + 1 synthetic pipeline entry), `registrar.ts`, `audit.ts`, `index.ts`.
- **Precedence** (all ANDed, registry authoritative): `status → flow membership → settings.[feature].enabled → hasTranscription`.
- **Migration:** all 8 feature modules + `main.ts` now register through a central `CommandRegistrar` (1:1 call-site swap). The 2 transcription commands drop their `if (hasTranscription)` wrapper and pass it as `userEnabled` so they're always *attempted* (visible to the audit).
- **Flow gates:** `SynapseRunner.fire()` ANDs in `isPipelineKeyInFlow(phase.key, 'fire-synapse')`; the elaboration startup scan ANDs in `isInFlow('synapse:scan-vault', 'startup')`.
- **Drift audit** at the end of `onload()` (and as a Vitest test) warns when an active palette entry has no handler, or a registered id is missing from the registry.
- **Docs:** machine-readable `docs/agent/command-registry.md`, a `DECISIONS.md` entry, and a regenerated `AGENTS.md` command table — which also **fixes pre-existing drift** (the table was missing `synapse:fire`, `synapse:rem-current-note`, `synapse:rem-directory`).

## Design note: the synthetic `tidy-vault` entry

Tidy is the only Fire Synapse phase with no matching palette command — the pipeline runs `tidy.scanVault()` (vault-wide) while the only tidy command runs `tidy()` on a single note. A synthetic, pipeline-only `tidy-vault` entry owns `pipelineKey: 'tidy'` so the tidy pipeline phase is controlled independently of the palette command (it's never registered as a command, and the audit ignores it).

To avoid a `commands ↔ pipeline` import cycle, `pipelineKey` is typed `string` (not `PipelineModuleKey`); `registry.test.ts` cross-checks the 6 keys against `SYNAPSE_PIPELINE` to recover type safety at test time.

## Testing

- New: `registry.test.ts`, `registrar.test.ts`, `audit.test.ts`, `pipeline/fire-flow-gate.test.ts`, `elaboration/startup-flow.test.ts`.
- Existing module tests updated to construct a real registrar (assertions unchanged).
- `npx tsc --noEmit --skipLibCheck` ✅ · `npm test` → **817 passing** ✅ · `node esbuild.config.mjs production` ✅

closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)