### PR TITLE
feat: auto-processing intake folder (epic #107)

### DIFF
--- a/docs/intake-folder.md
+++ b/docs/intake-folder.md
@@ -1,0 +1,122 @@
+# Intake Folder -- Frictionless Resource Capture
+
+**Date**: 2026-06-05
+**Status**: Implemented
+**Feature path**: `src/intake/`
+
+---
+
+## What the Intake Folder Does
+
+The intake folder is a single watched folder in your vault (default: `Inbox`). Drop a note into it -- a shared link, a snippet of text, or a half-formed idea -- and Synapse processes it automatically, then marks it so it is never touched again.
+
+The goal is capture without ceremony: get the thing into your vault from wherever you are (especially mobile) and let Synapse do the rest. No Shortcuts to install, no automation profiles, no custom URI scheme -- you use Obsidian's own share/create flow and Synapse watches the folder.
+
+When a markdown note appears in the intake folder (created or modified), Synapse waits briefly (~400 ms) for it to settle, then processes it exactly once.
+
+---
+
+## Capturing on Mobile (iOS & Android)
+
+Mobile capture uses **Obsidian's built-in share-to-vault** -- nothing else.
+
+1. In any app (browser, Reddit, YouTube, a notes app...), tap the system **Share** button.
+2. Choose **Obsidian** from the share sheet.
+3. Obsidian creates a note from the shared URL or text.
+4. Make sure that note lands in your **intake folder** (see below).
+
+Synapse picks it up and processes it automatically.
+
+### Getting the shared note into the intake folder
+
+The shared note only gets processed if it ends up *inside* the intake folder. Use whichever of these fits your setup:
+
+- **(a) Set a default location.** In Obsidian: **Settings → Files & Links → Default location for new notes** → point it at your intake folder (e.g. `Inbox`). Every new/shared note then lands there automatically -- the smoothest option.
+- **(b) Pick the folder in the share dialog**, where Obsidian's share UI lets you choose a destination.
+- **(c) Move the note** into the intake folder after it's created; the move is detected just like a fresh note.
+
+> Tip: Option (a) makes mobile capture truly one-tap -- Share → Obsidian, done.
+
+---
+
+## Capturing on Desktop
+
+On desktop, anything that puts a markdown note into the intake folder works:
+
+- **Drag** a link or an existing note into the intake folder in the file explorer.
+- **Create a new note** directly in the intake folder and paste a URL or some text into it.
+
+Synapse processes it the same way it processes mobile captures.
+
+---
+
+## Configuration
+
+All settings live under **Settings → Synapse → Intake Folder** (see issue #113). The default intake folder is `Inbox`; change it via the **Intake folder** setting.
+
+| Setting | Type | Default | What it does |
+|---------|------|---------|--------------|
+| **Enable intake processing** | toggle | on | Master switch. When off, the folder is not watched and nothing is auto-processed. |
+| **Intake folder** | text | `Inbox` | The folder Synapse watches. Notes here (and in its subfolders) are processed; everything else is ignored. Leaving it blank watches *nothing* -- Synapse never falls back to scanning the whole vault. |
+| **Mark processed in frontmatter** | toggle | on | Stamps `synapse-processed: true` on each note after handling so it is never reprocessed. See [Idempotency](#idempotency). |
+| **Move when done (optional)** | text | *(blank)* | Destination folder to move a note into after processing. Blank = leave it where it is. The folder is created if it doesn't exist, and inbound links are preserved on the move. |
+
+---
+
+## How Processing Works / What to Expect
+
+When a note settles in the intake folder, Synapse asks one question first: **is this note essentially just one URL?** (the classic share-to-vault case). The answer decides the route.
+
+### Bare-URL notes
+
+If the note body is essentially a single URL (the URL, modulo surrounding whitespace -- not `see <url> for details`), Synapse classifies that URL:
+
+| URL type | Examples | What Synapse does |
+|----------|----------|-------------------|
+| **Video / audio** | YouTube, TikTok, Spotify, Apple Podcasts, SoundCloud, podcast RSS feeds | **Not yet available.** Synapse shows a "coming soon" notice and leaves the note for you. See [Current limitation](#current-limitation-video--audio) below. |
+| **Article** | Medium, Substack, Wikipedia, or any other web page | Fetches the readable article content into the note, then runs **Elaboration** on the now-fleshed-out note. |
+| **Unrecognized URL** | anything `sanitizeUrl` can't accept (e.g. some parenthesized Wikipedia titles) | Treated as general content (below). |
+
+### Everything else
+
+If the note is *not* a bare URL -- shared text, a rough idea, a placeholder, prose, or multiple links -- Synapse runs the **full pipeline** on that single note:
+
+```
+Elaboration -> Summarize -> Enrichment -> REM -> Tidy -> Organize
+```
+
+Each stage only runs if that feature is **enabled in its own settings**. If you've turned a feature off, intake skips it -- intake does not override your feature toggles.
+
+### Idempotency
+
+Once a note is handled, Synapse stamps its frontmatter so it is **never reprocessed**:
+
+```yaml
+---
+synapse-processed: true
+synapse-processed-at: 2026-06-05T17:42:10.000Z
+---
+```
+
+This means edits, re-syncs, or the move itself won't trigger a second pass. The stamp is controlled by the **Mark processed in frontmatter** setting (on by default); if you turn it off, you take on responsibility for not re-triggering processing yourself. If processing *fails*, the note is left **un-stamped** on purpose so it can be retried.
+
+---
+
+## Current Limitation: Video / Audio
+
+Routing a bare video or audio URL to real transcription is **not part of this release**. For now, a video/audio link in the intake folder produces a "coming soon" notice and the note is left in place. Full URL-to-transcription routing is tracked in **#112**.
+
+Article links and general text/idea notes are fully supported today.
+
+---
+
+## Out of Scope
+
+These were considered and intentionally left out of the intake feature:
+
+- **iOS Shortcuts** -- no custom Shortcut is needed; use the system share sheet → Obsidian.
+- **Android Intents** -- same; the built-in Obsidian share target is enough.
+- **Tasker / Automate profiles** -- not required and not provided.
+- **An `obsidian://synapse` URI handler** -- there is no custom URI scheme; capture is folder-based, not URL-triggered.
+
+Mobile capture is deliberately built on Obsidian's own share-to-vault so there is nothing extra to install or maintain.

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -156,11 +156,13 @@ export class ElaborationModule {
 	 * 2. Confirmation snackbar -- user decides whether to generate proposals
 	 * 3. Heavy proposal generation with cancellation support
 	 */
-	async scanVault(folderPath?: string, skipConfirmation = false): Promise<number> {
+	async scanVault(folderPath?: string, skipConfirmation = false, onlyFile?: TFile): Promise<number> {
 		// --- Phase 1: Detection (lightweight, local-only) ---
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(scopeLabel, 'vault-scan');
-		const files = getMarkdownFiles(this.plugin.app, folderPath);
+		let files = getMarkdownFiles(this.plugin.app, folderPath);
+		// Per-file scoping (#111): narrow to the single requested note.
+		if (onlyFile) files = files.filter(f => f.path === onlyFile.path);
 		const detected: DetectionResult[] = [];
 
 		try {

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -171,7 +171,7 @@ export class EnrichmentModule {
 	 * 4. Resolve cross-note new-note candidates -- only topics referenced
 	 *    by 2+ notes become new-note link suggestions
 	 */
-	async scanVault(folderPath?: string, skipConfirmation = false): Promise<number> {
+	async scanVault(folderPath?: string, skipConfirmation = false, onlyFile?: TFile): Promise<number> {
 		// -- Phase 1: Collect eligible files & warm caches --
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(
@@ -179,7 +179,9 @@ export class EnrichmentModule {
 			'enrichment-vault-scan'
 		);
 
-		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		// Per-file scoping (#111): narrow to the single requested note.
+		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
 		const eligible: TFile[] = [];
 
 		try {

--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -1,0 +1,297 @@
+import { Plugin, TFile, normalizePath } from 'obsidian';
+import type { TAbstractFile } from 'obsidian';
+import { SynapseSettings } from '../settings';
+import {
+	NotificationManager,
+	ensureFolder,
+	fetchArticleContent,
+	parseFrontmatter,
+	serializeFrontmatter,
+} from '../shared';
+import { IntakeDispatcher } from './intake-dispatcher';
+import {
+	IntakeDeps,
+	IntakeRoute,
+	SYNAPSE_PROCESSED_AT_FLAG,
+	SYNAPSE_PROCESSED_FLAG,
+} from './types';
+
+export { IntakeDispatcher } from './intake-dispatcher';
+export type {
+	IntakeDeps,
+	IntakeRoute,
+} from './types';
+export {
+	SYNAPSE_PROCESSED_FLAG,
+	SYNAPSE_PROCESSED_AT_FLAG,
+} from './types';
+
+/** How long to wait after the last change to a path before flushing it. */
+const DEBOUNCE_MS = 400;
+
+/**
+ * IntakeModule — watches a configurable intake folder and auto-processes new
+ * notes (#111).
+ *
+ * Lifecycle mirrors the other feature modules (see src/tidy): `onload()`
+ * registers two vault listeners (create + modify) when intake is enabled;
+ * `onunload()` tears down every pending debounce timer.
+ *
+ * Per the architecture rule this module imports only `obsidian` and
+ * `src/shared/*`; all cross-module work (running the pipeline on a note,
+ * elaborating a note, future transcription) goes through the injected
+ * {@link IntakeDeps} bundle.
+ *
+ * Flow for a settled note:
+ *   create/modify event → cheap synchronous guards → per-path debounce →
+ *   flush() reads + parses the note → idempotency guard → dispatcher.route →
+ *   execute the branch → stamp `synapse-processed` (before any move) →
+ *   optional move to `moveWhenDone`.
+ */
+export class IntakeModule {
+	private readonly dispatcher = new IntakeDispatcher();
+
+	/** Paths with a pending (debounced, not-yet-flushed) change. */
+	private readonly pending = new Set<string>();
+	/** Per-path debounce timer handles, so onunload can clear them all. */
+	private readonly timers = new Map<string, number>();
+	/**
+	 * Paths currently being flushed/processed. Guards against the `modify`
+	 * echo that our own frontmatter-stamp write triggers re-entering flush.
+	 */
+	private readonly inFlight = new Set<string>();
+
+	constructor(
+		private plugin: Plugin,
+		private getSettings: () => SynapseSettings,
+		private notifications: NotificationManager,
+		private deps: IntakeDeps,
+	) {}
+
+	async onload(): Promise<void> {
+		// Only watch when enabled and an intake folder is configured. An empty
+		// folder must never fall back to watching the whole vault.
+		if (!this.getSettings().intake.enabled) {
+			return;
+		}
+
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on('create', (file) => this.handleEvent(file)),
+		);
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on('modify', (file) => this.handleEvent(file)),
+		);
+	}
+
+	onunload(): void {
+		for (const handle of this.timers.values()) {
+			window.clearTimeout(handle);
+		}
+		this.timers.clear();
+		this.pending.clear();
+		this.inFlight.clear();
+	}
+
+	/**
+	 * Cheap synchronous gatekeeper run on every vault event, before any async
+	 * work. Order is deliberately cheapest-first. Anything that passes is
+	 * debounced; everything else is ignored outright.
+	 */
+	private handleEvent(file: TAbstractFile): void {
+		if (!(file instanceof TFile) || file.extension !== 'md') {
+			return;
+		}
+
+		const settings = this.getSettings().intake;
+		if (!settings.enabled) {
+			return;
+		}
+
+		if (!this.isInIntakeFolder(file.path, settings.intakeFolder)) {
+			return;
+		}
+
+		// Suppress the self-echo from our own flag-stamp write.
+		if (this.inFlight.has(file.path)) {
+			return;
+		}
+
+		this.scheduleFlush(file.path);
+	}
+
+	/**
+	 * True when `path` lives inside the configured intake folder. Mirrors
+	 * getMarkdownFiles' membership rule (`startsWith(normalized + '/')`) so
+	 * subpaths are handled consistently. An empty/whitespace folder matches
+	 * nothing — we never watch the whole vault.
+	 */
+	private isInIntakeFolder(path: string, intakeFolder: string): boolean {
+		if (!intakeFolder || intakeFolder.trim().length === 0) {
+			return false;
+		}
+		const normalized = normalizePath(intakeFolder);
+		return path.startsWith(normalized + '/');
+	}
+
+	/**
+	 * Debounce a path: (re)start its timer so a create immediately followed by
+	 * a modify (the share-to-vault pattern) coalesces into a single flush.
+	 */
+	private scheduleFlush(path: string): void {
+		this.pending.add(path);
+
+		const existing = this.timers.get(path);
+		if (existing !== undefined) {
+			window.clearTimeout(existing);
+		}
+
+		const handle = window.setTimeout(() => {
+			this.timers.delete(path);
+			this.pending.delete(path);
+			void this.flush(path);
+		}, DEBOUNCE_MS);
+
+		this.timers.set(path, handle);
+	}
+
+	/**
+	 * Resolve, read, route, and process a single settled note. Skips silently
+	 * if the file vanished or is already processed. Errors are surfaced via a
+	 * notice and leave the note un-stamped so it can be retried.
+	 */
+	private async flush(path: string): Promise<void> {
+		const file = this.plugin.app.vault.getAbstractFileByPath(path);
+		if (!(file instanceof TFile)) {
+			return;
+		}
+
+		this.inFlight.add(path);
+		try {
+			const content = await this.plugin.app.vault.read(file);
+			const parsed = parseFrontmatter(content);
+
+			// Idempotency: never reprocess a note we've already stamped.
+			if (this.isProcessed(parsed.frontmatter)) {
+				return;
+			}
+
+			const route = this.dispatcher.route(file, parsed);
+			await this.execute(file, route);
+		} catch (error) {
+			// Do NOT stamp on failure — leave the note retriable.
+			this.notifications.notifyError(
+				`Intake processing failed for ${file.basename}`,
+				error,
+			);
+		} finally {
+			this.inFlight.delete(path);
+		}
+	}
+
+	/**
+	 * True when the note's frontmatter already carries the processed flag.
+	 * Accepts both the canonical boolean `true` and a string `'true'` so a
+	 * hand-written flag (or YAML that round-trips the value as a string) still
+	 * makes processing idempotent.
+	 */
+	private isProcessed(frontmatter: Record<string, unknown>): boolean {
+		const flag = frontmatter[SYNAPSE_PROCESSED_FLAG];
+		return flag === true || flag === 'true';
+	}
+
+	/**
+	 * Execute a resolved route, then (on success) stamp the processed flag and
+	 * optionally move the note. Throws on processing failure so flush() can
+	 * surface it and skip stamping.
+	 */
+	private async execute(
+		file: TFile,
+		route: IntakeRoute,
+	): Promise<void> {
+		switch (route.kind) {
+			case 'transcription':
+				// #112 — STUB. Surfaces a "coming soon" notice and no-ops.
+				await this.deps.transcribeUrlToNote(route.url, route.mediaType, file);
+				break;
+
+			case 'article': {
+				const articleContent = await fetchArticleContent(route.url);
+				await this.appendArticleContent(file, articleContent);
+				// Elaborate the now-fleshed-out note (single-note scope).
+				await this.deps.elaborateFile(file);
+				break;
+			}
+
+			case 'general':
+				await this.deps.fireOnFile(file);
+				break;
+		}
+
+		await this.markProcessedAndMaybeMove(file);
+	}
+
+	/**
+	 * Append fetched readable article content to the note body, preserving any
+	 * existing frontmatter via parse/serialize. Re-reads the file so we append
+	 * to its current on-disk state rather than a stale buffer.
+	 */
+	private async appendArticleContent(
+		file: TFile,
+		articleContent: string,
+	): Promise<void> {
+		if (!articleContent.trim()) {
+			return;
+		}
+
+		const current = await this.plugin.app.vault.read(file);
+		const parsed = parseFrontmatter(current);
+
+		const newBody = `${parsed.body.trimEnd()}\n\n${articleContent.trim()}\n`;
+		const updated = serializeFrontmatter(parsed.frontmatter, newBody);
+		await this.plugin.app.vault.modify(file, updated);
+	}
+
+	/**
+	 * Stamp the processed flag (when enabled) BEFORE any move, then move the
+	 * note to `moveWhenDone` (when set). Stamping first guarantees idempotency
+	 * survives the move and the move's own rename event.
+	 */
+	private async markProcessedAndMaybeMove(file: TFile): Promise<void> {
+		const settings = this.getSettings().intake;
+
+		if (settings.markProcessed) {
+			await this.stampProcessed(file);
+		}
+
+		const destination = settings.moveWhenDone;
+		if (destination && destination.trim().length > 0) {
+			await this.moveNote(file, destination.trim());
+		}
+	}
+
+	/** Write `synapse-processed: true` + an ISO timestamp into frontmatter. */
+	private async stampProcessed(file: TFile): Promise<void> {
+		const content = await this.plugin.app.vault.read(file);
+		const parsed = parseFrontmatter(content);
+		parsed.frontmatter[SYNAPSE_PROCESSED_FLAG] = true;
+		parsed.frontmatter[SYNAPSE_PROCESSED_AT_FLAG] = new Date().toISOString();
+		const stamped = serializeFrontmatter(parsed.frontmatter, parsed.body);
+		await this.plugin.app.vault.modify(file, stamped);
+	}
+
+	/**
+	 * Move the note into `destination`, creating the folder if needed and
+	 * using fileManager.renameFile so inbound links stay intact.
+	 */
+	private async moveNote(file: TFile, destination: string): Promise<void> {
+		const folder = normalizePath(destination);
+		await ensureFolder(this.plugin.app, folder);
+
+		const targetPath = normalizePath(`${folder}/${file.name}`);
+		if (targetPath === file.path) {
+			return;
+		}
+
+		await this.plugin.app.fileManager.renameFile(file, targetPath);
+	}
+}

--- a/src/intake/intake-dispatcher.test.ts
+++ b/src/intake/intake-dispatcher.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { IntakeDispatcher } from './intake-dispatcher';
+import { parseFrontmatter } from '../shared';
+import { TFile } from '../__mocks__/obsidian';
+
+/**
+ * Routing policy is pure: it depends only on the parsed body, so these tests
+ * construct a ParsedNote via parseFrontmatter and assert the IntakeRoute.
+ */
+describe('IntakeDispatcher.route', () => {
+	let dispatcher: IntakeDispatcher;
+	const file = new TFile('Inbox/capture.md') as any;
+
+	beforeEach(() => {
+		dispatcher = new IntakeDispatcher();
+	});
+
+	function routeFor(body: string) {
+		return dispatcher.route(file, parseFrontmatter(body));
+	}
+
+	describe('bare media URL → transcription', () => {
+		it('routes a lone YouTube URL to transcription with mediaType video', () => {
+			const route = routeFor('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+			expect(route).toEqual({
+				kind: 'transcription',
+				url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+				mediaType: 'video',
+			});
+		});
+
+		it('routes a lone Spotify URL to transcription with mediaType audio', () => {
+			const route = routeFor('https://open.spotify.com/episode/abc123');
+			expect(route).toEqual({
+				kind: 'transcription',
+				url: 'https://open.spotify.com/episode/abc123',
+				mediaType: 'audio',
+			});
+		});
+
+		it('treats surrounding whitespace/newlines as still bare', () => {
+			const route = routeFor('\n\n  https://www.youtube.com/watch?v=abc  \n');
+			expect(route.kind).toBe('transcription');
+		});
+	});
+
+	describe('bare article URL → article', () => {
+		it('routes a lone generic article URL to article', () => {
+			const route = routeFor('https://example.com/some-post');
+			expect(route).toEqual({
+				kind: 'article',
+				url: 'https://example.com/some-post',
+			});
+		});
+
+		it('routes a known article host (medium) to article', () => {
+			const route = routeFor('https://medium.com/@author/a-story-123');
+			expect(route).toEqual({
+				kind: 'article',
+				url: 'https://medium.com/@author/a-story-123',
+			});
+		});
+	});
+
+	describe('bare unknown URL → general', () => {
+		it('routes a lone unclassifiable URL to general', () => {
+			// A URL with shell metacharacters is rejected by sanitizeUrl, so
+			// classifyUrl returns `unknown` → general (not fetchable as article).
+			const route = routeFor('https://example.com/wiki/Obsidian_(software)');
+			expect(route.kind).toBe('general');
+		});
+	});
+
+	describe('non-bare bodies → general', () => {
+		it('routes prose with no URL to general', () => {
+			expect(routeFor('Just some plain text note.').kind).toBe('general');
+		});
+
+		it('routes a URL embedded in prose to general', () => {
+			const route = routeFor('Check out https://example.com/post for details.');
+			expect(route.kind).toBe('general');
+		});
+
+		it('routes multiple URLs to general', () => {
+			const route = routeFor(
+				'https://example.com/a\nhttps://example.com/b'
+			);
+			expect(route.kind).toBe('general');
+		});
+
+		it('routes a placeholder note to general', () => {
+			expect(routeFor('TODO: write this up later').kind).toBe('general');
+		});
+
+		it('routes an empty body to general', () => {
+			expect(routeFor('').kind).toBe('general');
+		});
+	});
+
+	describe('frontmatter does not affect bare-URL detection', () => {
+		it('treats a note whose body is just a URL as bare even with frontmatter', () => {
+			const content = '---\ntitle: Capture\n---\nhttps://example.com/post';
+			const route = dispatcher.route(file, parseFrontmatter(content));
+			expect(route).toEqual({
+				kind: 'article',
+				url: 'https://example.com/post',
+			});
+		});
+	});
+});

--- a/src/intake/intake-dispatcher.ts
+++ b/src/intake/intake-dispatcher.ts
@@ -1,0 +1,68 @@
+import type { TFile } from 'obsidian';
+import type { ParsedNote } from '../shared';
+import { classifyUrl, extractUrls } from '../shared';
+import type { IntakeRoute } from './types';
+
+/**
+ * Pure routing for the intake monitor: given a note plus its parsed
+ * frontmatter/body, decide which processing branch applies and return a
+ * typed {@link IntakeRoute}. No Obsidian writes happen here, so the policy is
+ * unit-testable in isolation.
+ *
+ * The central question is "is this note essentially just one URL?" (the
+ * share-to-vault / quick-capture case). If so, the URL is classified and
+ * routed to transcription (video/audio) or article fetching; an `unknown`
+ * URL, prose, multiple URLs, or plain text all fall through to the general
+ * pipeline.
+ */
+export class IntakeDispatcher {
+	/**
+	 * Determine the route for a parsed intake note.
+	 *
+	 * `file` is currently only used for symmetry with the processor and future
+	 * path-based heuristics; routing decisions are made entirely from `parsed`.
+	 */
+	route(file: TFile, parsed: ParsedNote): IntakeRoute {
+		void file;
+
+		const url = this.bareUrl(parsed.body);
+		if (url === null) {
+			return { kind: 'general' };
+		}
+
+		const classification = classifyUrl(url);
+		switch (classification.type) {
+			case 'video':
+			case 'audio':
+				return { kind: 'transcription', url, mediaType: classification.type };
+			case 'article':
+				return { kind: 'article', url };
+			case 'unknown':
+			default:
+				// A lone URL we can't classify (e.g. rejected by sanitizeUrl) is
+				// not fetchable as an article, so treat the note as general prose.
+				return { kind: 'general' };
+		}
+	}
+
+	/**
+	 * Return the single URL when the body is "essentially just one URL":
+	 * exactly one URL is present AND, once that URL is removed, only
+	 * whitespace remains (i.e. the body IS the URL modulo trailing/leading
+	 * whitespace). Returns null otherwise — including when there are zero or
+	 * multiple URLs, or the URL is surrounded by other prose.
+	 */
+	private bareUrl(body: string): string | null {
+		const urls = extractUrls(body);
+		if (urls.length !== 1) {
+			return null;
+		}
+
+		const url = urls[0];
+		// Strip the first occurrence of the URL and require the remainder to be
+		// blank. This rejects "see <url> for details" while accepting a body
+		// that is just the URL (possibly with surrounding whitespace/newlines).
+		const remainder = body.replace(url, '').trim();
+		return remainder.length === 0 ? url : null;
+	}
+}

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IntakeModule } from './index';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile, TFolder } from '../__mocks__/obsidian';
+
+// Mock only the article fetcher from shared; everything else (parseFrontmatter,
+// serializeFrontmatter, ensureFolder, classifyUrl, extractUrls) uses the real
+// implementation so routing + frontmatter behaviour is exercised end-to-end.
+vi.mock('../shared', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../shared')>();
+	return {
+		...actual,
+		fetchArticleContent: vi.fn().mockResolvedValue('FETCHED ARTICLE BODY'),
+	};
+});
+
+import { fetchArticleContent } from '../shared';
+
+const DEBOUNCE_MS = 400;
+
+function createMockNotifications() {
+	return {
+		startOperation: vi.fn().mockReturnValue({
+			update: vi.fn(),
+			progress: vi.fn(),
+			finish: vi.fn(),
+			error: vi.fn(),
+			cancelled: false,
+		}),
+		info: vi.fn(),
+		success: vi.fn(),
+		notifyError: vi.fn(),
+	};
+}
+
+/**
+ * Build a TFile whose `.parent` is a real TFolder, mirroring how Obsidian
+ * populates events. extension/name/basename are derived by the mock TFile ctor.
+ */
+function makeFile(path: string): TFile {
+	const file = new TFile(path);
+	const slash = path.lastIndexOf('/');
+	if (slash >= 0) {
+		file.parent = new TFolder(path.slice(0, slash));
+	}
+	return file;
+}
+
+describe('IntakeModule', () => {
+	let module: IntakeModule;
+	let plugin: any;
+	let notifications: ReturnType<typeof createMockNotifications>;
+	let settings: SynapseSettings;
+	let deps: {
+		fireOnFile: ReturnType<typeof vi.fn>;
+		elaborateFile: ReturnType<typeof vi.fn>;
+		transcribeUrlToNote: ReturnType<typeof vi.fn>;
+	};
+	/** Captured vault event handlers, keyed by event name. */
+	let handlers: Record<string, (file: any) => void>;
+	/** In-memory file content, keyed by path. */
+	let store: Map<string, string>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-05T12:00:00.000Z'));
+		// The module uses window.setTimeout (Obsidian/Electron idiom, matching
+		// elaboration). Under the node test env there is no window, so point it
+		// at globalThis whose timers vitest's fake timers control.
+		vi.stubGlobal('window', globalThis);
+
+		settings = structuredClone(DEFAULT_SETTINGS);
+		settings.intake.enabled = true;
+		settings.intake.intakeFolder = 'Inbox';
+		settings.intake.markProcessed = true;
+		settings.intake.moveWhenDone = '';
+
+		handlers = {};
+		store = new Map();
+
+		const vault = {
+			on: vi.fn((event: string, cb: (file: any) => void) => {
+				handlers[event] = cb;
+				return { event };
+			}),
+			read: vi.fn(async (file: any) => store.get(file.path) ?? ''),
+			modify: vi.fn(async (file: any, content: string) => {
+				store.set(file.path, content);
+			}),
+			create: vi.fn(),
+			createFolder: vi.fn().mockResolvedValue(undefined),
+			getAbstractFileByPath: vi.fn((path: string) => {
+				if (store.has(path)) return makeFile(path);
+				return null;
+			}),
+		};
+
+		const fileManager = {
+			renameFile: vi.fn(async (file: any, newPath: string) => {
+				const content = store.get(file.path);
+				store.delete(file.path);
+				if (content !== undefined) store.set(newPath, content);
+				file.path = newPath;
+			}),
+		};
+
+		plugin = {
+			app: { vault, fileManager },
+			registerEvent: vi.fn(),
+		};
+
+		notifications = createMockNotifications();
+		deps = {
+			fireOnFile: vi.fn().mockResolvedValue(undefined),
+			elaborateFile: vi.fn().mockResolvedValue(undefined),
+			transcribeUrlToNote: vi.fn().mockResolvedValue(undefined),
+		};
+
+		module = new IntakeModule(plugin, () => settings, notifications as any, deps as any);
+		(fetchArticleContent as any).mockClear();
+		(fetchArticleContent as any).mockResolvedValue('FETCHED ARTICLE BODY');
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	/** Seed a file and dispatch a synthetic 'create' event for it. */
+	function emit(event: string, path: string, content = '') {
+		store.set(path, content);
+		const file = makeFile(path);
+		handlers[event](file);
+		return file;
+	}
+
+	/** Run all pending timers, then drain microtasks so async flush settles. */
+	async function flushDebounce() {
+		await vi.runOnlyPendingTimersAsync();
+	}
+
+	describe('onload / listener registration', () => {
+		it('registers create and modify listeners when enabled', async () => {
+			await module.onload();
+			expect(plugin.app.vault.on).toHaveBeenCalledWith('create', expect.any(Function));
+			expect(plugin.app.vault.on).toHaveBeenCalledWith('modify', expect.any(Function));
+			expect(plugin.registerEvent).toHaveBeenCalledTimes(2);
+		});
+
+		it('registers no listeners when intake is disabled', async () => {
+			settings.intake.enabled = false;
+			await module.onload();
+			expect(plugin.app.vault.on).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('event filtering', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('ignores non-markdown files', async () => {
+			emit('create', 'Inbox/image.png', 'binary');
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+
+		it('ignores files outside the intake folder', async () => {
+			emit('create', 'Projects/note.md', 'hello');
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+
+		it('accepts a note in a subfolder of the intake folder', async () => {
+			emit('create', 'Inbox/sub/deep.md', 'hello prose');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('does nothing when intake is disabled at event time', async () => {
+			settings.intake.enabled = false;
+			emit('create', 'Inbox/note.md', 'hello');
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+
+		it('never watches the whole vault when the intake folder is empty', async () => {
+			settings.intake.intakeFolder = '';
+			emit('create', 'note.md', 'hello');
+			emit('create', 'Anywhere/note.md', 'hello');
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('debounce coalescing', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('coalesces a create + immediate modify of the same path into one flush', async () => {
+			const path = 'Inbox/capture.md';
+			store.set(path, 'hello prose');
+			handlers['create'](makeFile(path));
+			handlers['modify'](makeFile(path));
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('flushes two distinct paths separately', async () => {
+			store.set('Inbox/a.md', 'note a');
+			store.set('Inbox/b.md', 'note b');
+			handlers['create'](makeFile('Inbox/a.md'));
+			handlers['create'](makeFile('Inbox/b.md'));
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(2);
+		});
+
+		it('resets the debounce window on a subsequent event within the window', async () => {
+			const path = 'Inbox/capture.md';
+			store.set(path, 'hello prose');
+			handlers['create'](makeFile(path));
+
+			// Advance partway, then fire again to reset the timer.
+			await vi.advanceTimersByTimeAsync(DEBOUNCE_MS - 100);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			handlers['modify'](makeFile(path));
+
+			// The original deadline passes but the timer was reset → still no flush.
+			await vi.advanceTimersByTimeAsync(150);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+
+			// After the full window from the reset, it flushes exactly once.
+			await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not flush after onunload clears pending timers', async () => {
+			const path = 'Inbox/capture.md';
+			store.set(path, 'hello prose');
+			handlers['create'](makeFile(path));
+			module.onunload();
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('processed-flag idempotency', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('skips a note already stamped synapse-processed: true', async () => {
+			const content = '---\nsynapse-processed: true\n---\nhello prose';
+			emit('create', 'Inbox/done.md', content);
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+
+		it('stamps synapse-processed after a successful general run', async () => {
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+
+			const written = store.get('Inbox/note.md')!;
+			expect(written).toContain('synapse-processed: true');
+			expect(written).toContain('synapse-processed-at:');
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not reprocess on the modify echo from its own stamp write', async () => {
+			const path = 'Inbox/note.md';
+			emit('create', path, 'hello prose');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+
+			// Simulate Obsidian emitting a modify for our own stamp write.
+			handlers['modify'](makeFile(path));
+			await flushDebounce();
+			// The stamped note is now idempotent → still exactly one run.
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not stamp when markProcessed is false', async () => {
+			settings.intake.markProcessed = false;
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+			expect(store.get('Inbox/note.md')).not.toContain('synapse-processed');
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not stamp when processing throws (note stays retriable)', async () => {
+			deps.fireOnFile.mockRejectedValueOnce(new Error('boom'));
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+			expect(store.get('Inbox/note.md')).not.toContain('synapse-processed');
+			expect(notifications.notifyError).toHaveBeenCalled();
+		});
+	});
+
+	describe('dispatch routing → processing', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('bare video URL → transcription stub (no fire, no fetch)', async () => {
+			emit('create', 'Inbox/vid.md', 'https://www.youtube.com/watch?v=abc');
+			await flushDebounce();
+			expect(deps.transcribeUrlToNote).toHaveBeenCalledWith(
+				'https://www.youtube.com/watch?v=abc',
+				'video',
+				expect.anything()
+			);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			expect(fetchArticleContent).not.toHaveBeenCalled();
+		});
+
+		it('bare audio URL → transcription stub with mediaType audio', async () => {
+			emit('create', 'Inbox/pod.md', 'https://open.spotify.com/episode/xyz');
+			await flushDebounce();
+			expect(deps.transcribeUrlToNote).toHaveBeenCalledWith(
+				'https://open.spotify.com/episode/xyz',
+				'audio',
+				expect.anything()
+			);
+		});
+
+		it('bare article URL → fetch + append + elaborate', async () => {
+			emit('create', 'Inbox/art.md', 'https://example.com/post');
+			await flushDebounce();
+
+			expect(fetchArticleContent).toHaveBeenCalledWith('https://example.com/post');
+			const written = store.get('Inbox/art.md')!;
+			expect(written).toContain('FETCHED ARTICLE BODY');
+			expect(deps.elaborateFile).toHaveBeenCalledTimes(1);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+
+		it('bare unknown URL → general pipeline', async () => {
+			emit('create', 'Inbox/u.md', 'https://example.com/wiki/Obsidian_(software)');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+			expect(deps.transcribeUrlToNote).not.toHaveBeenCalled();
+			expect(fetchArticleContent).not.toHaveBeenCalled();
+		});
+
+		it('prose → general pipeline', async () => {
+			emit('create', 'Inbox/p.md', 'Some plain prose note.');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('multiple URLs → general pipeline', async () => {
+			emit('create', 'Inbox/m.md', 'https://a.com/x\nhttps://b.com/y');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+			expect(fetchArticleContent).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('move when done', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('stamps BEFORE moving the note', async () => {
+			settings.intake.moveWhenDone = 'Processed';
+			const order: string[] = [];
+
+			plugin.app.vault.modify.mockImplementation(async (file: any, content: string) => {
+				if (content.includes('synapse-processed: true')) order.push('stamp');
+				store.set(file.path, content);
+			});
+			plugin.app.fileManager.renameFile.mockImplementation(async (file: any, newPath: string) => {
+				order.push('move');
+				const content = store.get(file.path);
+				store.delete(file.path);
+				if (content !== undefined) store.set(newPath, content);
+				file.path = newPath;
+			});
+
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+
+			expect(order).toEqual(['stamp', 'move']);
+		});
+
+		it('moves the note into the destination folder, ensuring it exists', async () => {
+			settings.intake.moveWhenDone = 'Processed';
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+
+			expect(plugin.app.vault.createFolder).toHaveBeenCalledWith('Processed');
+			expect(plugin.app.fileManager.renameFile).toHaveBeenCalledWith(
+				expect.anything(),
+				'Processed/note.md'
+			);
+			expect(store.has('Processed/note.md')).toBe(true);
+		});
+
+		it('does not move when moveWhenDone is empty', async () => {
+			settings.intake.moveWhenDone = '';
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('flush resilience', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('drops a note that vanished before flush', async () => {
+			const path = 'Inbox/gone.md';
+			handlers['create'](makeFile(path)); // never seeded into store
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/intake/types.ts
+++ b/src/intake/types.ts
@@ -1,0 +1,60 @@
+import type { TFile } from 'obsidian';
+
+/**
+ * Frontmatter flag stamped onto a note once the intake monitor has finished
+ * processing it. Presence of this key (truthy) makes processing idempotent:
+ * the monitor skips any note already marked, which also prevents the
+ * `modify` echo from our own flag-stamp write from reprocessing the note.
+ */
+export const SYNAPSE_PROCESSED_FLAG = 'synapse-processed';
+
+/** Companion frontmatter key holding the ISO timestamp of processing. */
+export const SYNAPSE_PROCESSED_AT_FLAG = 'synapse-processed-at';
+
+/**
+ * The routing decision the dispatcher makes for an intake note, as a
+ * discriminated union. The `kind` discriminant tells the processor which
+ * branch to execute; each variant carries exactly the data that branch needs.
+ */
+export type IntakeRoute =
+	/**
+	 * The note is essentially a single video/audio URL. Carries the URL and
+	 * which media type it is so the (stubbed, #112) transcription branch can
+	 * route it. NOT implemented yet — see IntakeDeps.transcribeUrlToNote.
+	 */
+	| { kind: 'transcription'; url: string; mediaType: 'video' | 'audio' }
+	/**
+	 * The note is essentially a single article URL. Carries the URL so the
+	 * processor can fetch readable content, append it, then elaborate.
+	 */
+	| { kind: 'article'; url: string }
+	/**
+	 * Everything else: prose, multiple URLs, a placeholder, plain text, or a
+	 * single URL that classified as `unknown`. Runs the whole pipeline on the
+	 * note as-is.
+	 */
+	| { kind: 'general' };
+
+/**
+ * Cross-module callbacks injected into the IntakeModule by main.ts.
+ *
+ * The intake module must not import other feature modules (architecture
+ * rule), so every action that touches elaboration / the pipeline / future
+ * transcription is reached through this bundle, wired up in main.ts exactly
+ * like the enrichment/organize callback bundles.
+ */
+export interface IntakeDeps {
+	/** General branch: run the whole Synapse pipeline against ONE note. */
+	fireOnFile(file: TFile): Promise<void>;
+	/** Article branch: run elaboration against ONE note. */
+	elaborateFile(file: TFile): Promise<void>;
+	/**
+	 * Transcription branch (#112) — STUB. For now this just surfaces a
+	 * "coming soon" notice and no-ops; real URL transcription is out of scope.
+	 */
+	transcribeUrlToNote(
+		url: string,
+		mediaType: 'video' | 'audio',
+		file: TFile,
+	): Promise<void>;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { OrganizeModule } from './organize';
 import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
 import { RemModule } from './rem';
+import { IntakeModule } from './intake';
 import { CommandRegistrar, auditCommands } from './commands';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
@@ -43,6 +44,7 @@ export default class SynapsePlugin extends Plugin {
 	private deepDive!: DeepDiveModule;
 	private title!: TitleModule;
 	private rem!: RemModule;
+	private intake!: IntakeModule;
 	private startupTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	async onload(): Promise<void> {
@@ -285,16 +287,39 @@ export default class SynapsePlugin extends Plugin {
 			},
 		});
 
-		// Fire Synapse: run all enabled features on a directory
+		// Fire Synapse: run all enabled features on a directory.
+		// The third arg (onlyFile) is forwarded so SynapseRunner.fireOnFile
+		// can scope each phase to a single note (intake monitor, #111).
 		const moduleMap: PipelineModuleMap = {
-			elaboration: (fp, sc) => this.elaboration.scanVault(fp, sc),
-			summarize: (fp, sc) => this.summarize.scanVault(fp, sc),
-			enrichment: (fp, sc) => this.enrichment.scanVault(fp, sc),
-			rem: (fp) => this.rem.remScanDirectory(fp),
-			tidy: (fp, sc) => this.tidy.scanVault(fp, sc),
-			organize: (fp, sc) => this.organize.scanDirectory(fp, sc),
+			elaboration: (fp, sc, of) => this.elaboration.scanVault(fp, sc, of),
+			summarize: (fp, sc, of) => this.summarize.scanVault(fp, sc, of),
+			enrichment: (fp, sc, of) => this.enrichment.scanVault(fp, sc, of),
+			rem: (fp, sc, of) => this.rem.remScanDirectory(fp, sc, of),
+			tidy: (fp, sc, of) => this.tidy.scanVault(fp, sc, of),
+			organize: (fp, sc, of) => this.organize.scanDirectory(fp, sc, of),
 		};
 		const synapseRunner = new SynapseRunner(moduleMap, getSettings, this.notifications);
+
+		// Intake monitor (#111): watches the configured intake folder and
+		// auto-processes new notes. Cross-module work is injected as callbacks
+		// (the intake module never imports other feature modules):
+		//   - general notes  -> run the whole pipeline on the one note
+		//   - article URLs    -> elaboration on the one note (after fetch+append)
+		//   - media URLs      -> #112 transcription STUB (notice only)
+		this.intake = new IntakeModule(this, getSettings, this.notifications, {
+			fireOnFile: (file) => synapseRunner.fireOnFile(file),
+			elaborateFile: async (file) => {
+				if (this.settings.elaboration.enabled) {
+					await this.elaboration.scanNote(file, true);
+				}
+			},
+			transcribeUrlToNote: async (_url, _mediaType, _file) => {
+				new Notice('Synapse: URL transcription from intake is coming soon (#112)');
+			},
+		});
+		if (this.settings.intake.enabled) {
+			await this.intake.onload();
+		}
 
 		registrar.register('synapse:fire', true, {
 			name: 'Fire Synapse: run all features on a directory',
@@ -329,6 +354,7 @@ export default class SynapsePlugin extends Plugin {
 		this.deepDive?.onunload();
 		this.title?.onunload();
 		this.rem?.onunload();
+		this.intake?.onunload();
 		removeNotificationStyles();
 		UnifiedProposalView.removeStyles();
 	}

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -214,7 +214,7 @@ export class OrganizeModule {
 	 * 2. User confirmation
 	 * 3. Analyze and organize each file (cancellable)
 	 */
-	async scanDirectory(folderPath?: string, skipConfirmation = false): Promise<number> {
+	async scanDirectory(folderPath?: string, skipConfirmation = false, onlyFile?: TFile): Promise<number> {
 		// Phase 1: Collect eligible files
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(
@@ -222,7 +222,9 @@ export class OrganizeModule {
 			'organize-scan'
 		);
 
-		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		// Per-file scoping (#111): narrow to the single requested note.
+		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
 		const eligible: TFile[] = [];
 
 		try {

--- a/src/pipeline/synapse-runner.test.ts
+++ b/src/pipeline/synapse-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SynapseRunner } from './synapse-runner';
 import { DEFAULT_SETTINGS } from '../settings';
 import type { PipelineModuleMap } from './types';
+import { TFile, TFolder } from '../__mocks__/obsidian';
 
 function createMockNotifications() {
 	const handle = {
@@ -205,5 +206,88 @@ describe('SynapseRunner', () => {
 		expect(mockNotifications._handle.finish).toHaveBeenCalledWith(
 			'Fire Synapse complete — 4 phases run',
 		);
+	});
+
+	describe('fireOnFile (per-note scoping, #111)', () => {
+		// Returns `any`: the mock TFile is structurally compatible with the
+		// real obsidian.TFile that fireOnFile expects, but its `vault: unknown`
+		// trips strict assignability — the established pattern is to cast.
+		function fileIn(folder: string, name: string): any {
+			const file = new TFile(`${folder}/${name}`);
+			file.parent = new TFolder(folder);
+			return file;
+		}
+
+		it('runs each active phase exactly once for the file', async () => {
+			const file = fileIn('Inbox', 'note.md');
+
+			await runner.fireOnFile(file);
+
+			for (const key of Object.keys(mockModules) as (keyof PipelineModuleMap)[]) {
+				expect(mockModules[key]).toHaveBeenCalledTimes(1);
+			}
+		});
+
+		it('scopes each phase to the file via parent folder + onlyFile', async () => {
+			const file = fileIn('Inbox', 'note.md');
+
+			await runner.fireOnFile(file);
+
+			for (const key of Object.keys(mockModules) as (keyof PipelineModuleMap)[]) {
+				expect(mockModules[key]).toHaveBeenCalledWith('Inbox', true, file);
+			}
+		});
+
+		it('passes undefined folderPath for a root-level note', async () => {
+			const file: any = new TFile('note.md');
+			file.parent = new TFolder('/'); // root
+
+			await runner.fireOnFile(file);
+
+			expect(mockModules.elaboration).toHaveBeenCalledWith(undefined, true, file);
+		});
+
+		it('respects phase enable filtering', async () => {
+			settings.summarize.enabled = false;
+			settings.tidy.enabled = false;
+			const file = fileIn('Inbox', 'note.md');
+
+			await runner.fireOnFile(file);
+
+			expect(mockModules.elaboration).toHaveBeenCalledTimes(1);
+			expect(mockModules.enrichment).toHaveBeenCalledTimes(1);
+			expect(mockModules.rem).toHaveBeenCalledTimes(1);
+			expect(mockModules.organize).toHaveBeenCalledTimes(1);
+			expect(mockModules.summarize).not.toHaveBeenCalled();
+			expect(mockModules.tidy).not.toHaveBeenCalled();
+		});
+
+		it('reports no features when all phases are disabled', async () => {
+			settings.elaboration.enabled = false;
+			settings.summarize.enabled = false;
+			settings.enrichment.enabled = false;
+			settings.rem.enabled = false;
+			settings.tidy.enabled = false;
+			settings.organize.enabled = false;
+			const file = fileIn('Inbox', 'note.md');
+
+			await runner.fireOnFile(file);
+
+			expect(mockNotifications.info).toHaveBeenCalledWith('No features are enabled');
+			expect(mockModules.elaboration).not.toHaveBeenCalled();
+		});
+
+		it('a phase error does not abort the remaining phases', async () => {
+			(mockModules.enrichment as ReturnType<typeof vi.fn>).mockRejectedValue(
+				new Error('boom'),
+			);
+			const file = fileIn('Inbox', 'note.md');
+
+			await runner.fireOnFile(file);
+
+			expect(mockModules.rem).toHaveBeenCalledTimes(1);
+			expect(mockModules.tidy).toHaveBeenCalledTimes(1);
+			expect(mockModules.organize).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/pipeline/synapse-runner.ts
+++ b/src/pipeline/synapse-runner.ts
@@ -1,3 +1,4 @@
+import type { TFile } from 'obsidian';
 import type { NotificationManager } from '../shared';
 import type { SynapseSettings } from '../settings';
 import { isPipelineKeyInFlow } from '../commands';
@@ -40,6 +41,68 @@ export class SynapseRunner {
 
 			try {
 				await this.modules[phase.key](folderPath, true);
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				console.warn(`[Synapse] Phase ${phase.label} failed: ${msg}`);
+			}
+		}
+
+		if (!op.cancelled) {
+			op.finish(`Fire Synapse complete — ${completed} phases run`);
+		}
+	}
+
+	/**
+	 * Run the full pipeline against a single note instead of a folder.
+	 *
+	 * Mirrors {@link fire} exactly — same active-phase filtering
+	 * (enabled + `isPipelineKeyInFlow`) and the same per-phase progress /
+	 * error isolation — but scopes every phase to one file by passing the
+	 * note's parent folder plus the note itself as `onlyFile`. Each module's
+	 * scan fn applies `onlyFile` as a one-line filter after enumerating the
+	 * folder, so the note is processed exactly once by every active phase
+	 * with no rescan of its siblings.
+	 *
+	 * Used by the intake monitor (#111) to process a freshly added note. The
+	 * folder-scoped {@link fire} path is unaffected: it never passes
+	 * `onlyFile`.
+	 */
+	async fireOnFile(file: TFile): Promise<void> {
+		const settings = this.getSettings();
+		const activePhases = SYNAPSE_PIPELINE.filter(phase => {
+			const section = settings[phase.key] as { enabled: boolean };
+			return section.enabled && isPipelineKeyInFlow(phase.key, 'fire-synapse');
+		});
+
+		if (activePhases.length === 0) {
+			this.notifications.info('No features are enabled');
+			return;
+		}
+
+		// Scope every phase to the note's own folder so getMarkdownFiles
+		// returns a superset that includes it; onlyFile then narrows to it.
+		const folderPath = file.parent && !file.parent.isRoot()
+			? file.parent.path
+			: undefined;
+
+		const op = this.notifications.startOperation(
+			`Fire Synapse on ${file.basename} (0/${activePhases.length})`,
+			'synapse-fire-file',
+		);
+
+		let completed = 0;
+		for (const phase of activePhases) {
+			if (op.cancelled) break;
+
+			completed++;
+			op.progress(
+				completed,
+				activePhases.length,
+				`Phase ${completed}/${activePhases.length}: ${phase.label}`,
+			);
+
+			try {
+				await this.modules[phase.key](folderPath, true, file);
 			} catch (error) {
 				const msg = error instanceof Error ? error.message : String(error);
 				console.warn(`[Synapse] Phase ${phase.label} failed: ${msg}`);

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,11 +1,22 @@
+import type { TFile } from 'obsidian';
+
 /**
  * Scan function contract that each pipeline module must satisfy.
  * folderPath scopes the scan; skipConfirmation bypasses the
  * user-confirmation dialog (always true when called from Fire Synapse).
+ *
+ * onlyFile narrows an otherwise folder-scoped scan to a single note: when
+ * provided, the module restricts processing to that exact file (filtered
+ * right after getMarkdownFiles) while reusing all of its existing scan
+ * machinery (checkpoints, progress, exclusions). This backs
+ * SynapseRunner.fireOnFile so the intake monitor can target the specific
+ * added note without rescanning the whole intake folder per event. When
+ * omitted, behaviour is identical to the original folder-scoped scan.
  */
 export type PipelineScanFn = (
 	folderPath?: string,
 	skipConfirmation?: boolean,
+	onlyFile?: TFile,
 ) => Promise<number | void>;
 
 export type PipelineModuleKey =

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -135,9 +135,11 @@ export class RemModule {
 	/**
 	 * Scan all markdown files in a directory (or vault root) with checkpoint support.
 	 */
-	async remScanDirectory(folderPath?: string): Promise<number> {
+	async remScanDirectory(folderPath?: string, _skipConfirmation = false, onlyFile?: TFile): Promise<number> {
 		const settings = this.getSettings().rem;
-		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		// Per-file scoping (#111): narrow to the single requested note.
+		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
 
 		// Filter out excluded files
 		const eligible = allFiles.filter(f => !this.isExcluded(f));

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -199,6 +199,60 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// ── Intake Folder ──
+		new Setting(containerEl).setHeading().setName('Intake Folder');
+
+		new Setting(containerEl)
+			.setName('Enable intake processing')
+			.setDesc('Watch the intake folder and run enabled Synapse features on new notes')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.intake.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.intake.enabled = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Intake folder')
+			.setDesc('Folder to watch for new notes. See docs/intake-folder.md for the mobile capture workflow.')
+			.addText((text) =>
+				text
+					.setPlaceholder('Inbox')
+					.setValue(this.plugin.settings.intake.intakeFolder)
+					.onChange(async (value) => {
+						this.plugin.settings.intake.intakeFolder = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Mark processed in frontmatter')
+			.setDesc('Stamp `synapse-processed: true` on a note once handled so it is not reprocessed')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.intake.markProcessed)
+					.onChange(async (value) => {
+						this.plugin.settings.intake.markProcessed = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Move when done (optional)')
+			.setDesc('Destination folder to move notes into after processing. Leave blank to keep them in the intake folder.')
+			.addText((text) =>
+				text
+					.setPlaceholder('')
+					.setValue(this.plugin.settings.intake.moveWhenDone ?? '')
+					.onChange(async (value) => {
+						const trimmed = value.trim();
+						this.plugin.settings.intake.moveWhenDone = trimmed === '' ? undefined : trimmed;
+						await this.plugin.saveSettings();
+					})
+			);
+
 		// ── Media Transcription ──
 		new Setting(containerEl).setHeading().setName('Media Transcription');
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -192,6 +192,13 @@ export interface TitleSettings {
 	checkAfterOperations: boolean;
 }
 
+export interface IntakeSettings {
+	enabled: boolean;
+	intakeFolder: string;
+	markProcessed: boolean;
+	moveWhenDone?: string;
+}
+
 export interface SynapseSettings {
 	ai: AISettings;
 	elaboration: ElaborationSettings;
@@ -205,6 +212,7 @@ export interface SynapseSettings {
 	deepDive: DeepDiveSettings;
 	title: TitleSettings;
 	rem: RemSettings;
+	intake: IntakeSettings;
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
@@ -344,5 +352,11 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		confidenceThreshold: 0.5,
 		maxLinksPerNote: 20,
 		remFolderPath: '.synapse/rem',
+	},
+	intake: {
+		enabled: true,
+		intakeFolder: 'Inbox',
+		markProcessed: true,
+		moveWhenDone: '',
 	},
 };

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -49,6 +49,8 @@ export {
 	formatRecipeStructuredData,
 } from './content-fetcher';
 export type { RecipeJsonLd } from './content-fetcher';
+export { classifyUrl, extractUrls } from './url-classifier';
+export type { UrlContentType, UrlClassification } from './url-classifier';
 export { addEnhancedSlider } from './slider-helper';
 export { generateId, isValidCheckpointId } from './id-utils';
 export { CheckpointManager } from './checkpoint-manager';

--- a/src/shared/url-classifier.test.ts
+++ b/src/shared/url-classifier.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect } from 'vitest';
+import { classifyUrl, extractUrls } from './url-classifier';
+import { detectPlatform } from '../video/url-detector';
+
+describe('classifyUrl', () => {
+	describe('video URLs (delegated to video detector)', () => {
+		it('classifies a standard YouTube watch URL as video', () => {
+			const result = classifyUrl('https://youtube.com/watch?v=dQw4w9WgXcQ');
+			expect(result.type).toBe('video');
+			expect(result.platform).toBe('youtube');
+			expect(result.url).toBe('https://youtube.com/watch?v=dQw4w9WgXcQ');
+		});
+
+		it('classifies a youtu.be short URL as video', () => {
+			const result = classifyUrl('https://youtu.be/dQw4w9WgXcQ');
+			expect(result.type).toBe('video');
+			expect(result.platform).toBe('youtube');
+		});
+
+		it('classifies a YouTube Shorts URL as video', () => {
+			const result = classifyUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ');
+			expect(result.type).toBe('video');
+			expect(result.platform).toBe('youtube');
+		});
+
+		it('classifies a full TikTok video URL as video', () => {
+			const result = classifyUrl('https://www.tiktok.com/@user/video/1234567890123456789');
+			expect(result.type).toBe('video');
+			expect(result.platform).toBe('tiktok');
+		});
+
+		it('classifies a TikTok short share URL as video', () => {
+			const result = classifyUrl('https://vm.tiktok.com/ZMxxxxxxx/');
+			expect(result.type).toBe('video');
+			expect(result.platform).toBe('tiktok');
+		});
+
+		it('classifies an Instagram reel as video', () => {
+			const result = classifyUrl('https://www.instagram.com/reel/DAFnBq_xSHw/');
+			expect(result.type).toBe('video');
+			expect(result.platform).toBe('instagram');
+		});
+
+		it('carries the specific platform name in the platform field', () => {
+			expect(classifyUrl('https://youtube.com/watch?v=abc123').platform).toBe('youtube');
+			expect(classifyUrl('https://www.tiktok.com/@u/video/123').platform).toBe('tiktok');
+		});
+
+		it('routes video URLs via the existing detector (stays in sync)', () => {
+			// Any URL the video detector supports must classify as video with the
+			// same platform label the detector reports.
+			const videoUrls = [
+				'https://youtube.com/watch?v=dQw4w9WgXcQ',
+				'https://youtu.be/dQw4w9WgXcQ',
+				'https://www.tiktok.com/@user/video/1234567890123456789',
+				'https://www.instagram.com/reel/DAFnBq_xSHw/',
+			];
+			for (const url of videoUrls) {
+				const detected = detectPlatform(url);
+				const classified = classifyUrl(url);
+				expect(detected).not.toBeNull();
+				expect(classified.type).toBe('video');
+				expect(classified.platform).toBe(detected?.platform);
+			}
+		});
+
+		it('does NOT classify a Twitter/X status as video (detector excludes it)', () => {
+			// isSupportedUrl returns false for twitter, so it must not be 'video'.
+			const result = classifyUrl('https://twitter.com/user/status/1234567890');
+			expect(result.type).not.toBe('video');
+		});
+	});
+
+	describe('audio URLs', () => {
+		it('classifies a Spotify track as audio (spotify)', () => {
+			const result = classifyUrl('https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('spotify');
+		});
+
+		it('classifies a Spotify episode as audio (spotify)', () => {
+			const result = classifyUrl('https://open.spotify.com/episode/512ojhOuo1ktJprKbVcKyQ');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('spotify');
+		});
+
+		it('classifies a Spotify show as audio (spotify)', () => {
+			const result = classifyUrl('https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('spotify');
+		});
+
+		it('classifies a bare spotify.com host as audio', () => {
+			const result = classifyUrl('https://spotify.com/episode/abc123');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('spotify');
+		});
+
+		it('classifies an Apple Podcasts URL as audio (apple-podcasts)', () => {
+			const result = classifyUrl(
+				'https://podcasts.apple.com/us/podcast/the-daily/id1200361736'
+			);
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('apple-podcasts');
+		});
+
+		it('classifies a SoundCloud URL as audio (soundcloud)', () => {
+			const result = classifyUrl('https://soundcloud.com/artist/track-name');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('soundcloud');
+		});
+
+		it('classifies a SoundCloud subdomain as audio (soundcloud)', () => {
+			const result = classifyUrl('https://m.soundcloud.com/artist/track-name');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('soundcloud');
+		});
+
+		it('classifies a .rss feed URL as audio (podcast-rss)', () => {
+			const result = classifyUrl('https://example.com/podcast.rss');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('podcast-rss');
+		});
+
+		it('classifies a .xml feed URL as audio (podcast-rss)', () => {
+			const result = classifyUrl('https://example.com/podcast/feed.xml');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('podcast-rss');
+		});
+
+		it('classifies a /feed path URL as audio (podcast-rss)', () => {
+			const result = classifyUrl('https://example.com/show/feed');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('podcast-rss');
+		});
+
+		it('classifies a /rss path URL as audio (podcast-rss)', () => {
+			const result = classifyUrl('https://example.com/podcast/rss');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('podcast-rss');
+		});
+
+		it('classifies a feed hint in the query string as audio (podcast-rss)', () => {
+			const result = classifyUrl('https://example.com/podcast?format=rss');
+			expect(result.type).toBe('audio');
+			expect(result.platform).toBe('podcast-rss');
+		});
+
+		it('prefers known audio host over generic article default', () => {
+			// open.spotify.com would otherwise be a valid generic URL.
+			expect(classifyUrl('https://open.spotify.com/show/x').platform).toBe('spotify');
+		});
+	});
+
+	describe('article URLs', () => {
+		it('classifies medium.com as article (medium)', () => {
+			const result = classifyUrl('https://medium.com/@author/some-post-abc123');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('medium');
+		});
+
+		it('classifies a *.medium.com subdomain as article (medium)', () => {
+			const result = classifyUrl('https://blog.medium.com/some-post-abc123');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('medium');
+		});
+
+		it('classifies a *.substack.com subdomain as article (substack)', () => {
+			const result = classifyUrl('https://author.substack.com/p/some-post');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('substack');
+		});
+
+		it('classifies a *.wikipedia.org subdomain as article (wikipedia)', () => {
+			const result = classifyUrl('https://en.wikipedia.org/wiki/Markdown');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('wikipedia');
+		});
+
+		it('classifies any other valid http(s) URL as a generic article', () => {
+			const result = classifyUrl('https://example.com/some/article');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('generic');
+		});
+
+		it('classifies a plain news site URL as a generic article', () => {
+			const result = classifyUrl('https://www.nytimes.com/2026/01/01/tech/story.html');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('generic');
+		});
+
+		it('classifies an http (non-https) URL as a generic article', () => {
+			const result = classifyUrl('http://example.org/page');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('generic');
+		});
+
+		it('preserves the original url in the result', () => {
+			const url = 'https://example.com/some/article?x=1';
+			expect(classifyUrl(url).url).toBe(url);
+		});
+	});
+
+	describe('unknown / invalid URLs', () => {
+		it('classifies an empty string as unknown', () => {
+			const result = classifyUrl('');
+			expect(result.type).toBe('unknown');
+			expect(result.platform).toBe('unknown');
+		});
+
+		it('classifies a non-URL string as unknown', () => {
+			expect(classifyUrl('not a url').type).toBe('unknown');
+		});
+
+		it('classifies a bare word as unknown', () => {
+			expect(classifyUrl('hello').type).toBe('unknown');
+		});
+
+		it('classifies a non-http scheme (ftp) as unknown', () => {
+			expect(classifyUrl('ftp://example.com/file.zip').type).toBe('unknown');
+		});
+
+		it('classifies a javascript: scheme as unknown', () => {
+			expect(classifyUrl('javascript:alert(1)').type).toBe('unknown');
+		});
+
+		it('classifies a mailto: scheme as unknown', () => {
+			expect(classifyUrl('mailto:someone@example.com').type).toBe('unknown');
+		});
+
+		it('classifies a file: scheme as unknown', () => {
+			expect(classifyUrl('file:///etc/passwd').type).toBe('unknown');
+		});
+
+		it('classifies a URL with shell metacharacters as unknown (sanitizeUrl rejects)', () => {
+			expect(classifyUrl('https://example.com/$(rm -rf /)').type).toBe('unknown');
+		});
+
+		it('classifies a URL with parentheses as unknown (known sanitizeUrl limitation)', () => {
+			// Documents current behavior: sanitizeUrl rejects `()`, so even a real
+			// Wikipedia disambiguation URL is unknown until sanitizeUrl is relaxed
+			// for the fetch path (#109). Classification stays in sync with the gate
+			// every downstream fetcher applies.
+			expect(classifyUrl('https://en.wikipedia.org/wiki/Obsidian_(software)').type).toBe(
+				'unknown'
+			);
+		});
+
+		it('classifies a URL containing a null byte as unknown', () => {
+			expect(classifyUrl('https://example.com/\0').type).toBe('unknown');
+		});
+
+		it('returns the original (unparseable) url string in the result', () => {
+			expect(classifyUrl('not a url').url).toBe('not a url');
+		});
+
+		it('does not throw on any of a batch of malformed inputs', () => {
+			const bad = ['', ' ', 'http://', 'https://', '://nohost', '!!!', 'ftp://x'];
+			for (const input of bad) {
+				expect(() => classifyUrl(input)).not.toThrow();
+			}
+		});
+	});
+});
+
+describe('extractUrls', () => {
+	it('returns an empty array for text with no URLs', () => {
+		expect(extractUrls('just some plain note text with no links')).toEqual([]);
+	});
+
+	it('returns an empty array for an empty string', () => {
+		expect(extractUrls('')).toEqual([]);
+	});
+
+	it('extracts a single URL', () => {
+		expect(extractUrls('check https://example.com today')).toEqual([
+			'https://example.com',
+		]);
+	});
+
+	it('extracts a single URL with no surrounding text', () => {
+		expect(extractUrls('https://example.com/page')).toEqual([
+			'https://example.com/page',
+		]);
+	});
+
+	it('extracts multiple URLs in document order', () => {
+		const text =
+			'First https://a.com then https://b.com and finally https://c.com';
+		expect(extractUrls(text)).toEqual([
+			'https://a.com',
+			'https://b.com',
+			'https://c.com',
+		]);
+	});
+
+	it('extracts URLs embedded in prose across newlines', () => {
+		const text = [
+			'Here is a YouTube video: https://youtube.com/watch?v=abc123',
+			'And a podcast: https://open.spotify.com/episode/xyz',
+			'Read more at https://en.wikipedia.org/wiki/Topic.',
+		].join('\n');
+		expect(extractUrls(text)).toEqual([
+			'https://youtube.com/watch?v=abc123',
+			'https://open.spotify.com/episode/xyz',
+			'https://en.wikipedia.org/wiki/Topic',
+		]);
+	});
+
+	it('trims a trailing period that abuts a sentence-final URL', () => {
+		expect(extractUrls('See https://example.com/page.')).toEqual([
+			'https://example.com/page',
+		]);
+	});
+
+	it('trims trailing punctuation and closing brackets', () => {
+		expect(extractUrls('(link: https://example.com/page),')).toEqual([
+			'https://example.com/page',
+		]);
+		expect(extractUrls('quote "https://example.com"')).toEqual([
+			'https://example.com',
+		]);
+	});
+
+	it('keeps both http and https URLs', () => {
+		const text = 'insecure http://example.com and secure https://example.com/x';
+		expect(extractUrls(text)).toEqual([
+			'http://example.com',
+			'https://example.com/x',
+		]);
+	});
+
+	it('deduplicates repeated URLs, preserving first-seen order', () => {
+		const text = 'https://a.com then https://b.com then https://a.com again';
+		expect(extractUrls(text)).toEqual(['https://a.com', 'https://b.com']);
+	});
+
+	it('does not extract non-http schemes', () => {
+		expect(extractUrls('email me at mailto:x@y.com or ftp://z.com/file')).toEqual(
+			[]
+		);
+	});
+
+	it('extracted URLs can be fed straight into classifyUrl', () => {
+		const text =
+			'video https://youtu.be/abc123 and article https://example.com/post';
+		const [videoUrl, articleUrl] = extractUrls(text);
+		expect(classifyUrl(videoUrl).type).toBe('video');
+		expect(classifyUrl(articleUrl).type).toBe('article');
+	});
+});

--- a/src/shared/url-classifier.ts
+++ b/src/shared/url-classifier.ts
@@ -1,0 +1,190 @@
+import { detectPlatform, isSupportedUrl } from '../video/url-detector';
+import { sanitizeUrl } from './validation';
+
+/**
+ * Classify arbitrary URLs as video / audio / article / unknown so the intake
+ * monitor can route each link to the right pipeline.
+ *
+ * Lives in shared/ (alongside content-fetcher.ts) so any feature module can
+ * consume URL classification without creating cross-feature coupling. The
+ * video case is delegated to the existing video-only detector
+ * (video/url-detector.ts) rather than re-implementing platform regexes, which
+ * keeps the two in sync and preserves backward compatibility.
+ */
+
+export type UrlContentType = 'video' | 'audio' | 'article' | 'unknown';
+
+export interface UrlClassification {
+	type: UrlContentType;
+	platform: string;
+	url: string;
+}
+
+/**
+ * Host suffixes for audio platforms. A host matches when it equals the entry
+ * or ends with `.<entry>` (covers subdomains like `m.soundcloud.com`).
+ */
+const AUDIO_HOSTS: ReadonlyArray<{ suffix: string; platform: string }> = [
+	{ suffix: 'open.spotify.com', platform: 'spotify' },
+	{ suffix: 'spotify.com', platform: 'spotify' },
+	{ suffix: 'podcasts.apple.com', platform: 'apple-podcasts' },
+	{ suffix: 'soundcloud.com', platform: 'soundcloud' },
+];
+
+/**
+ * Host suffixes for known article platforms. Anything not matched here that is
+ * still a valid http(s) URL falls through to the generic-article default.
+ */
+const ARTICLE_HOSTS: ReadonlyArray<{ suffix: string; platform: string }> = [
+	{ suffix: 'medium.com', platform: 'medium' },
+	{ suffix: 'substack.com', platform: 'substack' },
+	{ suffix: 'wikipedia.org', platform: 'wikipedia' },
+];
+
+/**
+ * Global matcher for http(s) URLs embedded in free text. Trailing punctuation
+ * that commonly abuts a URL in prose (`.,;:!?` and closing brackets/quotes) is
+ * trimmed by {@link trimTrailingPunctuation} after extraction.
+ */
+const URL_IN_TEXT_REGEX = /https?:\/\/[^\s<>"'`]+/gi;
+
+/**
+ * Parse a URL into a {@link URL} after defensive sanitization, returning null
+ * when the input is not a safe, fetchable http(s) URL. Centralizing this keeps
+ * every classifier branch from having to guard `new URL` / `sanitizeUrl` throws.
+ *
+ * Classification is deliberately gated on the project's canonical
+ * {@link sanitizeUrl} (the same guard every downstream fetcher applies, e.g.
+ * content-fetcher.ts's fetchHtml). A URL that cannot pass sanitizeUrl cannot be
+ * fetched by any pipeline, so classifying it as anything other than `unknown`
+ * would route it to a pipeline guaranteed to throw. Keeping the gate identical
+ * means a non-`unknown` classification is always a fetchable URL.
+ *
+ * KNOWN LIMITATION: sanitizeUrl rejects shell metacharacters including `()`,
+ * so disambiguation URLs like `…/wiki/Obsidian_(software)` classify as
+ * `unknown` today. Relaxing that safely requires loosening sanitizeUrl for the
+ * non-shell (fetch) path, which is out of scope for this module (see #109).
+ */
+function safeParseUrl(url: string): URL | null {
+	if (typeof url !== 'string' || url.trim().length === 0) {
+		return null;
+	}
+
+	try {
+		// sanitizeUrl throws on null bytes, non-http(s) schemes, and shell
+		// metacharacters; treat any rejection as a non-classifiable URL.
+		sanitizeUrl(url);
+		return new URL(url);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * True when `host` equals `suffix` or is a subdomain of it
+ * (e.g. `example.medium.com` matches `medium.com`).
+ */
+function hostMatches(host: string, suffix: string): boolean {
+	return host === suffix || host.endsWith('.' + suffix);
+}
+
+/**
+ * Detect podcast RSS feeds by shape rather than host: a `.rss`/`.xml` path, or
+ * a path/host segment containing `feed` or `rss`. Pathname and search are
+ * lowercased so query-string feed hints (`?format=rss`) are caught too.
+ */
+function isPodcastFeed(parsed: URL): boolean {
+	const path = parsed.pathname.toLowerCase();
+	const search = parsed.search.toLowerCase();
+
+	if (path.endsWith('.rss') || path.endsWith('.xml')) {
+		return true;
+	}
+
+	const haystack = path + search;
+	return haystack.includes('/feed') || haystack.includes('feed') ||
+		haystack.includes('/rss') || haystack.includes('rss');
+}
+
+/**
+ * Trim a single run of trailing punctuation that prose commonly places right
+ * after a URL (sentence enders, closing brackets, quotes). Conservative by
+ * design: it only strips characters that are never meaningful as the final
+ * character of a real link in note text.
+ */
+function trimTrailingPunctuation(url: string): string {
+	return url.replace(/[.,;:!?)\]}>'"]+$/, '');
+}
+
+/**
+ * Classify a single URL into a content type plus a specific platform label.
+ *
+ * Order matters: video is checked first (so platform-specific routing wins
+ * over the generic-article default), then audio, then known article hosts,
+ * then any remaining valid http(s) URL is treated as a generic article.
+ * Anything that fails {@link safeParseUrl} is `unknown`.
+ */
+export function classifyUrl(url: string): UrlClassification {
+	const parsed = safeParseUrl(url);
+	if (!parsed) {
+		return { type: 'unknown', platform: 'unknown', url };
+	}
+
+	// 1. Video — delegate entirely to the existing video detector so the
+	//    supported-platform set stays in sync with video/url-detector.ts.
+	const videoResult = detectPlatform(url);
+	if (videoResult && isSupportedUrl(url)) {
+		return { type: 'video', platform: videoResult.platform, url };
+	}
+
+	const host = parsed.hostname.toLowerCase();
+
+	// 2. Audio — known audio hosts, then podcast-feed shape.
+	for (const { suffix, platform } of AUDIO_HOSTS) {
+		if (hostMatches(host, suffix)) {
+			return { type: 'audio', platform, url };
+		}
+	}
+	if (isPodcastFeed(parsed)) {
+		return { type: 'audio', platform: 'podcast-rss', url };
+	}
+
+	// 3. Article — known article hosts, then any valid http(s) URL as default.
+	for (const { suffix, platform } of ARTICLE_HOSTS) {
+		if (hostMatches(host, suffix)) {
+			return { type: 'article', platform, url };
+		}
+	}
+
+	return { type: 'article', platform: 'generic', url };
+}
+
+/**
+ * Extract every http(s) URL from free text, in document order, with trailing
+ * prose punctuation trimmed. Lets the intake monitor pull links out of a note
+ * body. Duplicates are removed while preserving first-seen order so callers
+ * get a stable, de-duplicated list.
+ */
+export function extractUrls(text: string): string[] {
+	if (typeof text !== 'string' || text.length === 0) {
+		return [];
+	}
+
+	const matches = text.match(URL_IN_TEXT_REGEX);
+	if (!matches) {
+		return [];
+	}
+
+	const seen = new Set<string>();
+	const urls: string[] = [];
+	for (const raw of matches) {
+		const cleaned = trimTrailingPunctuation(raw);
+		if (cleaned.length === 0 || seen.has(cleaned)) {
+			continue;
+		}
+		seen.add(cleaned);
+		urls.push(cleaned);
+	}
+
+	return urls;
+}

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -512,7 +512,7 @@ export class SummarizeModule {
 		return `${folderPrefix}${safeName}.md`;
 	}
 
-	async scanVault(folderPath?: string, skipConfirmation = false): Promise<void> {
+	async scanVault(folderPath?: string, skipConfirmation = false, onlyFile?: TFile): Promise<void> {
 		const settings = this.getSettings().summarize;
 
 		// Phase 1: Scan for files with targets
@@ -522,7 +522,9 @@ export class SummarizeModule {
 			'summarize-vault-scan'
 		);
 
-		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		// Per-file scoping (#111): narrow to the single requested note.
+		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
 		const filesWithTargets: Array<{ file: TFile; targets: SummarizeTarget[] }> = [];
 
 		try {

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -67,8 +67,10 @@ export class TidyModule {
 
 	onunload(): void {}
 
-	async scanVault(folderPath?: string, skipConfirmation = false): Promise<number> {
-		const allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+	async scanVault(folderPath?: string, skipConfirmation = false, onlyFile?: TFile): Promise<number> {
+		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
+		// Per-file scoping (#111): narrow to the single requested note.
+		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
 
 		if (allFiles.length === 0) {
 			return 0;

--- a/src/tidy/tidy-module.test.ts
+++ b/src/tidy/tidy-module.test.ts
@@ -187,6 +187,41 @@ describe('TidyModule', () => {
 		});
 	});
 
+	describe('scanVault onlyFile scoping (#111)', () => {
+		it('narrows the scan to a single note when onlyFile is given', async () => {
+			const a = new TFile('Inbox/a.md');
+			const b = new TFile('Inbox/b.md');
+			const c = new TFile('Inbox/c.md');
+			mockPlugin.app.vault.getMarkdownFiles = vi.fn().mockReturnValue([a, b, c]);
+
+			const tidied: string[] = [];
+			vi.spyOn(module, 'tidy').mockImplementation(async (f: any) => {
+				tidied.push(f.path);
+			});
+
+			const count = await module.scanVault('Inbox', true, b as any);
+
+			expect(count).toBe(1);
+			expect(tidied).toEqual(['Inbox/b.md']);
+		});
+
+		it('processes all files in folder when onlyFile is omitted', async () => {
+			const a = new TFile('Inbox/a.md');
+			const b = new TFile('Inbox/b.md');
+			mockPlugin.app.vault.getMarkdownFiles = vi.fn().mockReturnValue([a, b]);
+
+			const tidied: string[] = [];
+			vi.spyOn(module, 'tidy').mockImplementation(async (f: any) => {
+				tidied.push(f.path);
+			});
+
+			const count = await module.scanVault('Inbox', true);
+
+			expect(count).toBe(2);
+			expect(tidied).toEqual(['Inbox/a.md', 'Inbox/b.md']);
+		});
+	});
+
 	describe('undoTidy', () => {
 		it('restores original content from snapshot', async () => {
 			const file = new TFile('notes/test.md') as any;


### PR DESCRIPTION
## Summary

Implements the **zero-config auto-processing intake folder** epic: a watched folder (default `Inbox`) where any note added — by Obsidian's native mobile share, desktop drag-and-drop, or sync — is automatically processed by Synapse. Delivered as one epic branch with a clean commit per sub-issue.

Closes #107
Closes #109
Closes #111
Closes #113
Closes #114

## What's included

| Issue | Commit | What |
|-------|--------|------|
| #109 | `06d7847` | `src/shared/url-classifier.ts` — classify URLs as video/audio/article/unknown (+ `extractUrls`), wrapping the existing video detector. 54 tests. |
| #113 | `bd0070c` | `IntakeSettings` + an "Intake Folder" settings section (enable, folder, mark-processed, move-when-done). |
| #111 | `7d5dd35` | `src/intake/` monitor: debounced `vault` create/modify watcher, `synapse-processed` idempotency, URL/general dispatch, per-note pipeline scoping. 46 tests. |
| #114 | `73e3fd9` | `docs/intake-folder.md` — mobile + desktop capture workflow. |

## How it works

- **Bare-URL note** → classified: **article** (Medium/Substack/Wikipedia/any web page) → fetch readable content → Elaboration; **video/audio** → "coming soon" notice; unrecognized → general.
- **Everything else** → the full pipeline on that single note (Elaboration → Summarize → Enrichment → REM → Tidy → Organize), each phase gated by its existing enable flag.
- Processed notes get `synapse-processed: true` (+ `synapse-processed-at`) frontmatter so re-syncs/edits don't reprocess.

## Notable decisions

- **Per-note scoping (#111):** `SynapseRunner` only had folder scope. Added `SynapseRunner.fireOnFile(file)` and threaded an optional `onlyFile?: TFile` through `PipelineScanFn` (a one-line filter after each module's `getMarkdownFiles`). `fire(folderPath)` is unchanged — purely additive. Chosen over heterogeneous per-file methods because `summarize` has no clean public per-file entry (rationale in `7d5dd35`).
- **Architecture rule respected:** `src/intake/` imports only `obsidian` + `src/shared/*`; all cross-module calls (`fireOnFile`, `elaborateFile`, transcription stub) are injected as callbacks from `main.ts`.
- **#112 not included:** the video/audio transcription branch is a deliberate stub (out of scope for this work). Article + general branches are fully functional.

## Testing

- `npx tsc --noEmit --skipLibCheck` → clean
- `node esbuild.config.mjs production` → clean
- `npm test` → **912 passed**. The **5 failing tests are pre-existing on `main`** (`commands/registry.test.ts` ×1 from the recent "deactivate commands" change; `tidy/tidy-module.test.ts` ×4 undo-tidy) and are unrelated to this PR — **zero new failures introduced**.

## Verifying locally

Enable intake in settings, set the folder to `Inbox`, then drop notes:
- a note that is just an article URL → article content fetched + elaboration runs;
- a plain-text stub note → full pipeline runs on that single note;
- a note that is just a YouTube/TikTok URL → "coming soon" notice (pending #112);
- confirm each gets `synapse-processed: true` and a re-edit does not reprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
