### PR TITLE
test: fix pre-existing failing tests (registry + tidy)

### DIFF
--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -38,10 +38,25 @@ describe('COMMAND_REGISTRY', () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 
-	it('ships every entry as active (behavior preserving)', () => {
+	it('gives every entry a valid status', () => {
+		const validStatuses = ['active', 'deprecated', 'disabled'];
 		for (const entry of COMMAND_REGISTRY) {
-			expect(entry.status).toBe('active');
+			expect(validStatuses).toContain(entry.status);
 		}
+	});
+
+	it('disables exactly the intentionally-deactivated commands', () => {
+		const disabled = COMMAND_REGISTRY.filter(c => c.status === 'disabled')
+			.map(c => c.id)
+			.sort();
+		expect(disabled).toEqual([
+			'synapse:clear-deep-dive',
+			'synapse:clear-proposals',
+			'synapse:transcribe-media',
+			'synapse:undo-enrichment',
+			'synapse:undo-organize',
+			'synapse:undo-tidy',
+		]);
 	});
 
 	it('gives every real command the palette flow', () => {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -2,9 +2,9 @@
  * COMMAND_REGISTRY — the single declarative source of truth for every Synapse
  * command, plus the helpers that gate flows against it.
  *
- * Every entry ships `status: 'active'` with flows that preserve current behavior
- * exactly. To deprecate/disable a command or remove it from a flow, edit the
- * entry here — no module hunting required.
+ * Most entries ship `status: 'active'`; a few ship `'disabled'` as a developer-level
+ * master switch (the registry sits above user settings). To deprecate/disable a
+ * command or remove it from a flow, edit the entry here — no module hunting required.
  *
  * Precedence (all ANDed, registry authoritative):
  *   status (dev) -> flow membership (dev) -> settings.[feature].enabled (user) -> hasTranscription (runtime)

--- a/src/tidy/tidy-module.test.ts
+++ b/src/tidy/tidy-module.test.ts
@@ -75,13 +75,15 @@ describe('TidyModule', () => {
 	});
 
 	describe('onload', () => {
-		it('registers tidy and undo commands', async () => {
+		it('registers the tidy command (undo-tidy is gated off by the registry)', async () => {
 			await module.onload();
 
-			expect(mockPlugin.addCommand).toHaveBeenCalledTimes(2);
+			// `synapse:undo-tidy` ships as `status: 'disabled'` in COMMAND_REGISTRY, so
+			// the registrar gates it out — only the active tidy command registers.
+			expect(mockPlugin.addCommand).toHaveBeenCalledTimes(1);
 			const commands = mockPlugin.addCommand.mock.calls.map((c: any) => c[0].id);
 			expect(commands).toContain('synapse:tidy-current-note');
-			expect(commands).toContain('synapse:undo-tidy');
+			expect(commands).not.toContain('synapse:undo-tidy');
 		});
 	});
 
@@ -202,14 +204,10 @@ describe('TidyModule', () => {
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockSnapshotFile);
 			mockPlugin.app.vault.read.mockResolvedValue(JSON.stringify(snapshot));
 
-			// Access undoTidy through the command callback
+			// undo-tidy is gated off as a palette command (registry master switch), so
+			// invoke the still-present undo logic directly.
 			await module.onload();
-			const undoCommand = mockPlugin.addCommand.mock.calls.find(
-				(c: any) => c[0].id === 'synapse:undo-tidy'
-			)[0];
-
-			// Call the editorCallback directly
-			await undoCommand.editorCallback({}, { file });
+			await (module as any).undoTidy(file);
 
 			expect(mockPlugin.app.vault.modify).toHaveBeenCalledWith(
 				file,
@@ -223,11 +221,7 @@ describe('TidyModule', () => {
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
 
 			await module.onload();
-			const undoCommand = mockPlugin.addCommand.mock.calls.find(
-				(c: any) => c[0].id === 'synapse:undo-tidy'
-			)[0];
-
-			await undoCommand.editorCallback({}, { file });
+			await (module as any).undoTidy(file);
 
 			expect(mockNotifications.info).toHaveBeenCalledWith(
 				'No tidy to undo for this note'
@@ -249,11 +243,7 @@ describe('TidyModule', () => {
 			mockPlugin.app.vault.read.mockResolvedValue(JSON.stringify(snapshot));
 
 			await module.onload();
-			const undoCommand = mockPlugin.addCommand.mock.calls.find(
-				(c: any) => c[0].id === 'synapse:undo-tidy'
-			)[0];
-
-			await undoCommand.editorCallback({}, { file });
+			await (module as any).undoTidy(file);
 
 			expect(mockPlugin.app.vault.delete).toHaveBeenCalled();
 		});


### PR DESCRIPTION
## Summary

Fixes the 5 pre-existing failing tests on `main`. Both suites broke when `a496579` ("chore: deactivate certain commands") flipped several commands to `status: 'disabled'` while their tests still assumed the prior all-active behavior. No production logic changes — only test expectations and one stale comment.

## `src/commands/registry`
The `ships every entry as active (behavior preserving)` assertion is no longer valid: 6 commands intentionally ship disabled (`transcribe-media`, `clear-proposals`, `undo-enrichment`, `undo-organize`, `clear-deep-dive`, `undo-tidy`). Replaced it with two meaningful invariants:
- every entry has a valid `status`, and
- the **disabled set is pinned** to exactly those 6 ids, so any future status flip is deliberate rather than silently passing.

Also corrected the now-stale registry header comment ("Every entry ships `status: 'active'`…").

## `src/tidy/tidy-module`
Because `synapse:undo-tidy` is disabled, the registrar gates it out and `onload()` registers **1** command, not 2 — and the 3 undo tests could no longer fish the `undo-tidy` callback out of `addCommand`.
- The registration test now asserts only `tidy-current-note` registers and `undo-tidy` does not.
- The 3 undo behavior tests invoke the still-present `undoTidy` logic directly, preserving coverage for when the command is re-enabled (the implementation is intact; the registry disable is a reversible master switch).

## Testing
- `npx tsc --noEmit --skipLibCheck` → clean
- `npm test` → **818 passed, 0 failed** (was 5 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
