### PR TITLE
feat: Intake Processing v2 — settle window, full Fire-Synapse + auto-organize, capture log

### DIFF
--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -7,6 +7,7 @@ import {
 	fetchArticleContent,
 	parseFrontmatter,
 	serializeFrontmatter,
+	writeNote,
 } from '../shared';
 import { IntakeDispatcher } from './intake-dispatcher';
 import {
@@ -129,13 +130,45 @@ export class IntakeModule {
 	 * getMarkdownFiles' membership rule (`startsWith(normalized + '/')`) so
 	 * subpaths are handled consistently. An empty/whitespace folder matches
 	 * nothing — we never watch the whole vault.
+	 *
+	 * The capture-log subfolder (`‹intakeFolder›/‹captureLogFolder›`, #224) is
+	 * explicitly excluded so our own breadcrumbs — which live under the intake
+	 * folder — are NEVER ingested. Without this the watcher would re-process
+	 * every breadcrumb and, since breadcrumbs contain a link that organize would
+	 * try to move, spin into an infinite ingest loop.
 	 */
 	private isInIntakeFolder(path: string, intakeFolder: string): boolean {
 		if (!intakeFolder || intakeFolder.trim().length === 0) {
 			return false;
 		}
 		const normalized = normalizePath(intakeFolder);
-		return path.startsWith(normalized + '/');
+		if (!path.startsWith(normalized + '/')) {
+			return false;
+		}
+
+		const captureLogPath = this.captureLogPath(normalized);
+		if (
+			captureLogPath !== null &&
+			(path === captureLogPath || path.startsWith(captureLogPath + '/'))
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Absolute vault path of the capture-log subfolder for a given (already
+	 * normalized) intake folder, or null when no capture-log folder is
+	 * configured. Single source of truth for both the listener exclusion
+	 * (above) and where breadcrumbs are written (#224).
+	 */
+	private captureLogPath(normalizedIntakeFolder: string): string | null {
+		const folder = this.getSettings().intake.captureLogFolder;
+		if (!folder || folder.trim().length === 0) {
+			return null;
+		}
+		return normalizePath(`${normalizedIntakeFolder}/${folder.trim()}`);
 	}
 
 	/**
@@ -265,7 +298,14 @@ export class IntakeModule {
 				break;
 		}
 
-		await this.markProcessedAndMaybeMove(file, originalPath);
+		const movedOut = await this.markProcessedAndMaybeMove(file, originalPath);
+
+		// Leave a breadcrumb only when the note actually left the intake folder
+		// (organize, or the moveWhenDone fallback, relocated it). No move → the
+		// note is still browsable in the intake folder, so nothing to log (#224).
+		if (movedOut && this.getSettings().intake.captureLog) {
+			await this.writeCaptureBreadcrumb(originalPath, file.path);
+		}
 	}
 
 	/**
@@ -374,5 +414,79 @@ export class IntakeModule {
 		}
 
 		await this.plugin.app.fileManager.renameFile(file, targetPath);
+	}
+
+	/**
+	 * Drop a dated breadcrumb into the capture-log subfolder linking to a note
+	 * that was just organized out of the intake folder (#224). The file is
+	 * `‹intakeFolder›/‹captureLogFolder›/‹YYYY-MM-DD› — ‹sanitized title›.md`
+	 * and holds a wiki-link to the moved note plus small metadata.
+	 *
+	 * The breadcrumb is stamped `synapse-processed: true` as defense-in-depth:
+	 * the capture-log subfolder is already excluded from the watcher
+	 * (isInIntakeFolder), but the stamp guarantees it is skipped even if that
+	 * exclusion were ever bypassed.
+	 *
+	 * `movedPath` is the note's current (organized) path; `originalPath` its
+	 * pre-processing path inside the intake folder.
+	 */
+	private async writeCaptureBreadcrumb(
+		originalPath: string,
+		movedPath: string,
+	): Promise<void> {
+		const intakeFolder = normalizePath(this.getSettings().intake.intakeFolder);
+		const logFolder = this.captureLogPath(intakeFolder);
+		if (logFolder === null) {
+			return;
+		}
+
+		const date = new Date().toISOString().split('T')[0];
+		const title = this.sanitizeTitle(this.basenameOf(movedPath));
+		const breadcrumbPath = normalizePath(
+			`${logFolder}/${date} — ${title}.md`,
+		);
+
+		const body = [
+			this.wikiLink(movedPath),
+			'',
+			`- captured: ${date}`,
+			`- from: ${originalPath}`,
+			`- moved to: ${movedPath}`,
+			'',
+		].join('\n');
+		const content = serializeFrontmatter(
+			{ [SYNAPSE_PROCESSED_FLAG]: true },
+			body,
+		);
+
+		await ensureFolder(this.plugin.app, logFolder);
+		await writeNote(this.plugin.app, breadcrumbPath, content);
+	}
+
+	/** Basename (no extension) of a vault path, e.g. `A/B/note.md` → `note`. */
+	private basenameOf(path: string): string {
+		return path.replace(/\.md$/, '').split('/').pop() || path;
+	}
+
+	/**
+	 * Build an Obsidian wiki-link to a path (mirrors deep-dive's `wikiLink`:
+	 * `[[basename]]`). Inlined rather than imported to keep the intake module's
+	 * import boundary (only `obsidian` + `src/shared/*`).
+	 */
+	private wikiLink(path: string): string {
+		return `[[${this.basenameOf(path)}]]`;
+	}
+
+	/**
+	 * Sanitize a note title for use in a filename — the same rule used for video
+	 * download filenames (`src/video`): strip to `[a-zA-Z0-9-_ ]`, trim, cap
+	 * length. Falls back to `note` when nothing printable survives.
+	 */
+	private sanitizeTitle(title: string): string {
+		const cleaned = title
+			.replace(/[^a-zA-Z0-9-_ ]/g, '')
+			.trim()
+			.slice(0, 60);
+		return cleaned.length > 0 ? cleaned : 'note';
 	}
 }

--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -225,22 +225,38 @@ export class IntakeModule {
 	 * Execute a resolved route, then (on success) stamp the processed flag and
 	 * optionally move the note. Throws on processing failure so flush() can
 	 * surface it and skip stamping.
+	 *
+	 * Every content-bearing branch ends in the full `fireOnFile` pipeline whose
+	 * last phase (organize) is the primary, content-aware mover — it relocates
+	 * the note to its proper vault folder (#223). We capture the note's path
+	 * BEFORE running the pipeline so post-processing we can tell whether organize
+	 * moved it out of the intake folder; that signal drives both the
+	 * `moveWhenDone` fallback and (#224) the breadcrumb capture log.
 	 */
 	private async execute(
 		file: TFile,
 		route: IntakeRoute,
 	): Promise<void> {
+		// Organize mutates `file.path` in place on rename, so snapshot it now.
+		const originalPath = file.path;
+
 		switch (route.kind) {
 			case 'transcription':
-				// #112 — STUB. Surfaces a "coming soon" notice and no-ops.
+				// #112 — STUB. Surfaces a "coming soon" notice and no-ops. A
+				// content-less URL note has nothing for organize to analyse; once
+				// #112 produces a transcript this branch should also end in
+				// `await this.deps.fireOnFile(file)` so the note is enriched and
+				// organized like the others.
 				await this.deps.transcribeUrlToNote(route.url, route.mediaType, file);
 				break;
 
 			case 'article': {
 				const articleContent = await fetchArticleContent(route.url);
 				await this.appendArticleContent(file, articleContent);
-				// Elaborate the now-fleshed-out note (single-note scope).
-				await this.deps.elaborateFile(file);
+				// Run the full pipeline on the now-fleshed-out note. fireOnFile
+				// runs elaboration as phase 1 and organize as the last phase, so
+				// there is no separate elaborate-then-stop step anymore (#223).
+				await this.deps.fireOnFile(file);
 				break;
 			}
 
@@ -249,7 +265,7 @@ export class IntakeModule {
 				break;
 		}
 
-		await this.markProcessedAndMaybeMove(file);
+		await this.markProcessedAndMaybeMove(file, originalPath);
 	}
 
 	/**
@@ -274,21 +290,64 @@ export class IntakeModule {
 	}
 
 	/**
-	 * Stamp the processed flag (when enabled) BEFORE any move, then move the
-	 * note to `moveWhenDone` (when set). Stamping first guarantees idempotency
-	 * survives the move and the move's own rename event.
+	 * Stamp the processed flag (when enabled), then apply `moveWhenDone` as a
+	 * FALLBACK mover only. Organize (run inside `fireOnFile`) is now the primary,
+	 * content-aware mover; it may instead keep a note in place or create a
+	 * proposal when confidence is low (< 0.9). So `moveWhenDone` runs only when
+	 * organize did NOT move the note out of the intake folder, guaranteeing a
+	 * note never gets stuck in the intake folder while avoiding a double move
+	 * for notes organize already relocated (#223).
+	 *
+	 * Stamping happens first so idempotency survives any subsequent move and the
+	 * move's own rename echo. Returns whether the note ended up moved out of the
+	 * intake folder, so the caller can drive the breadcrumb capture log (#224).
+	 *
+	 * `originalPath` is the note's path captured BEFORE processing (organize
+	 * mutates `file.path` in place on rename).
 	 */
-	private async markProcessedAndMaybeMove(file: TFile): Promise<void> {
+	private async markProcessedAndMaybeMove(
+		file: TFile,
+		originalPath: string,
+	): Promise<boolean> {
 		const settings = this.getSettings().intake;
 
+		// Stamp first — this lands on the note's *current* path (post-organize).
+		// If organize moved it out of the intake folder, isInIntakeFolder rejects
+		// the resulting modify echo; if it stayed in the folder, the original-path
+		// inFlight guard (keyed on originalPath in flush) suppresses the echo.
 		if (settings.markProcessed) {
 			await this.stampProcessed(file);
 		}
 
-		const destination = settings.moveWhenDone;
-		if (destination && destination.trim().length > 0) {
-			await this.moveNote(file, destination.trim());
+		let movedOut = this.movedOutOfIntake(originalPath, file.path);
+
+		// Fallback mover: only when organize left the note inside the intake
+		// folder (low-confidence proposal / no-op). Skipped entirely when organize
+		// already relocated the note, which also fixes the prior general-branch
+		// double move.
+		if (!movedOut) {
+			const destination = settings.moveWhenDone;
+			if (destination && destination.trim().length > 0) {
+				await this.moveNote(file, destination.trim());
+				movedOut = this.movedOutOfIntake(originalPath, file.path);
+			}
 		}
+
+		return movedOut;
+	}
+
+	/**
+	 * True when a note that started under the intake folder no longer lives
+	 * there — i.e. organize (or the `moveWhenDone` fallback) relocated it out of
+	 * the intake folder. The single source of truth for the "left the inbox?"
+	 * signal, reused by the `moveWhenDone` fallback and the breadcrumb log (#224).
+	 */
+	private movedOutOfIntake(originalPath: string, currentPath: string): boolean {
+		const intakeFolder = this.getSettings().intake.intakeFolder;
+		return (
+			this.isInIntakeFolder(originalPath, intakeFolder) &&
+			!this.isInIntakeFolder(currentPath, intakeFolder)
+		);
 	}
 
 	/** Write `synapse-processed: true` + an ISO timestamp into frontmatter. */

--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -26,8 +26,13 @@ export {
 	SYNAPSE_PROCESSED_AT_FLAG,
 } from './types';
 
-/** How long to wait after the last change to a path before flushing it. */
-const DEBOUNCE_MS = 400;
+/**
+ * Fallback settle window (ms) used only when `intake.settleSeconds` is missing
+ * or not a positive number. The configured default is 5s (`settleSeconds`, see
+ * `DEFAULT_SETTINGS.intake`); this constant just guards a malformed setting so
+ * the watcher always has a sane debounce. See {@link IntakeModule.scheduleFlush}.
+ */
+const DEBOUNCE_MS = 5000;
 
 /**
  * IntakeModule — watches a configurable intake folder and auto-processes new
@@ -134,8 +139,11 @@ export class IntakeModule {
 	}
 
 	/**
-	 * Debounce a path: (re)start its timer so a create immediately followed by
-	 * a modify (the share-to-vault pattern) coalesces into a single flush.
+	 * Debounce a path against the configured settle window: (re)start its timer
+	 * on every event so processing fires only after the note has been quiet for
+	 * the full window. This coalesces a create immediately followed by a modify
+	 * (the share-to-vault pattern) AND defers a note whose content is still
+	 * arriving (chunked sync, the user still typing) — see #222.
 	 */
 	private scheduleFlush(path: string): void {
 		this.pending.add(path);
@@ -149,9 +157,23 @@ export class IntakeModule {
 			this.timers.delete(path);
 			this.pending.delete(path);
 			void this.flush(path);
-		}, DEBOUNCE_MS);
+		}, this.settleWindowMs());
 
 		this.timers.set(path, handle);
+	}
+
+	/**
+	 * Resolve the settle window in ms from `intake.settleSeconds`, falling back
+	 * to {@link DEBOUNCE_MS} when the setting is missing or not a positive
+	 * number. Read fresh on every schedule so changing the setting takes effect
+	 * immediately, without reloading the watcher.
+	 */
+	private settleWindowMs(): number {
+		const seconds = this.getSettings().intake.settleSeconds;
+		if (typeof seconds === 'number' && seconds > 0) {
+			return seconds * 1000;
+		}
+		return DEBOUNCE_MS;
 	}
 
 	/**

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -91,7 +91,10 @@ describe('IntakeModule', () => {
 			modify: vi.fn(async (file: any, content: string) => {
 				store.set(file.path, content);
 			}),
-			create: vi.fn(),
+			create: vi.fn(async (path: string, content: string) => {
+				store.set(path, content);
+				return makeFile(path);
+			}),
 			createFolder: vi.fn().mockResolvedValue(undefined),
 			getAbstractFileByPath: vi.fn((path: string) => {
 				if (store.has(path)) return makeFile(path);
@@ -572,6 +575,89 @@ describe('IntakeModule', () => {
 			handlers['modify'](makeFile('Inbox/note.md'));
 			await flushDebounce();
 			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('capture log breadcrumb (#224)', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('writes a dated breadcrumb linking to the new path when organized out of Inbox', async () => {
+			organizeMovesTo('Articles/My Note.md');
+
+			emit('create', 'Inbox/My Note.md', 'hello prose');
+			await flushDebounce();
+
+			// setSystemTime is 2026-06-05, so the breadcrumb is date-named for it.
+			const crumbPath = 'Inbox/_captured/2026-06-05 — My Note.md';
+			expect(store.has(crumbPath)).toBe(true);
+			const crumb = store.get(crumbPath)!;
+			// Links to the moved note by basename, and records the trail.
+			expect(crumb).toContain('[[My Note]]');
+			expect(crumb).toContain('from: Inbox/My Note.md');
+			expect(crumb).toContain('moved to: Articles/My Note.md');
+			// Stamped as defense-in-depth so it is never reprocessed.
+			expect(crumb).toContain('synapse-processed: true');
+		});
+
+		it('sanitizes the breadcrumb filename', async () => {
+			organizeMovesTo('Refs/Weird: Title*?.md');
+
+			emit('create', 'Inbox/Weird: Title*?.md', 'hello prose');
+			await flushDebounce();
+
+			// Illegal filename chars are stripped (the video sanitize rule).
+			expect(store.has('Inbox/_captured/2026-06-05 — Weird Title.md')).toBe(true);
+		});
+
+		it('writes no breadcrumb when the note is not moved out of Inbox', async () => {
+			organizeMovesTo(null); // organize keeps it in place
+
+			emit('create', 'Inbox/stay.md', 'hello prose');
+			await flushDebounce();
+
+			const captured = [...store.keys()].filter((p) => p.startsWith('Inbox/_captured/'));
+			expect(captured).toHaveLength(0);
+		});
+
+		it('writes no breadcrumb when captureLog is disabled', async () => {
+			settings.intake.captureLog = false;
+			organizeMovesTo('Articles/off.md');
+
+			emit('create', 'Inbox/off.md', 'hello prose');
+			await flushDebounce();
+
+			expect(store.has('Articles/off.md')).toBe(true); // still organized
+			const captured = [...store.keys()].filter((p) => p.startsWith('Inbox/_captured/'));
+			expect(captured).toHaveLength(0);
+		});
+
+		it('IGNORES a file created in the capture-log subfolder (no reprocessing / no loop)', async () => {
+			// A breadcrumb (or anything) appearing under Inbox/_captured must be
+			// invisible to the watcher — otherwise the watcher would re-ingest its
+			// own breadcrumbs and spin forever.
+			emit('create', 'Inbox/_captured/2026-06-05 — Something.md', '[[Something]]');
+			emit('modify', 'Inbox/_captured/2026-06-05 — Something.md', '[[Something]]');
+			await flushDebounce();
+
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			expect(deps.transcribeUrlToNote).not.toHaveBeenCalled();
+			expect(fetchArticleContent).not.toHaveBeenCalled();
+		});
+
+		it('respects a custom captureLogFolder for both writing and exclusion', async () => {
+			settings.intake.captureLogFolder = 'log';
+			organizeMovesTo('Articles/custom.md');
+
+			emit('create', 'Inbox/custom.md', 'hello prose');
+			await flushDebounce();
+			expect(store.has('Inbox/log/2026-06-05 — custom.md')).toBe(true);
+
+			// And the custom subfolder is excluded from the watcher.
+			emit('create', 'Inbox/log/2026-06-05 — custom.md', 'x');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1); // only the original run
 		});
 	});
 

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -57,7 +57,6 @@ describe('IntakeModule', () => {
 	let settings: SynapseSettings;
 	let deps: {
 		fireOnFile: ReturnType<typeof vi.fn>;
-		elaborateFile: ReturnType<typeof vi.fn>;
 		transcribeUrlToNote: ReturnType<typeof vi.fn>;
 	};
 	/** Captured vault event handlers, keyed by event name. */
@@ -117,7 +116,6 @@ describe('IntakeModule', () => {
 		notifications = createMockNotifications();
 		deps = {
 			fireOnFile: vi.fn().mockResolvedValue(undefined),
-			elaborateFile: vi.fn().mockResolvedValue(undefined),
 			transcribeUrlToNote: vi.fn().mockResolvedValue(undefined),
 		};
 
@@ -143,6 +141,22 @@ describe('IntakeModule', () => {
 	/** Run all pending timers, then drain microtasks so async flush settles. */
 	async function flushDebounce() {
 		await vi.runOnlyPendingTimersAsync();
+	}
+
+	/**
+	 * Make `fireOnFile` simulate organize relocating the note: move its content
+	 * in the store and mutate `file.path` in place, exactly as organize's
+	 * `vault.rename` does. Pass `null` to model organize keeping the note in
+	 * place (low confidence → proposal / no-op) — content/path are untouched.
+	 */
+	function organizeMovesTo(newPath: string | null) {
+		deps.fireOnFile.mockImplementation(async (file: any) => {
+			if (newPath === null || newPath === file.path) return;
+			const content = store.get(file.path);
+			store.delete(file.path);
+			if (content !== undefined) store.set(newPath, content);
+			file.path = newPath;
+		});
 	}
 
 	describe('onload / listener registration', () => {
@@ -401,15 +415,16 @@ describe('IntakeModule', () => {
 			);
 		});
 
-		it('bare article URL → fetch + append + elaborate', async () => {
+		it('bare article URL → fetch + append + full pipeline (#223)', async () => {
 			emit('create', 'Inbox/art.md', 'https://example.com/post');
 			await flushDebounce();
 
 			expect(fetchArticleContent).toHaveBeenCalledWith('https://example.com/post');
 			const written = store.get('Inbox/art.md')!;
 			expect(written).toContain('FETCHED ARTICLE BODY');
-			expect(deps.elaborateFile).toHaveBeenCalledTimes(1);
-			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			// The article branch now runs the whole pipeline (fireOnFile), whose
+			// organize phase relocates the note — there is no elaborate-only path.
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
 		});
 
 		it('bare unknown URL → general pipeline', async () => {
@@ -479,6 +494,84 @@ describe('IntakeModule', () => {
 			emit('create', 'Inbox/note.md', 'hello prose');
 			await flushDebounce();
 			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('full pipeline + auto-organize (#223)', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('runs the full pipeline on an article note and organizes it out of Inbox', async () => {
+			// Organize (pipeline phase) relocates the fleshed-out article note.
+			organizeMovesTo('Articles/art.md');
+
+			emit('create', 'Inbox/art.md', 'https://example.com/post');
+			await flushDebounce();
+
+			expect(fetchArticleContent).toHaveBeenCalledWith('https://example.com/post');
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+			// The note left Inbox and landed where organize put it, stamped.
+			expect(store.has('Inbox/art.md')).toBe(false);
+			const moved = store.get('Articles/art.md')!;
+			expect(moved).toContain('FETCHED ARTICLE BODY');
+			expect(moved).toContain('synapse-processed: true');
+		});
+
+		it('does NOT apply moveWhenDone when organize already moved the note out (no double move)', async () => {
+			settings.intake.moveWhenDone = 'Processed';
+			organizeMovesTo('Articles/note.md'); // organize relocates it
+
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+
+			// Fallback mover must not fire — organize already moved it out.
+			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
+			expect(store.has('Processed/note.md')).toBe(false);
+			expect(store.has('Articles/note.md')).toBe(true);
+		});
+
+		it('applies moveWhenDone as a fallback when organize keeps the note in Inbox', async () => {
+			settings.intake.moveWhenDone = 'Processed';
+			organizeMovesTo(null); // low confidence → organize keeps it in place
+
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+
+			// Note never left Inbox via organize → fallback relocates it.
+			expect(plugin.app.fileManager.renameFile).toHaveBeenCalledWith(
+				expect.anything(),
+				'Processed/note.md'
+			);
+			expect(store.has('Processed/note.md')).toBe(true);
+			expect(store.get('Processed/note.md')).toContain('synapse-processed: true');
+		});
+
+		it('does not re-enter flush after organize moves the note OUT of Inbox', async () => {
+			organizeMovesTo('Articles/note.md');
+
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+
+			// The post-organize stamp write lands on the NEW path. Obsidian emits
+			// a modify for it; isInIntakeFolder rejects it (outside Inbox).
+			handlers['modify'](makeFile('Articles/note.md'));
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not re-enter flush when organize keeps the note IN Inbox', async () => {
+			organizeMovesTo(null); // stays at Inbox/note.md
+
+			emit('create', 'Inbox/note.md', 'hello prose');
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+
+			// Stamp echo on the original in-Inbox path → idempotency guard skips it.
+			handlers['modify'](makeFile('Inbox/note.md'));
+			await flushDebounce();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -16,7 +16,11 @@ vi.mock('../shared', async (importOriginal) => {
 
 import { fetchArticleContent } from '../shared';
 
-const DEBOUNCE_MS = 400;
+// The settle window is now driven by `intake.settleSeconds` (#222). Tests seed
+// `settings.intake.settleSeconds = 5` (the default), so the effective debounce
+// is 5000ms; this local constant mirrors that so the timing assertions read
+// clearly. Individual tests override `settleSeconds` to exercise the setting.
+const SETTLE_MS = 5000;
 
 function createMockNotifications() {
 	return {
@@ -74,6 +78,7 @@ describe('IntakeModule', () => {
 		settings.intake.intakeFolder = 'Inbox';
 		settings.intake.markProcessed = true;
 		settings.intake.moveWhenDone = '';
+		settings.intake.settleSeconds = SETTLE_MS / 1000;
 
 		handlers = {};
 		store = new Map();
@@ -223,7 +228,7 @@ describe('IntakeModule', () => {
 			handlers['create'](makeFile(path));
 
 			// Advance partway, then fire again to reset the timer.
-			await vi.advanceTimersByTimeAsync(DEBOUNCE_MS - 100);
+			await vi.advanceTimersByTimeAsync(SETTLE_MS - 100);
 			expect(deps.fireOnFile).not.toHaveBeenCalled();
 			handlers['modify'](makeFile(path));
 
@@ -232,7 +237,7 @@ describe('IntakeModule', () => {
 			expect(deps.fireOnFile).not.toHaveBeenCalled();
 
 			// After the full window from the reset, it flushes exactly once.
-			await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+			await vi.advanceTimersByTimeAsync(SETTLE_MS);
 			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
 		});
 
@@ -243,6 +248,77 @@ describe('IntakeModule', () => {
 			module.onunload();
 			await flushDebounce();
 			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('settle window (#222)', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('keeps deferring while edits keep arriving inside the window', async () => {
+			const path = 'Inbox/capture.md';
+			store.set(path, 'draft');
+			handlers['create'](makeFile(path));
+
+			// Five edits, each just before the window would elapse. Every edit
+			// resets the timer, so the note never gets processed mid-write.
+			for (let i = 0; i < 5; i++) {
+				await vi.advanceTimersByTimeAsync(SETTLE_MS - 1);
+				expect(deps.fireOnFile).not.toHaveBeenCalled();
+				handlers['modify'](makeFile(path));
+			}
+
+			// Still nothing — the last edit just reset the timer again.
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+
+		it('fires exactly once, settleSeconds after the last edit', async () => {
+			const path = 'Inbox/capture.md';
+			store.set(path, 'hello prose');
+			handlers['create'](makeFile(path));
+
+			// A burst of edits within the window…
+			await vi.advanceTimersByTimeAsync(SETTLE_MS - 1);
+			handlers['modify'](makeFile(path));
+			await vi.advanceTimersByTimeAsync(SETTLE_MS - 1);
+			handlers['modify'](makeFile(path));
+
+			// One tick short of the window after the final edit → not yet.
+			await vi.advanceTimersByTimeAsync(SETTLE_MS - 1);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+
+			// Crossing the window from the last edit fires it once.
+			await vi.advanceTimersByTimeAsync(1);
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('respects a custom settleSeconds setting', async () => {
+			settings.intake.settleSeconds = 12;
+			const path = 'Inbox/slow.md';
+			store.set(path, 'hello prose');
+			handlers['create'](makeFile(path));
+
+			// The old 5s window elapses with no flush — we now wait 12s.
+			await vi.advanceTimersByTimeAsync(5000);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(7000);
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+		});
+
+		it('falls back to a sane window when settleSeconds is invalid', async () => {
+			// A malformed setting (0 / NaN / undefined) must not disable the
+			// watcher — it falls back to DEBOUNCE_MS (5000ms).
+			(settings.intake as any).settleSeconds = 0;
+			const path = 'Inbox/fallback.md';
+			store.set(path, 'hello prose');
+			handlers['create'](makeFile(path));
+
+			await vi.advanceTimersByTimeAsync(4999);
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			await vi.advanceTimersByTimeAsync(1);
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/intake/types.ts
+++ b/src/intake/types.ts
@@ -44,10 +44,13 @@ export type IntakeRoute =
  * like the enrichment/organize callback bundles.
  */
 export interface IntakeDeps {
-	/** General branch: run the whole Synapse pipeline against ONE note. */
+	/**
+	 * Run the whole Synapse pipeline (elaboration → … → organize) against ONE
+	 * note. Used by both the general and article branches; organize, its last
+	 * phase, relocates the note to its proper folder (#223). Elaboration runs as
+	 * pipeline phase 1, so there is no separate elaborate-only callback anymore.
+	 */
 	fireOnFile(file: TFile): Promise<void>;
-	/** Article branch: run elaboration against ONE note. */
-	elaborateFile(file: TFile): Promise<void>;
 	/**
 	 * Transcription branch (#112) — STUB. For now this just surfaces a
 	 * "coming soon" notice and no-ops; real URL transcription is out of scope.

--- a/src/main.ts
+++ b/src/main.ts
@@ -304,15 +304,13 @@ export default class SynapsePlugin extends Plugin {
 		// auto-processes new notes. Cross-module work is injected as callbacks
 		// (the intake module never imports other feature modules):
 		//   - general notes  -> run the whole pipeline on the one note
-		//   - article URLs    -> elaboration on the one note (after fetch+append)
+		//   - article URLs    -> fetch+append, then the whole pipeline (#223);
+		//                        the pipeline's organize phase relocates the note
 		//   - media URLs      -> #112 transcription STUB (notice only)
+		// fireOnFile runs elaboration as its first phase, so no separate
+		// elaborate-only callback is needed anymore (#223).
 		this.intake = new IntakeModule(this, getSettings, this.notifications, {
 			fireOnFile: (file) => synapseRunner.fireOnFile(file),
-			elaborateFile: async (file) => {
-				if (this.settings.elaboration.enabled) {
-					await this.elaboration.scanNote(file, true);
-				}
-			},
 			transcribeUrlToNote: async (_url, _mediaType, _file) => {
 				new Notice('Synapse: URL transcription from intake is coming soon (#112)');
 			},

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -215,6 +215,26 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName('Settle window (seconds)')
+			.setDesc(
+				'Wait this long after the last change to a note before processing it. ' +
+				'The timer resets on every edit, so active typing or chunked sync keeps ' +
+				'deferring — processing fires only once the note has been quiet for the ' +
+				'full window. Raise it if notes are still arriving when they get processed.'
+			)
+			.addText((text) =>
+				text
+					.setValue(String(this.plugin.settings.intake.settleSeconds))
+					.onChange(async (value) => {
+						const num = parseInt(value);
+						if (!isNaN(num) && num > 0) {
+							this.plugin.settings.intake.settleSeconds = num;
+							await this.plugin.saveSettings();
+						}
+					})
+			);
+
+		new Setting(containerEl)
 			.setName('Intake folder')
 			.setDesc('Folder to watch for new notes. See docs/intake-folder.md for the mobile capture workflow.')
 			.addText((text) =>

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -260,8 +260,13 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName('Move when done (optional)')
-			.setDesc('Destination folder to move notes into after processing. Leave blank to keep them in the intake folder.')
+			.setName('Move when done (fallback)')
+			.setDesc(
+				'Fallback destination used only when auto-organize keeps a note in ' +
+				'the intake folder (e.g. low confidence). Notes organize relocates ' +
+				'are left where it put them. Leave blank to keep unorganized notes ' +
+				'in the intake folder.'
+			)
 			.addText((text) =>
 				text
 					.setPlaceholder('')
@@ -270,6 +275,40 @@ export class SynapseSettingTab extends PluginSettingTab {
 						const trimmed = value.trim();
 						this.plugin.settings.intake.moveWhenDone = trimmed === '' ? undefined : trimmed;
 						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Capture log')
+			.setDesc(
+				'When a note is auto-organized out of the intake folder, leave a ' +
+				'dated breadcrumb linking to its new home in the capture-log subfolder.'
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.intake.captureLog)
+					.onChange(async (value) => {
+						this.plugin.settings.intake.captureLog = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Capture log folder')
+			.setDesc(
+				'Subfolder of the intake folder for breadcrumbs (relative to it). ' +
+				'This subfolder is ignored by the watcher so breadcrumbs are never reprocessed.'
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder('_captured')
+					.setValue(this.plugin.settings.intake.captureLogFolder)
+					.onChange(async (value) => {
+						const trimmed = value.trim();
+						if (trimmed.length > 0) {
+							this.plugin.settings.intake.captureLogFolder = trimmed;
+							await this.plugin.saveSettings();
+						}
 					})
 			);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -204,6 +204,18 @@ export interface IntakeSettings {
 	 * pipeline runs N seconds after the *last* change (#222).
 	 */
 	settleSeconds: number;
+	/**
+	 * When true, drop a dated breadcrumb link file each time a processed intake
+	 * note is organized out of the intake folder, so the capture leaves a trace
+	 * (#224). No move → no breadcrumb.
+	 */
+	captureLog: boolean;
+	/**
+	 * Flat subfolder of the intake folder where breadcrumbs are written
+	 * (default `_captured`). This subfolder is excluded from the watcher so
+	 * breadcrumbs are never re-ingested.
+	 */
+	captureLogFolder: string;
 }
 
 export interface SynapseSettings {
@@ -366,5 +378,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		markProcessed: true,
 		moveWhenDone: '',
 		settleSeconds: 5,
+		captureLog: true,
+		captureLogFolder: '_captured',
 	},
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -197,6 +197,13 @@ export interface IntakeSettings {
 	intakeFolder: string;
 	markProcessed: boolean;
 	moveWhenDone?: string;
+	/**
+	 * Settle window in seconds: processing fires only after a watched note has
+	 * had no create/modify events for this whole interval. The per-path timer
+	 * resets on every event, so active typing/sync keeps deferring and the
+	 * pipeline runs N seconds after the *last* change (#222).
+	 */
+	settleSeconds: number;
 }
 
 export interface SynapseSettings {
@@ -358,5 +365,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		intakeFolder: 'Inbox',
 		markProcessed: true,
 		moveWhenDone: '',
+		settleSeconds: 5,
 	},
 };


### PR DESCRIPTION
## Summary

Implements **Intake Processing v2** (epic #221), decomposed into three sub-issues, each its own commit in dependency order:

### #222 — Configurable settle window (`b8978df`)
Replaces the fixed 400ms intake debounce with a configurable **settle window** (`intake.settleSeconds`, default **5s**). The per-path timer already resets on every create/modify event, so processing now fires only after a note has been quiet for the full window — a half-written note arriving via mobile share-to-vault or chunked sync keeps deferring instead of being processed and stamped before its content lands.
- `settings.ts`: `settleSeconds` (default 5). `settings-tab.ts`: numeric control whose description explains the timer resets on every edit.
- `intake/index.ts`: `scheduleFlush` reads the window fresh from `settleSeconds * 1000` (so changing the setting takes effect without reloading the watcher); `DEBOUNCE_MS` is repurposed as a 5000ms fallback for a malformed value.

### #223 — Full Fire-Synapse + auto-organize on every note (`db694a4`)
Every content-bearing intake note now runs the complete `fireOnFile` pipeline, whose last phase (organize) relocates it to its proper vault folder. Previously only the `general` branch ran the pipeline; `article` stopped at elaboration.
- `execute()`: the **article** branch now ends in `fireOnFile` after fetch+append (`fireOnFile` runs elaboration as phase 1, so the separate `elaborateFile` step is dropped). **general** unchanged. **transcription** keeps the #112 stub, with a comment to wire `fireOnFile` once #112 produces a transcript.
- `IntakeDeps`/`main.ts`: removed the now-unused `elaborateFile` callback (nothing else referenced it).
- `markProcessedAndMaybeMove()`: captures `originalPath` **before** the pipeline (organize mutates `file.path` in place) and returns a `movedOut` boolean via the new `movedOutOfIntake(originalPath, currentPath)` helper — the single source of truth for "left the inbox?", reused by #224.

### #224 — Breadcrumb capture log (`2b2929d`)
When a note is auto-organized out of the intake folder, drop a dated breadcrumb link file into a flat, listener-ignored subfolder.
- `settings.ts`: `captureLog` (default `true`) + `captureLogFolder` (default `_captured`, relative to the intake folder); `settings-tab.ts` toggle + text control.
- `intake/index.ts`: reuses the #223 `movedOut` signal — when the note left the intake folder, writes `‹intakeFolder›/‹captureLogFolder›/‹YYYY-MM-DD› — ‹sanitized title›.md` via `ensureFolder` + `writeNote`, containing a `[[wiki-link]]` to the moved note plus metadata (captured date, original path, moved-to path). Date via `toISOString().split('T')[0]`; filename sanitized with the video rule (`[a-zA-Z0-9-_ ]`, trim, cap 60). **No move → no breadcrumb.**
- **Listener exclusion (prevents an infinite ingest loop):** the capture-log subfolder lives under the intake folder, which `isInIntakeFolder` matched. It is now excluded there (single source of truth: `captureLogPath()`), AND each breadcrumb is stamped `synapse-processed: true` as defense-in-depth.

## `moveWhenDone` precedence (per #223)

Organize (inside `fireOnFile`) is now the **primary, content-aware mover**. `intake.moveWhenDone` is demoted to a **fallback** that runs **only when organize did NOT move the note out of the intake folder** (low confidence → organize creates a proposal / keeps the note in place). Precedence:

1. **Organize moves the note out of the intake folder** → that's the final location. `moveWhenDone` is **skipped** (fixes a latent double-move for `general` notes, which previously ran organize *then* `moveWhenDone`).
2. **Organize keeps the note in the intake folder** (proposal / no-op) → `moveWhenDone` applies as the fallback so the note never gets stuck in the inbox.

Stamping happens first in both cases, so `synapse-processed` idempotency survives any subsequent move and its rename echo.

## Echo-guard coverage

`inFlight` keys on the original path; organize mutates `file.path` in place, so the post-move stamp write lands on the new path. Both cases are covered and tested:
- Organize moved the note **out** → `isInIntakeFolder` rejects the post-move stamp echo (now outside the intake folder).
- Organize kept the note **in** → the original-path `inFlight` guard / processed-flag idempotency suppress the echo.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm test` — **933 passed** (57 files; +15 intake tests: 4 settle-window, 5 pipeline/organize, 6 capture-log)
- [x] `node esbuild.config.mjs production` — succeeds

Closes #221
Closes #222
Closes #223
Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)