### PR TITLE
fix: downscale large images before API to avoid 5 MB limit error

### DIFF
--- a/src/elaboration/image-analyzer.ts
+++ b/src/elaboration/image-analyzer.ts
@@ -1,7 +1,8 @@
-import { App, TFile } from 'obsidian';
+import { App, Notice, TFile } from 'obsidian';
 import { AIClient } from '../shared';
 import type { ContentBlock } from '../shared';
 import { SynapseSettings } from '../settings';
+import { arrayBufferToBase64, preprocessImage } from '../image/preprocess';
 
 export interface ImageAnalysis {
 	/** Original reference as it appears in the note */
@@ -106,11 +107,20 @@ export class ImageAnalyzer {
 
 		// Read binary data
 		const data = await this.app.vault.readBinary(file);
-		const base64 = this.arrayBufferToBase64(data);
-		const mediaType = this.getMediaType(file.name);
+		const sourceMediaType = this.getMediaType(file.name);
 
 		// Apply vision model override if configured
 		const settings = this.getSettings();
+
+		// Downscale oversized images so they fit under the API's base64 size limit.
+		const maxBytes = (settings.image.maxImageSizeMb || 5) * 1024 * 1024;
+		const processed = await preprocessImage(data, sourceMediaType, maxBytes);
+		if (processed.downscaled) {
+			new Notice('Synapse: large image auto-downscaled to fit the API limit');
+		}
+		const base64 = arrayBufferToBase64(processed.data);
+		const mediaType = processed.mediaType;
+
 		const visionModel = settings.image.visionModel || settings.ai.model;
 		const originalModel = settings.ai.model;
 		if (visionModel !== originalModel) {
@@ -168,15 +178,6 @@ METADATA: Any observable metadata clues (timestamps visible in the image, camera
 			locationHints: locMatch?.[1]?.trim() || '',
 			metadata: metaMatch?.[1]?.trim() || '',
 		};
-	}
-
-	private arrayBufferToBase64(buffer: ArrayBuffer): string {
-		const bytes = new Uint8Array(buffer);
-		let binary = '';
-		for (let i = 0; i < bytes.length; i++) {
-			binary += String.fromCharCode(bytes[i]);
-		}
-		return btoa(binary);
 	}
 
 	private getMediaType(fileName: string): string {

--- a/src/image/extractor.ts
+++ b/src/image/extractor.ts
@@ -1,7 +1,9 @@
+import { Notice } from 'obsidian';
 import { AIClient } from '../shared';
 import type { ContentBlock } from '../shared';
 import { SynapseSettings } from '../settings';
 import { OCRResult } from './types';
+import { arrayBufferToBase64, preprocessImage } from './preprocess';
 
 export class ImageExtractor {
 	private aiClient: AIClient;
@@ -11,9 +13,17 @@ export class ImageExtractor {
 	}
 
 	async extract(imageData: ArrayBuffer, fileName: string): Promise<OCRResult> {
-		const base64 = this.arrayBufferToBase64(imageData);
-		const mediaType = this.getMediaType(fileName);
 		const settings = this.getSettings();
+		const sourceMediaType = this.getMediaType(fileName);
+
+		const maxBytes = (settings.image.maxImageSizeMb || 5) * 1024 * 1024;
+		const processed = await preprocessImage(imageData, sourceMediaType, maxBytes);
+		if (processed.downscaled) {
+			new Notice('Synapse: large image auto-downscaled to fit the API limit');
+		}
+
+		const base64 = arrayBufferToBase64(processed.data);
+		const mediaType = processed.mediaType;
 
 		const contentBlocks: ContentBlock[] = [
 			{
@@ -47,15 +57,6 @@ export class ImageExtractor {
 				settings.ai.model = originalModel;
 			}
 		}
-	}
-
-	private arrayBufferToBase64(buffer: ArrayBuffer): string {
-		const bytes = new Uint8Array(buffer);
-		let binary = '';
-		for (let i = 0; i < bytes.length; i++) {
-			binary += String.fromCharCode(bytes[i]);
-		}
-		return btoa(binary);
 	}
 
 	private getMediaType(fileName: string): string {

--- a/src/image/preprocess.test.ts
+++ b/src/image/preprocess.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { arrayBufferToBase64, base64EncodedLength, preprocessImage } from './preprocess';
+
+/**
+ * Vitest runs in a node env with no DOM/Canvas. We mock document.createElement('canvas'),
+ * the canvas 2d context, and createImageBitmap so the downscale path is exercisable.
+ */
+
+interface CanvasMock {
+	width: number;
+	height: number;
+	getContext: ReturnType<typeof vi.fn>;
+	toBlob: ReturnType<typeof vi.fn>;
+}
+
+let createdCanvases: CanvasMock[] = [];
+let drawImageCalls = 0;
+/** Bytes the mocked encoder returns; tests tune this to simulate over/under limit. */
+let encodedByteLength = 1024;
+
+function installCanvasMocks(): void {
+	createdCanvases = [];
+	drawImageCalls = 0;
+
+	const makeCanvas = (): CanvasMock => {
+		const canvas: CanvasMock = {
+			width: 0,
+			height: 0,
+			getContext: vi.fn(() => ({
+				drawImage: vi.fn(() => {
+					drawImageCalls++;
+				}),
+			})),
+			toBlob: vi.fn((cb: (blob: Blob | null) => void) => {
+				// Encode to a buffer of the currently-configured size.
+				const buf = new Uint8Array(encodedByteLength).buffer;
+				cb({
+					arrayBuffer: () => Promise.resolve(buf),
+				} as unknown as Blob);
+			}),
+		};
+		return canvas;
+	};
+
+	vi.stubGlobal('document', {
+		createElement: vi.fn((tag: string) => {
+			if (tag !== 'canvas') throw new Error(`unexpected element ${tag}`);
+			const c = makeCanvas();
+			createdCanvases.push(c);
+			return c;
+		}),
+	});
+
+	// Prefer the createImageBitmap path (simpler, no object URLs).
+	vi.stubGlobal(
+		'createImageBitmap',
+		vi.fn(() =>
+			Promise.resolve({
+				width: 4000,
+				height: 3000,
+				close: vi.fn(),
+			})
+		)
+	);
+
+	// Blob is available in node 18+, but stub a minimal version for determinism.
+	if (typeof globalThis.Blob === 'undefined') {
+		vi.stubGlobal('Blob', class {});
+	}
+}
+
+describe('arrayBufferToBase64', () => {
+	it('encodes bytes to base64', () => {
+		const bytes = new Uint8Array([72, 105]); // "Hi"
+		expect(arrayBufferToBase64(bytes.buffer)).toBe('SGk=');
+	});
+
+	it('handles large buffers without stack overflow', () => {
+		const big = new Uint8Array(100_000).fill(65); // 'A'
+		const encoded = arrayBufferToBase64(big.buffer);
+		expect(typeof encoded).toBe('string');
+		expect(encoded.length).toBeGreaterThan(0);
+	});
+});
+
+describe('base64EncodedLength', () => {
+	it('computes the inflated (~4/3, padded) length', () => {
+		expect(base64EncodedLength(3)).toBe(4);
+		expect(base64EncodedLength(1)).toBe(4);
+		expect(base64EncodedLength(6)).toBe(8);
+	});
+});
+
+describe('preprocessImage', () => {
+	beforeEach(() => {
+		encodedByteLength = 1024;
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('passes through small images without touching the canvas', async () => {
+		installCanvasMocks();
+		const small = new Uint8Array(1000).buffer; // base64 ~1336 bytes, well under limit
+		const result = await preprocessImage(small, 'image/png', 5 * 1024 * 1024);
+
+		expect(result.downscaled).toBe(false);
+		expect(result.data).toBe(small);
+		expect(result.mediaType).toBe('image/png');
+		expect(createdCanvases.length).toBe(0);
+		expect(drawImageCalls).toBe(0);
+	});
+
+	it('downscales oversized images and returns a smaller payload', async () => {
+		installCanvasMocks();
+		// 8 MB raw → way over a 5 MB limit → triggers downscale.
+		const big = new Uint8Array(8 * 1024 * 1024).buffer;
+		// Mocked encoder yields a tiny payload that fits the limit.
+		encodedByteLength = 50_000;
+
+		const result = await preprocessImage(big, 'image/jpeg', 5 * 1024 * 1024);
+
+		expect(result.downscaled).toBe(true);
+		expect(result.data.byteLength).toBe(50_000);
+		expect(result.data.byteLength).toBeLessThan(big.byteLength);
+		expect(drawImageCalls).toBeGreaterThan(0);
+	});
+
+	it('re-encodes lossless PNG sources to JPEG when downscaling', async () => {
+		installCanvasMocks();
+		const big = new Uint8Array(8 * 1024 * 1024).buffer;
+		encodedByteLength = 40_000;
+
+		const result = await preprocessImage(big, 'image/png', 5 * 1024 * 1024);
+
+		expect(result.downscaled).toBe(true);
+		expect(result.mediaType).toBe('image/jpeg');
+		// toBlob should have been asked for image/jpeg output.
+		const lastCanvas = createdCanvases[createdCanvases.length - 1];
+		expect(lastCanvas.toBlob).toHaveBeenCalled();
+		expect(lastCanvas.toBlob.mock.calls[0][1]).toBe('image/jpeg');
+	});
+
+	it('returns best-effort downscaled result when it still cannot fit', async () => {
+		installCanvasMocks();
+		const big = new Uint8Array(40 * 1024 * 1024).buffer;
+		// Encoder never gets under the limit, but produces a smaller buffer than input.
+		encodedByteLength = 9 * 1024 * 1024;
+
+		const result = await preprocessImage(big, 'image/jpeg', 5 * 1024 * 1024);
+
+		expect(result.downscaled).toBe(true);
+		expect(result.data.byteLength).toBeLessThan(big.byteLength);
+	});
+
+	it('passes oversized GIFs through unchanged (not rasterizable)', async () => {
+		installCanvasMocks();
+		const big = new Uint8Array(8 * 1024 * 1024).buffer;
+		const result = await preprocessImage(big, 'image/gif', 5 * 1024 * 1024);
+
+		expect(result.downscaled).toBe(false);
+		expect(result.data).toBe(big);
+		expect(createdCanvases.length).toBe(0);
+	});
+
+	it('degrades gracefully when canvas APIs are unavailable', async () => {
+		// No mocks installed → no document/createImageBitmap globals.
+		vi.stubGlobal('document', undefined);
+		vi.stubGlobal('createImageBitmap', undefined);
+		const big = new Uint8Array(8 * 1024 * 1024).buffer;
+		const result = await preprocessImage(big, 'image/png', 5 * 1024 * 1024);
+
+		expect(result.downscaled).toBe(false);
+		expect(result.data).toBe(big);
+	});
+});

--- a/src/image/preprocess.ts
+++ b/src/image/preprocess.ts
@@ -1,0 +1,271 @@
+/**
+ * Shared image preprocessing utilities.
+ *
+ * The Anthropic API rejects base64 image payloads above a hard limit (5 MB by
+ * default) with a 400 error. Both the OCR extractor and the elaboration image
+ * analyzer send raw base64 to the API, so this module provides a single place to
+ * (a) encode buffers to base64 and (b) downscale/re-encode oversized images so
+ * they fit under the limit before they ever reach the API.
+ */
+
+/** Lossless source formats that benefit from JPEG re-encoding when downscaling. */
+const LOSSLESS_MEDIA_TYPES = new Set(['image/png', 'image/bmp', 'image/tiff']);
+
+/** Formats the canvas re-encode path cannot safely rasterize/re-encode. */
+const NON_RASTERIZABLE_MEDIA_TYPES = new Set(['image/gif']);
+
+export interface PreprocessResult {
+	/** The (possibly re-encoded) image bytes to send to the API. */
+	data: ArrayBuffer;
+	/** The media type of `data` (may differ from input if converted to JPEG). */
+	mediaType: string;
+	/** True when the image was downscaled/re-encoded from its original form. */
+	downscaled: boolean;
+}
+
+/**
+ * Encode an ArrayBuffer to a base64 string.
+ * Single source of truth — previously duplicated in extractor.ts and image-analyzer.ts.
+ */
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer);
+	let binary = '';
+	// Chunk to avoid call-stack limits on very large buffers with String.fromCharCode(...spread).
+	const chunkSize = 0x8000;
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		const chunk = bytes.subarray(i, i + chunkSize);
+		binary += String.fromCharCode.apply(null, chunk as unknown as number[]);
+	}
+	return btoa(binary);
+}
+
+/**
+ * The size of a base64-encoded payload for `byteLength` raw bytes.
+ * Base64 inflates by ~4/3 and pads to a multiple of 4.
+ */
+export function base64EncodedLength(byteLength: number): number {
+	return Math.ceil(byteLength / 3) * 4;
+}
+
+/**
+ * Ensure an image's base64 payload fits within `maxBytes`.
+ *
+ * If the encoded payload is already within the limit, the input is passed
+ * through unchanged. Otherwise the image is rasterized to a `<canvas>`,
+ * downscaled (preserving aspect ratio) and — for lossless sources — re-encoded
+ * to JPEG, iterating scale/quality down until it fits. If it still cannot fit,
+ * the best-effort result is returned with `downscaled: true` so the caller can
+ * surface a Notice.
+ *
+ * Runs in Obsidian's Electron renderer, which has a full DOM. In non-DOM
+ * environments (e.g. unit tests without canvas mocks) it degrades gracefully by
+ * passing the original bytes through.
+ *
+ * @param data       Raw image bytes.
+ * @param mediaType  MIME type of `data` (e.g. "image/png").
+ * @param maxBytes   Maximum allowed base64 payload size in bytes.
+ */
+export async function preprocessImage(
+	data: ArrayBuffer,
+	mediaType: string,
+	maxBytes: number
+): Promise<PreprocessResult> {
+	// Already within limit → pass through untouched.
+	if (base64EncodedLength(data.byteLength) <= maxBytes) {
+		return { data, mediaType, downscaled: false };
+	}
+
+	// Can't safely rasterize this format (e.g. animated GIF) — pass through and
+	// let the caller/API decide. Signal downscaled:true is NOT appropriate here
+	// since we didn't change anything; surface as a best-effort passthrough.
+	if (NON_RASTERIZABLE_MEDIA_TYPES.has(mediaType)) {
+		return { data, mediaType, downscaled: false };
+	}
+
+	// If the DOM/canvas APIs aren't available (non-Electron test env without
+	// mocks), degrade gracefully rather than throwing.
+	if (!canUseCanvas()) {
+		return { data, mediaType, downscaled: false };
+	}
+
+	try {
+		return await downscaleToFit(data, mediaType, maxBytes);
+	} catch (error) {
+		console.warn('[Synapse] Image downscale failed; sending original bytes:', error);
+		return { data, mediaType, downscaled: false };
+	}
+}
+
+function canUseCanvas(): boolean {
+	return (
+		typeof document !== 'undefined' &&
+		typeof document.createElement === 'function' &&
+		(typeof createImageBitmap === 'function' || typeof Image !== 'undefined')
+	);
+}
+
+/**
+ * Rasterize the image and iteratively reduce scale/quality until the encoded
+ * payload fits within `maxBytes`. Returns best-effort output if it can't fit.
+ */
+async function downscaleToFit(
+	data: ArrayBuffer,
+	mediaType: string,
+	maxBytes: number
+): Promise<PreprocessResult> {
+	const source = await loadImageSource(data, mediaType);
+	const { width: srcWidth, height: srcHeight } = source;
+
+	if (!srcWidth || !srcHeight) {
+		// Couldn't determine dimensions — nothing reliable to do.
+		releaseImageSource(source);
+		return { data, mediaType, downscaled: false };
+	}
+
+	// Lossless sources re-encode to JPEG for much better compression; otherwise
+	// keep JPEG/WebP as JPEG (canvas re-encodes consistently).
+	const outputType =
+		LOSSLESS_MEDIA_TYPES.has(mediaType) || mediaType === 'image/jpeg' ? 'image/jpeg' : 'image/jpeg';
+
+	// Scale/quality ladder. Each pass shrinks dimensions and/or JPEG quality.
+	const scales = [1, 0.85, 0.7, 0.55, 0.4, 0.3, 0.2, 0.12];
+	const qualities = [0.85, 0.75, 0.6, 0.45];
+
+	let best: { data: ArrayBuffer; mediaType: string } | null = null;
+
+	for (const scale of scales) {
+		const width = Math.max(1, Math.round(srcWidth * scale));
+		const height = Math.max(1, Math.round(srcHeight * scale));
+
+		for (const quality of qualities) {
+			const encoded = await rasterizeToBuffer(source, width, height, outputType, quality);
+			if (!encoded) continue;
+
+			// Track the smallest payload seen as best-effort fallback.
+			if (!best || encoded.byteLength < best.data.byteLength) {
+				best = { data: encoded, mediaType: outputType };
+			}
+
+			if (base64EncodedLength(encoded.byteLength) <= maxBytes) {
+				releaseImageSource(source);
+				return { data: encoded, mediaType: outputType, downscaled: true };
+			}
+		}
+	}
+
+	releaseImageSource(source);
+
+	// Couldn't get under the limit — return the smallest we produced (best effort).
+	if (best) {
+		return { data: best.data, mediaType: best.mediaType, downscaled: true };
+	}
+	return { data, mediaType, downscaled: false };
+}
+
+interface ImageSource {
+	width: number;
+	height: number;
+	bitmap?: ImageBitmap;
+	element?: HTMLImageElement;
+}
+
+/** Load image bytes into a drawable source (ImageBitmap preferred, else <img>). */
+async function loadImageSource(data: ArrayBuffer, mediaType: string): Promise<ImageSource> {
+	const blob = new Blob([data], { type: mediaType });
+
+	if (typeof createImageBitmap === 'function') {
+		const bitmap = await createImageBitmap(blob);
+		return { width: bitmap.width, height: bitmap.height, bitmap };
+	}
+
+	// Fallback: load via <img> + object URL.
+	const url = URL.createObjectURL(blob);
+	try {
+		const element = await loadImageElement(url);
+		return { width: element.naturalWidth, height: element.naturalHeight, element };
+	} finally {
+		URL.revokeObjectURL(url);
+	}
+}
+
+function loadImageElement(url: string): Promise<HTMLImageElement> {
+	return new Promise((resolve, reject) => {
+		const img = new Image();
+		img.onload = () => resolve(img);
+		img.onerror = () => reject(new Error('Failed to load image for downscaling'));
+		img.src = url;
+	});
+}
+
+function releaseImageSource(source: ImageSource): void {
+	if (source.bitmap && typeof source.bitmap.close === 'function') {
+		source.bitmap.close();
+	}
+}
+
+/** Draw the source onto a canvas at the given size and encode to a buffer. */
+async function rasterizeToBuffer(
+	source: ImageSource,
+	width: number,
+	height: number,
+	outputType: string,
+	quality: number
+): Promise<ArrayBuffer | null> {
+	const canvas = document.createElement('canvas');
+	canvas.width = width;
+	canvas.height = height;
+
+	const ctx = canvas.getContext('2d');
+	if (!ctx) return null;
+
+	const drawable = (source.bitmap ?? source.element) as CanvasImageSource;
+	ctx.drawImage(drawable, 0, 0, width, height);
+
+	return canvasToBuffer(canvas, outputType, quality);
+}
+
+/** Encode a canvas to an ArrayBuffer, preferring toBlob and falling back to toDataURL. */
+function canvasToBuffer(
+	canvas: HTMLCanvasElement,
+	outputType: string,
+	quality: number
+): Promise<ArrayBuffer | null> {
+	return new Promise((resolve) => {
+		if (typeof canvas.toBlob === 'function') {
+			canvas.toBlob(
+				(blob) => {
+					if (!blob) {
+						resolve(dataUrlFallback(canvas, outputType, quality));
+						return;
+					}
+					blob
+						.arrayBuffer()
+						.then((buf) => resolve(buf))
+						.catch(() => resolve(dataUrlFallback(canvas, outputType, quality)));
+				},
+				outputType,
+				quality
+			);
+		} else {
+			resolve(dataUrlFallback(canvas, outputType, quality));
+		}
+	});
+}
+
+function dataUrlFallback(
+	canvas: HTMLCanvasElement,
+	outputType: string,
+	quality: number
+): ArrayBuffer | null {
+	if (typeof canvas.toDataURL !== 'function') return null;
+	const dataUrl = canvas.toDataURL(outputType, quality);
+	const commaIdx = dataUrl.indexOf(',');
+	if (commaIdx === -1) return null;
+	const base64 = dataUrl.slice(commaIdx + 1);
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes.buffer;
+}

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -312,6 +312,41 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// ── Image ──
+		new Setting(containerEl).setHeading().setName('Image');
+
+		new Setting(containerEl)
+			.setName('Enable image analysis')
+			.setDesc('Run OCR and image analysis on images referenced in notes')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.image.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.image.enabled = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Max image size (MB)')
+			.setDesc(
+				'Images whose base64 payload exceeds this size are automatically downscaled ' +
+				'before being sent to the API. The Anthropic API limit is 5 MB; lower this only ' +
+				'if your provider enforces a smaller limit.'
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder('5')
+					.setValue(String(this.plugin.settings.image.maxImageSizeMb))
+					.onChange(async (value) => {
+						const num = parseFloat(value);
+						if (!isNaN(num) && num > 0) {
+							this.plugin.settings.image.maxImageSizeMb = num;
+							await this.plugin.saveSettings();
+						}
+					})
+			);
+
 		// ── Media Transcription ──
 		new Setting(containerEl).setHeading().setName('Media Transcription');
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -95,6 +95,8 @@ export interface ImageSettings {
 	enabled: boolean;
 	visionModel: string;
 	language: string;
+	/** Maximum base64 image payload size in MB before auto-downscaling (API limit is 5 MB). */
+	maxImageSizeMb: number;
 }
 
 export interface EnrichmentWeightSettings {
@@ -296,6 +298,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		enabled: true,
 		visionModel: '',
 		language: '',
+		maxImageSizeMb: 5,
 	},
 	enrichment: {
 		enabled: true,


### PR DESCRIPTION
## Summary

Large images (>5 MB base64) sent to the Anthropic API hard-failed with a 400 (`image exceeds 5 MB maximum`). Both the OCR extractor and the elaboration image analyzer sent raw base64 with no size guard.

This PR adds a shared image preprocessor and wires it into both paths:

- **New `src/image/preprocess.ts`:**
  - `arrayBufferToBase64()` — single source of truth (removes the byte-identical helper duplicated in `extractor.ts` and `image-analyzer.ts`).
  - `preprocessImage(data, mediaType, maxBytes)` — passes through when the encoded payload fits; otherwise rasterizes to a `<canvas>`, downscales preserving aspect ratio, and re-encodes lossless sources (png/bmp/tiff) to JPEG @ ~0.85, iterating scale/quality down until under the limit. Compares the **encoded** length (base64 inflates ~4/3). Returns best-effort with `downscaled: true` if it still can't fit, and degrades gracefully when canvas APIs are unavailable (animated GIFs pass through untouched).
- **Both paths** (`ImageExtractor.extract`, `ImageAnalyzer.analyzeImage`) now preprocess before encoding and show an Obsidian `Notice` when an image was auto-downscaled.
- **New setting** `image.maxImageSizeMb` (default `5`), exposed in a new **Image** section in the settings tab (added as its own block before Media Transcription to keep regions clean). MB→bytes conversion at the call sites.
- **Tests** `src/image/preprocess.test.ts` — under-limit passthrough (no canvas calls), over-limit downscale yields a smaller payload, lossless→JPEG conversion, best-effort fallback, GIF passthrough, and graceful degradation. Canvas/`createImageBitmap` mocked for the node env.

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (942 tests pass)
- `node esbuild.config.mjs production` ✅

closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)