### PR TITLE
feat: hide local Whisper provider from transcription dropdown

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -333,9 +333,8 @@ export class SynapseSettingTab extends PluginSettingTab {
 			'whisper-api': 'OpenAI Whisper API',
 			deepgram: 'Deepgram',
 		};
-		if (Platform.isDesktop) {
-			providerOptions['local-whisper'] = 'Local Whisper';
-		}
+		// 'local-whisper' is intentionally hidden from the dropdown until implemented
+		// (see src/audio/transcriber.ts). The type is kept for forward compatibility.
 
 		new Setting(containerEl)
 			.setName('Transcription provider')


### PR DESCRIPTION
## Summary

The "Local Whisper" transcription provider was shown in the settings provider dropdown but throws "not implemented" when selected, confusing users.

This hides `local-whisper` from the dropdown by removing the `Platform.isDesktop` block that added it, replacing it with an explanatory comment.

For forward compatibility, **no** behavioral/type changes:
- `src/settings.ts` provider union (`'whisper-api' | 'deepgram' | 'local-whisper'`) is left intact.
- `src/audio/transcriber.ts` not-implemented throw is left intact (existing test "throws for local-whisper" still passes).
- `Platform` import is retained — it is still used elsewhere in the file (line ~452).

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (57 files, 933 tests passed)
- `node esbuild.config.mjs production` ✅

closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)