### PR TITLE
chore: gitignore agent/tooling harness artifacts and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,12 @@ coverage/
 .claude/worktrees
 .claude/settings.local.json
 .obsidian/
+
+# Agent / tooling harness artifacts (Claude Code, Codex, etc.)
+.agents/
+.codex/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-error.log*


### PR DESCRIPTION
Adds ignore rules for scratch directories created by agent harnesses