### PR TITLE
feat(#235): collapsible feature accordions in settings

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -71,17 +71,98 @@ export class Modal {
 	onClose(): void {}
 }
 
-/** Helper to create a stub DOM element with Obsidian's augmented methods */
-function createStubEl(): any {
+/**
+ * Helper to create a stub DOM element with Obsidian's augmented methods.
+ *
+ * Supports the subset of the HTMLElement + Obsidian DOM API used across the
+ * plugin. Class state, attributes, children, and event listeners are tracked
+ * so tests can introspect structure and dispatch synthetic events.
+ */
+function createStubEl(tag = 'div'): any {
+	const classes = new Set<string>();
+	const attributes: Record<string, string> = {};
+	const listeners: Record<string, Array<(evt: any) => void>> = {};
+	const children: any[] = [];
+
+	const applyInfo = (child: any, info?: any): any => {
+		if (typeof info === 'string') {
+			info.split(/\s+/).filter(Boolean).forEach((c: string) => child.classList.add(c));
+		} else if (info && typeof info === 'object') {
+			if (info.cls) {
+				const clsList = Array.isArray(info.cls) ? info.cls : [info.cls];
+				clsList.forEach((c: string) => child.classList.add(c));
+			}
+			if (info.text != null) child.textContent = String(info.text);
+			if (info.attr) {
+				for (const [k, v] of Object.entries(info.attr)) child.setAttribute(k, String(v));
+			}
+		}
+		return child;
+	};
+
+	const make = (childTag: string) => (info?: any, cb?: (el: any) => void) => {
+		const child = createStubEl(childTag);
+		applyInfo(child, info);
+		children.push(child);
+		if (cb) cb(child);
+		return child;
+	};
+
 	const el: any = {
-		classList: { add: vi.fn(), remove: vi.fn() },
-		className: '',
+		tagName: tag.toUpperCase(),
+		classList: {
+			add: vi.fn((...c: string[]) => c.forEach((x) => classes.add(x))),
+			remove: vi.fn((...c: string[]) => c.forEach((x) => classes.delete(x))),
+			contains: (c: string) => classes.has(c),
+			toggle: vi.fn((c: string) => (classes.has(c) ? classes.delete(c) : classes.add(c))),
+		},
+		get className() {
+			return [...classes].join(' ');
+		},
+		set className(value: string) {
+			classes.clear();
+			String(value)
+				.split(/\s+/)
+				.filter(Boolean)
+				.forEach((c) => classes.add(c));
+		},
 		textContent: '',
-		empty: vi.fn(),
-		createEl: vi.fn().mockImplementation(() => createStubEl()),
-		createDiv: vi.fn().mockImplementation(() => createStubEl()),
-		addEventListener: vi.fn(),
+		children,
+		empty: vi.fn(() => {
+			children.length = 0;
+		}),
+		createEl: vi.fn((t: string, info?: any, cb?: (el: any) => void) =>
+			make(t)(info, cb),
+		),
+		createDiv: vi.fn(make('div')),
+		createSpan: vi.fn(make('span')),
+		addClass: vi.fn((...c: string[]) => c.forEach((x) => classes.add(x))),
+		removeClass: vi.fn((...c: string[]) => c.forEach((x) => classes.delete(x))),
+		toggleClass: vi.fn((c: string, on: boolean) =>
+			on ? classes.add(c) : classes.delete(c),
+		),
+		hasClass: (c: string) => classes.has(c),
+		setText: vi.fn((t: string) => {
+			el.textContent = t;
+		}),
+		setAttribute: vi.fn((k: string, v: string) => {
+			attributes[k] = v;
+		}),
+		getAttribute: vi.fn((k: string) => (k in attributes ? attributes[k] : null)),
+		removeAttribute: vi.fn((k: string) => {
+			delete attributes[k];
+		}),
+		addEventListener: vi.fn((type: string, cb: (evt: any) => void) => {
+			(listeners[type] ??= []).push(cb);
+		}),
+		removeEventListener: vi.fn(),
+		/** Test helper: synchronously invoke registered listeners for an event. */
+		dispatchEvent: (evt: { type: string; [k: string]: unknown }) => {
+			(listeners[evt.type] ?? []).forEach((cb) => cb(evt));
+			return true;
+		},
 		closest: vi.fn().mockReturnValue(null),
+		style: {},
 	};
 	return el;
 }
@@ -148,14 +229,41 @@ export class SuggestModal<T = unknown> {
 	onClose(): void {}
 }
 
+export class ToggleComponent {
+	toggleEl: any = createStubEl();
+	private value = false;
+	private changeCb: ((value: boolean) => unknown) | undefined;
+	getValue = () => this.value;
+	setValue = vi.fn((v: boolean) => {
+		this.value = v;
+		return this;
+	});
+	setTooltip = vi.fn().mockReturnThis();
+	setDisabled = vi.fn().mockReturnThis();
+	onChange = vi.fn((cb: (value: boolean) => unknown) => {
+		this.changeCb = cb;
+		return this;
+	});
+	/** Test helper: simulate a user toggling the control. */
+	_trigger(v: boolean): unknown {
+		this.value = v;
+		return this.changeCb?.(v);
+	}
+}
+
 export class Setting {
+	settingEl: any = createStubEl();
 	constructor(_containerEl: unknown) {}
 	setName = vi.fn().mockReturnThis();
 	setDesc = vi.fn().mockReturnThis();
+	setHeading = vi.fn().mockReturnThis();
 	addText = vi.fn().mockReturnThis();
 	addTextArea = vi.fn().mockReturnThis();
 	addDropdown = vi.fn().mockReturnThis();
-	addToggle = vi.fn().mockReturnThis();
+	addToggle = vi.fn(function (this: Setting, cb?: (t: ToggleComponent) => void) {
+		if (cb) cb(new ToggleComponent());
+		return this;
+	});
 	addSlider = vi.fn().mockReturnThis();
 	addButton = vi.fn().mockReturnThis();
 	setClass = vi.fn().mockReturnThis();

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -2,11 +2,82 @@ import { App, Platform, PluginSettingTab, Setting } from 'obsidian';
 import type SynapsePlugin from './main';
 import { MODEL_OPTIONS } from './settings';
 import type { AIProvider } from './settings';
-import { addEnhancedSlider } from './shared';
+import { addCollapsibleSection, addEnhancedSlider } from './shared';
 
 export class SynapseSettingTab extends PluginSettingTab {
 	constructor(app: App, private plugin: SynapsePlugin) {
 		super(app, plugin);
+	}
+
+	/**
+	 * Resolve the persisted collapse state for a section, falling back to a
+	 * sensible default: collapsed when the feature is disabled, expanded when
+	 * it is enabled. A `null` `enabled` (config sections with no toggle, e.g.
+	 * AI Configuration) defaults to expanded.
+	 */
+	private isSectionCollapsed(key: string, enabled: boolean | null): boolean {
+		const persisted = this.plugin.settings.ui.collapsedSections[key];
+		if (persisted !== undefined) return persisted;
+		return enabled === false;
+	}
+
+	/** Persist a section's collapse state and save. */
+	private async persistCollapse(key: string, collapsed: boolean): Promise<void> {
+		this.plugin.settings.ui.collapsedSections[key] = collapsed;
+		await this.plugin.saveSettings();
+	}
+
+	/**
+	 * Render a feature accordion with an enable toggle in the header and return
+	 * the body element to populate with the feature's sub-settings.
+	 *
+	 * The toggle is wired to the feature's `enabled` flag: turning it off
+	 * auto-collapses the body, turning it on auto-expands it. Manual header
+	 * clicks fold/unfold independently. All collapse changes persist under
+	 * `ui.collapsedSections[key]`.
+	 */
+	private featureSection(
+		containerEl: HTMLElement,
+		key: string,
+		title: string,
+		getEnabled: () => boolean,
+		setEnabled: (value: boolean) => void,
+		toggleDesc?: string,
+	): HTMLElement {
+		const enabled = getEnabled();
+		const { bodyEl } = addCollapsibleSection(containerEl, {
+			title,
+			enabled,
+			collapsed: this.isSectionCollapsed(key, enabled),
+			toggleAriaLabel: toggleDesc ?? `Enable ${title}`,
+			onToggle: async (value) => {
+				setEnabled(value);
+				await this.plugin.saveSettings();
+			},
+			onCollapseChange: async (collapsed) => {
+				await this.persistCollapse(key, collapsed);
+			},
+		});
+		return bodyEl;
+	}
+
+	/**
+	 * Render a config accordion that has no enable toggle (always-needed
+	 * settings). It is collapsible/persistent but never auto-collapses.
+	 */
+	private configSection(
+		containerEl: HTMLElement,
+		key: string,
+		title: string,
+	): HTMLElement {
+		const { bodyEl } = addCollapsibleSection(containerEl, {
+			title,
+			collapsed: this.isSectionCollapsed(key, null),
+			onCollapseChange: async (collapsed) => {
+				await this.persistCollapse(key, collapsed);
+			},
+		});
+		return bodyEl;
 	}
 
 	display(): void {
@@ -15,10 +86,10 @@ export class SynapseSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl).setHeading().setName(`Synapse v${this.plugin.manifest.version}`);
 
-		// ── AI Configuration ──
-		new Setting(containerEl).setHeading().setName('AI Configuration');
+		// ── AI Configuration (always-needed config — no enable toggle) ──
+		const aiBody = this.configSection(containerEl, 'ai', 'AI Configuration');
 
-		new Setting(containerEl)
+		new Setting(aiBody)
 			.setName('AI Provider')
 			.setDesc('Which AI service to use for elaboration and post-processing')
 			.addDropdown((dd) =>
@@ -40,7 +111,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(aiBody)
 			.setName('API Key')
 			.setDesc('API key for OpenAI or Anthropic')
 			.addText((text) => {
@@ -56,7 +127,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			});
 
 		if (this.plugin.settings.ai.provider === 'ollama') {
-			new Setting(containerEl)
+			new Setting(aiBody)
 				.setName('Ollama Endpoint')
 				.setDesc('URL for local Ollama server (HTTPS required for non-localhost)')
 				.addText((text) =>
@@ -82,7 +153,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		const currentProvider = this.plugin.settings.ai.provider;
 		const models = MODEL_OPTIONS[currentProvider];
 
-		new Setting(containerEl)
+		new Setting(aiBody)
 			.setName('Model')
 			.setDesc('Model to use for AI operations')
 			.addDropdown((dd) => {
@@ -99,7 +170,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			});
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(aiBody)
 				.setName('Temperature')
 				.setDesc('Controls randomness (0-1)'),
 			{
@@ -116,7 +187,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(aiBody)
 				.setName('Max tokens')
 				.setDesc('Maximum tokens in AI responses (256-8192)'),
 			{
@@ -133,21 +204,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 		);
 
 		// ── Note Elaboration ──
-		new Setting(containerEl).setHeading().setName('Note Elaboration');
+		const elaborationBody = this.featureSection(
+			containerEl,
+			'elaboration',
+			'Note Elaboration',
+			() => this.plugin.settings.elaboration.enabled,
+			(v) => { this.plugin.settings.elaboration.enabled = v; },
+			'Enable stub note detection and proposal generation',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable elaboration')
-			.setDesc('Enable stub note detection and proposal generation')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.elaboration.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.elaboration.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
+		new Setting(elaborationBody)
 			.setName('Minimum word threshold')
 			.setDesc('Notes with fewer words than this are considered stubs')
 			.addText((text) =>
@@ -162,7 +228,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(elaborationBody)
 			.setName('Detect TODO markers')
 			.setDesc('Flag notes containing TODO, TBD, FIXME, PLACEHOLDER')
 			.addToggle((toggle) =>
@@ -174,7 +240,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(elaborationBody)
 			.setName('Detect empty sections')
 			.setDesc('Flag notes with headings but no content beneath them')
 			.addToggle((toggle) =>
@@ -186,7 +252,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(elaborationBody)
 			.setName('Excluded folders')
 			.setDesc('Comma-separated list of folders to skip')
 			.addText((text) =>
@@ -200,21 +266,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		// ── Intake Folder ──
-		new Setting(containerEl).setHeading().setName('Intake Folder');
+		const intakeBody = this.featureSection(
+			containerEl,
+			'intake',
+			'Intake Folder',
+			() => this.plugin.settings.intake.enabled,
+			(v) => { this.plugin.settings.intake.enabled = v; },
+			'Watch the intake folder and run enabled Synapse features on new notes',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable intake processing')
-			.setDesc('Watch the intake folder and run enabled Synapse features on new notes')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.intake.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.intake.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
+		new Setting(intakeBody)
 			.setName('Settle window (seconds)')
 			.setDesc(
 				'Wait this long after the last change to a note before processing it. ' +
@@ -234,7 +295,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(intakeBody)
 			.setName('Intake folder')
 			.setDesc('Folder to watch for new notes. See docs/intake-folder.md for the mobile capture workflow.')
 			.addText((text) =>
@@ -247,7 +308,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(intakeBody)
 			.setName('Mark processed in frontmatter')
 			.setDesc('Stamp `synapse-processed: true` on a note once handled so it is not reprocessed')
 			.addToggle((toggle) =>
@@ -259,7 +320,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(intakeBody)
 			.setName('Move when done (fallback)')
 			.setDesc(
 				'Fallback destination used only when auto-organize keeps a note in ' +
@@ -278,7 +339,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(intakeBody)
 			.setName('Capture log')
 			.setDesc(
 				'When a note is auto-organized out of the intake folder, leave a ' +
@@ -293,7 +354,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(intakeBody)
 			.setName('Capture log folder')
 			.setDesc(
 				'Subfolder of the intake folder for breadcrumbs (relative to it). ' +
@@ -313,21 +374,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		// ── Image ──
-		new Setting(containerEl).setHeading().setName('Image');
+		const imageBody = this.featureSection(
+			containerEl,
+			'image',
+			'Image',
+			() => this.plugin.settings.image.enabled,
+			(v) => { this.plugin.settings.image.enabled = v; },
+			'Run OCR and image analysis on images referenced in notes',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable image analysis')
-			.setDesc('Run OCR and image analysis on images referenced in notes')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.image.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.image.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
+		new Setting(imageBody)
 			.setName('Max image size (MB)')
 			.setDesc(
 				'Images whose base64 payload exceeds this size are automatically downscaled ' +
@@ -347,22 +403,18 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		// ── Media Transcription ──
+		// ── Media Transcription (visual grouping header) ──
 		new Setting(containerEl).setHeading().setName('Media Transcription');
 
 		// ── Audio Transcription ──
-		new Setting(containerEl).setHeading().setName('Audio Transcription');
-
-		new Setting(containerEl)
-			.setName('Enable audio transcription')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.audio.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.audio.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
+		const audioBody = this.featureSection(
+			containerEl,
+			'audio',
+			'Audio Transcription',
+			() => this.plugin.settings.audio.enabled,
+			(v) => { this.plugin.settings.audio.enabled = v; },
+			'Enable audio transcription',
+		);
 
 		const providerOptions: Record<string, string> = {
 			'whisper-api': 'OpenAI Whisper API',
@@ -371,7 +423,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		// 'local-whisper' is intentionally hidden from the dropdown until implemented
 		// (see src/audio/transcriber.ts). The type is kept for forward compatibility.
 
-		new Setting(containerEl)
+		new Setting(audioBody)
 			.setName('Transcription provider')
 			.addDropdown((dd) =>
 				dd
@@ -391,7 +443,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			this.plugin.settings.audio.transcriptionProvider === 'whisper-api' &&
 			this.plugin.settings.ai.provider !== 'openai'
 		) {
-			new Setting(containerEl)
+			new Setting(audioBody)
 				.setName('OpenAI API Key (Whisper)')
 				.setDesc(
 					'Whisper uses the OpenAI API. Provide your OpenAI key here since your AI provider is set to ' +
@@ -412,7 +464,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		}
 
 		if (this.plugin.settings.audio.transcriptionProvider === 'deepgram') {
-			new Setting(containerEl)
+			new Setting(audioBody)
 				.setName('Deepgram API Key')
 				.setDesc('Required for Deepgram transcription provider')
 				.addText((text) => {
@@ -428,7 +480,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 				});
 		}
 
-		new Setting(containerEl)
+		new Setting(audioBody)
 			.setName('Language')
 			.setDesc('Audio language for transcription (auto-detect if empty)')
 			.addDropdown((dd) =>
@@ -459,7 +511,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(audioBody)
 			.setName('Post-processing')
 			.setDesc('Clean up and structure transcriptions with AI')
 			.addToggle((toggle) =>
@@ -471,7 +523,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(audioBody)
 			.setName('Remove filler words')
 			.addToggle((toggle) =>
 				toggle
@@ -484,20 +536,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 
 		// ── Video Transcription (desktop only — requires yt-dlp + ffmpeg) ──
 		if (Platform.isDesktop) {
-			new Setting(containerEl).setHeading().setName('Video Transcription');
+			const videoBody = this.featureSection(
+				containerEl,
+				'video',
+				'Video Transcription',
+				() => this.plugin.settings.video.enabled,
+				(v) => { this.plugin.settings.video.enabled = v; },
+				'Enable video transcription',
+			);
 
-			new Setting(containerEl)
-				.setName('Enable video transcription')
-				.addToggle((toggle) =>
-					toggle
-						.setValue(this.plugin.settings.video.enabled)
-						.onChange(async (value) => {
-							this.plugin.settings.video.enabled = value;
-							await this.plugin.saveSettings();
-						})
-				);
-
-			new Setting(containerEl)
+			new Setting(videoBody)
 				.setName('yt-dlp path')
 				.setDesc('Path to yt-dlp binary')
 				.addText((text) =>
@@ -509,7 +557,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 						})
 				);
 
-			new Setting(containerEl)
+			new Setting(videoBody)
 				.setName('ffmpeg path')
 				.setDesc('Path to ffmpeg binary')
 				.addText((text) =>
@@ -521,7 +569,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 						})
 				);
 
-			new Setting(containerEl)
+			new Setting(videoBody)
 				.setName('Video download folder')
 				.setDesc('Where to save downloaded video files in the vault')
 				.addText((text) =>
@@ -533,7 +581,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 						})
 				);
 
-			new Setting(containerEl)
+			new Setting(videoBody)
 				.setName('Embed video in note')
 				.setDesc('Add an embed link to the downloaded video file in the note')
 				.addToggle((toggle) =>
@@ -547,21 +595,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 		}
 
 		// ── Note Enrichment ──
-		new Setting(containerEl).setHeading().setName('Note Enrichment');
+		const enrichmentBody = this.featureSection(
+			containerEl,
+			'enrichment',
+			'Note Enrichment',
+			() => this.plugin.settings.enrichment.enabled,
+			(v) => { this.plugin.settings.enrichment.enabled = v; },
+			'Add tags, links, references, and metadata to notes',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable enrichment')
-			.setDesc('Add tags, links, references, and metadata to notes')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.enrichment.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.enrichment.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Auto-enrich')
 			.setDesc('Automatically generate enrichment proposals after elaboration or transcription')
 			.addToggle((toggle) =>
@@ -573,7 +616,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Max metadata tags')
 			.setDesc('Maximum number of metadata tags (status, type, source) to suggest per note')
 			.addText((text) =>
@@ -588,7 +631,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Max topic links')
 			.setDesc('Maximum number of AI-extracted topic links to suggest')
 			.addText((text) =>
@@ -603,7 +646,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Suggest new notes')
 			.setDesc('Suggest links to notes that don\'t exist yet (Obsidian grayed-out links)')
 			.addToggle((toggle) =>
@@ -615,7 +658,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Max internal links')
 			.setDesc('Maximum number of related note links to suggest')
 			.addText((text) =>
@@ -630,7 +673,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Max external references')
 			.setDesc('Maximum external links to suggest (stingy — keep this low)')
 			.addText((text) =>
@@ -646,7 +689,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(enrichmentBody)
 				.setName('Internal link threshold')
 				.setDesc('Minimum relevance score for internal links (0-1, lower = more liberal)'),
 			{
@@ -662,8 +705,8 @@ export class SynapseSettingTab extends PluginSettingTab {
 			},
 		);
 
-		// Weight settings
-		new Setting(containerEl).setHeading().setName('Proximity Weights');
+		// Weight settings (sub-section within enrichment)
+		new Setting(enrichmentBody).setHeading().setName('Proximity Weights');
 
 		type WeightKey = keyof import('./settings').EnrichmentWeightSettings;
 		const weightFields: Array<{ key: WeightKey; name: string; desc: string }> = [
@@ -678,7 +721,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		for (const field of weightFields) {
 			const key = field.key;
 			addEnhancedSlider(
-				new Setting(containerEl)
+				new Setting(enrichmentBody)
 					.setName(field.name)
 					.setDesc(field.desc),
 				{
@@ -695,13 +738,13 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 		}
 
-		// Tag Vocabulary
-		new Setting(containerEl).setHeading().setName('Tag Vocabulary').setDesc('Define metadata tag categories. Tags classify notes (status, type, source) — topics become [[links]] instead.');
+		// Tag Vocabulary (sub-section within enrichment)
+		new Setting(enrichmentBody).setHeading().setName('Tag Vocabulary').setDesc('Define metadata tag categories. Tags classify notes (status, type, source) — topics become [[links]] instead.');
 
 		for (let i = 0; i < this.plugin.settings.enrichment.tagVocabulary.length; i++) {
 			const entry = this.plugin.settings.enrichment.tagVocabulary[i];
 
-			new Setting(containerEl)
+			new Setting(enrichmentBody)
 				.setName(entry.category)
 				.setDesc(entry.description)
 				.addText((text) =>
@@ -716,7 +759,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 				);
 		}
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Excluded folders')
 			.setDesc('Comma-separated list of folders to skip for enrichment')
 			.addText((text) =>
@@ -729,7 +772,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(enrichmentBody)
 			.setName('Excluded tags')
 			.setDesc('Notes with these tags will skip enrichment')
 			.addText((text) =>
@@ -743,21 +786,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		// ── Summarize ──
-		new Setting(containerEl).setHeading().setName('Summarize');
+		const summarizeBody = this.featureSection(
+			containerEl,
+			'summarize',
+			'Summarize',
+			() => this.plugin.settings.summarize.enabled,
+			(v) => { this.plugin.settings.summarize.enabled = v; },
+			'Summarize URLs and transcriptions in notes',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable summarize')
-			.setDesc('Summarize URLs and transcriptions in notes')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.summarize.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.summarize.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
+		new Setting(summarizeBody)
 			.setName('Summary style')
 			.setDesc('Format for generated summaries')
 			.addDropdown((dd) =>
@@ -775,7 +813,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(summarizeBody)
 			.setName('Auto-detect content templates')
 			.setDesc('Automatically detect content type (e.g. recipes) and use a specialized summary format')
 			.addToggle(toggle => toggle
@@ -786,7 +824,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 				}));
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(summarizeBody)
 				.setName('Max content length')
 				.setDesc('Maximum characters of content to send to AI for summarization'),
 			{
@@ -802,7 +840,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			},
 		);
 
-		new Setting(containerEl)
+		new Setting(summarizeBody)
 			.setName('Custom prompt')
 			.setDesc('Override the default summarization prompt (leave empty for default)')
 			.addTextArea((text) =>
@@ -815,7 +853,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(summarizeBody)
 			.setName('Excluded folders')
 			.setDesc('Comma-separated list of folders to skip for summarization')
 			.addText((text) =>
@@ -828,7 +866,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(summarizeBody)
 			.setName('Excluded tags')
 			.setDesc('Notes with these tags will skip summarization')
 			.addText((text) =>
@@ -841,7 +879,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(summarizeBody)
 			.setName('Auto-organize after summarize')
 			.setDesc('Automatically organize the current note after summarization completes (single-note only, not vault-wide)')
 			.addToggle((toggle) =>
@@ -854,37 +892,32 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		// ── Note Tidy ──
-		new Setting(containerEl).setHeading().setName('Note Tidy');
+		const tidyBody = this.featureSection(
+			containerEl,
+			'tidy',
+			'Note Tidy',
+			() => this.plugin.settings.tidy.enabled,
+			(v) => { this.plugin.settings.tidy.enabled = v; },
+			'Spelling correction and markdown formatting (no content changes)',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable tidy')
-			.setDesc('Spelling correction and markdown formatting (no content changes)')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.tidy.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.tidy.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
+		tidyBody.createDiv({
+			cls: 'setting-item-description synapse-accordion-empty-note',
+			text: 'Tidy applies spelling correction and markdown formatting without changing content. No additional options.',
+		});
 
 		// ── Note Organize ──
-		new Setting(containerEl).setHeading().setName('Note Organize');
-
-		new Setting(containerEl)
-			.setName('Enable organize')
-			.setDesc('AI-powered semantic directory structuring for notes')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.organize.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.organize.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
+		const organizeBody = this.featureSection(
+			containerEl,
+			'organize',
+			'Note Organize',
+			() => this.plugin.settings.organize.enabled,
+			(v) => { this.plugin.settings.organize.enabled = v; },
+			'AI-powered semantic directory structuring for notes',
+		);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(organizeBody)
 				.setName('New folder confidence threshold')
 				.setDesc('Minimum topic confidence to propose a new folder (0.5-1.0). Higher = fewer new folders.'),
 			{
@@ -900,7 +933,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			},
 		);
 
-		new Setting(containerEl)
+		new Setting(organizeBody)
 			.setName('Excluded folders')
 			.setDesc('Comma-separated list of folders to skip for organization')
 			.addText((text) =>
@@ -913,7 +946,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(organizeBody)
 			.setName('Excluded tags')
 			.setDesc('Notes with these tags will skip organization')
 			.addText((text) =>
@@ -927,22 +960,17 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		// ── Deep Dive ──
-		new Setting(containerEl).setHeading().setName('Deep Dive');
-
-		new Setting(containerEl)
-			.setName('Enable deep dive')
-			.setDesc('Recursively explore a note into a tree of interlinked child notes')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.deepDive.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
+		const deepDiveBody = this.featureSection(
+			containerEl,
+			'deepDive',
+			'Deep Dive',
+			() => this.plugin.settings.deepDive.enabled,
+			(v) => { this.plugin.settings.deepDive.enabled = v; },
+			'Recursively explore a note into a tree of interlinked child notes',
+		);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(deepDiveBody)
 				.setName('Max depth')
 				.setDesc('Maximum levels of recursion (1-5)'),
 			{
@@ -959,7 +987,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(deepDiveBody)
 				.setName('Quality threshold')
 				.setDesc('Minimum quality score to continue recursing (0.1-0.9)'),
 			{
@@ -976,7 +1004,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(deepDiveBody)
 				.setName('Max notes per run')
 				.setDesc('Maximum number of notes to generate in a single deep dive (10-100)'),
 			{
@@ -992,7 +1020,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			},
 		);
 
-		new Setting(containerEl)
+		new Setting(deepDiveBody)
 			.setName('Note output folder')
 			.setDesc('Where to create new notes. Uses a subfolder per root note. (empty = same folder as source)')
 			.addText((text) =>
@@ -1005,7 +1033,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(deepDiveBody)
 			.setName('Folder nesting mode')
 			.setDesc('How child notes are placed: nested under parent topic folders, flat in a single folder, or AI-organized by content semantics')
 			.addDropdown((dd) =>
@@ -1023,7 +1051,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(deepDiveBody)
 			.setName('Auto-enrich on accept')
 			.setDesc('Automatically trigger enrichment when a deep dive note is accepted')
 			.addToggle((toggle) =>
@@ -1035,7 +1063,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(deepDiveBody)
 			.setName('Auto-organize on accept')
 			.setDesc('Automatically trigger organize when a deep dive note is accepted')
 			.addToggle((toggle) =>
@@ -1047,7 +1075,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(deepDiveBody)
 			.setName('Excluded folders')
 			.setDesc('Comma-separated list of folders to skip for deep dive')
 			.addText((text) =>
@@ -1060,7 +1088,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl)
+		new Setting(deepDiveBody)
 			.setName('Excluded tags')
 			.setDesc('Notes with these tags will skip deep dive')
 			.addText((text) =>
@@ -1074,21 +1102,16 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		// ── REM (Link Discovery) ──
-		new Setting(containerEl).setHeading().setName('REM (Link Discovery)');
+		const remBody = this.featureSection(
+			containerEl,
+			'rem',
+			'REM (Link Discovery)',
+			() => this.plugin.settings.rem.enabled,
+			(v) => { this.plugin.settings.rem.enabled = v; },
+			'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions',
+		);
 
-		new Setting(containerEl)
-			.setName('Enable REM')
-			.setDesc('Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.rem.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.rem.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
+		new Setting(remBody)
 			.setName('Semantic matching')
 			.setDesc('Use AI to find conceptual matches beyond literal title/alias matching')
 			.addToggle((toggle) =>
@@ -1101,7 +1124,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			);
 
 		addEnhancedSlider(
-			new Setting(containerEl)
+			new Setting(remBody)
 				.setName('Confidence threshold')
 				.setDesc('Minimum confidence for semantic matches (0-1)'),
 			{
@@ -1117,7 +1140,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 			},
 		);
 
-		new Setting(containerEl)
+		new Setting(remBody)
 			.setName('Max links per note')
 			.setDesc('Maximum number of link candidates to suggest per scanned note')
 			.addText((text) =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -220,6 +220,21 @@ export interface IntakeSettings {
 	captureLogFolder: string;
 }
 
+/**
+ * Presentation-only UI preferences that persist across sessions but do not
+ * affect plugin behavior. Currently tracks the per-section collapse state of
+ * the settings tab accordions (#235).
+ */
+export interface UISettings {
+	/**
+	 * Maps a settings accordion's section key (e.g. `elaboration`, `audio`) to
+	 * its collapsed state. `true` = collapsed (body hidden), `false` = expanded.
+	 * A missing key means "use the default", which is collapsed when the
+	 * section's feature is disabled and expanded when it is enabled.
+	 */
+	collapsedSections: Record<string, boolean>;
+}
+
 export interface SynapseSettings {
 	ai: AISettings;
 	elaboration: ElaborationSettings;
@@ -234,6 +249,7 @@ export interface SynapseSettings {
 	title: TitleSettings;
 	rem: RemSettings;
 	intake: IntakeSettings;
+	ui: UISettings;
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
@@ -383,5 +399,8 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		settleSeconds: 5,
 		captureLog: true,
 		captureLogFolder: '_captured',
+	},
+	ui: {
+		collapsedSections: {},
 	},
 };

--- a/src/shared/collapsible-section.test.ts
+++ b/src/shared/collapsible-section.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { addCollapsibleSection } from './collapsible-section';
+
+/**
+ * Recursive stub element mirroring the Obsidian DOM augmentation, with enough
+ * introspection (classes, attributes, children, listeners) to assert accordion
+ * behavior. Matches the shape produced by the obsidian mock's createStubEl.
+ */
+function stubEl(tag = 'div'): any {
+	const classes = new Set<string>();
+	const attributes: Record<string, string> = {};
+	const listeners: Record<string, Array<(evt: any) => void>> = {};
+	const children: any[] = [];
+
+	const apply = (child: any, info?: any) => {
+		if (info && typeof info === 'object') {
+			if (info.cls) {
+				(Array.isArray(info.cls) ? info.cls : [info.cls]).forEach((c: string) =>
+					child.classList.add(c),
+				);
+			}
+			if (info.text != null) child.textContent = String(info.text);
+		}
+		return child;
+	};
+	const make = (t: string) => (info?: any, cb?: (el: any) => void) => {
+		const child = stubEl(t);
+		apply(child, info);
+		children.push(child);
+		if (cb) cb(child);
+		return child;
+	};
+
+	const el: any = {
+		tagName: tag.toUpperCase(),
+		textContent: '',
+		children,
+		classList: {
+			add: (...c: string[]) => c.forEach((x) => classes.add(x)),
+			remove: (...c: string[]) => c.forEach((x) => classes.delete(x)),
+			contains: (c: string) => classes.has(c),
+		},
+		hasClass: (c: string) => classes.has(c),
+		addClass: (...c: string[]) => c.forEach((x) => classes.add(x)),
+		removeClass: (...c: string[]) => c.forEach((x) => classes.delete(x)),
+		setText: (t: string) => {
+			el.textContent = t;
+		},
+		setAttribute: (k: string, v: string) => {
+			attributes[k] = v;
+		},
+		getAttribute: (k: string) => (k in attributes ? attributes[k] : null),
+		createDiv: make('div'),
+		createSpan: make('span'),
+		createEl: (t: string, info?: any, cb?: (el: any) => void) => make(t)(info, cb),
+		addEventListener: (type: string, cb: (evt: any) => void) => {
+			(listeners[type] ??= []).push(cb);
+		},
+		dispatchEvent: (evt: { type: string; [k: string]: unknown }) => {
+			(listeners[evt.type] ?? []).forEach((cb) => cb(evt));
+			return true;
+		},
+	};
+	return el;
+}
+
+/**
+ * Dispatch a synthetic event on a stub element. Casts away the real-DOM
+ * `Event` type since stub elements accept plain `{ type, ... }` payloads.
+ */
+function fire(el: any, evt: Record<string, unknown> & { type: string }): void {
+	el.dispatchEvent(evt);
+}
+
+/** Recursively find the first descendant element whose class set contains `cls`. */
+function findByClass(root: any, cls: string): any | undefined {
+	for (const child of root.children ?? []) {
+		if (child.hasClass?.(cls)) return child;
+		const nested = findByClass(child, cls);
+		if (nested) return nested;
+	}
+	return undefined;
+}
+
+describe('addCollapsibleSection', () => {
+	let container: any;
+
+	beforeEach(() => {
+		container = stubEl();
+	});
+
+	describe('structure', () => {
+		it('renders a header and a body into the container', () => {
+			const section = addCollapsibleSection(container, { title: 'Audio' });
+
+			expect(section.headerEl.hasClass('synapse-accordion-header')).toBe(true);
+			expect(section.bodyEl.hasClass('synapse-accordion-body')).toBe(true);
+			expect(findByClass(container, 'synapse-accordion')).toBe(section.sectionEl);
+		});
+
+		it('renders the title text and a chevron in the header', () => {
+			const section = addCollapsibleSection(container, { title: 'Note Tidy' });
+
+			const title = findByClass(section.headerEl, 'synapse-accordion-title');
+			const chevron = findByClass(section.headerEl, 'synapse-accordion-chevron');
+			expect(title?.textContent).toBe('Note Tidy');
+			expect(chevron).toBeDefined();
+		});
+
+		it('makes the header keyboard-focusable with a button role', () => {
+			const section = addCollapsibleSection(container, { title: 'X' });
+			expect(section.headerEl.getAttribute('role')).toBe('button');
+			expect(section.headerEl.getAttribute('tabindex')).toBe('0');
+		});
+
+		it('does not render a toggle when enabled is undefined', () => {
+			const section = addCollapsibleSection(container, { title: 'AI Config' });
+			expect(section.toggle).toBeUndefined();
+		});
+
+		it('renders a header toggle when enabled is provided', () => {
+			const section = addCollapsibleSection(container, {
+				title: 'Audio',
+				enabled: true,
+			});
+			expect(section.toggle).toBeDefined();
+			expect(section.toggle?.getValue()).toBe(true);
+		});
+	});
+
+	describe('initial collapsed state', () => {
+		it('starts expanded by default', () => {
+			const section = addCollapsibleSection(container, { title: 'X' });
+			expect(section.isCollapsed()).toBe(false);
+			expect(section.sectionEl.hasClass('is-collapsed')).toBe(false);
+			expect(section.headerEl.getAttribute('aria-expanded')).toBe('true');
+			expect(section.bodyEl.getAttribute('aria-hidden')).toBe('false');
+		});
+
+		it('starts collapsed when collapsed: true', () => {
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				collapsed: true,
+			});
+			expect(section.isCollapsed()).toBe(true);
+			expect(section.sectionEl.hasClass('is-collapsed')).toBe(true);
+			expect(section.headerEl.getAttribute('aria-expanded')).toBe('false');
+			expect(section.bodyEl.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		it('does not fire onCollapseChange during initial render', () => {
+			const onCollapseChange = vi.fn();
+			addCollapsibleSection(container, {
+				title: 'X',
+				collapsed: true,
+				onCollapseChange,
+			});
+			expect(onCollapseChange).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('manual header toggle', () => {
+		it('collapses an expanded section on header click', () => {
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				onCollapseChange,
+			});
+
+			fire(section.headerEl, { type: 'click' });
+
+			expect(section.isCollapsed()).toBe(true);
+			expect(section.sectionEl.hasClass('is-collapsed')).toBe(true);
+			expect(onCollapseChange).toHaveBeenCalledWith(true);
+		});
+
+		it('expands a collapsed section on header click', () => {
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				collapsed: true,
+				onCollapseChange,
+			});
+
+			fire(section.headerEl, { type: 'click' });
+
+			expect(section.isCollapsed()).toBe(false);
+			expect(onCollapseChange).toHaveBeenCalledWith(false);
+		});
+
+		it('toggles via Enter key and prevents default', () => {
+			const section = addCollapsibleSection(container, { title: 'X' });
+			const preventDefault = vi.fn();
+
+			fire(section.headerEl, { type: 'keydown', key: 'Enter', preventDefault });
+
+			expect(preventDefault).toHaveBeenCalled();
+			expect(section.isCollapsed()).toBe(true);
+		});
+
+		it('toggles via Space key', () => {
+			const section = addCollapsibleSection(container, { title: 'X' });
+			fire(section.headerEl, {
+				type: 'keydown',
+				key: ' ',
+				preventDefault: vi.fn(),
+			});
+			expect(section.isCollapsed()).toBe(true);
+		});
+
+		it('ignores other keys', () => {
+			const section = addCollapsibleSection(container, { title: 'X' });
+			fire(section.headerEl, {
+				type: 'keydown',
+				key: 'a',
+				preventDefault: vi.fn(),
+			});
+			expect(section.isCollapsed()).toBe(false);
+		});
+	});
+
+	describe('toggle drives collapse', () => {
+		it('auto-collapses when the toggle is turned off', async () => {
+			const onToggle = vi.fn();
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'Audio',
+				enabled: true,
+				onToggle,
+				onCollapseChange,
+			});
+
+			await (section.toggle as any)._trigger(false);
+
+			expect(section.isCollapsed()).toBe(true);
+			expect(onCollapseChange).toHaveBeenCalledWith(true);
+			expect(onToggle).toHaveBeenCalledWith(false);
+		});
+
+		it('auto-expands when the toggle is turned on', async () => {
+			const onToggle = vi.fn();
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'Audio',
+				enabled: false,
+				collapsed: true,
+				onToggle,
+				onCollapseChange,
+			});
+
+			await (section.toggle as any)._trigger(true);
+
+			expect(section.isCollapsed()).toBe(false);
+			expect(onCollapseChange).toHaveBeenCalledWith(false);
+			expect(onToggle).toHaveBeenCalledWith(true);
+		});
+
+		it('collapses before invoking onToggle so persisted state is consistent', async () => {
+			const order: string[] = [];
+			const section = addCollapsibleSection(container, {
+				title: 'Audio',
+				enabled: true,
+				onToggle: () => {
+					order.push(`toggle:collapsed=${section.isCollapsed()}`);
+				},
+				onCollapseChange: () => {
+					order.push('collapseChange');
+				},
+			});
+
+			await (section.toggle as any)._trigger(false);
+
+			expect(order).toEqual(['collapseChange', 'toggle:collapsed=true']);
+		});
+	});
+
+	describe('setCollapsed', () => {
+		it('programmatically collapses and fires onCollapseChange', () => {
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				onCollapseChange,
+			});
+
+			section.setCollapsed(true);
+
+			expect(section.isCollapsed()).toBe(true);
+			expect(onCollapseChange).toHaveBeenCalledWith(true);
+		});
+
+		it('suppresses onCollapseChange when silent', () => {
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				onCollapseChange,
+			});
+
+			section.setCollapsed(true, true);
+
+			expect(section.isCollapsed()).toBe(true);
+			expect(onCollapseChange).not.toHaveBeenCalled();
+		});
+
+		it('is a no-op (no callback) when state is unchanged', () => {
+			const onCollapseChange = vi.fn();
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				onCollapseChange,
+			});
+
+			section.setCollapsed(false); // already expanded
+
+			expect(onCollapseChange).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/shared/collapsible-section.ts
+++ b/src/shared/collapsible-section.ts
@@ -1,0 +1,194 @@
+import { Setting } from 'obsidian';
+import type { ToggleComponent } from 'obsidian';
+
+/**
+ * Configuration for a collapsible settings accordion section.
+ */
+export interface CollapsibleSectionOptions {
+	/** Heading text shown in the accordion header. */
+	title: string;
+	/**
+	 * Initial collapsed state. `true` renders the body hidden, `false` expanded.
+	 * Defaults to `false` (expanded).
+	 */
+	collapsed?: boolean;
+	/**
+	 * When provided, an enable/disable toggle is rendered in the header.
+	 * This is the toggle's initial value.
+	 *
+	 * Omit (leave `undefined`) for always-needed config sections that should
+	 * be collapsible but have no enable toggle (e.g. AI Configuration).
+	 */
+	enabled?: boolean;
+	/**
+	 * Invoked when the header toggle changes. The accordion auto-expands when
+	 * toggled on and auto-collapses when toggled off *before* this fires, then
+	 * reports the resulting collapse state via {@link onCollapseChange}.
+	 * Only used when `enabled` is provided.
+	 */
+	onToggle?: (value: boolean) => void | Promise<void>;
+	/**
+	 * Invoked whenever the collapsed state changes — from a manual header click,
+	 * keyboard activation, or an auto collapse/expand driven by the toggle.
+	 * Use this to persist the per-section collapse state.
+	 */
+	onCollapseChange?: (collapsed: boolean) => void | Promise<void>;
+	/**
+	 * Optional aria-label for the header toggle (falls back to `title`).
+	 */
+	toggleAriaLabel?: string;
+}
+
+/**
+ * Handle returned by {@link addCollapsibleSection}. Render a feature's
+ * sub-settings into {@link bodyEl}; use {@link setCollapsed} to drive the
+ * accordion programmatically.
+ */
+export interface CollapsibleSection {
+	/** The outermost section wrapper (`.synapse-accordion`). */
+	sectionEl: HTMLElement;
+	/** The clickable/focusable header row (`.synapse-accordion-header`). */
+	headerEl: HTMLElement;
+	/**
+	 * The collapsible body container (`.synapse-accordion-body`). Render all of
+	 * the feature's sub-settings into this element.
+	 */
+	bodyEl: HTMLElement;
+	/** The header toggle component, if one was rendered (`enabled` provided). */
+	toggle?: ToggleComponent;
+	/** Whether the section is currently collapsed. */
+	isCollapsed: () => boolean;
+	/**
+	 * Programmatically collapse or expand the section. Pass `silent: true` to
+	 * suppress the {@link CollapsibleSectionOptions.onCollapseChange} callback
+	 * (used for the initial render so it does not persist a no-op).
+	 */
+	setCollapsed: (collapsed: boolean, silent?: boolean) => void;
+}
+
+/**
+ * Adds a collapsible "accordion" section to a settings container.
+ *
+ * The section renders a header row (chevron + title + optional enable toggle)
+ * above a collapsible body. Clicking the header (or pressing Enter/Space while
+ * it is focused) folds/unfolds the body. When an enable toggle is present,
+ * turning it off auto-collapses the body and turning it on auto-expands it,
+ * while the header stays visible so the feature can be re-enabled.
+ *
+ * Collapse/expand animates via CSS (`max-height`/`opacity`); environments
+ * without that CSS degrade to instant show/hide because the collapsed class
+ * also sets `display` semantics through `aria-hidden` + CSS.
+ *
+ * Mirrors the DOM-wrapper style of {@link addEnhancedSlider}: it builds its own
+ * `createDiv({cls: 'synapse-*'})` structure and returns a handle for the caller
+ * to populate and control.
+ *
+ * @param containerEl - The container to append the section to.
+ * @param options - Section configuration.
+ * @returns A {@link CollapsibleSection} handle (render sub-settings into `bodyEl`).
+ */
+export function addCollapsibleSection(
+	containerEl: HTMLElement,
+	options: CollapsibleSectionOptions,
+): CollapsibleSection {
+	const {
+		title,
+		collapsed = false,
+		enabled,
+		onToggle,
+		onCollapseChange,
+		toggleAriaLabel,
+	} = options;
+
+	const hasToggle = enabled !== undefined;
+
+	const sectionEl = containerEl.createDiv({ cls: 'synapse-accordion' });
+
+	// ── Header (chevron + title + optional toggle) ──
+	const headerEl = sectionEl.createDiv({ cls: 'synapse-accordion-header' });
+	headerEl.setAttribute('role', 'button');
+	headerEl.setAttribute('tabindex', '0');
+
+	const chevronEl = headerEl.createSpan({ cls: 'synapse-accordion-chevron' });
+	// Unicode right-pointing triangle; CSS rotates it to point down when open.
+	chevronEl.setText('▶');
+	chevronEl.setAttribute('aria-hidden', 'true');
+
+	headerEl.createSpan({ cls: 'synapse-accordion-title', text: title });
+
+	// Spacer pushes the toggle to the trailing edge of the header row.
+	const controlEl = headerEl.createDiv({ cls: 'synapse-accordion-control' });
+
+	let toggle: ToggleComponent | undefined;
+	if (hasToggle) {
+		// Render the enable toggle inside the header using a borderless Setting
+		// so we reuse Obsidian's native ToggleComponent and styling.
+		const toggleSetting = new Setting(controlEl);
+		toggleSetting.settingEl.addClass('synapse-accordion-toggle-setting');
+		toggleSetting.addToggle((t) => {
+			toggle = t;
+			t.setValue(enabled as boolean);
+			t.setTooltip(toggleAriaLabel ?? title);
+			t.onChange(async (value) => {
+				// Toggle drives collapse: ON expands, OFF collapses. Do this
+				// first so the persisted collapse state reflects the new value.
+				setCollapsed(!value);
+				await onToggle?.(value);
+			});
+		});
+		// A click on the toggle must not also bubble to the header's fold handler.
+		controlEl.addEventListener('click', (evt) => evt.stopPropagation());
+	}
+
+	// ── Body (collapsible) ──
+	const bodyEl = sectionEl.createDiv({ cls: 'synapse-accordion-body' });
+
+	let isCollapsed = collapsed;
+
+	function applyCollapsedClass(): void {
+		if (isCollapsed) {
+			sectionEl.addClass('is-collapsed');
+		} else {
+			sectionEl.removeClass('is-collapsed');
+		}
+		headerEl.setAttribute('aria-expanded', String(!isCollapsed));
+		bodyEl.setAttribute('aria-hidden', String(isCollapsed));
+	}
+
+	function setCollapsed(next: boolean, silent = false): void {
+		if (next === isCollapsed) {
+			// Still re-apply attributes/classes on first render even if unchanged.
+			applyCollapsedClass();
+			return;
+		}
+		isCollapsed = next;
+		applyCollapsedClass();
+		if (!silent) {
+			void onCollapseChange?.(isCollapsed);
+		}
+	}
+
+	function toggleCollapsed(): void {
+		setCollapsed(!isCollapsed);
+	}
+
+	headerEl.addEventListener('click', () => toggleCollapsed());
+	headerEl.addEventListener('keydown', (evt: KeyboardEvent) => {
+		if (evt.key === 'Enter' || evt.key === ' ' || evt.key === 'Spacebar') {
+			evt.preventDefault();
+			toggleCollapsed();
+		}
+	});
+
+	// Initial paint without firing onCollapseChange (no-op persistence).
+	applyCollapsedClass();
+
+	return {
+		sectionEl,
+		headerEl,
+		bodyEl,
+		toggle,
+		isCollapsed: () => isCollapsed,
+		setCollapsed,
+	};
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -52,6 +52,11 @@ export type { RecipeJsonLd } from './content-fetcher';
 export { classifyUrl, extractUrls } from './url-classifier';
 export type { UrlContentType, UrlClassification } from './url-classifier';
 export { addEnhancedSlider } from './slider-helper';
+export { addCollapsibleSection } from './collapsible-section';
+export type {
+	CollapsibleSection,
+	CollapsibleSectionOptions,
+} from './collapsible-section';
 export { generateId, isValidCheckpointId } from './id-utils';
 export { CheckpointManager } from './checkpoint-manager';
 export type {

--- a/styles.css
+++ b/styles.css
@@ -257,11 +257,112 @@
   color: var(--text-normal);
 }
 
+/* ── Collapsible settings accordions (#235) ── */
+
+.synapse-accordion {
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.synapse-accordion-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 4px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 6px;
+}
+
+.synapse-accordion-header:hover {
+  background-color: var(--background-modifier-hover);
+}
+
+.synapse-accordion-header:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: -2px;
+}
+
+.synapse-accordion-chevron {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  font-size: 0.7em;
+  color: var(--text-muted);
+  /* Rotates from ▶ (collapsed) to ▼ (expanded). */
+  transform: rotate(90deg);
+  transition: transform 150ms ease;
+}
+
+.synapse-accordion.is-collapsed .synapse-accordion-chevron {
+  transform: rotate(0deg);
+}
+
+.synapse-accordion-title {
+  flex-grow: 1;
+  font-weight: var(--font-semibold);
+  color: var(--text-normal);
+}
+
+.synapse-accordion-control {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+/*
+ * The enable toggle lives inside a borderless Setting so we reuse the native
+ * ToggleComponent. Strip the Setting's default block layout/border/padding so
+ * it sits inline in the header next to the title.
+ */
+.synapse-accordion-toggle-setting {
+  border-top: none !important;
+  padding: 0 !important;
+  margin: 0;
+}
+
+.synapse-accordion-toggle-setting .setting-item-info {
+  display: none;
+}
+
+.synapse-accordion-toggle-setting .setting-item-control {
+  padding: 0;
+}
+
+/*
+ * Body: animate height + opacity on collapse/expand. A generous max-height
+ * accommodates the tallest feature section; it is purely an animation ceiling.
+ * Environments without this CSS fall back to instant show/hide via the
+ * is-collapsed display rule below.
+ */
+.synapse-accordion-body {
+  overflow: hidden;
+  max-height: 4000px;
+  opacity: 1;
+  transition: max-height 250ms ease, opacity 200ms ease;
+}
+
+.synapse-accordion.is-collapsed .synapse-accordion-body {
+  max-height: 0;
+  opacity: 0;
+  /*
+   * display:none after the transition would kill the animation, so we keep it
+   * laid out but zero-height. For no-transition fallbacks, max-height:0 +
+   * overflow:hidden already hides the content.
+   */
+  pointer-events: none;
+}
+
 /* ── Mobile-responsive overrides ── */
 
 @media (max-width: 768px) {
   .synapse-slider-wrapper {
     min-width: 0;
+  }
+
+  .synapse-accordion-header {
+    padding: 12px 4px;
   }
 
   .synapse-proposal-editor {


### PR DESCRIPTION
## Summary

Refactors the long, flat settings panel (`src/settings-tab.ts`) into per-feature **collapsible accordions** whose collapse state is tied to each feature's enable toggle, with manual override and persistence.

- **Accordion helper** — new `addCollapsibleSection()` in `src/shared/collapsible-section.ts`, mirroring the `slider-helper.ts` DOM-wrapper pattern. Builds a header (chevron + title + optional enable-toggle slot) above a collapsible body and returns a handle exposing `bodyEl` + `setCollapsed()`.
- **Toggle drives collapse** — turning a feature **off** auto-collapses its sub-settings; **on** auto-expands. The header + toggle always stay visible so the feature can be re-enabled.
- **Manual accordion** — clicking the header (or Enter/Space while focused) folds/unfolds independent of enabled state.
- **Persistence** — new `ui.collapsedSections: Record<string, boolean>` map in settings (auto-migrated via `deepMerge`, no migration code). A section defaults to collapsed when its feature is disabled. The two provider-change `display()` rebuilds (AI provider, audio transcription provider) now restore persisted state, so the tab no longer jumps open/closed on a provider switch.
- **Migrated all 11 feature sections**: elaboration, intake, image, audio, video, enrichment, summarize, tidy, organize, deepDive, rem.
- **AI Configuration** stays always-visible — collapsible/persistent but **no** enable toggle, so it never auto-collapses. Provider-conditional fields (Ollama endpoint, Whisper/Deepgram API keys) are preserved across the refactor.
- **Animation/ARIA** — CSS `max-height`/`opacity` transition + rotating chevron, header `role=button` / `tabindex=0` / `aria-expanded`; degrades to instant show/hide without the CSS.
- **Tests** — enhanced the centralized obsidian mock (introspectable stub elements, `ToggleComponent`, `Setting.settingEl` + `addToggle` callback) and added `src/shared/collapsible-section.test.ts` covering structure, initial collapsed state, manual header/keyboard toggle, toggle→collapse wiring, and `setCollapsed`.

## Files changed
- `src/shared/collapsible-section.ts` (new — accordion helper)
- `src/shared/collapsible-section.test.ts` (new — 19 tests)
- `src/shared/index.ts` (export helper)
- `src/settings.ts` (`UISettings` interface + `ui` default)
- `src/settings-tab.ts` (migrate all sections into accordion bodies)
- `styles.css` (accordion styles + mobile override)
- `src/__mocks__/obsidian.ts` (richer stub elements, `ToggleComponent`, `Setting` enhancements)

## Test plan
- [x] Types pass (`npx tsc --noEmit --skipLibCheck`)
- [x] Tests pass (`npm test` — 984 passed, incl. 19 new)
- [x] Production build passes (`node esbuild.config.mjs production`)

closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)