### PR TITLE
feat(#228): per-proposal-type auto-accept

### DIFF
--- a/src/deep-dive/auto-accept.test.ts
+++ b/src/deep-dive/auto-accept.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeepDiveModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { DeepDiveProposal } from './types';
+
+vi.mock('./topic-analyzer', () => ({
+	TopicAnalyzer: class MockTopicAnalyzer {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		extractTopics = vi.fn().mockResolvedValue([]);
+	},
+}));
+vi.mock('./note-generator', () => ({
+	NoteGenerator: class MockNoteGenerator {
+		constructor(_getSettings: unknown) {}
+		generateContent = vi.fn().mockResolvedValue('# Generated\n\nbody');
+	},
+}));
+
+/** In-memory adapter so DeepDiveStore round-trips proposals/runs via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+function makeProposal(id: string): DeepDiveProposal {
+	return {
+		id,
+		runId: 'run-1',
+		sourceNotePath: 'notes/root.md',
+		topic: { title: 'Backpropagation', existsInVault: false, reason: 'new concept' } as never,
+		proposedPath: 'Deep Dives/Root/Backpropagation.md',
+		proposedContent: '# Backpropagation\n\nGenerated content.',
+		depth: 0,
+		qualityScore: { score: 0.9 } as never,
+		childProposalIds: [],
+		createdAt: new Date().toISOString(),
+		status: 'pending',
+	};
+}
+
+describe('DeepDiveModule auto-accept guard (#228)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: { app: Record<string, unknown>; addCommand: ReturnType<typeof vi.fn>; registerEvent: ReturnType<typeof vi.fn> };
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+	let createSpy: ReturnType<typeof vi.fn>;
+	let modifySpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = new NotificationManager();
+		createSpy = vi.fn().mockResolvedValue(undefined);
+		modifySpy = vi.fn().mockResolvedValue(undefined);
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Root\n\nroot content'),
+					create: createSpy,
+					modify: modifySpy,
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					// No run is stored, so updateRunNavigation returns early and
+					// the accept reduces to a status flip — keeps the test focused
+					// on the double-accept guard.
+					getAbstractFileByPath: vi.fn().mockReturnValue(null),
+					adapter,
+				},
+				metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(): DeepDiveModule {
+		return new DeepDiveModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			() => settings.autoAccept['deep-dive']
+		);
+	}
+
+	it('marks a proposal accepted on first accept and is idempotent on a second (cascade guard)', async () => {
+		const mod = build();
+		await mod.onload();
+
+		// Seed one pending proposal directly in the store, under the exact file
+		// name the store derives (topic-slug + depth + shortId) so that the
+		// status-update re-save overwrites the SAME file rather than leaving a
+		// stale pending copy.
+		const proposal = makeProposal('p1');
+		adapter._files.set(
+			`${settings.deepDive.proposalFolderPath}/proposals/backpropagation-d0-p1.json`,
+			JSON.stringify(proposal)
+		);
+
+		// Proves the proposal was actually found & pending before accept.
+		expect(await mod.getPendingProposals()).toHaveLength(1);
+
+		// First accept flips status to accepted, firing the chain hook once.
+		const onNoteAccepted = vi.fn();
+		mod.onNoteAccepted = onNoteAccepted;
+		await mod.acceptProposal('p1');
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+		expect(onNoteAccepted).toHaveBeenCalledTimes(1);
+
+		// Second accept is a no-op (cascade guard): no throw, no second
+		// note-accepted hook, still nothing pending.
+		await mod.acceptProposal('p1');
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+		expect(onNoteAccepted).toHaveBeenCalledTimes(1);
+	});
+
+	it('fires the enrichment chain hook (onNoteAccepted) on accept', async () => {
+		settings.autoAccept['deep-dive'] = true;
+		const mod = build();
+		await mod.onload();
+		const onNoteAccepted = vi.fn();
+		mod.onNoteAccepted = onNoteAccepted;
+
+		const proposal = makeProposal('p2');
+		adapter._files.set(
+			`${settings.deepDive.proposalFolderPath}/proposals/backpropagation-d0-p2.json`,
+			JSON.stringify(proposal)
+		);
+
+		await mod.acceptProposal('p2');
+
+		expect(onNoteAccepted).toHaveBeenCalledWith('Deep Dives/Root/Backpropagation.md');
+	});
+});

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -58,13 +58,23 @@ export class DeepDiveModule {
 	private contentAnalyzer: ContentAnalyzer;
 	private directoryMatcher: DirectoryMatcher;
 
+	/**
+	 * Live accessor for the deep-dive auto-accept flag (#228). Wired by main.ts
+	 * to `() => this.settings.autoAccept['deep-dive']`. Defaults to "never
+	 * auto-accept". Deep dive generates a tree; auto-accept creates every
+	 * generated node's note (in creation order, after the run finishes).
+	 */
+	private shouldAutoAccept: () => boolean = () => false;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager,
-		private registrar: CommandRegistrar
+		private registrar: CommandRegistrar,
+		shouldAutoAccept?: () => boolean
 	) {
+		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
 		this.analyzer = new TopicAnalyzer(plugin.app, getSettings);
 		this.generator = new NoteGenerator(getSettings);
 		this.store = new DeepDiveStore(plugin.app, getSettings);
@@ -116,13 +126,21 @@ export class DeepDiveModule {
 	 * Accept a proposal: create the new note in the vault with navigation,
 	 * generate/update the syllabus index, and update navigation in all
 	 * previously accepted notes in the same run.
+	 *
+	 * `options.silent` suppresses the per-note success Notice and the view
+	 * refresh; used by batch auto-accept so the run emits a single summary
+	 * Notice and refreshes once. The enrichment / organize follow-on hooks
+	 * still fire (they are the intended, acyclic chain).
 	 */
-	async acceptProposal(id: string): Promise<void> {
+	async acceptProposal(id: string, options?: { silent?: boolean }): Promise<void> {
 		const proposal = await this.store.loadProposal(id);
 		if (!proposal) {
 			this.notifications.info('Proposal not found');
 			return;
 		}
+		// Guard against double-acceptance (cascade safety): never create the
+		// note twice for the same proposal.
+		if (proposal.status !== 'pending') return;
 
 		try {
 			await this.store.updateProposalStatus(id, 'accepted');
@@ -130,7 +148,9 @@ export class DeepDiveModule {
 			// Build navigation for all accepted proposals in this run
 			await this.updateRunNavigation(proposal.runId, proposal.proposedPath, proposal.proposedContent);
 
-			this.notifications.success(`Created ${proposal.proposedPath}`);
+			if (!options?.silent) {
+				this.notifications.success(`Created ${proposal.proposedPath}`);
+			}
 
 			// Trigger enrichment on the new note
 			this.onNoteAccepted?.(proposal.proposedPath);
@@ -145,12 +165,40 @@ export class DeepDiveModule {
 				}
 			}
 
-			await this.onViewRefreshNeeded?.();
+			if (!options?.silent) {
+				await this.onViewRefreshNeeded?.();
+			}
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			this.notifications.notifyError('Failed to accept proposal', error);
 			throw new Error(`Accept proposal failed: ${msg}`);
 		}
+	}
+
+	/**
+	 * Auto-accept all proposals generated in a run (#228), if the deep-dive
+	 * auto-accept flag is on. Accepts in creation order (parents before
+	 * children, per the BFS queue) so navigation resolves correctly, then emits
+	 * a single summary Notice. Returns the number accepted.
+	 *
+	 * Done AFTER the generation loop (not mid-loop) so the recursive queue is
+	 * not disturbed and navigation is not rebuilt on every node mid-flight.
+	 */
+	private async maybeAutoAcceptRun(proposalIds: string[]): Promise<number> {
+		if (!this.shouldAutoAccept()) return 0;
+		let accepted = 0;
+		for (const id of proposalIds) {
+			// acceptProposal re-loads and re-checks pending, so a child whose
+			// parent was already accepted is still safe.
+			await this.acceptProposal(id, { silent: true });
+			accepted++;
+		}
+		if (accepted > 0) {
+			this.notifications.info(
+				`Auto-accepted ${accepted} deep dive note${accepted === 1 ? '' : 's'}`
+			);
+		}
+		return accepted;
 	}
 
 	/**
@@ -438,6 +486,10 @@ export class DeepDiveModule {
 				genOp.finish(
 					`Generated ${run.stats.totalProposals} proposals (${depthSummary})`
 				);
+
+				// Auto-accept the whole generated tree if enabled (#228), in
+				// creation order so navigation resolves. Skipped on cancellation.
+				await this.maybeAutoAcceptRun(run.proposalIds);
 			}
 
 			await this.onViewRefreshNeeded?.();

--- a/src/elaboration/auto-accept.test.ts
+++ b/src/elaboration/auto-accept.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ElaborationModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { mockFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+// The proposer uses AIClient under the hood; stub it so no network is hit.
+const sharedCompleteMock = vi.fn().mockResolvedValue('AI-generated elaboration content');
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		constructor(_getSettings: unknown) {}
+		complete(...args: unknown[]) {
+			return sharedCompleteMock(...args);
+		}
+	},
+}));
+
+/**
+ * A minimal in-memory vault adapter so ProposalStore.save → load/loadPending
+ * round-trips through real JSON, letting us assert the persisted status of a
+ * proposal after a scan (pending vs accepted).
+ */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			// Folder exists if any file lives under it, plus the note itself.
+			if (files.has(path)) return true;
+			for (const key of files.keys()) {
+				if (key.startsWith(path + '/')) return true;
+			}
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) {
+				if (key.startsWith(folder + '/')) out.push(key);
+			}
+			return { files: out, folders: [] };
+		}),
+		mkdir: vi.fn(async () => undefined),
+	};
+}
+
+function createMockPlugin(noteContent: string, adapter: ReturnType<typeof createMemoryAdapter>) {
+	const noteFile = mockFile('notes/topic.md');
+	const vault = {
+		read: vi.fn().mockResolvedValue(noteContent),
+		modify: vi.fn().mockResolvedValue(undefined),
+		create: vi.fn(),
+		createFolder: vi.fn().mockResolvedValue(undefined),
+		getAbstractFileByPath: vi.fn((path: string) =>
+			path === 'notes/topic.md' ? noteFile : null
+		),
+		getMarkdownFiles: vi.fn().mockReturnValue([]),
+		adapter,
+	};
+	const metadataCache = {
+		getFileCache: vi.fn().mockReturnValue(null),
+		getCache: vi.fn().mockReturnValue(null),
+		getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+	};
+	const workspace = {
+		getLeavesOfType: vi.fn().mockReturnValue([]),
+		getRightLeaf: vi.fn().mockReturnValue(null),
+		revealLeaf: vi.fn(),
+		getActiveFile: vi.fn().mockReturnValue(null),
+	};
+	return {
+		app: { vault, metadataCache, workspace },
+		addCommand: vi.fn(),
+		addRibbonIcon: vi.fn(),
+		addSettingTab: vi.fn(),
+		registerView: vi.fn(),
+		registerEvent: vi.fn(),
+		loadData: vi.fn().mockResolvedValue(null),
+		saveData: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe('ElaborationModule auto-accept (#228)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: ReturnType<typeof createMockPlugin>;
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+
+	const longContent = '# Topic\n\n' + 'A fully written note with plenty of content. '.repeat(20);
+
+	beforeEach(() => {
+		sharedCompleteMock.mockClear();
+		adapter = createMemoryAdapter();
+		// The proposer reads the source note via adapter.read(notePath), so the
+		// note content must live in the in-memory adapter, not just vault.read.
+		adapter._files.set('notes/topic.md', longContent);
+		settings = structuredClone(DEFAULT_SETTINGS);
+		mockPlugin = createMockPlugin(longContent, adapter);
+		notifications = new NotificationManager();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(shouldAutoAccept: () => boolean): ElaborationModule {
+		return new ElaborationModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			shouldAutoAccept
+		);
+	}
+
+	it('auto-accepts a freshly generated proposal when the flag is on', async () => {
+		settings.autoAccept.elaboration = true;
+		const mod = build(() => settings.autoAccept.elaboration);
+
+		await mod.scanNote(mockFile('notes/topic.md') as never);
+
+		// No pending proposals remain — the generated one was accepted.
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(0);
+
+		// The note was modified (the elaboration callout was appended on accept).
+		expect(mockPlugin.app.vault.modify).toHaveBeenCalledTimes(1);
+	});
+
+	it('leaves the proposal pending when the flag is off', async () => {
+		settings.autoAccept.elaboration = false;
+		const mod = build(() => settings.autoAccept.elaboration);
+
+		await mod.scanNote(mockFile('notes/topic.md') as never);
+
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+		expect(pending[0].status).toBe('pending');
+
+		// The note is untouched while the proposal awaits review.
+		expect(mockPlugin.app.vault.modify).not.toHaveBeenCalled();
+	});
+
+	it('reads the flag live, so toggling after construction takes effect', async () => {
+		// Flag starts off; module reads it live via the accessor.
+		settings.autoAccept.elaboration = false;
+		const mod = build(() => settings.autoAccept.elaboration);
+
+		// Flip it on before scanning — no reconstruction.
+		settings.autoAccept.elaboration = true;
+		await mod.scanNote(mockFile('notes/topic.md') as never);
+
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('fires the onProposalAccepted chain hook on auto-accept', async () => {
+		settings.autoAccept.elaboration = true;
+		const mod = build(() => settings.autoAccept.elaboration);
+		const chained = vi.fn();
+		mod.onProposalAccepted = chained;
+
+		await mod.scanNote(mockFile('notes/topic.md') as never);
+
+		expect(chained).toHaveBeenCalledWith('notes/topic.md');
+	});
+});

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -26,13 +26,22 @@ export class ElaborationModule {
 	/** Optional callback to refresh the unified proposal view. Wired by main.ts. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/**
+	 * Live accessor for the elaboration auto-accept flag (#228). Wired by
+	 * main.ts to `() => this.settings.autoAccept.elaboration` so a settings
+	 * change takes effect without a reload. Defaults to "never auto-accept".
+	 */
+	private shouldAutoAccept: () => boolean = () => false;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager,
-		private registrar: CommandRegistrar
+		private registrar: CommandRegistrar,
+		shouldAutoAccept?: () => boolean
 	) {
+		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
 		this.detector = new PlaceholderDetector(plugin.app, getSettings);
 		this.proposer = new ProposalGenerator(plugin.app, getSettings);
 		this.store = new ProposalStore(plugin.app, getSettings);
@@ -106,6 +115,7 @@ export class ElaborationModule {
 		);
 		const createdProposalIds: string[] = [];
 		let proposalCount = 0;
+		let autoAcceptedCount = 0;
 
 		try {
 			for (let i = 0; i < checkpoint.remainingItems.length; i++) {
@@ -126,6 +136,7 @@ export class ElaborationModule {
 				await this.store.save(proposal);
 				createdProposalIds.push(proposal.id);
 				proposalCount++;
+				if (await this.maybeAutoAccept(proposal, true)) autoAcceptedCount++;
 
 				await this.checkpointManager.completeItem(checkpoint.id, item.id);
 			}
@@ -147,6 +158,11 @@ export class ElaborationModule {
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
 		genOp.finish(`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
+		if (autoAcceptedCount > 0) {
+			this.notifications.info(
+				`Auto-accepted ${autoAcceptedCount} elaboration proposal${autoAcceptedCount === 1 ? '' : 's'}`
+			);
+		}
 		await this.refreshView();
 	}
 
@@ -205,6 +221,7 @@ export class ElaborationModule {
 		);
 		const createdProposalIds: string[] = [];
 		let proposalCount = 0;
+		let autoAcceptedCount = 0;
 
 		// Create checkpoint for resumability
 		const checkpointItems: CheckpointWorkItem[] = detected.map((d, i) => ({
@@ -234,6 +251,7 @@ export class ElaborationModule {
 				await this.store.save(proposal);
 				createdProposalIds.push(proposal.id);
 				proposalCount++;
+				if (await this.maybeAutoAccept(proposal, true)) autoAcceptedCount++;
 
 				// Save checkpoint progress
 				await this.checkpointManager.completeItem(
@@ -263,6 +281,11 @@ export class ElaborationModule {
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
 		genOp.finish(`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
+		if (autoAcceptedCount > 0) {
+			this.notifications.info(
+				`Auto-accepted ${autoAcceptedCount} elaboration proposal${autoAcceptedCount === 1 ? '' : 's'}`
+			);
+		}
 		await this.refreshView();
 		return proposalCount;
 	}
@@ -288,6 +311,7 @@ export class ElaborationModule {
 				const proposal = await this.proposer.generate(result);
 				await this.store.save(proposal);
 				op.finish('Proposal generated');
+				await this.maybeAutoAccept(proposal);
 				await this.refreshView();
 			} else {
 				op.finish('Note does not appear to be a stub');
@@ -301,10 +325,21 @@ export class ElaborationModule {
 	/**
 	 * Accept a proposal, optionally with edited content from the review panel.
 	 * If editedContent is provided, it's used instead of the stored proposedAdditions.
+	 *
+	 * `options.silent` suppresses the per-proposal success Notice and the view
+	 * refresh; used by batch auto-accept so callers can emit a single summary
+	 * Notice and refresh once.
 	 */
-	async acceptProposal(id: string, editedContent?: string): Promise<void> {
+	async acceptProposal(
+		id: string,
+		editedContent?: string,
+		options?: { silent?: boolean }
+	): Promise<void> {
 		const proposal = await this.store.load(id);
 		if (!proposal) return;
+		// Guard against double-acceptance (cascade safety): a proposal that is
+		// no longer pending has already been applied — never apply it twice.
+		if (proposal.status !== 'pending') return;
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
 		if (!(file instanceof TFile)) return;
@@ -321,9 +356,27 @@ export class ElaborationModule {
 		await this.plugin.app.vault.modify(file, newContent);
 
 		await this.store.updateStatus(id, 'accepted');
-		this.notifications.success('Proposal accepted');
-		await this.refreshView();
+		if (!options?.silent) {
+			this.notifications.success('Proposal accepted');
+			await this.refreshView();
+		}
 		this.onProposalAccepted?.(proposal.sourceNotePath);
+	}
+
+	/**
+	 * Auto-accept a freshly generated proposal as the unedited draft (#228),
+	 * if the elaboration auto-accept flag is on. Returns `true` when accepted.
+	 *
+	 * `batch` suppresses the per-proposal Notice (the caller emits one summary
+	 * Notice). Single-note callers get one Notice per auto-accept.
+	 */
+	private async maybeAutoAccept(proposal: Proposal, batch = false): Promise<boolean> {
+		if (!this.shouldAutoAccept()) return false;
+		await this.acceptProposal(proposal.id, proposal.proposedAdditions, { silent: batch });
+		if (!batch) {
+			this.notifications.info(`Auto-accepted elaboration for ${proposal.sourceNotePath}`);
+		}
+		return true;
 	}
 
 	async rejectProposal(id: string): Promise<void> {

--- a/src/enrichment/auto-accept.test.ts
+++ b/src/enrichment/auto-accept.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EnrichmentModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+// Deterministic enrichment result: one tag, one internal link, one frontmatter key.
+vi.mock('./vault-analyzer', () => ({
+	VaultAnalyzer: class MockVaultAnalyzer {
+		constructor(_app: unknown) {}
+		invalidate = vi.fn();
+		getFileTags = vi.fn().mockReturnValue([]);
+		getOutgoingLinks = vi.fn().mockReturnValue(new Set<string>());
+		buildTagIndex = vi.fn();
+		buildLinkGraph = vi.fn();
+	},
+}));
+
+vi.mock('./metadata-classifier', () => ({
+	MetadataClassifier: class MockMetadataClassifier {
+		constructor(_getSettings: unknown) {}
+		classify = vi.fn().mockResolvedValue([
+			{ tag: 'reference', category: 'Status', confidence: 0.9, rawScore: 1, weightedScore: 1, sources: [] },
+		]);
+	},
+}));
+
+vi.mock('./link-resolver', () => ({
+	LinkResolver: class MockLinkResolver {
+		constructor(_app: unknown, _analyzer: unknown, _getSettings: unknown) {}
+		findInternalLinks = vi.fn().mockReturnValue([
+			{ targetPath: 'Notes/Related.md', displayText: 'Related', relevanceScore: 0.8, reason: 'shares tags' },
+		]);
+		mergeTopicCandidates = vi.fn((_topics: unknown, graphLinks: unknown[]) => graphLinks);
+	},
+}));
+
+vi.mock('./topic-extractor', () => ({
+	TopicExtractor: class MockTopicExtractor {
+		constructor(_app: unknown, _analyzer: unknown, _getSettings: unknown) {}
+		clearPending = vi.fn();
+		extractTopics = vi.fn().mockResolvedValue([]);
+		resolveNewNoteCandidates = vi.fn().mockReturnValue(new Map());
+	},
+}));
+
+vi.mock('./prompt-builder', () => ({
+	PromptBuilder: class MockPromptBuilder {
+		constructor(_getSettings: unknown) {}
+		suggestExternalLinks = vi.fn().mockResolvedValue([]);
+		suggestFrontmatter = vi.fn().mockResolvedValue([
+			{ key: 'type', value: 'reference', action: 'add' },
+		]);
+	},
+}));
+
+// The applier is the side effect we assert on for auto-accept.
+const applySpy = vi.fn().mockResolvedValue(undefined);
+vi.mock('./enrichment-applier', () => ({
+	EnrichmentApplier: class MockEnrichmentApplier {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		apply = applySpy;
+		undo = vi.fn().mockResolvedValue(undefined);
+	},
+}));
+
+/** In-memory adapter so EnrichmentStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+describe('EnrichmentModule auto-accept (#228)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: { app: Record<string, unknown>; addCommand: ReturnType<typeof vi.fn>; registerEvent: ReturnType<typeof vi.fn> };
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		applySpy.mockClear();
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = new NotificationManager();
+		sourceFile = new TFile('notes/ml.md');
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# ML\n\nA note about machine learning.'),
+					modify: vi.fn().mockResolvedValue(undefined),
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					getAbstractFileByPath: vi.fn((path: string) =>
+						path === 'notes/ml.md' ? sourceFile : null
+					),
+					adapter,
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+					on: vi.fn(),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(shouldAutoAccept: () => boolean): EnrichmentModule {
+		return new EnrichmentModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			shouldAutoAccept
+		);
+	}
+
+	it('auto-accepts a freshly generated enrichment proposal, applying all suggested items', async () => {
+		settings.autoAccept.enrichment = true;
+		const mod = build(() => settings.autoAccept.enrichment);
+		await mod.onload();
+
+		await mod.enrich('notes/ml.md', 'manual');
+
+		// The applier ran with the full generated result accepted.
+		expect(applySpy).toHaveBeenCalledTimes(1);
+		const accepted = applySpy.mock.calls[0][1];
+		expect(accepted.tags).toEqual(['reference']);
+		expect(accepted.internalLinks).toEqual(['Notes/Related.md']);
+		expect(accepted.frontmatter).toEqual(['type']);
+
+		// Nothing left pending; status is fully accepted.
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(0);
+	});
+
+	it('leaves the enrichment proposal pending and applies nothing when the flag is off', async () => {
+		settings.autoAccept.enrichment = false;
+		const mod = build(() => settings.autoAccept.enrichment);
+		await mod.onload();
+
+		await mod.enrich('notes/ml.md', 'manual');
+
+		expect(applySpy).not.toHaveBeenCalled();
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+		expect(pending[0].status).toBe('pending');
+	});
+});

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -39,13 +39,22 @@ export class EnrichmentModule {
 	/** Optional callback to refresh the unified proposal view. Wired by main.ts. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/**
+	 * Live accessor for the enrichment auto-accept flag (#228). Wired by
+	 * main.ts to `() => this.settings.autoAccept.enrichment`. Defaults to
+	 * "never auto-accept".
+	 */
+	private shouldAutoAccept: () => boolean = () => false;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager,
-		private registrar: CommandRegistrar
+		private registrar: CommandRegistrar,
+		shouldAutoAccept?: () => boolean
 	) {
+		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
 		this.analyzer = new VaultAnalyzer(plugin.app);
 		this.classifier = new MetadataClassifier(getSettings);
 		this.topicExtractor = new TopicExtractor(plugin.app, this.analyzer, getSettings);
@@ -155,9 +164,23 @@ export class EnrichmentModule {
 			return;
 		}
 
+		// Auto-accept (#228) the resumed proposals. Resume has no Phase 4 merge,
+		// so each stored proposal is final. Batch mode: one summary Notice.
+		let autoAcceptedCount = 0;
+		if (this.shouldAutoAccept()) {
+			for (const { id } of createdProposals) {
+				if (await this.maybeAutoAccept(id, true)) autoAcceptedCount++;
+			}
+		}
+
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
 		genOp.finish(`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
+		if (autoAcceptedCount > 0) {
+			this.notifications.info(
+				`Auto-accepted ${autoAcceptedCount} enrichment proposal${autoAcceptedCount === 1 ? '' : 's'}`
+			);
+		}
 		await this.refreshView();
 	}
 
@@ -313,12 +336,26 @@ export class EnrichmentModule {
 			}
 		}
 
+		// Auto-accept (#228) AFTER Phase 4 so each accepted proposal includes
+		// the merged cross-note candidates. Batch mode: one summary Notice.
+		let autoAcceptedCount = 0;
+		if (this.shouldAutoAccept()) {
+			for (const { id } of createdProposals) {
+				if (await this.maybeAutoAccept(id, true)) autoAcceptedCount++;
+			}
+		}
+
 		// Mark checkpoint completed and dispatch deferred tasks (I1)
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
 		genOp.finish(
 			`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`
 		);
+		if (autoAcceptedCount > 0) {
+			this.notifications.info(
+				`Auto-accepted ${autoAcceptedCount} enrichment proposal${autoAcceptedCount === 1 ? '' : 's'}`
+			);
+		}
 		await this.refreshView();
 		return proposalCount;
 	}
@@ -347,6 +384,9 @@ export class EnrichmentModule {
 			this.topicExtractor.clearPending();
 			if (id) {
 				op.finish('Enrichment proposal created');
+				// Single-note path is final here (no Phase 4 merge), so the
+				// stored proposal is fully formed — safe to auto-accept (#228).
+				await this.maybeAutoAccept(id);
 			} else {
 				op.finish('No enrichments needed');
 			}
@@ -435,8 +475,46 @@ export class EnrichmentModule {
 	}
 
 	/** Accept selected items in a proposal. Called from unified view. */
-	async acceptSelectedFromView(id: string, accepted: AcceptedItems): Promise<void> {
-		await this.acceptSelected(id, accepted);
+	async acceptSelectedFromView(
+		id: string,
+		accepted: AcceptedItems,
+		options?: { silent?: boolean }
+	): Promise<void> {
+		await this.acceptSelected(id, accepted, options);
+	}
+
+	/**
+	 * Build an {@link AcceptedItems} that accepts EVERYTHING the proposal
+	 * suggested — used for auto-accept (#228), which takes the full generated
+	 * result with no manual cherry-picking.
+	 */
+	private buildAcceptAll(result: EnrichmentResult): AcceptedItems {
+		return {
+			tags: result.tags.map(t => t.tag),
+			internalLinks: result.internalLinks.map(l => l.targetPath),
+			externalLinks: result.externalLinks.map(l => l.url),
+			frontmatter: result.frontmatter.map(f => f.key),
+		};
+	}
+
+	/**
+	 * Auto-accept a freshly generated enrichment proposal in full (#228), if the
+	 * enrichment auto-accept flag is on. Returns `true` when accepted.
+	 *
+	 * `batch` suppresses the per-proposal Notice/refresh (the caller emits one
+	 * summary Notice and refreshes once).
+	 */
+	private async maybeAutoAccept(proposalId: string, batch = false): Promise<boolean> {
+		if (!this.shouldAutoAccept()) return false;
+		const proposal = await this.store.load(proposalId);
+		// Guard against double-acceptance (cascade safety).
+		if (!proposal || proposal.status !== 'pending') return false;
+		const acceptAll = this.buildAcceptAll(proposal.result);
+		await this.acceptSelectedFromView(proposalId, acceptAll, { silent: batch });
+		if (!batch) {
+			this.notifications.info(`Auto-accepted enrichment for ${proposal.sourceNotePath}`);
+		}
+		return true;
 	}
 
 	/** Reject a proposal. Called from unified view. */
@@ -448,10 +526,13 @@ export class EnrichmentModule {
 
 	private async acceptSelected(
 		id: string,
-		accepted: AcceptedItems
+		accepted: AcceptedItems,
+		options?: { silent?: boolean }
 	): Promise<void> {
 		const proposal = await this.store.load(id);
 		if (!proposal) return;
+		// Guard against double-acceptance (cascade safety).
+		if (proposal.status !== 'pending') return;
 
 		const hasItems =
 			accepted.tags.length > 0 ||
@@ -481,8 +562,10 @@ export class EnrichmentModule {
 			totalAccepted < totalAvailable ? 'partially-accepted' : 'accepted';
 
 		await this.store.updateStatus(id, status, accepted);
-		this.notifications.success(`Enrichment ${status}`);
-		await this.refreshView();
+		if (!options?.silent) {
+			this.notifications.success(`Enrichment ${status}`);
+			await this.refreshView();
+		}
 	}
 
 	private async rejectProposalBatch(ids: string[]): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,9 +72,15 @@ export default class SynapsePlugin extends Plugin {
 		// by the command registry (developer source of truth / master control).
 		const registrar = new CommandRegistrar(this);
 
+		// Per-proposal-type auto-accept accessors (#228). Each module receives a
+		// live `() => this.settings.autoAccept[kind]` getter — consistent with the
+		// getSettings accessor pattern — so toggling the setting takes effect
+		// immediately without a reload, and modules never import global settings.
+		// Read through `this.settings` (not a captured reference) so it stays live.
+
 		// Initialize modules (Audio before Video since Video depends on Audio)
 		// Pass checkpointManager to each module instead of letting them create their own
-		this.elaboration = new ElaborationModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
+		this.elaboration = new ElaborationModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept.elaboration);
 		// Create a shared AudioExtractor on desktop for clipping support
 		const audioExtractor = Platform.isDesktop ? new AudioExtractor(getSettings) : undefined;
 		this.audioExtractor = audioExtractor;
@@ -83,7 +89,7 @@ export default class SynapsePlugin extends Plugin {
 			this.video = new VideoModule(this, getSettings, this.audio, this.notifications, this.checkpointManager, registrar);
 		}
 		this.image = new ImageModule(this, getSettings, this.notifications, this.checkpointManager);
-		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
+		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept.enrichment);
 		this.summarize = new SummarizeModule(
 			this, getSettings, this.notifications, this.checkpointManager, registrar,
 			this.video
@@ -97,10 +103,10 @@ export default class SynapsePlugin extends Plugin {
 			(files) => this.audio.transcribeAudioCombined(files)
 		);
 		this.tidy = new TidyModule(this, getSettings, this.notifications, registrar);
-		this.organize = new OrganizeModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
-		this.deepDive = new DeepDiveModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
-		this.title = new TitleModule(this, getSettings, this.notifications);
-		this.rem = new RemModule(this, getSettings, this.notifications, this.checkpointManager, registrar);
+		this.organize = new OrganizeModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept.organize);
+		this.deepDive = new DeepDiveModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept['deep-dive']);
+		this.title = new TitleModule(this, getSettings, this.notifications, () => this.settings.autoAccept.title);
+		this.rem = new RemModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept.rem);
 
 		// Register the unified proposal view
 		this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {

--- a/src/organize/auto-accept.test.ts
+++ b/src/organize/auto-accept.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OrganizeModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+// Analyzer finds a topic; matcher proposes a NEW directory (the only path that
+// creates an organize proposal).
+vi.mock('./content-analyzer', () => ({
+	ContentAnalyzer: class MockContentAnalyzer {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		analyze = vi.fn().mockResolvedValue({
+			notePath: 'inbox/note.md',
+			topics: [{ label: 'machine learning', confidence: 0.95 }],
+			tags: [],
+			links: [],
+		});
+	},
+}));
+
+vi.mock('./directory-matcher', () => ({
+	DirectoryMatcher: class MockDirectoryMatcher {
+		constructor(_app: unknown) {}
+		scoreDirectories = vi.fn().mockReturnValue([]);
+		determineAction = vi.fn().mockReturnValue({
+			type: 'propose-new-directory',
+			targetDirectory: 'Machine Learning',
+			reasoning: 'Note is about machine learning',
+		});
+	},
+}));
+
+/** In-memory adapter so OrganizeStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+describe('OrganizeModule auto-accept (#228)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: { app: Record<string, unknown>; addCommand: ReturnType<typeof vi.fn>; registerEvent: ReturnType<typeof vi.fn> };
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+	let renameSpy: ReturnType<typeof vi.fn>;
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = new NotificationManager();
+		renameSpy = vi.fn().mockResolvedValue(undefined);
+		sourceFile = new TFile('inbox/note.md');
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Note\n\nMachine learning content.'),
+					rename: renameSpy,
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					// Source note exists; destination path does not (no conflict).
+					getAbstractFileByPath: vi.fn((path: string) =>
+						path === 'inbox/note.md' ? sourceFile : null
+					),
+					adapter,
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(shouldAutoAccept: () => boolean): OrganizeModule {
+		return new OrganizeModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			shouldAutoAccept
+		);
+	}
+
+	it('auto-accepts a freshly created organize proposal, moving the note', async () => {
+		settings.autoAccept.organize = true;
+		const mod = build(() => settings.autoAccept.organize);
+		await mod.onload();
+
+		const result = await mod.organizeNote(sourceFile as never);
+
+		// A proposal was created and immediately accepted (note moved).
+		expect(result?.proposalCreated).toBe(true);
+		expect(result?.autoAccepted).toBe(true);
+		expect(renameSpy).toHaveBeenCalledTimes(1);
+		expect(renameSpy.mock.calls[0][1]).toBe('Machine Learning/note.md');
+
+		// Nothing left pending.
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('leaves the organize proposal pending and does not move the note when the flag is off', async () => {
+		settings.autoAccept.organize = false;
+		const mod = build(() => settings.autoAccept.organize);
+		await mod.onload();
+
+		const result = await mod.organizeNote(sourceFile as never);
+
+		expect(result?.proposalCreated).toBe(true);
+		expect(result?.autoAccepted).toBe(false);
+		expect(renameSpy).not.toHaveBeenCalled();
+
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+		expect(pending[0].status).toBe('pending');
+		expect(pending[0].proposedDirectory).toBe('Machine Learning');
+	});
+});

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -32,13 +32,22 @@ export class OrganizeModule {
 	private matcher: DirectoryMatcher;
 	private store: OrganizeStore;
 
+	/**
+	 * Live accessor for the organize auto-accept flag (#228). Wired by main.ts
+	 * to `() => this.settings.autoAccept.organize`. Defaults to "never
+	 * auto-accept". NOTE: organize auto-accept MOVES the note on the filesystem.
+	 */
+	private shouldAutoAccept: () => boolean = () => false;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager,
-		private registrar: CommandRegistrar
+		private registrar: CommandRegistrar,
+		shouldAutoAccept?: () => boolean
 	) {
+		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
 		this.analyzer = new ContentAnalyzer(plugin.app, getSettings);
 		this.matcher = new DirectoryMatcher(plugin.app);
 		this.store = new OrganizeStore(plugin.app, getSettings);
@@ -97,6 +106,7 @@ export class OrganizeModule {
 
 		let movedCount = 0;
 		let proposalCount = 0;
+		let autoAcceptedCount = 0;
 		let errorCount = 0;
 		const moveRecords: MoveRecord[] = [];
 
@@ -115,7 +125,7 @@ export class OrganizeModule {
 
 				try {
 					const originalPath = file.path;
-					const result = await this.organizeFile(file);
+					const result = await this.organizeFile(file, true);
 
 					if (result) {
 						if (result.movedDirectly && result.action.type === 'move') {
@@ -126,6 +136,7 @@ export class OrganizeModule {
 							moveRecords.push({ originalPath, newPath });
 						}
 						if (result.proposalCreated) proposalCount++;
+						if (result.autoAccepted) autoAcceptedCount++;
 					}
 				} catch (error) {
 					errorCount++;
@@ -160,6 +171,12 @@ export class OrganizeModule {
 			if (summaryPath) {
 				this.notifications.info(`Organize summary saved to ${summaryPath}`);
 			}
+		}
+
+		if (autoAcceptedCount > 0) {
+			this.notifications.info(
+				`Auto-accepted ${autoAcceptedCount} organize proposal${autoAcceptedCount === 1 ? '' : 's'} (notes moved)`
+			);
 		}
 
 		if (proposalCount > 0) {
@@ -267,6 +284,7 @@ export class OrganizeModule {
 
 		let movedCount = 0;
 		let proposalCount = 0;
+		let autoAcceptedCount = 0;
 		let errorCount = 0;
 		const moveRecords: MoveRecord[] = [];
 
@@ -295,7 +313,7 @@ export class OrganizeModule {
 			genOp.progress(i + 1, eligible.length, 'Organizing notes');
 			try {
 				const originalPath = eligible[i].path;
-				const result = await this.organizeFile(eligible[i]);
+				const result = await this.organizeFile(eligible[i], true);
 
 				if (result) {
 					if (result.movedDirectly && result.action.type === 'move') {
@@ -306,6 +324,7 @@ export class OrganizeModule {
 						moveRecords.push({ originalPath, newPath });
 					}
 					if (result.proposalCreated) proposalCount++;
+					if (result.autoAccepted) autoAcceptedCount++;
 				}
 			} catch (error) {
 				errorCount++;
@@ -347,6 +366,12 @@ export class OrganizeModule {
 			}
 		}
 
+		if (autoAcceptedCount > 0) {
+			this.notifications.info(
+				`Auto-accepted ${autoAcceptedCount} organize proposal${autoAcceptedCount === 1 ? '' : 's'} (notes moved)`
+			);
+		}
+
 		if (proposalCount > 0) {
 			await this.onViewRefreshNeeded?.();
 		}
@@ -356,13 +381,20 @@ export class OrganizeModule {
 
 	/**
 	 * Accept a proposal: create the new directory and move the note.
+	 *
+	 * `options.silent` suppresses the success / summary-path Notices and the
+	 * view refresh; used by batch auto-accept so callers emit one summary
+	 * Notice and refresh once. (Error and "cannot move" Notices still fire.)
 	 */
-	async acceptProposal(id: string): Promise<void> {
+	async acceptProposal(id: string, options?: { silent?: boolean }): Promise<void> {
 		const proposal = await this.store.loadProposal(id);
 		if (!proposal) {
 			this.notifications.info('Proposal not found');
 			return;
 		}
+		// Guard against double-acceptance (cascade safety): only act on a
+		// still-pending proposal so the note is never moved twice.
+		if (proposal.status !== 'pending') return;
 
 		try {
 			// Create the new directory
@@ -402,25 +434,42 @@ export class OrganizeModule {
 			await this.plugin.app.vault.rename(file, newPath);
 
 			await this.store.updateProposalStatus(id, 'accepted');
-			this.notifications.success(`Moved to ${proposal.proposedDirectory}`);
 
 			// Generate organize summary with move diagram
 			const moveRecords: MoveRecord[] = [
 				{ originalPath: file.path, newPath },
 			];
 			const summaryPath = await this.writeOrganizeSummary(moveRecords);
-			if (summaryPath) {
-				this.notifications.info(
-					`Organize summary saved to ${summaryPath}`
-				);
-			}
 
-			await this.onViewRefreshNeeded?.();
+			if (!options?.silent) {
+				this.notifications.success(`Moved to ${proposal.proposedDirectory}`);
+				if (summaryPath) {
+					this.notifications.info(
+						`Organize summary saved to ${summaryPath}`
+					);
+				}
+				await this.onViewRefreshNeeded?.();
+			}
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			this.notifications.notifyError('Failed to accept proposal', error);
 			throw new Error(`Accept proposal failed: ${msg}`);
 		}
+	}
+
+	/**
+	 * Auto-accept a freshly created organize proposal (#228), if the organize
+	 * auto-accept flag is on. Returns `true` when accepted. This MOVES the note.
+	 *
+	 * `batch` suppresses the per-proposal Notice (caller emits a summary).
+	 */
+	private async maybeAutoAccept(proposalId: string, batch = false): Promise<boolean> {
+		if (!this.shouldAutoAccept()) return false;
+		await this.acceptProposal(proposalId, { silent: batch });
+		if (!batch) {
+			this.notifications.info('Auto-accepted organize proposal');
+		}
+		return true;
 	}
 
 	/**
@@ -464,8 +513,12 @@ export class OrganizeModule {
 	/**
 	 * Core logic for organizing a single file.
 	 * Returns null if the note is already well-placed.
+	 *
+	 * When a new-directory proposal is created and organize auto-accept is on
+	 * (#228), the proposal is accepted immediately (the note is moved). `batch`
+	 * suppresses per-proposal Notices so batch callers can summarize.
 	 */
-	private async organizeFile(file: TFile): Promise<OrganizeResult | null> {
+	private async organizeFile(file: TFile, batch = false): Promise<OrganizeResult | null> {
 		const analysis = await this.analyzer.analyze(file);
 
 		if (analysis.topics.length === 0) {
@@ -525,11 +578,15 @@ export class OrganizeModule {
 
 		await this.store.saveProposal(proposal);
 
+		// Auto-accept the freshly created proposal if enabled (#228).
+		const autoAccepted = await this.maybeAutoAccept(proposal.id, batch);
+
 		return {
 			notePath: file.path,
 			action,
 			proposalCreated: true,
 			movedDirectly: false,
+			autoAccepted,
 		};
 	}
 

--- a/src/organize/types.ts
+++ b/src/organize/types.ts
@@ -72,4 +72,9 @@ export interface OrganizeResult {
 	proposalCreated: boolean;
 	/** Whether the note was moved directly (for existing directories) */
 	movedDirectly: boolean;
+	/**
+	 * Whether a created proposal was auto-accepted as generated (#228), moving
+	 * the note. Only meaningful when `proposalCreated` is `true`.
+	 */
+	autoAccepted?: boolean;
 }

--- a/src/rem/auto-accept.test.ts
+++ b/src/rem/auto-accept.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RemModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { RemLinkCandidate } from './types';
+
+// Fixed literal candidate the scanner "finds" — two occurrences of one term.
+const CANDIDATE: RemLinkCandidate = {
+	targetPath: 'Concepts/Backpropagation.md',
+	targetDisplayName: 'Backpropagation',
+	matchedText: 'backpropagation',
+	matchType: 'title',
+	occurrences: [
+		{ lineNumber: 0, lineText: 'about backpropagation', startOffset: 6, endOffset: 21 },
+	],
+	confidence: 1.0,
+};
+
+vi.mock('./mention-scanner', () => ({
+	MentionScanner: class MockMentionScanner {
+		constructor(_app: unknown) {}
+		scan = vi.fn().mockReturnValue([CANDIDATE]);
+	},
+}));
+
+// Applier returns a sentinel so we can confirm the accept path wrote it.
+vi.mock('./rem-applier', () => ({
+	RemApplier: class MockRemApplier {
+		apply = vi.fn().mockReturnValue('CONTENT WITH [[Backpropagation]] LINK');
+	},
+}));
+
+vi.mock('./semantic-matcher', () => ({
+	SemanticMatcher: class MockSemanticMatcher {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		match = vi.fn().mockResolvedValue([]);
+	},
+}));
+
+/** In-memory adapter so RemStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+describe('RemModule auto-accept (#228)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: { app: Record<string, unknown>; addCommand: ReturnType<typeof vi.fn>; registerEvent: ReturnType<typeof vi.fn> };
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+	let modifySpy: ReturnType<typeof vi.fn>;
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = new NotificationManager();
+		modifySpy = vi.fn().mockResolvedValue(undefined);
+		sourceFile = new TFile('notes/ml.md');
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# ML\n\nThis note is about backpropagation in depth.'),
+					modify: modifySpy,
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					getAbstractFileByPath: vi.fn((path: string) =>
+						path === 'notes/ml.md' ? sourceFile : null
+					),
+					adapter,
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(shouldAutoAccept: () => boolean): RemModule {
+		return new RemModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			shouldAutoAccept
+		);
+	}
+
+	it('auto-accepts a freshly generated REM proposal, inserting all candidate links', async () => {
+		settings.autoAccept.rem = true;
+		const mod = build(() => settings.autoAccept.rem);
+		await mod.onload();
+
+		await mod.remScanNote('notes/ml.md');
+
+		// The note body was rewritten with the applied links.
+		expect(modifySpy).toHaveBeenCalledTimes(1);
+		expect(modifySpy.mock.calls[0][1]).toBe('CONTENT WITH [[Backpropagation]] LINK');
+
+		// Nothing left pending.
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('leaves the REM proposal pending and does not modify the note when the flag is off', async () => {
+		settings.autoAccept.rem = false;
+		const mod = build(() => settings.autoAccept.rem);
+		await mod.onload();
+
+		await mod.remScanNote('notes/ml.md');
+
+		expect(modifySpy).not.toHaveBeenCalled();
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+		expect(pending[0].status).toBe('pending');
+		expect(pending[0].candidates).toHaveLength(1);
+	});
+});

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -25,13 +25,23 @@ export class RemModule {
 	/** Optional callback to refresh the unified proposal view. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/**
+	 * Live accessor for the REM auto-accept flag (#228). Wired by main.ts to
+	 * `() => this.settings.autoAccept.rem`. Defaults to "never auto-accept".
+	 * NOTE: REM auto-accept REWRITES note body text (inserts [[wikilinks]]).
+	 */
+	private shouldAutoAccept: () => boolean = () => false;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager,
-		private registrar: CommandRegistrar
-	) {}
+		private registrar: CommandRegistrar,
+		shouldAutoAccept?: () => boolean
+	) {
+		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
+	}
 
 	async onload(): Promise<void> {
 		this.store = new RemStore(this.plugin.app, this.getSettings);
@@ -128,6 +138,9 @@ export class RemModule {
 			`Found ${allCandidates.length} linkable mention${allCandidates.length === 1 ? '' : 's'}`
 		);
 
+		// Single-note path: auto-accept the whole proposal if enabled (#228).
+		await this.maybeAutoAccept(proposal);
+
 		await this.refreshView();
 		return proposal;
 	}
@@ -175,6 +188,7 @@ export class RemModule {
 		});
 
 		let created = 0;
+		let autoAcceptedCount = 0;
 		const createdProposalIds: string[] = [];
 
 		try {
@@ -215,6 +229,7 @@ export class RemModule {
 					await this.store.save(proposal);
 					created++;
 					createdProposalIds.push(proposal.id);
+					if (await this.maybeAutoAccept(proposal, true)) autoAcceptedCount++;
 				}
 
 				await this.checkpointManager.completeItem(checkpoint.id, checkpointItems[i].id);
@@ -234,6 +249,11 @@ export class RemModule {
 			const tasks = await this.checkpointManager.complete(checkpoint.id);
 			this.dispatchDeferredTasks(tasks);
 			op.finish(`REM scan complete -- ${created} note${created === 1 ? '' : 's'} with linkable mentions`);
+			if (autoAcceptedCount > 0) {
+				this.notifications.info(
+					`Auto-accepted REM links in ${autoAcceptedCount} note${autoAcceptedCount === 1 ? '' : 's'}`
+				);
+			}
 		}
 
 		return created;
@@ -250,6 +270,7 @@ export class RemModule {
 		);
 
 		const createdProposalIds: string[] = [];
+		let autoAcceptedCount = 0;
 
 		try {
 			for (let i = 0; i < checkpoint.remainingItems.length; i++) {
@@ -279,6 +300,7 @@ export class RemModule {
 					};
 					await this.store.save(proposal);
 					createdProposalIds.push(proposal.id);
+					if (await this.maybeAutoAccept(proposal, true)) autoAcceptedCount++;
 				}
 
 				await this.checkpointManager.completeItem(checkpoint.id, item.id);
@@ -297,6 +319,11 @@ export class RemModule {
 			const tasks = await this.checkpointManager.complete(checkpoint.id);
 			this.dispatchDeferredTasks(tasks);
 			op.finish(`Resumed -- generated ${createdProposalIds.length} proposals`);
+			if (autoAcceptedCount > 0) {
+				this.notifications.info(
+					`Auto-accepted REM links in ${autoAcceptedCount} note${autoAcceptedCount === 1 ? '' : 's'}`
+				);
+			}
 		}
 
 		await this.refreshView();
@@ -304,10 +331,20 @@ export class RemModule {
 
 	/**
 	 * Accept a REM proposal: apply selected links to the note.
+	 *
+	 * `options.silent` suppresses the success Notice and view refresh; used by
+	 * batch auto-accept so callers emit one summary Notice and refresh once.
 	 */
-	async acceptProposal(id: string, acceptedMatchTexts: string[]): Promise<void> {
+	async acceptProposal(
+		id: string,
+		acceptedMatchTexts: string[],
+		options?: { silent?: boolean }
+	): Promise<void> {
 		const proposal = await this.store.load(id);
 		if (!proposal) return;
+		// Guard against double-acceptance (cascade safety): never rewrite the
+		// note's body text twice for the same proposal.
+		if (proposal.status !== 'pending') return;
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
 		if (!file) {
@@ -344,11 +381,28 @@ export class RemModule {
 			originalContent
 		);
 
-		this.notifications.success(
-			`Inserted ${accepted.length} wikilink${accepted.length === 1 ? '' : 's'}`
-		);
+		if (!options?.silent) {
+			this.notifications.success(
+				`Inserted ${accepted.length} wikilink${accepted.length === 1 ? '' : 's'}`
+			);
+			await this.refreshView();
+		}
+	}
 
-		await this.refreshView();
+	/**
+	 * Auto-accept a freshly generated REM proposal in full (#228) — accepts
+	 * every candidate match text as generated. Returns `true` when accepted.
+	 *
+	 * `batch` suppresses the per-proposal Notice (caller emits one summary).
+	 */
+	private async maybeAutoAccept(proposal: RemProposal, batch = false): Promise<boolean> {
+		if (!this.shouldAutoAccept()) return false;
+		const allMatchTexts = [...new Set(proposal.candidates.map(c => c.matchedText))];
+		await this.acceptProposal(proposal.id, allMatchTexts, { silent: batch });
+		if (!batch) {
+			this.notifications.info(`Auto-accepted REM links for ${proposal.sourceNotePath}`);
+		}
+		return true;
 	}
 
 	/**

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -3,6 +3,40 @@ import type SynapsePlugin from './main';
 import { MODEL_OPTIONS } from './settings';
 import type { AIProvider } from './settings';
 import { addCollapsibleSection, addEnhancedSlider } from './shared';
+import { PROPOSAL_KINDS } from './views';
+import type { ProposalKind } from './views';
+
+/**
+ * Per-kind display copy for the Auto-Accept Proposals section (#228). MUTATING
+ * kinds carry a caution note in their description: organize moves notes, title
+ * renames files, rem rewrites body text.
+ */
+const AUTO_ACCEPT_LABELS: Record<ProposalKind, { name: string; desc: string }> = {
+	elaboration: {
+		name: 'Elaboration',
+		desc: 'Automatically accept elaboration proposals as generated (appends an elaboration callout to the note).',
+	},
+	enrichment: {
+		name: 'Enrichment',
+		desc: 'Automatically accept all suggested tags, links, references, and metadata as generated.',
+	},
+	organize: {
+		name: 'Organize',
+		desc: 'Caution: moves notes. Automatically accept organize proposals, relocating notes into the proposed folders without review.',
+	},
+	'deep-dive': {
+		name: 'Deep Dive',
+		desc: 'Automatically accept every generated deep dive note in a run, creating all of them in the vault.',
+	},
+	title: {
+		name: 'Title',
+		desc: 'Caution: renames files. Automatically accept title proposals, renaming notes without review.',
+	},
+	rem: {
+		name: 'REM (Link Discovery)',
+		desc: 'Caution: rewrites note body text. Automatically insert all discovered [[wikilinks]] without review.',
+	},
+};
 
 export class SynapseSettingTab extends PluginSettingTab {
 	constructor(app: App, private plugin: SynapsePlugin) {
@@ -1154,5 +1188,34 @@ export class SynapseSettingTab extends PluginSettingTab {
 						}
 					})
 			);
+
+		// ── Auto-Accept Proposals (no enable toggle — a group of per-kind toggles) ──
+		// Rendered like the AI Configuration section: a collapsible config
+		// section with no header toggle, persisting its own collapse state.
+		const autoAcceptBody = this.configSection(
+			containerEl,
+			'autoAccept',
+			'Auto-Accept Proposals',
+		);
+
+		autoAcceptBody.createDiv({
+			cls: 'setting-item-description synapse-accordion-empty-note',
+			text: 'When enabled for a proposal type, future proposals of that type are accepted automatically as generated, applied without review. Already-pending proposals are left untouched. Off by default for every type.',
+		});
+
+		for (const kind of PROPOSAL_KINDS) {
+			const { name, desc } = AUTO_ACCEPT_LABELS[kind];
+			new Setting(autoAcceptBody)
+				.setName(name)
+				.setDesc(desc)
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.autoAccept[kind])
+						.onChange(async (value) => {
+							this.plugin.settings.autoAccept[kind] = value;
+							await this.plugin.saveSettings();
+						})
+				);
+		}
 	}
 }

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from './settings';
+import { PROPOSAL_KINDS } from './views/types';
+
+describe('autoAccept settings (#228)', () => {
+	it('defines an autoAccept flag for every proposal kind', () => {
+		const keys = Object.keys(DEFAULT_SETTINGS.autoAccept).sort();
+		expect(keys).toEqual([...PROPOSAL_KINDS].sort());
+	});
+
+	it('defaults every auto-accept flag to false (opt-in)', () => {
+		for (const kind of PROPOSAL_KINDS) {
+			expect(DEFAULT_SETTINGS.autoAccept[kind]).toBe(false);
+		}
+	});
+
+	it('has no extra keys beyond the known proposal kinds', () => {
+		expect(Object.keys(DEFAULT_SETTINGS.autoAccept)).toHaveLength(PROPOSAL_KINDS.length);
+	});
+
+	it('exposes exactly the six expected proposal kinds', () => {
+		expect([...PROPOSAL_KINDS]).toEqual([
+			'elaboration',
+			'enrichment',
+			'organize',
+			'deep-dive',
+			'title',
+			'rem',
+		]);
+	});
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,7 @@
+// Type-only import (erased at compile time) so settings.ts stays free of a
+// runtime cycle with views/types.ts → feature modules → settings.ts.
+import type { ProposalKind } from './views/types';
+
 export type AIProvider = 'openai' | 'anthropic' | 'ollama';
 
 /** Provider-specific model options. Dropdown values, not free text. */
@@ -235,6 +239,16 @@ export interface UISettings {
 	collapsedSections: Record<string, boolean>;
 }
 
+/**
+ * Per-proposal-type auto-accept flags (#228). When a kind's flag is `true`,
+ * every *future* proposal of that kind is accepted automatically as generated
+ * (the unedited draft), so it lands accepted — not pending — in the unified
+ * view. Already-pending proposals are never touched. Opt-in: default `false`
+ * for every kind. Keyed by {@link ProposalKind} so it stays in sync with the
+ * set of kinds Synapse can produce.
+ */
+export type AutoAcceptSettings = Record<ProposalKind, boolean>;
+
 export interface SynapseSettings {
 	ai: AISettings;
 	elaboration: ElaborationSettings;
@@ -250,6 +264,7 @@ export interface SynapseSettings {
 	rem: RemSettings;
 	intake: IntakeSettings;
 	ui: UISettings;
+	autoAccept: AutoAcceptSettings;
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
@@ -402,5 +417,13 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 	},
 	ui: {
 		collapsedSections: {},
+	},
+	autoAccept: {
+		elaboration: false,
+		enrichment: false,
+		organize: false,
+		'deep-dive': false,
+		title: false,
+		rem: false,
 	},
 };

--- a/src/title/auto-accept.test.ts
+++ b/src/title/auto-accept.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TitleModule } from './index';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile, TFolder } from '../__mocks__/obsidian';
+
+// Stub the title suggester so checkUntitled produces a deterministic proposal
+// without any AI/network call.
+vi.mock('./title-suggester', () => ({
+	TitleSuggester: class MockTitleSuggester {
+		constructor(_client: unknown) {}
+		suggestTitle = vi.fn().mockResolvedValue({
+			title: 'Neural Networks',
+			reasoning: 'Content is about neural networks',
+		});
+		checkTitleMismatch = vi.fn().mockResolvedValue({ isMismatch: false });
+	},
+}));
+
+/** In-memory adapter so TitleProposalStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+function makeUntitledFile(): TFile {
+	const file = new TFile('Inbox/Untitled.md');
+	const folder = new TFolder('Inbox');
+	file.parent = folder;
+	return file;
+}
+
+describe('TitleModule auto-accept (#228)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: { app: { vault: Record<string, unknown>; metadataCache: Record<string, unknown> } };
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+	let untitledFile: TFile;
+	let renameSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = new NotificationManager();
+		untitledFile = makeUntitledFile();
+		renameSpy = vi.fn().mockResolvedValue(undefined);
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Notes\n\nDetailed content about neural networks and training.'),
+					rename: renameSpy,
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					getAbstractFileByPath: vi.fn((path: string) => {
+						// The source note exists; the rename target does not.
+						if (path === 'Inbox/Untitled.md') return untitledFile;
+						return null;
+					}),
+					adapter,
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+				},
+			},
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(shouldAutoAccept: () => boolean): TitleModule {
+		return new TitleModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			shouldAutoAccept
+		);
+	}
+
+	it('auto-accepts a freshly generated title proposal by renaming the file', async () => {
+		settings.autoAccept.title = true;
+		const mod = build(() => settings.autoAccept.title);
+		await mod.onload();
+
+		await mod.checkUntitled('Inbox/Untitled.md');
+
+		// The file was renamed to the proposed title.
+		expect(renameSpy).toHaveBeenCalledTimes(1);
+		expect(renameSpy.mock.calls[0][1]).toBe('Inbox/Neural Networks.md');
+
+		// Nothing left pending.
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('leaves the title proposal pending and does not rename when the flag is off', async () => {
+		settings.autoAccept.title = false;
+		const mod = build(() => settings.autoAccept.title);
+		await mod.onload();
+
+		await mod.checkUntitled('Inbox/Untitled.md');
+
+		expect(renameSpy).not.toHaveBeenCalled();
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+		expect(pending[0].status).toBe('pending');
+		expect(pending[0].proposedTitle).toBe('Neural Networks');
+	});
+});

--- a/src/title/index.ts
+++ b/src/title/index.ts
@@ -16,14 +16,36 @@ export class TitleModule {
 	/** Optional callback to refresh the unified proposal view. Wired by main.ts. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/**
+	 * Live accessor for the title auto-accept flag (#228). Wired by main.ts to
+	 * `() => this.settings.autoAccept.title`. Defaults to "never auto-accept".
+	 * NOTE: title auto-accept RENAMES the file on the filesystem.
+	 */
+	private shouldAutoAccept: () => boolean = () => false;
+
 	constructor(
 		private plugin: Plugin,
 		private getSettings: () => SynapseSettings,
-		private notifications: NotificationManager
+		private notifications: NotificationManager,
+		shouldAutoAccept?: () => boolean
 	) {
 		const aiClient = new AIClient(getSettings);
 		this.store = new TitleProposalStore(plugin.app, getSettings);
 		this.suggester = new TitleSuggester(aiClient);
+		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
+	}
+
+	/**
+	 * Auto-accept a freshly generated title proposal (#228), if the title
+	 * auto-accept flag is on. This RENAMES the file. A single Notice fires
+	 * (title proposals are generated one-at-a-time, never in a tight batch).
+	 */
+	private async maybeAutoAccept(proposal: TitleProposal): Promise<void> {
+		if (!this.shouldAutoAccept()) return;
+		await this.acceptProposal(proposal.id, { silent: true });
+		this.notifications.info(
+			`Auto-accepted title "${proposal.proposedTitle}"`
+		);
 	}
 
 	async onload(): Promise<void> {
@@ -72,6 +94,7 @@ export class TitleModule {
 			};
 
 			await this.store.save(proposal);
+			await this.maybeAutoAccept(proposal);
 			await this.refreshView();
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
@@ -113,6 +136,7 @@ export class TitleModule {
 			};
 
 			await this.store.save(proposal);
+			await this.maybeAutoAccept(proposal);
 			await this.refreshView();
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
@@ -137,10 +161,16 @@ export class TitleModule {
 
 	/**
 	 * Accept a title proposal: rename the file via vault.rename().
+	 *
+	 * `options.silent` suppresses the success Notice and view refresh; used by
+	 * auto-accept, which emits its own distinct Notice. Error and conflict
+	 * Notices still fire.
 	 */
-	async acceptProposal(id: string): Promise<void> {
+	async acceptProposal(id: string, options?: { silent?: boolean }): Promise<void> {
 		const proposal = await this.store.load(id);
 		if (!proposal) return;
+		// Guard against double-acceptance (cascade safety): never rename twice.
+		if (proposal.status !== 'pending') return;
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
 		if (!(file instanceof TFile)) {
@@ -166,8 +196,10 @@ export class TitleModule {
 		try {
 			await this.plugin.app.vault.rename(file, newPath);
 			await this.store.updateStatus(id, 'accepted');
-			this.notifications.success(`Renamed to "${proposal.proposedTitle}"`);
-			await this.refreshView();
+			if (!options?.silent) {
+				this.notifications.success(`Renamed to "${proposal.proposedTitle}"`);
+				await this.refreshView();
+			}
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			this.notifications.notifyError('Failed to rename note', error);

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -2,7 +2,9 @@ export {
 	UNIFIED_VIEW_TYPE,
 	UnifiedProposalView,
 } from './unified-proposal-view';
+export { PROPOSAL_KINDS } from './types';
 export type {
 	UnifiedItem,
 	UnifiedViewCallbacks,
+	ProposalKind,
 } from './types';

--- a/src/views/types.ts
+++ b/src/views/types.ts
@@ -5,6 +5,23 @@ import type { DeepDiveProposal } from '../deep-dive';
 import type { TitleProposal } from '../title';
 import type { RemProposal } from '../rem';
 
+/**
+ * The single source of truth for the set of proposal kinds Synapse generates.
+ *
+ * Settings (`autoAccept`), defaults, and the settings UI all iterate this list
+ * so they stay in lockstep with {@link UnifiedItem}. A compile-time check below
+ * asserts this tuple is exactly the union of {@link UnifiedItem}['kind'] — if a
+ * new kind is added to one without the other, the build fails.
+ */
+export const PROPOSAL_KINDS = [
+	'elaboration',
+	'enrichment',
+	'organize',
+	'deep-dive',
+	'title',
+	'rem',
+] as const;
+
 /** Wrapper to unify elaboration, enrichment, organize, deep-dive, title, and REM proposals in one list. */
 export type UnifiedItem =
 	| { kind: 'elaboration'; data: Proposal }
@@ -13,6 +30,16 @@ export type UnifiedItem =
 	| { kind: 'deep-dive'; data: DeepDiveProposal }
 	| { kind: 'title'; data: TitleProposal }
 	| { kind: 'rem'; data: RemProposal };
+
+/** A single proposal kind — derived from {@link PROPOSAL_KINDS}, equal to {@link UnifiedItem}['kind']. */
+export type ProposalKind = (typeof PROPOSAL_KINDS)[number];
+
+// Compile-time guard: PROPOSAL_KINDS must cover exactly UnifiedItem['kind'].
+// Both assignments must type-check; if the two ever diverge, this errors.
+type _AssertKindsCoverUnion = UnifiedItem['kind'] extends ProposalKind ? true : never;
+type _AssertUnionCoversKinds = ProposalKind extends UnifiedItem['kind'] ? true : never;
+const _kindsMatchUnion: _AssertKindsCoverUnion & _AssertUnionCoversKinds = true;
+void _kindsMatchUnion;
 
 export interface UnifiedViewCallbacks {
 	// Elaboration


### PR DESCRIPTION
## Summary

Adds an opt-in, per-proposal-type **auto-accept** setting (default **off** for every kind). When enabled for a kind, every *future* proposal of that kind is accepted automatically as generated (the unedited draft) so it lands **accepted**, not pending, in the Unified Proposal View. Already-pending proposals are left untouched.

Closes #228.

> **Stacked PR.** This branches off `feat/issue-235-collapsible-settings-accordions` (PR #236), not `main`. The "Auto-Accept Proposals" settings section reuses the accordion helper that #236 introduced. **Merge after #236.** The diff against this base contains only the #228 changes.

## What changed
- **Settings**: new top-level `autoAccept: Record<ProposalKind, boolean>` group on `SynapseSettings` + `DEFAULT_SETTINGS` (all `false`). Migration is automatic via the existing `deepMerge` in `loadSettings` — no migration code.
- **Shared kinds list**: new `PROPOSAL_KINDS` tuple co-located with `UnifiedItem` in `src/views/types.ts`, exported from `src/views`. A compile-time guard asserts it equals `UnifiedItem['kind']`, so adding a kind to one without the other fails the build. Settings, defaults, and the UI all iterate it.
- **Per-module wiring**: each of the six modules receives a live `() => this.settings.autoAccept[kind]` accessor via its constructor (consistent with the existing `getSettings` accessor pattern + callback wiring). Modules never import the global settings object. After a module persists a proposal, it calls its **existing accept path** with accept-all-as-generated inputs when the flag is on.
- **Notice noise + safety**: accept paths gained a `{ silent }` option so batch generators (vault scans, recursive deep-dive) emit one **summary** Notice instead of a storm; single-note ops emit one Notice per auto-accept. Every accept path now **guards against double-acceptance** (status must be `pending`).
- **Settings UI**: new "Auto-Accept Proposals" section rendered like the AI Configuration accordion (no enable toggle, own persisted collapse state under key `autoAccept`), one toggle per kind. Caution notes on the mutating kinds: **organize** (moves notes), **title** (renames files), **rem** (rewrites body text).

## Cascade-loop safety
Auto-accept fires the existing chained generation (e.g. elaboration-accept → enrichment/title; deep-dive-accept → enrichment/organize). These chains are **acyclic** — enrichment, title, and rem are leaves; organize doesn't modify content; title only renames — so any chain is bounded to a couple of hops. Two invariants make a loop impossible:
1. Every accept path is **idempotent**: it returns early unless the proposal is still `pending`, so a proposal can never be accepted (or its note created/moved/renamed) twice.
2. A module's auto-accept calls only its own **accept** path, never its own **generation** path, so it can't re-trigger itself.

Deep-dive (recursive tree) auto-accepts the whole run **after** the generation loop, in creation order (parents before children), so the recursive queue is undisturbed and navigation isn't rebuilt mid-flight.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm test` — 1002 passed (was 984; +18 new across 7 files)
- [x] `node esbuild.config.mjs production`

New tests cover: defaults all `false`; `PROPOSAL_KINDS` shape; enabled kinds auto-accept a freshly generated proposal; disabled kinds stay pending; the double-accept guard; and that cascade hooks fire — across all four distinct accept signatures (elaboration `id+content`, enrichment `AcceptedItems`, organize/title/deep-dive `id`, rem `id+matchTexts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)