### PR TITLE
feat(#172): coalesce similar organize folder names

### DIFF
--- a/src/organize/AGENTS.md
+++ b/src/organize/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-07
 ---
 
 # organize module
@@ -34,8 +34,15 @@ Exported types: `OrganizeProposal`, `OrganizeSnapshot`, `OrganizeResult`, `Conte
 |------|---------------|------|
 | `content-analyzer.ts` | `ContentAnalyzer` | AI topic extraction from note content, tags, and links |
 | `directory-matcher.ts` | `DirectoryMatcher` | Matches topics to existing directories or proposes new ones |
+| `folder-normalize.ts` | `singularize`, `canonicalKey`, `editDistance`, `isFuzzyMatch` | Morphology-aware canonical keys for coalescing similar folder names (#172) |
 | `organize-store.ts` | `OrganizeStore` | JSON persistence for proposals and move snapshots |
 | `types.ts` | -- | All organize types |
+
+`folder-normalize` is the single source of truth for folder-name coalescing,
+reused in three places: `DirectoryMatcher.buildDirectoryPath` emits new folders
+in canonical (singular) form; `DirectoryMatcher.scoreDirectory` matches topics to
+existing folders on canonical keys plus a conservative edit-distance tier; and
+`OrganizeModule` deduplicates proposed directories across a batch scan.
 
 ## Data Flow
 
@@ -122,4 +129,7 @@ interface OrganizeResult {
 
 - `content-analyzer.test.ts`
 - `directory-matcher.test.ts`
+- `folder-normalize.test.ts`
 - `organize-store.test.ts`
+- `auto-accept.test.ts`
+- `batch-dedup.test.ts`

--- a/src/organize/batch-dedup.test.ts
+++ b/src/organize/batch-dedup.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OrganizeModule } from './index';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+// Each note yields a topic whose RAW label differs ("models" vs "model") but
+// canonicalizes to the same key. The matcher proposes a new directory named
+// after that raw label, so without batch dedup the two notes would propose two
+// different folders.
+vi.mock('./content-analyzer', () => ({
+	ContentAnalyzer: class MockContentAnalyzer {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		analyze = vi.fn(async (file: TFile) => ({
+			notePath: file.path,
+			topics: [
+				{ label: file.path.includes('a.md') ? 'models' : 'model', confidence: 0.95 },
+			],
+			tags: [],
+			links: [],
+		}));
+	},
+}));
+
+vi.mock('./directory-matcher', () => ({
+	DirectoryMatcher: class MockDirectoryMatcher {
+		constructor(_app: unknown) {}
+		scoreDirectories = vi.fn().mockReturnValue([]);
+		// Propose a new directory named after the (un-normalized) topic label so
+		// the dedup pass in OrganizeModule is what coalesces the variants.
+		determineAction = vi.fn((analysis: { topics: { label: string }[] }) => ({
+			type: 'propose-new-directory',
+			targetDirectory: analysis.topics[0].label,
+			reasoning: 'new directory',
+		}));
+	},
+}));
+
+/** In-memory adapter so OrganizeStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+describe('OrganizeModule batch dedup (#172)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+	let mockPlugin: { app: Record<string, unknown>; addCommand: ReturnType<typeof vi.fn>; registerEvent: ReturnType<typeof vi.fn> };
+	let files: TFile[];
+
+	beforeEach(() => {
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = new NotificationManager();
+		files = [new TFile('inbox/a.md'), new TFile('inbox/b.md')];
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Note\n\nbody'),
+					rename: vi.fn().mockResolvedValue(undefined),
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					getMarkdownFiles: vi.fn().mockReturnValue(files),
+					getAbstractFileByPath: vi.fn(() => null),
+					adapter,
+				},
+				metadataCache: {
+					getFileCache: vi.fn().mockReturnValue(null),
+				},
+			},
+			addCommand: vi.fn(),
+			registerEvent: vi.fn(),
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('coalesces singular/plural proposals across a scan to one directory', async () => {
+		const mod = new OrganizeModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			() => false // auto-accept off: proposals stay pending for inspection
+		);
+		await mod.onload();
+
+		// skipConfirmation = true to bypass the interactive modal.
+		await mod.scanDirectory(undefined, true);
+
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(2);
+
+		// Both notes resolve to a single proposed directory despite differing
+		// raw topic labels ("models" vs "model").
+		const dirs = new Set(pending.map(p => p.proposedDirectory));
+		expect(dirs.size).toBe(1);
+	});
+});

--- a/src/organize/content-analyzer.test.ts
+++ b/src/organize/content-analyzer.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContentAnalyzer } from './content-analyzer';
 import { createMockApp } from '../__test-utils__/mock-factories';
 import { DEFAULT_SETTINGS } from '../settings';
+
+const mockComplete = vi.fn().mockResolvedValue('[{"label": "test", "confidence": 0.5}]');
+
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		complete = mockComplete;
+	},
+}));
 
 /**
  * Only the pure/parseable methods of ContentAnalyzer are unit-tested here.
@@ -122,6 +130,23 @@ describe('ContentAnalyzer', () => {
 			const analyzer = makeAnalyzer();
 			const result = analyzer.topicsFromTags(['#']);
 			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe('extractTopics — prompt steering (#172)', () => {
+		beforeEach(() => {
+			mockComplete.mockClear();
+			mockComplete.mockResolvedValue('[{"label": "test", "confidence": 0.5}]');
+		});
+
+		it('asks the model for broad, singular category labels', async () => {
+			const analyzer = makeAnalyzer();
+			await analyzer.extractTopics('Some note body about machine learning.', []);
+
+			expect(mockComplete).toHaveBeenCalled();
+			const systemPrompt = mockComplete.mock.calls[0][1] as string;
+			expect(systemPrompt).toContain('singular');
+			expect(systemPrompt).toMatch(/broad|umbrella/i);
 		});
 	});
 });

--- a/src/organize/content-analyzer.ts
+++ b/src/organize/content-analyzer.ts
@@ -11,7 +11,8 @@ Return a JSON array of topic objects. Each object has:
 
 Rules:
 - Return 1-3 topics maximum, ordered by confidence (highest first)
-- Use broad, folder-appropriate categories (these will become directory names)
+- Prefer broad, reusable umbrella categories over hyper-specific labels (e.g. "networking", not "tcp-ip-configuration") — these become directory names
+- Use the singular form of nouns (e.g. "model", not "models")
 - Prefer existing common categories over inventing new ones
 - Labels should be suitable as directory names (no special characters)
 - Return ONLY the JSON array, no markdown fences or explanation

--- a/src/organize/directory-matcher.test.ts
+++ b/src/organize/directory-matcher.test.ts
@@ -328,4 +328,86 @@ describe('DirectoryMatcher', () => {
 			}
 		});
 	});
+
+	describe('coalescing similar names (#172)', () => {
+		it('singularizes folder names built from topics', () => {
+			const matcher = new DirectoryMatcher(makeMockApp([]));
+			expect(matcher.buildDirectoryPath('models')).toBe('model');
+			expect(matcher.buildDirectoryPath('meeting notes')).toBe('meeting-note');
+			expect(matcher.buildDirectoryPath('Categories')).toBe('category');
+		});
+
+		it('scores a singular topic highly against a plural directory', () => {
+			const matcher = new DirectoryMatcher(makeMockApp(['models', 'other']));
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'model', confidence: 1.0 }],
+			});
+
+			expect(matcher.scoreDirectory('models', analysis, 'inbox')).toBeCloseTo(0.6, 5);
+			expect(matcher.scoreDirectory('other', analysis, 'inbox')).toBe(0);
+		});
+
+		it('moves a plural topic into an existing singular directory', () => {
+			const matcher = new DirectoryMatcher(makeMockApp(['model']));
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'models', confidence: 1.0 }],
+			});
+
+			const action = matcher.determineAction(analysis);
+			expect(action.type).toBe('move');
+			if (action.type === 'move') {
+				expect(action.targetDirectory).toBe('model');
+			}
+		});
+
+		it('proposes a singular (canonical) directory for a new plural topic', () => {
+			const matcher = new DirectoryMatcher(makeMockApp(['unrelated']));
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'models', confidence: 0.95 }],
+			});
+
+			const action = matcher.determineAction(analysis);
+			expect(action.type).toBe('propose-new-directory');
+			if (action.type === 'propose-new-directory') {
+				expect(action.targetDirectory).toBe('model');
+			}
+		});
+
+		it('applies a conservative fuzzy match for long near-identical names', () => {
+			const matcher = new DirectoryMatcher(makeMockApp(['marketing']));
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'marketng', confidence: 1.0 }],
+			});
+
+			// Weak tier: scores below the exact-match tier, above zero.
+			expect(matcher.scoreDirectory('marketing', analysis, 'inbox')).toBeCloseTo(0.4, 5);
+		});
+
+		it('does not fuzzy-match short, distinct names', () => {
+			const matcher = new DirectoryMatcher(makeMockApp(['code']));
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'node', confidence: 1.0 }],
+			});
+
+			expect(matcher.scoreDirectory('code', analysis, 'inbox')).toBe(0);
+		});
+
+		it('does not let a lone fuzzy match cross the move threshold', () => {
+			const matcher = new DirectoryMatcher(makeMockApp(['marketing']));
+			const analysis = makeAnalysis({
+				notePath: 'inbox/test.md',
+				topics: [{ label: 'marketng', confidence: 1.0 }],
+			});
+
+			// 0.4 fuzzy score is below the 0.6 move threshold, so a new directory
+			// is proposed rather than hijacking the near-match folder.
+			const action = matcher.determineAction(analysis);
+			expect(action.type).toBe('propose-new-directory');
+		});
+	});
 });

--- a/src/organize/directory-matcher.ts
+++ b/src/organize/directory-matcher.ts
@@ -1,5 +1,6 @@
 import { App, TFolder } from 'obsidian';
 import { ContentAnalysis, DirectoryScore, OrganizeAction } from './types';
+import { canonicalKey, isFuzzyMatch } from './folder-normalize';
 
 /**
  * Matches notes to existing directories by semantic relevance.
@@ -90,31 +91,43 @@ export class DirectoryMatcher {
 		noteDir: string
 	): number {
 		let score = 0;
-		const dirName = this.getDirectoryName(dirPath).toLowerCase();
-		const dirParts = dirPath.toLowerCase().split('/').filter(Boolean);
+		const dirKey = canonicalKey(this.getDirectoryName(dirPath));
+		const partKeys = dirPath
+			.split('/')
+			.filter(Boolean)
+			.map(p => canonicalKey(p))
+			.filter(Boolean);
 
-		// 1. Topic match — strongest signal
+		// 1. Topic match — strongest signal. Compared on canonical (singular,
+		// punctuation-normalized) keys so "model" coalesces with "models" and
+		// "machine learning" with "machine-learning".
 		for (const topic of analysis.topics) {
-			const topicLabel = topic.label.toLowerCase();
+			const topicKey = canonicalKey(topic.label);
+			if (!topicKey) continue;
 
-			// Exact match with directory name
-			if (dirName === topicLabel) {
+			// Exact canonical match with directory name
+			if (dirKey && dirKey === topicKey) {
 				score += 0.6 * topic.confidence;
 			}
-			// Directory name contains the topic
-			else if (dirName.includes(topicLabel) || topicLabel.includes(dirName)) {
+			// Directory name contains the topic (or vice versa)
+			else if (dirKey && (dirKey.includes(topicKey) || topicKey.includes(dirKey))) {
 				score += 0.4 * topic.confidence;
 			}
 			// Any path segment matches
-			else if (dirParts.some(p => p === topicLabel || p.includes(topicLabel) || topicLabel.includes(p))) {
+			else if (partKeys.some(p => p === topicKey || p.includes(topicKey) || topicKey.includes(p))) {
 				score += 0.25 * topic.confidence;
+			}
+			// Conservative near-match (typo tolerance). Weak tier — cannot reach
+			// the move threshold on its own.
+			else if (dirKey && isFuzzyMatch(topicKey, dirKey)) {
+				score += 0.4 * topic.confidence;
 			}
 		}
 
 		// 2. Tag match — directories that share tag names
 		for (const tag of analysis.tags) {
-			const cleanTag = tag.replace(/^#/, '').toLowerCase();
-			if (dirName === cleanTag || dirName.includes(cleanTag)) {
+			const tagKey = canonicalKey(tag.replace(/^#/, ''));
+			if (tagKey && dirKey && (dirKey === tagKey || dirKey.includes(tagKey))) {
 				score += 0.15;
 			}
 		}
@@ -149,21 +162,24 @@ export class DirectoryMatcher {
 	 * Build a human-readable reason for why a directory was scored.
 	 */
 	private buildReason(dirPath: string, analysis: ContentAnalysis): string {
-		const dirName = this.getDirectoryName(dirPath).toLowerCase();
+		const dirKey = canonicalKey(this.getDirectoryName(dirPath));
 		const reasons: string[] = [];
 
 		for (const topic of analysis.topics) {
-			const topicLabel = topic.label.toLowerCase();
-			if (dirName === topicLabel) {
+			const topicKey = canonicalKey(topic.label);
+			if (!topicKey || !dirKey) continue;
+			if (dirKey === topicKey) {
 				reasons.push(`exact topic match: "${topic.label}"`);
-			} else if (dirName.includes(topicLabel) || topicLabel.includes(dirName)) {
+			} else if (dirKey.includes(topicKey) || topicKey.includes(dirKey)) {
 				reasons.push(`partial topic match: "${topic.label}"`);
+			} else if (isFuzzyMatch(topicKey, dirKey)) {
+				reasons.push(`similar topic match: "${topic.label}"`);
 			}
 		}
 
 		for (const tag of analysis.tags) {
-			const cleanTag = tag.replace(/^#/, '').toLowerCase();
-			if (dirName === cleanTag || dirName.includes(cleanTag)) {
+			const tagKey = canonicalKey(tag.replace(/^#/, ''));
+			if (tagKey && dirKey && (dirKey === tagKey || dirKey.includes(tagKey))) {
 				reasons.push(`tag match: ${tag}`);
 			}
 		}
@@ -202,15 +218,10 @@ export class DirectoryMatcher {
 
 	/**
 	 * Build a clean directory path from a topic label.
-	 * Converts to lowercase kebab-case suitable for folder names.
+	 * Converts to lowercase kebab-case and singularizes each word so that
+	 * equivalent topics ("model" / "models") yield an identical folder name.
 	 */
 	buildDirectoryPath(topicLabel: string): string {
-		return topicLabel
-			.toLowerCase()
-			.replace(/[^a-z0-9\s-]/g, '')
-			.replace(/\s+/g, '-')
-			.replace(/-+/g, '-')
-			.replace(/^-|-$/g, '')
-			.slice(0, 50);
+		return canonicalKey(topicLabel).slice(0, 50);
 	}
 }

--- a/src/organize/folder-normalize.test.ts
+++ b/src/organize/folder-normalize.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { singularize, canonicalKey, editDistance, isFuzzyMatch } from './folder-normalize';
+
+describe('folder-normalize', () => {
+	describe('singularize', () => {
+		it('strips a simple trailing "s"', () => {
+			expect(singularize('models')).toBe('model');
+			expect(singularize('projects')).toBe('project');
+			expect(singularize('videos')).toBe('video');
+		});
+
+		it('handles "ies" -> "y"', () => {
+			expect(singularize('categories')).toBe('category');
+			expect(singularize('dependencies')).toBe('dependency');
+			expect(singularize('stories')).toBe('story');
+			expect(singularize('queries')).toBe('query');
+		});
+
+		it('handles "-ie" plurals that keep the "e"', () => {
+			expect(singularize('movies')).toBe('movie');
+			expect(singularize('cookies')).toBe('cookie');
+		});
+
+		it('strips "es" after a sibilant cluster', () => {
+			expect(singularize('classes')).toBe('class');
+			expect(singularize('boxes')).toBe('box');
+			expect(singularize('watches')).toBe('watch');
+			expect(singularize('dishes')).toBe('dish');
+			expect(singularize('branches')).toBe('branch');
+		});
+
+		it('keeps the stem "e" for "-se"/"-ge"/"-ze" plurals', () => {
+			expect(singularize('phases')).toBe('phase');
+			expect(singularize('pages')).toBe('page');
+			expect(singularize('databases')).toBe('database');
+			expect(singularize('sizes')).toBe('size');
+			expect(singularize('releases')).toBe('release');
+		});
+
+		it('applies overrides for sibilant collisions', () => {
+			expect(singularize('caches')).toBe('cache');
+			expect(singularize('niches')).toBe('niche');
+		});
+
+		it('applies irregular plurals', () => {
+			expect(singularize('children')).toBe('child');
+			expect(singularize('people')).toBe('person');
+		});
+
+		it('leaves uncountable / already-singular words intact', () => {
+			expect(singularize('news')).toBe('news');
+			expect(singularize('series')).toBe('series');
+			expect(singularize('status')).toBe('status');
+			expect(singularize('analysis')).toBe('analysis');
+			expect(singularize('axis')).toBe('axis');
+			expect(singularize('class')).toBe('class');
+			expect(singularize('lens')).toBe('lens');
+		});
+
+		it('leaves short words (<= 3 chars) intact', () => {
+			expect(singularize('ios')).toBe('ios');
+			expect(singularize('css')).toBe('css');
+			expect(singularize('js')).toBe('js');
+		});
+
+		it('is idempotent', () => {
+			for (const w of ['models', 'categories', 'movies', 'classes', 'phases', 'caches', 'children', 'news']) {
+				expect(singularize(singularize(w))).toBe(singularize(w));
+			}
+		});
+	});
+
+	describe('canonicalKey', () => {
+		it('coalesces singular and plural forms', () => {
+			expect(canonicalKey('models')).toBe(canonicalKey('model'));
+			expect(canonicalKey('categories')).toBe(canonicalKey('category'));
+		});
+
+		it('unifies casing, punctuation, and space-vs-hyphen', () => {
+			expect(canonicalKey('Machine Learning')).toBe('machine-learning');
+			expect(canonicalKey('machine-learning')).toBe('machine-learning');
+			expect(canonicalKey('C++ Programming!')).toBe('c-programming');
+		});
+
+		it('singularizes each word of a multi-word label', () => {
+			expect(canonicalKey('meeting notes')).toBe('meeting-note');
+			expect(canonicalKey('design patterns')).toBe('design-pattern');
+		});
+
+		it('returns an empty string for input with no alphanumerics', () => {
+			expect(canonicalKey('   --- ')).toBe('');
+		});
+	});
+
+	describe('editDistance', () => {
+		it('returns 0 for identical strings', () => {
+			expect(editDistance('marketing', 'marketing')).toBe(0);
+		});
+
+		it('counts single-character edits', () => {
+			expect(editDistance('marketing', 'marketng')).toBe(1); // deletion
+			expect(editDistance('color', 'colour')).toBe(1); // insertion
+			expect(editDistance('cat', 'cot')).toBe(1); // substitution
+		});
+	});
+
+	describe('isFuzzyMatch', () => {
+		it('matches long strings within one edit', () => {
+			expect(isFuzzyMatch('marketing', 'marketng')).toBe(true);
+		});
+
+		it('rejects short, distinct words even at distance 1', () => {
+			expect(isFuzzyMatch('node', 'code')).toBe(false);
+			expect(isFuzzyMatch('table', 'cable')).toBe(false);
+		});
+
+		it('rejects strings more than one edit apart', () => {
+			expect(isFuzzyMatch('database', 'metadata')).toBe(false);
+		});
+	});
+});

--- a/src/organize/folder-normalize.ts
+++ b/src/organize/folder-normalize.ts
@@ -1,0 +1,146 @@
+/**
+ * Folder-name normalization for the organize module (#172).
+ *
+ * Equivalent topic labels ("model" vs "models", "machine learning" vs
+ * "machine-learning") should coalesce to a single folder. These pure helpers
+ * provide a canonical, morphology-aware key used for:
+ *   1. emitting new folder names in canonical (singular) form,
+ *   2. matching topics against existing directories, and
+ *   3. deduplicating proposed directories within a batch scan.
+ *
+ * Scope is deliberately singular/plural only — no abbreviation/synonym map.
+ * Singularization is rule-based and biased toward NOT mangling words: when a
+ * rule is ambiguous it prefers leaving the word intact over producing a
+ * non-word. Known collisions are handled by the curated sets below, which are
+ * expected to grow as edge cases surface in tests.
+ */
+
+/** Words ending in s/es/ies that are already singular (or mass nouns). */
+const UNCOUNTABLE = new Set([
+	'news', 'series', 'species', 'physics', 'mathematics', 'economics',
+	'politics', 'ethics', 'statistics', 'analytics', 'status', 'focus',
+	'virus', 'bonus', 'corpus', 'campus', 'census', 'chaos', 'kudos',
+	'ethos', 'pathos', 'cosmos', 'analysis', 'basis', 'crisis', 'thesis',
+	'axis', 'oasis', 'diagnosis', 'synthesis', 'hypothesis', 'lens',
+]);
+
+/** Irregular plural -> singular forms. */
+const IRREGULAR: Record<string, string> = {
+	children: 'child',
+	people: 'person',
+	men: 'man',
+	women: 'woman',
+	feet: 'foot',
+	teeth: 'tooth',
+	geese: 'goose',
+	mice: 'mouse',
+};
+
+/**
+ * Plural forms the generic rules would mangle (singular keeps a trailing "e",
+ * but the suffix looks like a sibilant cluster). Add to this map as needed.
+ */
+const OVERRIDE: Record<string, string> = {
+	caches: 'cache',
+	niches: 'niche',
+};
+
+/**
+ * Words ending in "ies" whose singular is "...ie" (just drop the "s"), not the
+ * "y" form ("category" <- "categories"). Without this list, "movies" would
+ * incorrectly become "movy".
+ */
+const IE_PLURALS = new Set([
+	'movies', 'cookies', 'zombies', 'calories', 'newbies', 'genies',
+	'rookies', 'brownies', 'pies', 'ties', 'lies', 'dies',
+]);
+
+/**
+ * Reduce a single word to a naive singular form. Idempotent: applying it to an
+ * already-singular word returns that word unchanged.
+ */
+export function singularize(input: string): string {
+	const word = input.toLowerCase();
+
+	if (OVERRIDE[word]) return OVERRIDE[word];
+	if (IRREGULAR[word]) return IRREGULAR[word];
+	if (word.length <= 3 || UNCOUNTABLE.has(word)) return word;
+
+	// "categories" -> "category", but "movies" -> "movie"
+	if (word.endsWith('ies') && word.length > 4) {
+		if (IE_PLURALS.has(word)) return word.slice(0, -1);
+		const before = word[word.length - 4];
+		if (!'aeiou'.includes(before)) return word.slice(0, -3) + 'y';
+	}
+
+	// "classes" -> "class", "boxes" -> "box", "watches" -> "watch",
+	// but "phases" -> "phase", "pages" -> "page" (stem keeps its "e").
+	if (word.endsWith('es')) {
+		const stem = word.slice(0, -2);
+		if (/(?:ss|x|ch|sh)$/.test(stem)) return stem;
+		return word.slice(0, -1);
+	}
+
+	// "models" -> "model", "videos" -> "video"; leave "class", "status",
+	// "analysis", "axis" intact.
+	if (word.endsWith('s') && !/(?:ss|us|sis|xis)$/.test(word)) {
+		return word.slice(0, -1);
+	}
+
+	return word;
+}
+
+/**
+ * Canonical comparison key for a topic label or directory name. Lowercases,
+ * collapses every non-alphanumeric run to a word boundary, singularizes each
+ * word, and rejoins with "-". This unifies casing, punctuation, and
+ * space-vs-hyphen ("Machine Learning" === "machine-learning") in addition to
+ * singular/plural. Intended for comparison/dedup, never shown to the user.
+ */
+export function canonicalKey(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, ' ')
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean)
+		.map(singularize)
+		.join('-');
+}
+
+/** Levenshtein edit distance (single-row dynamic programming). */
+export function editDistance(a: string, b: string): number {
+	if (a === b) return 0;
+	const m = a.length;
+	const n = b.length;
+	if (m === 0) return n;
+	if (n === 0) return m;
+
+	const row = Array.from({ length: n + 1 }, (_, i) => i);
+	for (let i = 1; i <= m; i++) {
+		let prevDiag = row[0];
+		row[0] = i;
+		for (let j = 1; j <= n; j++) {
+			const tmp = row[j];
+			row[j] = Math.min(
+				row[j] + 1,
+				row[j - 1] + 1,
+				prevDiag + (a[i - 1] === b[j - 1] ? 0 : 1)
+			);
+			prevDiag = tmp;
+		}
+	}
+	return row[n];
+}
+
+/**
+ * Conservative near-match test for two canonical keys. Requires both keys to be
+ * reasonably long (>= 6 chars) so short, semantically distinct words like
+ * "node"/"code" or "table"/"cable" never match; within that, allows a single
+ * edit (one typo). Used only as a weak scoring tier and for batch dedup.
+ */
+export function isFuzzyMatch(a: string, b: string): boolean {
+	if (a === b) return true;
+	if (Math.min(a.length, b.length) < 6) return false;
+	return editDistance(a, b) <= 1;
+}

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -9,8 +9,9 @@ import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import type { MoveRecord } from '../shared';
 import { ContentAnalyzer } from './content-analyzer';
 import { DirectoryMatcher } from './directory-matcher';
+import { canonicalKey, isFuzzyMatch } from './folder-normalize';
 import { OrganizeStore } from './organize-store';
-import { OrganizeProposal, OrganizeResult, OrganizeSnapshot } from './types';
+import { OrganizeAction, OrganizeProposal, OrganizeResult, OrganizeSnapshot } from './types';
 
 export type {
 	OrganizeProposal,
@@ -109,6 +110,8 @@ export class OrganizeModule {
 		let autoAcceptedCount = 0;
 		let errorCount = 0;
 		const moveRecords: MoveRecord[] = [];
+		// Coalesce new-directory proposals within this resumed run (#172).
+		const batchProposedDirs = new Map<string, string>();
 
 		try {
 			for (let i = 0; i < checkpoint.remainingItems.length; i++) {
@@ -125,7 +128,7 @@ export class OrganizeModule {
 
 				try {
 					const originalPath = file.path;
-					const result = await this.organizeFile(file, true);
+					const result = await this.organizeFile(file, true, batchProposedDirs);
 
 					if (result) {
 						if (result.movedDirectly && result.action.type === 'move') {
@@ -287,6 +290,10 @@ export class OrganizeModule {
 		let autoAcceptedCount = 0;
 		let errorCount = 0;
 		const moveRecords: MoveRecord[] = [];
+		// Coalesce new-directory proposals within this scan so variants like
+		// "model"/"models" resolve to a single folder (#172). Maps a canonical
+		// key to the representative directory chosen for it.
+		const batchProposedDirs = new Map<string, string>();
 
 		// Create checkpoint for resumability
 		const checkpointItems: CheckpointWorkItem[] = eligible.map((f, i) => ({
@@ -313,7 +320,7 @@ export class OrganizeModule {
 			genOp.progress(i + 1, eligible.length, 'Organizing notes');
 			try {
 				const originalPath = eligible[i].path;
-				const result = await this.organizeFile(eligible[i], true);
+				const result = await this.organizeFile(eligible[i], true, batchProposedDirs);
 
 				if (result) {
 					if (result.movedDirectly && result.action.type === 'move') {
@@ -517,8 +524,16 @@ export class OrganizeModule {
 	 * When a new-directory proposal is created and organize auto-accept is on
 	 * (#228), the proposal is accepted immediately (the note is moved). `batch`
 	 * suppresses per-proposal Notices so batch callers can summarize.
+	 *
+	 * `batchProposedDirs` (when supplied by a batch caller) coalesces new
+	 * directory proposals across the run so variants like "model"/"models"
+	 * resolve to a single folder (#172).
 	 */
-	private async organizeFile(file: TFile, batch = false): Promise<OrganizeResult | null> {
+	private async organizeFile(
+		file: TFile,
+		batch = false,
+		batchProposedDirs?: Map<string, string>
+	): Promise<OrganizeResult | null> {
 		const analysis = await this.analyzer.analyze(file);
 
 		if (analysis.topics.length === 0) {
@@ -566,11 +581,20 @@ export class OrganizeModule {
 			};
 		}
 
-		// New directory needed -- create a proposal
+		// New directory needed -- create a proposal. Within a batch run, coalesce
+		// near-identical proposed directories to a single representative (#172).
+		const proposedDirectory = batchProposedDirs
+			? this.coalesceProposedDirectory(action.targetDirectory, batchProposedDirs)
+			: action.targetDirectory;
+		const resolvedAction: OrganizeAction =
+			proposedDirectory === action.targetDirectory
+				? action
+				: { ...action, targetDirectory: proposedDirectory };
+
 		const proposal: OrganizeProposal = {
 			id: generateId(),
 			sourceNotePath: file.path,
-			proposedDirectory: action.targetDirectory,
+			proposedDirectory,
 			reasoning: action.reasoning,
 			createdAt: new Date().toISOString(),
 			status: 'pending',
@@ -583,11 +607,34 @@ export class OrganizeModule {
 
 		return {
 			notePath: file.path,
-			action,
+			action: resolvedAction,
 			proposalCreated: true,
 			movedDirectly: false,
 			autoAccepted,
 		};
+	}
+
+	/**
+	 * Resolve a proposed new-directory path against directories already proposed
+	 * in this batch run, coalescing exact canonical matches and conservative
+	 * near-matches to a single representative folder (#172).
+	 */
+	private coalesceProposedDirectory(
+		directory: string,
+		batchProposedDirs: Map<string, string>
+	): string {
+		const key = canonicalKey(directory);
+		if (!key) return directory;
+
+		const exact = batchProposedDirs.get(key);
+		if (exact) return exact;
+
+		for (const [existingKey, existingDir] of batchProposedDirs) {
+			if (isFuzzyMatch(key, existingKey)) return existingDir;
+		}
+
+		batchProposedDirs.set(key, directory);
+		return directory;
 	}
 
 	private isExcluded(file: TFile): boolean {


### PR DESCRIPTION
## Summary

Improves the organize module so equivalent topic labels **coalesce to a single folder** instead of creating divergent directories (`model` vs `models`, `machine learning` vs `machine-learning`). Addresses all sub-issues of #172 except the deliberately-skipped abbreviation/synonym map (see Decisions).

A single canonical-key util is the source of truth, reused in three places:

1. **New folder names** — `DirectoryMatcher.buildDirectoryPath()` emits canonical (singular) names, so equivalent topics yield an identical `proposedDirectory`.
2. **Existing-folder matching** — `scoreDirectory()`/`buildReason()` compare canonical keys, with a conservative edit-distance tier, so a `model` topic matches an existing `models/` folder and moves there.
3. **Batch dedup** — `OrganizeModule` coalesces proposed directories across a scan (and resumed runs).

## Changes

- **New** `src/organize/folder-normalize.ts` — `singularize()`, `canonicalKey()`, `editDistance()`, `isFuzzyMatch()`. Hand-rolled, **zero runtime dependencies**.
- `directory-matcher.ts` — canonical `buildDirectoryPath`; canonical + fuzzy matching in `scoreDirectory`/`buildReason`.
- `content-analyzer.ts` — prompt steers the model toward broad, **singular** category labels.
- `index.ts` — `coalesceProposedDirectory()` + per-run dedup map threaded through `scanDirectory` and `resumeFromCheckpoint`.
- Tests: `folder-normalize.test.ts`, `batch-dedup.test.ts`, plus extensions to `directory-matcher.test.ts` and `content-analyzer.test.ts`.

## Decisions (confirmed with maintainer)

- **Hand-rolled** singular/plural normalization — no `pluralize` dependency (project has zero runtime deps).
- **Singular/plural only** — no abbreviation/synonym map (too opinionated). Broader-category goal handled via the AI prompt.
- **Conservative edit-distance** (min length 6, ≤1 edit) added on top of stem equality. Safety property: a lone fuzzy match (`0.4 * confidence`) cannot cross the `0.6` move threshold by itself, so it only contributes alongside other signals.

## Behavior change

New proposed folders are now **singular** (e.g. `meeting-note`, not `meeting-notes`). Existing folders are never renamed; topics simply match/move into them.

## Verification

- `npx tsc --noEmit --skipLibCheck` — clean
- `npm test` — 1030 passed (73 files; +9 new organize tests)
- `node esbuild.config.mjs production` — bundle builds

closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)