### PR TITLE
fix: grant contents:write to tag-on-version-bump workflow

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
     paths: ['manifest.json']
 
+# Required so the `tag` job can push the tag, and so the reusable `release`
+# workflow call can be granted `contents: write`. A called workflow cannot have
+# more permissions than its caller; without this the run fails at startup when
+# the repo default workflow permission is read-only.
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
Merging the v0.9.0 version bump (#240) **did not** create the `v0.9.0` tag or release. The `Tag on version bump` workflow died with `startup_failure`.

**Root cause:** `tag-on-version-bump.yml` invokes `release.yml` as a reusable workflow, which requests `permissions: contents: write`. A called (reusable) workflow cannot hold more permissions than its caller. This caller had **no `permissions:` block**, so it inherited the repository default workflow permission — which is **read-only** (`default_workflow_permissions: read`). GitHub validates this at startup and rejects the whole run before any job executes, so the `tag` job never even pushed the tag.

This wiring (reusable `release.yml` call) was added on Jun 5 and had never actually fired until #240 was merged — earlier releases (v0.2.1–v0.3.2) used `release.yml` triggered *directly* by a tag push, which carries its own explicit write permission and is unaffected.

## Fix
Add top-level `permissions: contents: write` to `tag-on-version-bump.yml` so:
- the `tag` job can `git push` the tag, and
- the reusable `release` call can be granted `contents: write`.

## Note
The `v0.9.0` release itself has already been cut by pushing the `v0.9.0` tag manually (which triggers `release.yml` via its direct `push: tags` path). This PR repairs the automation so the **next** version bump tags and releases automatically.

## Test plan
- [ ] On next merged version bump, `Tag on version bump` completes successfully and creates the tag + release.

Co-Authored-By: Claude <bot@wafflenet.io>