### PR TITLE
feat: disable auto-accept toggles when feature is disabled

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -167,6 +167,15 @@ function createStubEl(tag = 'div'): any {
 	return el;
 }
 
+/**
+ * Test helper: build a detached stub element that supports the Obsidian DOM
+ * helpers (createDiv/createSpan/createEl/empty/classList/…). Useful for
+ * rendering components that expect a real `containerEl`.
+ */
+export function createEl(tag = 'div'): any {
+	return createStubEl(tag);
+}
+
 export class Notice {
 	noticeEl: any;
 	constructor(_message: string | DocumentFragment, _duration?: number) {
@@ -230,15 +239,24 @@ export class SuggestModal<T = unknown> {
 }
 
 export class ToggleComponent {
+	/** Test helper: every instance ever constructed (clear between tests). */
+	static instances: ToggleComponent[] = [];
 	toggleEl: any = createStubEl();
+	tooltip = '';
 	private value = false;
 	private changeCb: ((value: boolean) => unknown) | undefined;
+	constructor() {
+		ToggleComponent.instances.push(this);
+	}
 	getValue = () => this.value;
 	setValue = vi.fn((v: boolean) => {
 		this.value = v;
 		return this;
 	});
-	setTooltip = vi.fn().mockReturnThis();
+	setTooltip = vi.fn((t: string) => {
+		this.tooltip = t;
+		return this;
+	});
 	setDisabled = vi.fn().mockReturnThis();
 	onChange = vi.fn((cb: (value: boolean) => unknown) => {
 		this.changeCb = cb;
@@ -253,6 +271,8 @@ export class ToggleComponent {
 
 export class Setting {
 	settingEl: any = createStubEl();
+	/** Child components created via add*, mirroring Obsidian's `components`. */
+	components: ToggleComponent[] = [];
 	constructor(_containerEl: unknown) {}
 	setName = vi.fn().mockReturnThis();
 	setDesc = vi.fn().mockReturnThis();
@@ -261,7 +281,9 @@ export class Setting {
 	addTextArea = vi.fn().mockReturnThis();
 	addDropdown = vi.fn().mockReturnThis();
 	addToggle = vi.fn(function (this: Setting, cb?: (t: ToggleComponent) => void) {
-		if (cb) cb(new ToggleComponent());
+		const toggle = new ToggleComponent();
+		this.components.push(toggle);
+		if (cb) cb(toggle);
 		return this;
 	});
 	addSlider = vi.fn().mockReturnThis();

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent, Setting } from './__mocks__/obsidian';
+import { SynapseSettingTab } from './settings-tab';
+import { DEFAULT_SETTINGS } from './settings';
+import type { SynapseSettings } from './settings';
+
+/**
+ * Tooltip of the REM feature's accordion-header enable toggle (see
+ * `featureSection('rem', …)` in settings-tab.ts). Used to locate that toggle
+ * among all rendered toggles so a test can simulate a user enabling/disabling
+ * the REM feature itself.
+ */
+const REM_FEATURE_TOOLTIP =
+	'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions';
+
+interface MockPlugin {
+	settings: SynapseSettings;
+	saveSettings: ReturnType<typeof vi.fn>;
+	manifest: { version: string };
+}
+
+function makeTab(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const plugin: MockPlugin = {
+		settings,
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		manifest: { version: '0.0.0-test' },
+	};
+	const tab = new SynapseSettingTab({} as never, plugin as never);
+	// The mock PluginSettingTab gives a bare containerEl; swap in a full stub el
+	// that supports createDiv/createSpan/etc. so display() can render.
+	(tab as unknown as { containerEl: HTMLElement }).containerEl = createEl();
+	return { tab, plugin, settings };
+}
+
+/** The per-kind Auto-Accept `Setting` rows the tab tracks for live updates. */
+function autoAcceptRows(tab: SynapseSettingTab): Record<string, Setting> {
+	return (tab as unknown as { autoAcceptSettings: Record<string, Setting> })
+		.autoAcceptSettings;
+}
+
+/** The Setting's first child toggle (the Auto-Accept on/off control). */
+function rowToggle(row: Setting): ToggleComponent {
+	return row.components[0];
+}
+
+function lastSetDisabledArg(row: Setting): boolean {
+	const calls = (row.setDisabled as ReturnType<typeof vi.fn>).mock.calls;
+	return calls[calls.length - 1][0] as boolean;
+}
+
+describe('SynapseSettingTab — Auto-Accept disabled state', () => {
+	beforeEach(() => {
+		ToggleComponent.instances.length = 0;
+	});
+
+	it('disables an Auto-Accept row when its feature is disabled, enables it when enabled', () => {
+		const { tab } = makeTab((s) => {
+			s.rem.enabled = false; // disabled feature
+			s.elaboration.enabled = true; // enabled feature
+		});
+		tab.display();
+
+		const rows = autoAcceptRows(tab);
+		expect(lastSetDisabledArg(rows['rem'])).toBe(true);
+		expect(lastSetDisabledArg(rows['elaboration'])).toBe(false);
+	});
+
+	it('maps deep-dive to the deepDive feature flag (keys are not 1:1)', () => {
+		const { tab } = makeTab((s) => {
+			s.deepDive.enabled = false;
+			s.organize.enabled = true;
+		});
+		tab.display();
+
+		const rows = autoAcceptRows(tab);
+		expect(lastSetDisabledArg(rows['deep-dive'])).toBe(true);
+		expect(lastSetDisabledArg(rows['organize'])).toBe(false);
+	});
+
+	it('preserves the stored autoAccept value across a disable → re-enable cycle', async () => {
+		const { tab, plugin } = makeTab((s) => {
+			s.rem.enabled = true;
+			s.autoAccept.rem = false;
+		});
+		tab.display();
+
+		// User turns ON auto-accept for REM.
+		const remRow = autoAcceptRows(tab)['rem'];
+		await rowToggle(remRow)._trigger(true);
+		expect(plugin.settings.autoAccept.rem).toBe(true);
+
+		// Locate the REM feature's header enable toggle and turn the feature OFF.
+		const remFeatureToggle = ToggleComponent.instances.find(
+			(t) => t.tooltip === REM_FEATURE_TOOLTIP,
+		);
+		expect(remFeatureToggle).toBeDefined();
+		await remFeatureToggle!._trigger(false);
+
+		// Feature now disabled, but the stored auto-accept value is untouched…
+		expect(plugin.settings.rem.enabled).toBe(false);
+		expect(plugin.settings.autoAccept.rem).toBe(true);
+		// …and the row was greyed out live (no full re-render).
+		expect(lastSetDisabledArg(remRow)).toBe(true);
+
+		// Re-enable the feature: value still intact, row re-enabled live.
+		await remFeatureToggle!._trigger(true);
+		expect(plugin.settings.autoAccept.rem).toBe(true);
+		expect(lastSetDisabledArg(remRow)).toBe(false);
+
+		// A fresh render restores the toggle exactly as the user left it (ON).
+		tab.display();
+		const remRowAfter = autoAcceptRows(tab)['rem'];
+		expect(rowToggle(remRowAfter).getValue()).toBe(true);
+	});
+
+	it('never writes autoAccept when a feature is toggled (value falls out for free)', async () => {
+		const { tab, plugin } = makeTab((s) => {
+			s.rem.enabled = true;
+			s.autoAccept.rem = false; // user left it OFF
+		});
+		tab.display();
+
+		const remFeatureToggle = ToggleComponent.instances.find(
+			(t) => t.tooltip === REM_FEATURE_TOOLTIP,
+		);
+		await remFeatureToggle!._trigger(false);
+		await remFeatureToggle!._trigger(true);
+
+		// A disable→re-enable cycle must not flip the stored OFF value to ON.
+		expect(plugin.settings.autoAccept.rem).toBe(false);
+	});
+});

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -44,6 +44,59 @@ export class SynapseSettingTab extends PluginSettingTab {
 	}
 
 	/**
+	 * Live references to the per-kind Auto-Accept rows, keyed by ProposalKind.
+	 * Rebuilt on every {@link display}. Lets a feature enable/disable toggle grey
+	 * out the matching row in place (see {@link refreshAutoAcceptDisabledState}).
+	 */
+	private autoAcceptSettings: Partial<Record<ProposalKind, Setting>> = {};
+
+	/**
+	 * Whether the feature that produces a given proposal kind is enabled. When a
+	 * feature is off, its Auto-Accept row is greyed out — but its stored value is
+	 * never touched, so re-enabling restores the toggle exactly as left. Note the
+	 * keys are not 1:1: `deep-dive` maps to the `deepDive` settings group.
+	 */
+	private isFeatureEnabled(kind: ProposalKind): boolean {
+		const s = this.plugin.settings;
+		switch (kind) {
+			case 'elaboration':
+				return s.elaboration.enabled;
+			case 'enrichment':
+				return s.enrichment.enabled;
+			case 'organize':
+				return s.organize.enabled;
+			case 'deep-dive':
+				return s.deepDive.enabled;
+			case 'title':
+				return s.title.enabled;
+			case 'rem':
+				return s.rem.enabled;
+		}
+	}
+
+	/** Description for an Auto-Accept row, with a hint appended when disabled. */
+	private autoAcceptDesc(kind: ProposalKind): string {
+		const { name, desc } = AUTO_ACCEPT_LABELS[kind];
+		return this.isFeatureEnabled(kind)
+			? desc
+			: `${desc} (Enable ${name} to configure auto-accept.)`;
+	}
+
+	/**
+	 * Sync every rendered Auto-Accept row's disabled state (and hint) to its
+	 * feature's enabled flag. Called after a feature enable toggle so the change
+	 * propagates live, without re-rendering the whole settings tab.
+	 */
+	private refreshAutoAcceptDisabledState(): void {
+		for (const kind of PROPOSAL_KINDS) {
+			const setting = this.autoAcceptSettings[kind];
+			if (!setting) continue;
+			setting.setDisabled(!this.isFeatureEnabled(kind));
+			setting.setDesc(this.autoAcceptDesc(kind));
+		}
+	}
+
+	/**
 	 * Resolve the persisted collapse state for a section, falling back to a
 	 * sensible default: collapsed when the feature is disabled, expanded when
 	 * it is enabled. A `null` `enabled` (config sections with no toggle, e.g.
@@ -87,6 +140,10 @@ export class SynapseSettingTab extends PluginSettingTab {
 			onToggle: async (value) => {
 				setEnabled(value);
 				await this.plugin.saveSettings();
+				// Greying out a feature must propagate to its Auto-Accept row in
+				// place — flip the stored Setting's disabled state directly rather
+				// than re-rendering (which would jump scroll and collapse accordions).
+				this.refreshAutoAcceptDisabledState();
 			},
 			onCollapseChange: async (collapsed) => {
 				await this.persistCollapse(key, collapsed);
@@ -1200,19 +1257,27 @@ export class SynapseSettingTab extends PluginSettingTab {
 			text: 'When enabled for a proposal type, future proposals of that type are accepted automatically as generated, applied without review. Already-pending proposals are left untouched. Off by default for every type.',
 		});
 
+		// Rebuilt each render; feature toggles flip these rows' disabled state live.
+		this.autoAcceptSettings = {};
 		for (const kind of PROPOSAL_KINDS) {
-			const { name, desc } = AUTO_ACCEPT_LABELS[kind];
-			new Setting(autoAcceptBody)
+			const { name } = AUTO_ACCEPT_LABELS[kind];
+			const setting = new Setting(autoAcceptBody)
 				.setName(name)
-				.setDesc(desc)
+				.setDesc(this.autoAcceptDesc(kind))
 				.addToggle((toggle) =>
 					toggle
+						// The stored value is shown verbatim even while disabled, and
+						// onChange never fires on a disabled toggle — so a disable →
+						// re-enable cycle preserves the user's setting for free.
 						.setValue(this.plugin.settings.autoAccept[kind])
 						.onChange(async (value) => {
 							this.plugin.settings.autoAccept[kind] = value;
 							await this.plugin.saveSettings();
 						})
 				);
+			// Grey out (and disable child toggle) when the feature is off.
+			setting.setDisabled(!this.isFeatureEnabled(kind));
+			this.autoAcceptSettings[kind] = setting;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The **Auto-Accept Proposals** section rendered an independent toggle per proposal kind (`elaboration`, `enrichment`, `organize`, `deep-dive`, `title`, `rem`) regardless of whether the underlying feature was enabled. A user could flip on "Auto-accept REM" while REM itself was disabled — the toggle did nothing yet still read as active.

Now each Auto-Accept row is **greyed out** (`Setting.setDisabled`) whenever its feature is disabled, with a hint appended to the description ("Enable REM (Link Discovery) to configure auto-accept."). The stored `settings.autoAccept[kind]` value is **never reset**, so a disable → re-enable cycle restores the toggle exactly as the user left it.

## Implementation

- Added `isFeatureEnabled(kind)` mapping each `ProposalKind` to its feature flag — note the keys are **not 1:1** (`deep-dive` → `deepDive`).
- The auto-accept render loop holds per-kind `Setting` references and calls `.setDisabled(!enabled)`.
- Feature enable toggles (accordion headers) propagate to the matching row **in place** via `refreshAutoAcceptDisabledState()`, avoiding a full `this.display()` re-render that would jump scroll and collapse accordions.
- No reset logic: because disabling the UI never writes the value, persistence across disable→re-enable falls out for free.

## Tests

New `src/settings-tab.test.ts` (Vitest, against the Obsidian mock):
- A row's disabled state tracks its feature's `enabled` flag.
- `deep-dive` maps to the `deepDive` flag.
- Stored `autoAccept[kind]` value survives a disable → re-enable cycle (live, no re-render).
- A feature toggle never writes `autoAccept`.

Mock additions (`Setting.components`, `ToggleComponent.instances`, `createEl` helper) follow existing mock patterns and are additive.

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (1034 passed / 74 files)
- `node esbuild.config.mjs production` ✅

## Note
Part of a stacked pair — issue #243 refactors this file next and branches off this branch. Change is kept surgical and contained to the auto-accept loop + live-update wiring.

closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)