### PR TITLE
refactor: split settings-tab into per-feature settings modules

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -432,3 +432,6 @@ export class AudioModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderAudioSettings } from './settings-section';

--- a/src/audio/settings-section.test.ts
+++ b/src/audio/settings-section.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderAudioSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Enable audio transcription';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const rerender = vi.fn();
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender,
+	});
+	return { ctx, plugin, containerEl, saveSettings, rerender };
+}
+
+describe('renderAudioSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.audio.enabled = true; });
+		renderAudioSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.audio.enabled = true; });
+		renderAudioSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.audio.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+
+	it('renders without throwing for either AI provider (Whisper key visibility branch)', () => {
+		const openai = makeCtx((s) => { s.audio.transcriptionProvider = 'whisper-api'; s.ai.provider = 'openai'; });
+		expect(() => renderAudioSettings(openai.ctx)).not.toThrow();
+		const anthropic = makeCtx((s) => { s.audio.transcriptionProvider = 'whisper-api'; s.ai.provider = 'anthropic'; });
+		expect(() => renderAudioSettings(anthropic.ctx)).not.toThrow();
+	});
+});

--- a/src/audio/settings-section.ts
+++ b/src/audio/settings-section.ts
@@ -1,0 +1,139 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Audio Transcription settings accordion (#243).
+ *
+ * The transcription provider dropdown and AI provider together decide which
+ * API-key fields are shown, so changing the provider triggers a full re-render
+ * via {@link SettingsSectionContext.rerender}.
+ */
+export function renderAudioSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const audioBody = ctx.featureSection(
+		'audio',
+		'Audio Transcription',
+		() => plugin.settings.audio.enabled,
+		(v) => { plugin.settings.audio.enabled = v; },
+		'Enable audio transcription',
+	);
+
+	const providerOptions: Record<string, string> = {
+		'whisper-api': 'OpenAI Whisper API',
+		deepgram: 'Deepgram',
+	};
+	// 'local-whisper' is intentionally hidden from the dropdown until implemented
+	// (see src/audio/transcriber.ts). The type is kept for forward compatibility.
+
+	new Setting(audioBody)
+		.setName('Transcription provider')
+		.addDropdown((dd) =>
+			dd
+				.addOptions(providerOptions)
+				.setValue(plugin.settings.audio.transcriptionProvider)
+				.onChange(async (value) => {
+					plugin.settings.audio.transcriptionProvider =
+						value as 'whisper-api' | 'deepgram' | 'local-whisper';
+					await plugin.saveSettings();
+					ctx.rerender(); // Re-render to show/hide provider-specific fields
+				})
+		);
+
+	// Show Whisper API key field when provider is whisper-api and AI provider isn't OpenAI
+	// (if AI provider is OpenAI, the shared API key is already an OpenAI key)
+	if (
+		plugin.settings.audio.transcriptionProvider === 'whisper-api' &&
+		plugin.settings.ai.provider !== 'openai'
+	) {
+		new Setting(audioBody)
+			.setName('OpenAI API Key (Whisper)')
+			.setDesc(
+				'Whisper uses the OpenAI API. Provide your OpenAI key here since your AI provider is set to ' +
+				plugin.settings.ai.provider.charAt(0).toUpperCase() +
+				plugin.settings.ai.provider.slice(1) + '.'
+			)
+			.addText((text) => {
+				text
+					.setPlaceholder('sk-...')
+					.setValue(plugin.settings.audio.whisperApiKey)
+					.onChange(async (value) => {
+						plugin.settings.audio.whisperApiKey = value;
+						await plugin.saveSettings();
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.autocomplete = 'off';
+			});
+	}
+
+	if (plugin.settings.audio.transcriptionProvider === 'deepgram') {
+		new Setting(audioBody)
+			.setName('Deepgram API Key')
+			.setDesc('Required for Deepgram transcription provider')
+			.addText((text) => {
+				text
+					.setPlaceholder('dg-...')
+					.setValue(plugin.settings.audio.deepgramApiKey)
+					.onChange(async (value) => {
+						plugin.settings.audio.deepgramApiKey = value;
+						await plugin.saveSettings();
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.autocomplete = 'off';
+			});
+	}
+
+	new Setting(audioBody)
+		.setName('Language')
+		.setDesc('Audio language for transcription (auto-detect if empty)')
+		.addDropdown((dd) =>
+			dd
+				.addOptions({
+					'': 'Auto-detect',
+					en: 'English',
+					es: 'Spanish',
+					fr: 'French',
+					de: 'German',
+					ja: 'Japanese',
+					zh: 'Chinese',
+					ko: 'Korean',
+					pt: 'Portuguese',
+					ru: 'Russian',
+					ar: 'Arabic',
+					hi: 'Hindi',
+					it: 'Italian',
+					nl: 'Dutch',
+					pl: 'Polish',
+					sv: 'Swedish',
+					tr: 'Turkish',
+				})
+				.setValue(plugin.settings.audio.language)
+				.onChange(async (value) => {
+					plugin.settings.audio.language = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(audioBody)
+		.setName('Post-processing')
+		.setDesc('Clean up and structure transcriptions with AI')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.audio.postProcessing.enabled)
+				.onChange(async (value) => {
+					plugin.settings.audio.postProcessing.enabled = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(audioBody)
+		.setName('Remove filler words')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.audio.postProcessing.removeFiller)
+				.onChange(async (value) => {
+					plugin.settings.audio.postProcessing.removeFiller = value;
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -707,3 +707,6 @@ export function buildDeepDivePath(
 	const path = folder ? `${folder}/${safeName}.md` : `${safeName}.md`;
 	return normalizePath(path);
 }
+
+// Settings section renderer (#243)
+export { renderDeepDiveSettings } from './settings-section';

--- a/src/deep-dive/settings-section.test.ts
+++ b/src/deep-dive/settings-section.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderDeepDiveSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Recursively explore a note into a tree of interlinked child notes';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderDeepDiveSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion (key "deepDive") with the header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.deepDive.enabled = true; });
+		renderDeepDiveSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('uses the deepDive collapse key (deep-dive → deepDive nuance)', async () => {
+		const { ctx, plugin } = makeCtx((s) => { s.deepDive.enabled = true; });
+		renderDeepDiveSettings(ctx);
+		// Collapsing the section persists under ui.collapsedSections['deepDive'].
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false); // disabling auto-collapses → persists collapse
+		expect(plugin.settings.ui.collapsedSections['deepDive']).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.deepDive.enabled = true; });
+		renderDeepDiveSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.deepDive.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/deep-dive/settings-section.ts
+++ b/src/deep-dive/settings-section.ts
@@ -1,0 +1,154 @@
+import { Setting } from 'obsidian';
+import { addEnhancedSlider } from '../shared';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Deep Dive settings accordion (#243).
+ *
+ * NOTE: the accordion key is `deepDive` (camelCase) even though the feature
+ * directory is `deep-dive` — it must match the `settings.deepDive` group and
+ * the existing persisted `ui.collapsedSections['deepDive']` key. Do not change.
+ */
+export function renderDeepDiveSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const deepDiveBody = ctx.featureSection(
+		'deepDive',
+		'Deep Dive',
+		() => plugin.settings.deepDive.enabled,
+		(v) => { plugin.settings.deepDive.enabled = v; },
+		'Recursively explore a note into a tree of interlinked child notes',
+	);
+
+	addEnhancedSlider(
+		new Setting(deepDiveBody)
+			.setName('Max depth')
+			.setDesc('Maximum levels of recursion (1-5)'),
+		{
+			min: 1,
+			max: 5,
+			step: 1,
+			value: plugin.settings.deepDive.maxDepth,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.deepDive.maxDepth = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	addEnhancedSlider(
+		new Setting(deepDiveBody)
+			.setName('Quality threshold')
+			.setDesc('Minimum quality score to continue recursing (0.1-0.9)'),
+		{
+			min: 0.1,
+			max: 0.9,
+			step: 0.05,
+			value: plugin.settings.deepDive.qualityThreshold,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.deepDive.qualityThreshold = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	addEnhancedSlider(
+		new Setting(deepDiveBody)
+			.setName('Max notes per run')
+			.setDesc('Maximum number of notes to generate in a single deep dive (10-100)'),
+		{
+			min: 10,
+			max: 100,
+			step: 5,
+			value: plugin.settings.deepDive.maxNotesPerRun,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.deepDive.maxNotesPerRun = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	new Setting(deepDiveBody)
+		.setName('Note output folder')
+		.setDesc('Where to create new notes. Uses a subfolder per root note. (empty = same folder as source)')
+		.addText((text) =>
+			text
+				.setPlaceholder('Deep Dives')
+				.setValue(plugin.settings.deepDive.noteOutputFolder)
+				.onChange(async (value) => {
+					plugin.settings.deepDive.noteOutputFolder = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(deepDiveBody)
+		.setName('Folder nesting mode')
+		.setDesc('How child notes are placed: nested under parent topic folders, flat in a single folder, or AI-organized by content semantics')
+		.addDropdown((dd) =>
+			dd
+				.addOptions({
+					nested: 'Nested (subfolder per parent topic)',
+					flat: 'Flat (all in root subfolder)',
+					'auto-organize': 'Auto-organize (AI-based placement)',
+				})
+				.setValue(plugin.settings.deepDive.nestingMode || 'nested')
+				.onChange(async (value) => {
+					plugin.settings.deepDive.nestingMode =
+						value as 'nested' | 'flat' | 'auto-organize';
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(deepDiveBody)
+		.setName('Auto-enrich on accept')
+		.setDesc('Automatically trigger enrichment when a deep dive note is accepted')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.deepDive.autoEnrichOnAccept)
+				.onChange(async (value) => {
+					plugin.settings.deepDive.autoEnrichOnAccept = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(deepDiveBody)
+		.setName('Auto-organize on accept')
+		.setDesc('Automatically trigger organize when a deep dive note is accepted')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.deepDive.autoOrganizeOnAccept)
+				.onChange(async (value) => {
+					plugin.settings.deepDive.autoOrganizeOnAccept = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(deepDiveBody)
+		.setName('Excluded folders')
+		.setDesc('Comma-separated list of folders to skip for deep dive')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.deepDive.excludeFolders.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.deepDive.excludeFolders =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(deepDiveBody)
+		.setName('Excluded tags')
+		.setDesc('Notes with these tags will skip deep dive')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.deepDive.excludeTags.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.deepDive.excludeTags =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -421,3 +421,6 @@ export class ElaborationModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderElaborationSettings } from './settings-section';

--- a/src/elaboration/settings-section.test.ts
+++ b/src/elaboration/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderElaborationSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Enable stub note detection and proposal generation';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderElaborationSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.elaboration.enabled = true; });
+		renderElaborationSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.elaboration.enabled = true; });
+		renderElaborationSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.elaboration.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/elaboration/settings-section.ts
+++ b/src/elaboration/settings-section.ts
@@ -1,0 +1,70 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Note Elaboration settings accordion (#243). Pure renderer over the
+ * shared {@link SettingsSectionContext}; owns no state.
+ */
+export function renderElaborationSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const elaborationBody = ctx.featureSection(
+		'elaboration',
+		'Note Elaboration',
+		() => plugin.settings.elaboration.enabled,
+		(v) => { plugin.settings.elaboration.enabled = v; },
+		'Enable stub note detection and proposal generation',
+	);
+
+	new Setting(elaborationBody)
+		.setName('Minimum word threshold')
+		.setDesc('Notes with fewer words than this are considered stubs')
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.elaboration.detection.minWordThreshold))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.elaboration.detection.minWordThreshold = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+
+	new Setting(elaborationBody)
+		.setName('Detect TODO markers')
+		.setDesc('Flag notes containing TODO, TBD, FIXME, PLACEHOLDER')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.elaboration.detection.detectTodoMarkers)
+				.onChange(async (value) => {
+					plugin.settings.elaboration.detection.detectTodoMarkers = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(elaborationBody)
+		.setName('Detect empty sections')
+		.setDesc('Flag notes with headings but no content beneath them')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.elaboration.detection.detectEmptySections)
+				.onChange(async (value) => {
+					plugin.settings.elaboration.detection.detectEmptySections = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(elaborationBody)
+		.setName('Excluded folders')
+		.setDesc('Comma-separated list of folders to skip')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.elaboration.detection.excludeFolders.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.elaboration.detection.excludeFolders =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -652,3 +652,6 @@ export class EnrichmentModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderEnrichmentSettings } from './settings-section';

--- a/src/enrichment/settings-section.test.ts
+++ b/src/enrichment/settings-section.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderEnrichmentSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Add tags, links, references, and metadata to notes';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderEnrichmentSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.enrichment.enabled = true; });
+		renderEnrichmentSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.enrichment.enabled = true; });
+		renderEnrichmentSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.enrichment.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+
+	it('renders the Proximity Weights and Tag Vocabulary sub-sections without throwing', () => {
+		const { ctx } = makeCtx();
+		expect(() => renderEnrichmentSettings(ctx)).not.toThrow();
+	});
+});

--- a/src/enrichment/settings-section.ts
+++ b/src/enrichment/settings-section.ts
@@ -1,0 +1,201 @@
+import { Setting } from 'obsidian';
+import { addEnhancedSlider } from '../shared';
+import type { SettingsSectionContext } from '../shared';
+import type { EnrichmentWeightSettings } from '../settings';
+
+/**
+ * Render the Note Enrichment settings accordion (#243). Includes the Proximity
+ * Weights and Tag Vocabulary sub-sections.
+ */
+export function renderEnrichmentSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const enrichmentBody = ctx.featureSection(
+		'enrichment',
+		'Note Enrichment',
+		() => plugin.settings.enrichment.enabled,
+		(v) => { plugin.settings.enrichment.enabled = v; },
+		'Add tags, links, references, and metadata to notes',
+	);
+
+	new Setting(enrichmentBody)
+		.setName('Auto-enrich')
+		.setDesc('Automatically generate enrichment proposals after elaboration or transcription')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.enrichment.autoEnrich)
+				.onChange(async (value) => {
+					plugin.settings.enrichment.autoEnrich = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(enrichmentBody)
+		.setName('Max metadata tags')
+		.setDesc('Maximum number of metadata tags (status, type, source) to suggest per note')
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.enrichment.maxTags))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.enrichment.maxTags = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+
+	new Setting(enrichmentBody)
+		.setName('Max topic links')
+		.setDesc('Maximum number of AI-extracted topic links to suggest')
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.enrichment.maxTopicLinks))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.enrichment.maxTopicLinks = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+
+	new Setting(enrichmentBody)
+		.setName('Suggest new notes')
+		.setDesc('Suggest links to notes that don\'t exist yet (Obsidian grayed-out links)')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.enrichment.suggestNewNotes)
+				.onChange(async (value) => {
+					plugin.settings.enrichment.suggestNewNotes = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(enrichmentBody)
+		.setName('Max internal links')
+		.setDesc('Maximum number of related note links to suggest')
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.enrichment.maxInternalLinks))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.enrichment.maxInternalLinks = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+
+	new Setting(enrichmentBody)
+		.setName('Max external references')
+		.setDesc('Maximum external links to suggest (stingy — keep this low)')
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.enrichment.maxExternalLinks))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num >= 0) {
+						plugin.settings.enrichment.maxExternalLinks = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+
+	addEnhancedSlider(
+		new Setting(enrichmentBody)
+			.setName('Internal link threshold')
+			.setDesc('Minimum relevance score for internal links (0-1, lower = more liberal)'),
+		{
+			min: 0,
+			max: 1,
+			step: 0.05,
+			value: plugin.settings.enrichment.internalLinkThreshold,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.enrichment.internalLinkThreshold = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	// Weight settings (sub-section within enrichment)
+	new Setting(enrichmentBody).setHeading().setName('Proximity Weights');
+
+	type WeightKey = keyof EnrichmentWeightSettings;
+	const weightFields: Array<{ key: WeightKey; name: string; desc: string }> = [
+		{ key: 'sameFolder', name: 'Same folder', desc: 'Weight for files in the same folder' },
+		{ key: 'siblingFolder', name: 'Sibling folder', desc: 'Weight for files in sibling folders' },
+		{ key: 'cousinFolder', name: 'Cousin folder', desc: 'Weight for files two levels apart' },
+		{ key: 'distantFolder', name: 'Distant folder', desc: 'Weight for files in distant folders' },
+		{ key: 'decayPerLevel', name: 'Decay per level', desc: 'Weight reduction per additional folder hop' },
+		{ key: 'minWeight', name: 'Minimum weight', desc: 'Floor weight — distant files are never invisible' },
+	];
+
+	for (const field of weightFields) {
+		const key = field.key;
+		addEnhancedSlider(
+			new Setting(enrichmentBody)
+				.setName(field.name)
+				.setDesc(field.desc),
+			{
+				min: 0,
+				max: 1,
+				step: 0.05,
+				value: plugin.settings.enrichment.weights[key],
+				showTicks: true,
+				onChange: async (value) => {
+					plugin.settings.enrichment.weights[key] = value;
+					await plugin.saveSettings();
+				},
+			},
+		);
+	}
+
+	// Tag Vocabulary (sub-section within enrichment)
+	new Setting(enrichmentBody).setHeading().setName('Tag Vocabulary').setDesc('Define metadata tag categories. Tags classify notes (status, type, source) — topics become [[links]] instead.');
+
+	for (let i = 0; i < plugin.settings.enrichment.tagVocabulary.length; i++) {
+		const entry = plugin.settings.enrichment.tagVocabulary[i];
+
+		new Setting(enrichmentBody)
+			.setName(entry.category)
+			.setDesc(entry.description)
+			.addText((text) =>
+				text
+					.setValue(entry.tags.join(', '))
+					.setPlaceholder('tag1, tag2, tag3')
+					.onChange(async (value) => {
+						plugin.settings.enrichment.tagVocabulary[i].tags =
+							value.split(',').map(s => s.trim()).filter(Boolean);
+						await plugin.saveSettings();
+					})
+			);
+	}
+
+	new Setting(enrichmentBody)
+		.setName('Excluded folders')
+		.setDesc('Comma-separated list of folders to skip for enrichment')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.enrichment.excludeFolders.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.enrichment.excludeFolders =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(enrichmentBody)
+		.setName('Excluded tags')
+		.setDesc('Notes with these tags will skip enrichment')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.enrichment.excludeTags.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.enrichment.excludeTags =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -180,3 +180,6 @@ export class ImageModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderImageSettings } from './settings-section';

--- a/src/image/settings-section.test.ts
+++ b/src/image/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderImageSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Run OCR and image analysis on images referenced in notes';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderImageSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.image.enabled = true; });
+		renderImageSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.image.enabled = true; });
+		renderImageSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.image.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/image/settings-section.ts
+++ b/src/image/settings-section.ts
@@ -1,0 +1,37 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Image settings accordion (#243).
+ */
+export function renderImageSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const imageBody = ctx.featureSection(
+		'image',
+		'Image',
+		() => plugin.settings.image.enabled,
+		(v) => { plugin.settings.image.enabled = v; },
+		'Run OCR and image analysis on images referenced in notes',
+	);
+
+	new Setting(imageBody)
+		.setName('Max image size (MB)')
+		.setDesc(
+			'Images whose base64 payload exceeds this size are automatically downscaled ' +
+			'before being sent to the API. The Anthropic API limit is 5 MB; lower this only ' +
+			'if your provider enforces a smaller limit.'
+		)
+		.addText((text) =>
+			text
+				.setPlaceholder('5')
+				.setValue(String(plugin.settings.image.maxImageSizeMb))
+				.onChange(async (value) => {
+					const num = parseFloat(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.image.maxImageSizeMb = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+}

--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -490,3 +490,6 @@ export class IntakeModule {
 		return cleaned.length > 0 ? cleaned : 'note';
 	}
 }
+
+// Settings section renderer (#243)
+export { renderIntakeSettings } from './settings-section';

--- a/src/intake/settings-section.test.ts
+++ b/src/intake/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderIntakeSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Watch the intake folder and run enabled Synapse features on new notes';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderIntakeSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.intake.enabled = true; });
+		renderIntakeSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.intake.enabled = true; });
+		renderIntakeSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.intake.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/intake/settings-section.ts
+++ b/src/intake/settings-section.ts
@@ -1,0 +1,115 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Intake Folder settings accordion (#243).
+ */
+export function renderIntakeSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const intakeBody = ctx.featureSection(
+		'intake',
+		'Intake Folder',
+		() => plugin.settings.intake.enabled,
+		(v) => { plugin.settings.intake.enabled = v; },
+		'Watch the intake folder and run enabled Synapse features on new notes',
+	);
+
+	new Setting(intakeBody)
+		.setName('Settle window (seconds)')
+		.setDesc(
+			'Wait this long after the last change to a note before processing it. ' +
+			'The timer resets on every edit, so active typing or chunked sync keeps ' +
+			'deferring — processing fires only once the note has been quiet for the ' +
+			'full window. Raise it if notes are still arriving when they get processed.'
+		)
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.intake.settleSeconds))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.intake.settleSeconds = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+
+	new Setting(intakeBody)
+		.setName('Intake folder')
+		.setDesc('Folder to watch for new notes. See docs/intake-folder.md for the mobile capture workflow.')
+		.addText((text) =>
+			text
+				.setPlaceholder('Inbox')
+				.setValue(plugin.settings.intake.intakeFolder)
+				.onChange(async (value) => {
+					plugin.settings.intake.intakeFolder = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(intakeBody)
+		.setName('Mark processed in frontmatter')
+		.setDesc('Stamp `synapse-processed: true` on a note once handled so it is not reprocessed')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.intake.markProcessed)
+				.onChange(async (value) => {
+					plugin.settings.intake.markProcessed = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(intakeBody)
+		.setName('Move when done (fallback)')
+		.setDesc(
+			'Fallback destination used only when auto-organize keeps a note in ' +
+			'the intake folder (e.g. low confidence). Notes organize relocates ' +
+			'are left where it put them. Leave blank to keep unorganized notes ' +
+			'in the intake folder.'
+		)
+		.addText((text) =>
+			text
+				.setPlaceholder('')
+				.setValue(plugin.settings.intake.moveWhenDone ?? '')
+				.onChange(async (value) => {
+					const trimmed = value.trim();
+					plugin.settings.intake.moveWhenDone = trimmed === '' ? undefined : trimmed;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(intakeBody)
+		.setName('Capture log')
+		.setDesc(
+			'When a note is auto-organized out of the intake folder, leave a ' +
+			'dated breadcrumb linking to its new home in the capture-log subfolder.'
+		)
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.intake.captureLog)
+				.onChange(async (value) => {
+					plugin.settings.intake.captureLog = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(intakeBody)
+		.setName('Capture log folder')
+		.setDesc(
+			'Subfolder of the intake folder for breadcrumbs (relative to it). ' +
+			'This subfolder is ignored by the watcher so breadcrumbs are never reprocessed.'
+		)
+		.addText((text) =>
+			text
+				.setPlaceholder('_captured')
+				.setValue(plugin.settings.intake.captureLogFolder)
+				.onChange(async (value) => {
+					const trimmed = value.trim();
+					if (trimmed.length > 0) {
+						plugin.settings.intake.captureLogFolder = trimmed;
+						await plugin.saveSettings();
+					}
+				})
+		);
+}

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -722,3 +722,6 @@ export function buildSummaryPath(timestamp: string): string {
 	const date = timestamp.split('T')[0] || timestamp;
 	return normalizePath(`.synapse/organize/summaries/${date}-organize-summary.md`);
 }
+
+// Settings section renderer (#243)
+export { renderOrganizeSettings } from './settings-section';

--- a/src/organize/settings-section.test.ts
+++ b/src/organize/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderOrganizeSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'AI-powered semantic directory structuring for notes';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderOrganizeSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.organize.enabled = true; });
+		renderOrganizeSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.organize.enabled = true; });
+		renderOrganizeSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.organize.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/organize/settings-section.ts
+++ b/src/organize/settings-section.ts
@@ -1,0 +1,61 @@
+import { Setting } from 'obsidian';
+import { addEnhancedSlider } from '../shared';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Note Organize settings accordion (#243).
+ */
+export function renderOrganizeSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const organizeBody = ctx.featureSection(
+		'organize',
+		'Note Organize',
+		() => plugin.settings.organize.enabled,
+		(v) => { plugin.settings.organize.enabled = v; },
+		'AI-powered semantic directory structuring for notes',
+	);
+
+	addEnhancedSlider(
+		new Setting(organizeBody)
+			.setName('New folder confidence threshold')
+			.setDesc('Minimum topic confidence to propose a new folder (0.5-1.0). Higher = fewer new folders.'),
+		{
+			min: 0.5,
+			max: 1.0,
+			step: 0.05,
+			value: plugin.settings.organize.organizeConfidenceThreshold,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.organize.organizeConfidenceThreshold = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	new Setting(organizeBody)
+		.setName('Excluded folders')
+		.setDesc('Comma-separated list of folders to skip for organization')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.organize.excludeFolders.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.organize.excludeFolders =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(organizeBody)
+		.setName('Excluded tags')
+		.setDesc('Notes with these tags will skip organization')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.organize.excludeTags.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.organize.excludeTags =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -493,3 +493,6 @@ export class RemModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderRemSettings } from './settings-section';

--- a/src/rem/settings-section.test.ts
+++ b/src/rem/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderRemSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderRemSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.rem.enabled = true; });
+		renderRemSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.rem.enabled = true; });
+		renderRemSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.rem.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/rem/settings-section.ts
+++ b/src/rem/settings-section.ts
@@ -1,0 +1,62 @@
+import { Setting } from 'obsidian';
+import { addEnhancedSlider } from '../shared';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the REM (Link Discovery) settings accordion (#243).
+ */
+export function renderRemSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const remBody = ctx.featureSection(
+		'rem',
+		'REM (Link Discovery)',
+		() => plugin.settings.rem.enabled,
+		(v) => { plugin.settings.rem.enabled = v; },
+		'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions',
+	);
+
+	new Setting(remBody)
+		.setName('Semantic matching')
+		.setDesc('Use AI to find conceptual matches beyond literal title/alias matching')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.rem.semanticMatching)
+				.onChange(async (value) => {
+					plugin.settings.rem.semanticMatching = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	addEnhancedSlider(
+		new Setting(remBody)
+			.setName('Confidence threshold')
+			.setDesc('Minimum confidence for semantic matches (0-1)'),
+		{
+			min: 0,
+			max: 1,
+			step: 0.05,
+			value: plugin.settings.rem.confidenceThreshold,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.rem.confidenceThreshold = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	new Setting(remBody)
+		.setName('Max links per note')
+		.setDesc('Maximum number of link candidates to suggest per scanned note')
+		.addText((text) =>
+			text
+				.setValue(String(plugin.settings.rem.maxLinksPerNote))
+				.onChange(async (value) => {
+					const num = parseInt(value);
+					if (!isNaN(num) && num > 0) {
+						plugin.settings.rem.maxLinksPerNote = num;
+						await plugin.saveSettings();
+					}
+				})
+		);
+}

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -2,9 +2,24 @@ import { App, Platform, PluginSettingTab, Setting } from 'obsidian';
 import type SynapsePlugin from './main';
 import { MODEL_OPTIONS } from './settings';
 import type { AIProvider } from './settings';
-import { addCollapsibleSection, addEnhancedSlider } from './shared';
+import {
+	addEnhancedSlider,
+	createSettingsSectionContext,
+} from './shared';
+import type { SettingsSectionContext } from './shared';
 import { PROPOSAL_KINDS } from './views';
 import type { ProposalKind } from './views';
+import { renderElaborationSettings } from './elaboration';
+import { renderIntakeSettings } from './intake';
+import { renderImageSettings } from './image';
+import { renderAudioSettings } from './audio';
+import { renderVideoSettings } from './video';
+import { renderEnrichmentSettings } from './enrichment';
+import { renderSummarizeSettings } from './summarize';
+import { renderTidySettings } from './tidy';
+import { renderOrganizeSettings } from './organize';
+import { renderDeepDiveSettings } from './deep-dive';
+import { renderRemSettings } from './rem';
 
 /**
  * Per-kind display copy for the Auto-Accept Proposals section (#228). MUTATING
@@ -38,6 +53,35 @@ const AUTO_ACCEPT_LABELS: Record<ProposalKind, { name: string; desc: string }> =
 	},
 };
 
+/**
+ * The ordered list of per-feature section renderers (#243). Video is gated
+ * behind `Platform.isDesktop` in {@link SynapseSettingTab.display} and inserted
+ * here at render time, preserving the historical section order:
+ * Elaboration, Intake, Image, Audio, Video, Enrichment, Summarize, Tidy,
+ * Organize, Deep Dive, REM.
+ */
+const FEATURE_SECTION_RENDERERS: Array<(ctx: SettingsSectionContext) => void> = [
+	renderElaborationSettings,
+	renderIntakeSettings,
+	renderImageSettings,
+	renderAudioSettings,
+	// renderVideoSettings is spliced in after Audio when Platform.isDesktop.
+	renderEnrichmentSettings,
+	renderSummarizeSettings,
+	renderTidySettings,
+	renderOrganizeSettings,
+	renderDeepDiveSettings,
+	renderRemSettings,
+];
+
+/**
+ * Thin orchestrator for the settings tab (#243). Owns only cross-cutting
+ * concerns: the version heading, section ORDER, platform gating (Video), and
+ * the global/non-feature sections (AI Configuration, Auto-Accept Proposals).
+ * Each feature renders its own section through a `render<Feature>Settings(ctx)`
+ * function imported from the feature's public `index.ts` — the tab never reaches
+ * into a feature's internals, and no feature imports from this file.
+ */
 export class SynapseSettingTab extends PluginSettingTab {
 	constructor(app: App, private plugin: SynapsePlugin) {
 		super(app, plugin);
@@ -96,89 +140,47 @@ export class SynapseSettingTab extends PluginSettingTab {
 		}
 	}
 
-	/**
-	 * Resolve the persisted collapse state for a section, falling back to a
-	 * sensible default: collapsed when the feature is disabled, expanded when
-	 * it is enabled. A `null` `enabled` (config sections with no toggle, e.g.
-	 * AI Configuration) defaults to expanded.
-	 */
-	private isSectionCollapsed(key: string, enabled: boolean | null): boolean {
-		const persisted = this.plugin.settings.ui.collapsedSections[key];
-		if (persisted !== undefined) return persisted;
-		return enabled === false;
-	}
-
-	/** Persist a section's collapse state and save. */
-	private async persistCollapse(key: string, collapsed: boolean): Promise<void> {
-		this.plugin.settings.ui.collapsedSections[key] = collapsed;
-		await this.plugin.saveSettings();
-	}
-
-	/**
-	 * Render a feature accordion with an enable toggle in the header and return
-	 * the body element to populate with the feature's sub-settings.
-	 *
-	 * The toggle is wired to the feature's `enabled` flag: turning it off
-	 * auto-collapses the body, turning it on auto-expands it. Manual header
-	 * clicks fold/unfold independently. All collapse changes persist under
-	 * `ui.collapsedSections[key]`.
-	 */
-	private featureSection(
-		containerEl: HTMLElement,
-		key: string,
-		title: string,
-		getEnabled: () => boolean,
-		setEnabled: (value: boolean) => void,
-		toggleDesc?: string,
-	): HTMLElement {
-		const enabled = getEnabled();
-		const { bodyEl } = addCollapsibleSection(containerEl, {
-			title,
-			enabled,
-			collapsed: this.isSectionCollapsed(key, enabled),
-			toggleAriaLabel: toggleDesc ?? `Enable ${title}`,
-			onToggle: async (value) => {
-				setEnabled(value);
-				await this.plugin.saveSettings();
-				// Greying out a feature must propagate to its Auto-Accept row in
-				// place — flip the stored Setting's disabled state directly rather
-				// than re-rendering (which would jump scroll and collapse accordions).
-				this.refreshAutoAcceptDisabledState();
-			},
-			onCollapseChange: async (collapsed) => {
-				await this.persistCollapse(key, collapsed);
-			},
-		});
-		return bodyEl;
-	}
-
-	/**
-	 * Render a config accordion that has no enable toggle (always-needed
-	 * settings). It is collapsible/persistent but never auto-collapses.
-	 */
-	private configSection(
-		containerEl: HTMLElement,
-		key: string,
-		title: string,
-	): HTMLElement {
-		const { bodyEl } = addCollapsibleSection(containerEl, {
-			title,
-			collapsed: this.isSectionCollapsed(key, null),
-			onCollapseChange: async (collapsed) => {
-				await this.persistCollapse(key, collapsed);
-			},
-		});
-		return bodyEl;
-	}
-
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
 
 		new Setting(containerEl).setHeading().setName(`Synapse v${this.plugin.manifest.version}`);
 
+		// Rebuilt each render; feature toggles flip Auto-Accept rows' disabled
+		// state live via the context's onFeatureToggle hook.
+		this.autoAcceptSettings = {};
+
+		const ctx = createSettingsSectionContext({
+			containerEl,
+			plugin: this.plugin,
+			onFeatureToggle: () => this.refreshAutoAcceptDisabledState(),
+			rerender: () => this.display(),
+		});
+
 		// ── AI Configuration (always-needed config — no enable toggle) ──
-		const aiBody = this.configSection(containerEl, 'ai', 'AI Configuration');
+		this.renderAIConfiguration(ctx);
+
+		// ── Per-feature sections, in order (Video gated to desktop) ──
+		for (const render of FEATURE_SECTION_RENDERERS) {
+			render(ctx);
+			// Video Transcription slots in after Audio (desktop only — requires
+			// yt-dlp + ffmpeg). Splicing here keeps the historical section order.
+			if (render === renderAudioSettings && Platform.isDesktop) {
+				renderVideoSettings(ctx);
+			}
+		}
+
+		// ── Auto-Accept Proposals (global, non-feature) ──
+		this.renderAutoAccept(ctx);
+	}
+
+	/**
+	 * AI Configuration — always-needed config shared across features. No enable
+	 * toggle; collapsible with persisted state. Orchestrator-owned because it is
+	 * not tied to any single feature.
+	 */
+	private renderAIConfiguration(ctx: SettingsSectionContext): void {
+		const aiBody = ctx.configSection('ai', 'AI Configuration');
 
 		new Setting(aiBody)
 			.setName('AI Provider')
@@ -293,972 +295,24 @@ export class SynapseSettingTab extends PluginSettingTab {
 				},
 			},
 		);
-
-		// ── Note Elaboration ──
-		const elaborationBody = this.featureSection(
-			containerEl,
-			'elaboration',
-			'Note Elaboration',
-			() => this.plugin.settings.elaboration.enabled,
-			(v) => { this.plugin.settings.elaboration.enabled = v; },
-			'Enable stub note detection and proposal generation',
-		);
-
-		new Setting(elaborationBody)
-			.setName('Minimum word threshold')
-			.setDesc('Notes with fewer words than this are considered stubs')
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.elaboration.detection.minWordThreshold))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.elaboration.detection.minWordThreshold = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		new Setting(elaborationBody)
-			.setName('Detect TODO markers')
-			.setDesc('Flag notes containing TODO, TBD, FIXME, PLACEHOLDER')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.elaboration.detection.detectTodoMarkers)
-					.onChange(async (value) => {
-						this.plugin.settings.elaboration.detection.detectTodoMarkers = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(elaborationBody)
-			.setName('Detect empty sections')
-			.setDesc('Flag notes with headings but no content beneath them')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.elaboration.detection.detectEmptySections)
-					.onChange(async (value) => {
-						this.plugin.settings.elaboration.detection.detectEmptySections = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(elaborationBody)
-			.setName('Excluded folders')
-			.setDesc('Comma-separated list of folders to skip')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.elaboration.detection.excludeFolders.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.elaboration.detection.excludeFolders =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		// ── Intake Folder ──
-		const intakeBody = this.featureSection(
-			containerEl,
-			'intake',
-			'Intake Folder',
-			() => this.plugin.settings.intake.enabled,
-			(v) => { this.plugin.settings.intake.enabled = v; },
-			'Watch the intake folder and run enabled Synapse features on new notes',
-		);
-
-		new Setting(intakeBody)
-			.setName('Settle window (seconds)')
-			.setDesc(
-				'Wait this long after the last change to a note before processing it. ' +
-				'The timer resets on every edit, so active typing or chunked sync keeps ' +
-				'deferring — processing fires only once the note has been quiet for the ' +
-				'full window. Raise it if notes are still arriving when they get processed.'
-			)
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.intake.settleSeconds))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.intake.settleSeconds = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		new Setting(intakeBody)
-			.setName('Intake folder')
-			.setDesc('Folder to watch for new notes. See docs/intake-folder.md for the mobile capture workflow.')
-			.addText((text) =>
-				text
-					.setPlaceholder('Inbox')
-					.setValue(this.plugin.settings.intake.intakeFolder)
-					.onChange(async (value) => {
-						this.plugin.settings.intake.intakeFolder = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(intakeBody)
-			.setName('Mark processed in frontmatter')
-			.setDesc('Stamp `synapse-processed: true` on a note once handled so it is not reprocessed')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.intake.markProcessed)
-					.onChange(async (value) => {
-						this.plugin.settings.intake.markProcessed = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(intakeBody)
-			.setName('Move when done (fallback)')
-			.setDesc(
-				'Fallback destination used only when auto-organize keeps a note in ' +
-				'the intake folder (e.g. low confidence). Notes organize relocates ' +
-				'are left where it put them. Leave blank to keep unorganized notes ' +
-				'in the intake folder.'
-			)
-			.addText((text) =>
-				text
-					.setPlaceholder('')
-					.setValue(this.plugin.settings.intake.moveWhenDone ?? '')
-					.onChange(async (value) => {
-						const trimmed = value.trim();
-						this.plugin.settings.intake.moveWhenDone = trimmed === '' ? undefined : trimmed;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(intakeBody)
-			.setName('Capture log')
-			.setDesc(
-				'When a note is auto-organized out of the intake folder, leave a ' +
-				'dated breadcrumb linking to its new home in the capture-log subfolder.'
-			)
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.intake.captureLog)
-					.onChange(async (value) => {
-						this.plugin.settings.intake.captureLog = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(intakeBody)
-			.setName('Capture log folder')
-			.setDesc(
-				'Subfolder of the intake folder for breadcrumbs (relative to it). ' +
-				'This subfolder is ignored by the watcher so breadcrumbs are never reprocessed.'
-			)
-			.addText((text) =>
-				text
-					.setPlaceholder('_captured')
-					.setValue(this.plugin.settings.intake.captureLogFolder)
-					.onChange(async (value) => {
-						const trimmed = value.trim();
-						if (trimmed.length > 0) {
-							this.plugin.settings.intake.captureLogFolder = trimmed;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		// ── Image ──
-		const imageBody = this.featureSection(
-			containerEl,
-			'image',
-			'Image',
-			() => this.plugin.settings.image.enabled,
-			(v) => { this.plugin.settings.image.enabled = v; },
-			'Run OCR and image analysis on images referenced in notes',
-		);
-
-		new Setting(imageBody)
-			.setName('Max image size (MB)')
-			.setDesc(
-				'Images whose base64 payload exceeds this size are automatically downscaled ' +
-				'before being sent to the API. The Anthropic API limit is 5 MB; lower this only ' +
-				'if your provider enforces a smaller limit.'
-			)
-			.addText((text) =>
-				text
-					.setPlaceholder('5')
-					.setValue(String(this.plugin.settings.image.maxImageSizeMb))
-					.onChange(async (value) => {
-						const num = parseFloat(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.image.maxImageSizeMb = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		// ── Audio Transcription ──
-		const audioBody = this.featureSection(
-			containerEl,
-			'audio',
-			'Audio Transcription',
-			() => this.plugin.settings.audio.enabled,
-			(v) => { this.plugin.settings.audio.enabled = v; },
-			'Enable audio transcription',
-		);
-
-		const providerOptions: Record<string, string> = {
-			'whisper-api': 'OpenAI Whisper API',
-			deepgram: 'Deepgram',
-		};
-		// 'local-whisper' is intentionally hidden from the dropdown until implemented
-		// (see src/audio/transcriber.ts). The type is kept for forward compatibility.
-
-		new Setting(audioBody)
-			.setName('Transcription provider')
-			.addDropdown((dd) =>
-				dd
-					.addOptions(providerOptions)
-					.setValue(this.plugin.settings.audio.transcriptionProvider)
-					.onChange(async (value) => {
-						this.plugin.settings.audio.transcriptionProvider =
-							value as 'whisper-api' | 'deepgram' | 'local-whisper';
-						await this.plugin.saveSettings();
-						this.display(); // Re-render to show/hide provider-specific fields
-					})
-			);
-
-		// Show Whisper API key field when provider is whisper-api and AI provider isn't OpenAI
-		// (if AI provider is OpenAI, the shared API key is already an OpenAI key)
-		if (
-			this.plugin.settings.audio.transcriptionProvider === 'whisper-api' &&
-			this.plugin.settings.ai.provider !== 'openai'
-		) {
-			new Setting(audioBody)
-				.setName('OpenAI API Key (Whisper)')
-				.setDesc(
-					'Whisper uses the OpenAI API. Provide your OpenAI key here since your AI provider is set to ' +
-					this.plugin.settings.ai.provider.charAt(0).toUpperCase() +
-					this.plugin.settings.ai.provider.slice(1) + '.'
-				)
-				.addText((text) => {
-					text
-						.setPlaceholder('sk-...')
-						.setValue(this.plugin.settings.audio.whisperApiKey)
-						.onChange(async (value) => {
-							this.plugin.settings.audio.whisperApiKey = value;
-							await this.plugin.saveSettings();
-						});
-					text.inputEl.type = 'password';
-					text.inputEl.autocomplete = 'off';
-				});
-		}
-
-		if (this.plugin.settings.audio.transcriptionProvider === 'deepgram') {
-			new Setting(audioBody)
-				.setName('Deepgram API Key')
-				.setDesc('Required for Deepgram transcription provider')
-				.addText((text) => {
-					text
-						.setPlaceholder('dg-...')
-						.setValue(this.plugin.settings.audio.deepgramApiKey)
-						.onChange(async (value) => {
-							this.plugin.settings.audio.deepgramApiKey = value;
-							await this.plugin.saveSettings();
-						});
-					text.inputEl.type = 'password';
-					text.inputEl.autocomplete = 'off';
-				});
-		}
-
-		new Setting(audioBody)
-			.setName('Language')
-			.setDesc('Audio language for transcription (auto-detect if empty)')
-			.addDropdown((dd) =>
-				dd
-					.addOptions({
-						'': 'Auto-detect',
-						en: 'English',
-						es: 'Spanish',
-						fr: 'French',
-						de: 'German',
-						ja: 'Japanese',
-						zh: 'Chinese',
-						ko: 'Korean',
-						pt: 'Portuguese',
-						ru: 'Russian',
-						ar: 'Arabic',
-						hi: 'Hindi',
-						it: 'Italian',
-						nl: 'Dutch',
-						pl: 'Polish',
-						sv: 'Swedish',
-						tr: 'Turkish',
-					})
-					.setValue(this.plugin.settings.audio.language)
-					.onChange(async (value) => {
-						this.plugin.settings.audio.language = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(audioBody)
-			.setName('Post-processing')
-			.setDesc('Clean up and structure transcriptions with AI')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.audio.postProcessing.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.audio.postProcessing.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(audioBody)
-			.setName('Remove filler words')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.audio.postProcessing.removeFiller)
-					.onChange(async (value) => {
-						this.plugin.settings.audio.postProcessing.removeFiller = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		// ── Video Transcription (desktop only — requires yt-dlp + ffmpeg) ──
-		if (Platform.isDesktop) {
-			const videoBody = this.featureSection(
-				containerEl,
-				'video',
-				'Video Transcription',
-				() => this.plugin.settings.video.enabled,
-				(v) => { this.plugin.settings.video.enabled = v; },
-				'Enable video transcription',
-			);
-
-			new Setting(videoBody)
-				.setName('yt-dlp path')
-				.setDesc('Path to yt-dlp binary')
-				.addText((text) =>
-					text
-						.setValue(this.plugin.settings.video.ytDlpPath)
-						.onChange(async (value) => {
-							this.plugin.settings.video.ytDlpPath = value;
-							await this.plugin.saveSettings();
-						})
-				);
-
-			new Setting(videoBody)
-				.setName('ffmpeg path')
-				.setDesc('Path to ffmpeg binary')
-				.addText((text) =>
-					text
-						.setValue(this.plugin.settings.video.ffmpegPath)
-						.onChange(async (value) => {
-							this.plugin.settings.video.ffmpegPath = value;
-							await this.plugin.saveSettings();
-						})
-				);
-
-			new Setting(videoBody)
-				.setName('Video download folder')
-				.setDesc('Where to save downloaded video files in the vault')
-				.addText((text) =>
-					text
-						.setValue(this.plugin.settings.video.downloadFolder)
-						.onChange(async (value) => {
-							this.plugin.settings.video.downloadFolder = value;
-							await this.plugin.saveSettings();
-						})
-				);
-
-			new Setting(videoBody)
-				.setName('Embed video in note')
-				.setDesc('Add an embed link to the downloaded video file in the note')
-				.addToggle((toggle) =>
-					toggle
-						.setValue(this.plugin.settings.video.embedInNote)
-						.onChange(async (value) => {
-							this.plugin.settings.video.embedInNote = value;
-							await this.plugin.saveSettings();
-						})
-				);
-		}
-
-		// ── Note Enrichment ──
-		const enrichmentBody = this.featureSection(
-			containerEl,
-			'enrichment',
-			'Note Enrichment',
-			() => this.plugin.settings.enrichment.enabled,
-			(v) => { this.plugin.settings.enrichment.enabled = v; },
-			'Add tags, links, references, and metadata to notes',
-		);
-
-		new Setting(enrichmentBody)
-			.setName('Auto-enrich')
-			.setDesc('Automatically generate enrichment proposals after elaboration or transcription')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.enrichment.autoEnrich)
-					.onChange(async (value) => {
-						this.plugin.settings.enrichment.autoEnrich = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(enrichmentBody)
-			.setName('Max metadata tags')
-			.setDesc('Maximum number of metadata tags (status, type, source) to suggest per note')
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.enrichment.maxTags))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.enrichment.maxTags = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		new Setting(enrichmentBody)
-			.setName('Max topic links')
-			.setDesc('Maximum number of AI-extracted topic links to suggest')
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.enrichment.maxTopicLinks))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.enrichment.maxTopicLinks = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		new Setting(enrichmentBody)
-			.setName('Suggest new notes')
-			.setDesc('Suggest links to notes that don\'t exist yet (Obsidian grayed-out links)')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.enrichment.suggestNewNotes)
-					.onChange(async (value) => {
-						this.plugin.settings.enrichment.suggestNewNotes = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(enrichmentBody)
-			.setName('Max internal links')
-			.setDesc('Maximum number of related note links to suggest')
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.enrichment.maxInternalLinks))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.enrichment.maxInternalLinks = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		new Setting(enrichmentBody)
-			.setName('Max external references')
-			.setDesc('Maximum external links to suggest (stingy — keep this low)')
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.enrichment.maxExternalLinks))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num >= 0) {
-							this.plugin.settings.enrichment.maxExternalLinks = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		addEnhancedSlider(
-			new Setting(enrichmentBody)
-				.setName('Internal link threshold')
-				.setDesc('Minimum relevance score for internal links (0-1, lower = more liberal)'),
-			{
-				min: 0,
-				max: 1,
-				step: 0.05,
-				value: this.plugin.settings.enrichment.internalLinkThreshold,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.enrichment.internalLinkThreshold = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		// Weight settings (sub-section within enrichment)
-		new Setting(enrichmentBody).setHeading().setName('Proximity Weights');
-
-		type WeightKey = keyof import('./settings').EnrichmentWeightSettings;
-		const weightFields: Array<{ key: WeightKey; name: string; desc: string }> = [
-			{ key: 'sameFolder', name: 'Same folder', desc: 'Weight for files in the same folder' },
-			{ key: 'siblingFolder', name: 'Sibling folder', desc: 'Weight for files in sibling folders' },
-			{ key: 'cousinFolder', name: 'Cousin folder', desc: 'Weight for files two levels apart' },
-			{ key: 'distantFolder', name: 'Distant folder', desc: 'Weight for files in distant folders' },
-			{ key: 'decayPerLevel', name: 'Decay per level', desc: 'Weight reduction per additional folder hop' },
-			{ key: 'minWeight', name: 'Minimum weight', desc: 'Floor weight — distant files are never invisible' },
-		];
-
-		for (const field of weightFields) {
-			const key = field.key;
-			addEnhancedSlider(
-				new Setting(enrichmentBody)
-					.setName(field.name)
-					.setDesc(field.desc),
-				{
-					min: 0,
-					max: 1,
-					step: 0.05,
-					value: this.plugin.settings.enrichment.weights[key],
-					showTicks: true,
-					onChange: async (value) => {
-						this.plugin.settings.enrichment.weights[key] = value;
-						await this.plugin.saveSettings();
-					},
-				},
-			);
-		}
-
-		// Tag Vocabulary (sub-section within enrichment)
-		new Setting(enrichmentBody).setHeading().setName('Tag Vocabulary').setDesc('Define metadata tag categories. Tags classify notes (status, type, source) — topics become [[links]] instead.');
-
-		for (let i = 0; i < this.plugin.settings.enrichment.tagVocabulary.length; i++) {
-			const entry = this.plugin.settings.enrichment.tagVocabulary[i];
-
-			new Setting(enrichmentBody)
-				.setName(entry.category)
-				.setDesc(entry.description)
-				.addText((text) =>
-					text
-						.setValue(entry.tags.join(', '))
-						.setPlaceholder('tag1, tag2, tag3')
-						.onChange(async (value) => {
-							this.plugin.settings.enrichment.tagVocabulary[i].tags =
-								value.split(',').map(s => s.trim()).filter(Boolean);
-							await this.plugin.saveSettings();
-						})
-				);
-		}
-
-		new Setting(enrichmentBody)
-			.setName('Excluded folders')
-			.setDesc('Comma-separated list of folders to skip for enrichment')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.enrichment.excludeFolders.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.enrichment.excludeFolders =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(enrichmentBody)
-			.setName('Excluded tags')
-			.setDesc('Notes with these tags will skip enrichment')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.enrichment.excludeTags.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.enrichment.excludeTags =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		// ── Summarize ──
-		const summarizeBody = this.featureSection(
-			containerEl,
-			'summarize',
-			'Summarize',
-			() => this.plugin.settings.summarize.enabled,
-			(v) => { this.plugin.settings.summarize.enabled = v; },
-			'Summarize URLs and transcriptions in notes',
-		);
-
-		new Setting(summarizeBody)
-			.setName('Summary style')
-			.setDesc('Format for generated summaries')
-			.addDropdown((dd) =>
-				dd
-					.addOptions({
-						bullets: 'Bullet Points',
-						paragraph: 'Paragraph',
-						'key-points': 'Key Points',
-					})
-					.setValue(this.plugin.settings.summarize.summaryStyle)
-					.onChange(async (value) => {
-						this.plugin.settings.summarize.summaryStyle =
-							value as 'bullets' | 'paragraph' | 'key-points';
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(summarizeBody)
-			.setName('Auto-detect content templates')
-			.setDesc('Automatically detect content type (e.g. recipes) and use a specialized summary format')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.summarize.autoDetectTemplates)
-				.onChange(async (value) => {
-					this.plugin.settings.summarize.autoDetectTemplates = value;
-					await this.plugin.saveSettings();
-				}));
-
-		addEnhancedSlider(
-			new Setting(summarizeBody)
-				.setName('Max content length')
-				.setDesc('Maximum characters of content to send to AI for summarization'),
-			{
-				min: 1000,
-				max: 10000,
-				step: 500,
-				value: this.plugin.settings.summarize.maxContentLength,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.summarize.maxContentLength = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		new Setting(summarizeBody)
-			.setName('Custom prompt')
-			.setDesc('Override the default summarization prompt (leave empty for default)')
-			.addTextArea((text) =>
-				text
-					.setPlaceholder('Custom summarization instructions...')
-					.setValue(this.plugin.settings.summarize.customPrompt)
-					.onChange(async (value) => {
-						this.plugin.settings.summarize.customPrompt = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(summarizeBody)
-			.setName('Excluded folders')
-			.setDesc('Comma-separated list of folders to skip for summarization')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.summarize.excludeFolders.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.summarize.excludeFolders =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(summarizeBody)
-			.setName('Excluded tags')
-			.setDesc('Notes with these tags will skip summarization')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.summarize.excludeTags.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.summarize.excludeTags =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(summarizeBody)
-			.setName('Auto-organize after summarize')
-			.setDesc('Automatically organize the current note after summarization completes (single-note only, not vault-wide)')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.summarize.autoOrganizeOnSummarize)
-					.onChange(async (value) => {
-						this.plugin.settings.summarize.autoOrganizeOnSummarize = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		// ── Note Tidy ──
-		const tidyBody = this.featureSection(
-			containerEl,
-			'tidy',
-			'Note Tidy',
-			() => this.plugin.settings.tidy.enabled,
-			(v) => { this.plugin.settings.tidy.enabled = v; },
-			'Spelling correction and markdown formatting (no content changes)',
-		);
-
-		tidyBody.createDiv({
-			cls: 'setting-item-description synapse-accordion-empty-note',
-			text: 'Tidy applies spelling correction and markdown formatting without changing content. No additional options.',
-		});
-
-		// ── Note Organize ──
-		const organizeBody = this.featureSection(
-			containerEl,
-			'organize',
-			'Note Organize',
-			() => this.plugin.settings.organize.enabled,
-			(v) => { this.plugin.settings.organize.enabled = v; },
-			'AI-powered semantic directory structuring for notes',
-		);
-
-		addEnhancedSlider(
-			new Setting(organizeBody)
-				.setName('New folder confidence threshold')
-				.setDesc('Minimum topic confidence to propose a new folder (0.5-1.0). Higher = fewer new folders.'),
-			{
-				min: 0.5,
-				max: 1.0,
-				step: 0.05,
-				value: this.plugin.settings.organize.organizeConfidenceThreshold,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.organize.organizeConfidenceThreshold = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		new Setting(organizeBody)
-			.setName('Excluded folders')
-			.setDesc('Comma-separated list of folders to skip for organization')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.organize.excludeFolders.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.organize.excludeFolders =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(organizeBody)
-			.setName('Excluded tags')
-			.setDesc('Notes with these tags will skip organization')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.organize.excludeTags.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.organize.excludeTags =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		// ── Deep Dive ──
-		const deepDiveBody = this.featureSection(
-			containerEl,
-			'deepDive',
-			'Deep Dive',
-			() => this.plugin.settings.deepDive.enabled,
-			(v) => { this.plugin.settings.deepDive.enabled = v; },
-			'Recursively explore a note into a tree of interlinked child notes',
-		);
-
-		addEnhancedSlider(
-			new Setting(deepDiveBody)
-				.setName('Max depth')
-				.setDesc('Maximum levels of recursion (1-5)'),
-			{
-				min: 1,
-				max: 5,
-				step: 1,
-				value: this.plugin.settings.deepDive.maxDepth,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.deepDive.maxDepth = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		addEnhancedSlider(
-			new Setting(deepDiveBody)
-				.setName('Quality threshold')
-				.setDesc('Minimum quality score to continue recursing (0.1-0.9)'),
-			{
-				min: 0.1,
-				max: 0.9,
-				step: 0.05,
-				value: this.plugin.settings.deepDive.qualityThreshold,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.deepDive.qualityThreshold = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		addEnhancedSlider(
-			new Setting(deepDiveBody)
-				.setName('Max notes per run')
-				.setDesc('Maximum number of notes to generate in a single deep dive (10-100)'),
-			{
-				min: 10,
-				max: 100,
-				step: 5,
-				value: this.plugin.settings.deepDive.maxNotesPerRun,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.deepDive.maxNotesPerRun = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		new Setting(deepDiveBody)
-			.setName('Note output folder')
-			.setDesc('Where to create new notes. Uses a subfolder per root note. (empty = same folder as source)')
-			.addText((text) =>
-				text
-					.setPlaceholder('Deep Dives')
-					.setValue(this.plugin.settings.deepDive.noteOutputFolder)
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.noteOutputFolder = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(deepDiveBody)
-			.setName('Folder nesting mode')
-			.setDesc('How child notes are placed: nested under parent topic folders, flat in a single folder, or AI-organized by content semantics')
-			.addDropdown((dd) =>
-				dd
-					.addOptions({
-						nested: 'Nested (subfolder per parent topic)',
-						flat: 'Flat (all in root subfolder)',
-						'auto-organize': 'Auto-organize (AI-based placement)',
-					})
-					.setValue(this.plugin.settings.deepDive.nestingMode || 'nested')
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.nestingMode =
-							value as 'nested' | 'flat' | 'auto-organize';
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(deepDiveBody)
-			.setName('Auto-enrich on accept')
-			.setDesc('Automatically trigger enrichment when a deep dive note is accepted')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.deepDive.autoEnrichOnAccept)
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.autoEnrichOnAccept = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(deepDiveBody)
-			.setName('Auto-organize on accept')
-			.setDesc('Automatically trigger organize when a deep dive note is accepted')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.deepDive.autoOrganizeOnAccept)
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.autoOrganizeOnAccept = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(deepDiveBody)
-			.setName('Excluded folders')
-			.setDesc('Comma-separated list of folders to skip for deep dive')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.deepDive.excludeFolders.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.excludeFolders =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(deepDiveBody)
-			.setName('Excluded tags')
-			.setDesc('Notes with these tags will skip deep dive')
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.deepDive.excludeTags.join(', '))
-					.onChange(async (value) => {
-						this.plugin.settings.deepDive.excludeTags =
-							value.split(',').map((s) => s.trim()).filter(Boolean);
-						await this.plugin.saveSettings();
-					})
-			);
-
-		// ── REM (Link Discovery) ──
-		const remBody = this.featureSection(
-			containerEl,
-			'rem',
-			'REM (Link Discovery)',
-			() => this.plugin.settings.rem.enabled,
-			(v) => { this.plugin.settings.rem.enabled = v; },
-			'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions',
-		);
-
-		new Setting(remBody)
-			.setName('Semantic matching')
-			.setDesc('Use AI to find conceptual matches beyond literal title/alias matching')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.rem.semanticMatching)
-					.onChange(async (value) => {
-						this.plugin.settings.rem.semanticMatching = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		addEnhancedSlider(
-			new Setting(remBody)
-				.setName('Confidence threshold')
-				.setDesc('Minimum confidence for semantic matches (0-1)'),
-			{
-				min: 0,
-				max: 1,
-				step: 0.05,
-				value: this.plugin.settings.rem.confidenceThreshold,
-				showTicks: true,
-				onChange: async (value) => {
-					this.plugin.settings.rem.confidenceThreshold = value;
-					await this.plugin.saveSettings();
-				},
-			},
-		);
-
-		new Setting(remBody)
-			.setName('Max links per note')
-			.setDesc('Maximum number of link candidates to suggest per scanned note')
-			.addText((text) =>
-				text
-					.setValue(String(this.plugin.settings.rem.maxLinksPerNote))
-					.onChange(async (value) => {
-						const num = parseInt(value);
-						if (!isNaN(num) && num > 0) {
-							this.plugin.settings.rem.maxLinksPerNote = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
-
-		// ── Auto-Accept Proposals (no enable toggle — a group of per-kind toggles) ──
+	}
+
+	/**
+	 * Auto-Accept Proposals — a group of per-kind toggles with no feature enable
+	 * toggle. Orchestrator-owned: each row's disabled state mirrors its producing
+	 * feature's enabled flag, and feature toggles refresh these rows live via
+	 * {@link refreshAutoAcceptDisabledState}.
+	 */
+	private renderAutoAccept(ctx: SettingsSectionContext): void {
 		// Rendered like the AI Configuration section: a collapsible config
 		// section with no header toggle, persisting its own collapse state.
-		const autoAcceptBody = this.configSection(
-			containerEl,
-			'autoAccept',
-			'Auto-Accept Proposals',
-		);
+		const autoAcceptBody = ctx.configSection('autoAccept', 'Auto-Accept Proposals');
 
 		autoAcceptBody.createDiv({
 			cls: 'setting-item-description synapse-accordion-empty-note',
 			text: 'When enabled for a proposal type, future proposals of that type are accepted automatically as generated, applied without review. Already-pending proposals are left untouched. Off by default for every type.',
 		});
 
-		// Rebuilt each render; feature toggles flip these rows' disabled state live.
-		this.autoAcceptSettings = {};
 		for (const kind of PROPOSAL_KINDS) {
 			const { name } = AUTO_ACCEPT_LABELS[kind];
 			const setting = new Setting(autoAcceptBody)

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -59,6 +59,15 @@ export type {
 	CollapsibleSection,
 	CollapsibleSectionOptions,
 } from './collapsible-section';
+export {
+	createSettingsSectionContext,
+	isSectionCollapsed,
+	persistCollapse,
+} from './settings-section';
+export type {
+	SettingsSectionContext,
+	SettingsSectionContextOptions,
+} from './settings-section';
 export { generateId, isValidCheckpointId } from './id-utils';
 export { CheckpointManager } from './checkpoint-manager';
 export type {

--- a/src/shared/settings-section.ts
+++ b/src/shared/settings-section.ts
@@ -1,0 +1,150 @@
+import type SynapsePlugin from '../main';
+import { addCollapsibleSection } from './collapsible-section';
+
+/**
+ * Shared accordion plumbing for the settings tab (#243).
+ *
+ * The settings tab is a thin orchestrator that owns section ORDER and the
+ * cross-cutting sections (AI Configuration, Auto-Accept). Each feature renders
+ * its own section through a uniform `render<Feature>Settings(ctx)` function that
+ * receives a {@link SettingsSectionContext}. This module is the only place that
+ * knows how an accordion is built, so feature modules never import from
+ * `settings-tab.ts` — they depend on `shared/` only.
+ */
+export interface SettingsSectionContext {
+	/** The settings tab's root container element. */
+	containerEl: HTMLElement;
+	/** The plugin instance (settings + saveSettings + manifest). */
+	plugin: SynapsePlugin;
+	/**
+	 * Render a feature accordion with an enable toggle in the header and return
+	 * the body element to populate with the feature's sub-settings.
+	 *
+	 * The toggle is wired to the feature's `enabled` flag: turning it off
+	 * auto-collapses the body, turning it on auto-expands it. Manual header
+	 * clicks fold/unfold independently. All collapse changes persist under
+	 * `ui.collapsedSections[key]`. After the toggle changes (and the new value
+	 * is saved), the context's `onFeatureToggle` hook fires so the orchestrator
+	 * can react — e.g. grey out the matching Auto-Accept row in place.
+	 */
+	featureSection(
+		key: string,
+		title: string,
+		getEnabled: () => boolean,
+		setEnabled: (value: boolean) => void,
+		toggleDesc?: string,
+	): HTMLElement;
+	/**
+	 * Render a config accordion that has no enable toggle (always-needed
+	 * settings). It is collapsible/persistent but never auto-collapses.
+	 */
+	configSection(key: string, title: string): HTMLElement;
+	/**
+	 * Trigger a full re-render of the settings tab. Used by sections whose layout
+	 * depends on a just-changed value (e.g. the audio transcription provider
+	 * dropdown showing/hiding provider-specific fields).
+	 */
+	rerender: () => void;
+}
+
+/**
+ * Options for {@link createSettingsSectionContext}. The orchestrator supplies
+ * the container, plugin, a re-render hook, and an optional post-toggle hook.
+ */
+export interface SettingsSectionContextOptions {
+	containerEl: HTMLElement;
+	plugin: SynapsePlugin;
+	/**
+	 * Invoked after any feature header enable-toggle changes and the new value
+	 * is persisted. Lets the orchestrator propagate the change live (without a
+	 * full re-render) — e.g. refresh Auto-Accept rows' disabled state.
+	 */
+	onFeatureToggle?: () => void | Promise<void>;
+	/** Full re-render hook (defaults to a no-op). */
+	rerender?: () => void;
+}
+
+/**
+ * Resolve the persisted collapse state for a section, falling back to a
+ * sensible default: collapsed when the feature is disabled, expanded when it is
+ * enabled. A `null` `enabled` (config sections with no toggle, e.g. AI
+ * Configuration) defaults to expanded.
+ */
+export function isSectionCollapsed(
+	plugin: SynapsePlugin,
+	key: string,
+	enabled: boolean | null,
+): boolean {
+	const persisted = plugin.settings.ui.collapsedSections[key];
+	if (persisted !== undefined) return persisted;
+	return enabled === false;
+}
+
+/** Persist a section's collapse state and save. */
+export async function persistCollapse(
+	plugin: SynapsePlugin,
+	key: string,
+	collapsed: boolean,
+): Promise<void> {
+	plugin.settings.ui.collapsedSections[key] = collapsed;
+	await plugin.saveSettings();
+}
+
+/**
+ * Build a {@link SettingsSectionContext} bound to a plugin and container. The
+ * returned `featureSection`/`configSection` helpers close over the collapse
+ * persistence and the post-toggle hook so feature renderers stay declarative.
+ */
+export function createSettingsSectionContext(
+	options: SettingsSectionContextOptions,
+): SettingsSectionContext {
+	const { containerEl, plugin, onFeatureToggle, rerender } = options;
+
+	function featureSection(
+		key: string,
+		title: string,
+		getEnabled: () => boolean,
+		setEnabled: (value: boolean) => void,
+		toggleDesc?: string,
+	): HTMLElement {
+		const enabled = getEnabled();
+		const { bodyEl } = addCollapsibleSection(containerEl, {
+			title,
+			enabled,
+			collapsed: isSectionCollapsed(plugin, key, enabled),
+			toggleAriaLabel: toggleDesc ?? `Enable ${title}`,
+			onToggle: async (value) => {
+				setEnabled(value);
+				await plugin.saveSettings();
+				// Greying out a feature must propagate to its Auto-Accept row in
+				// place — the orchestrator flips the stored Setting's disabled
+				// state directly rather than re-rendering (which would jump scroll
+				// and collapse accordions).
+				await onFeatureToggle?.();
+			},
+			onCollapseChange: async (collapsed) => {
+				await persistCollapse(plugin, key, collapsed);
+			},
+		});
+		return bodyEl;
+	}
+
+	function configSection(key: string, title: string): HTMLElement {
+		const { bodyEl } = addCollapsibleSection(containerEl, {
+			title,
+			collapsed: isSectionCollapsed(plugin, key, null),
+			onCollapseChange: async (collapsed) => {
+				await persistCollapse(plugin, key, collapsed);
+			},
+		});
+		return bodyEl;
+	}
+
+	return {
+		containerEl,
+		plugin,
+		featureSection,
+		configSection,
+		rerender: rerender ?? (() => {}),
+	};
+}

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -819,3 +819,6 @@ export class SummarizeModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderSummarizeSettings } from './settings-section';

--- a/src/summarize/settings-section.test.ts
+++ b/src/summarize/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderSummarizeSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Summarize URLs and transcriptions in notes';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderSummarizeSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.summarize.enabled = true; });
+		renderSummarizeSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.summarize.enabled = true; });
+		renderSummarizeSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.summarize.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/summarize/settings-section.ts
+++ b/src/summarize/settings-section.ts
@@ -1,0 +1,114 @@
+import { Setting } from 'obsidian';
+import { addEnhancedSlider } from '../shared';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Summarize settings accordion (#243).
+ */
+export function renderSummarizeSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const summarizeBody = ctx.featureSection(
+		'summarize',
+		'Summarize',
+		() => plugin.settings.summarize.enabled,
+		(v) => { plugin.settings.summarize.enabled = v; },
+		'Summarize URLs and transcriptions in notes',
+	);
+
+	new Setting(summarizeBody)
+		.setName('Summary style')
+		.setDesc('Format for generated summaries')
+		.addDropdown((dd) =>
+			dd
+				.addOptions({
+					bullets: 'Bullet Points',
+					paragraph: 'Paragraph',
+					'key-points': 'Key Points',
+				})
+				.setValue(plugin.settings.summarize.summaryStyle)
+				.onChange(async (value) => {
+					plugin.settings.summarize.summaryStyle =
+						value as 'bullets' | 'paragraph' | 'key-points';
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(summarizeBody)
+		.setName('Auto-detect content templates')
+		.setDesc('Automatically detect content type (e.g. recipes) and use a specialized summary format')
+		.addToggle(toggle => toggle
+			.setValue(plugin.settings.summarize.autoDetectTemplates)
+			.onChange(async (value) => {
+				plugin.settings.summarize.autoDetectTemplates = value;
+				await plugin.saveSettings();
+			}));
+
+	addEnhancedSlider(
+		new Setting(summarizeBody)
+			.setName('Max content length')
+			.setDesc('Maximum characters of content to send to AI for summarization'),
+		{
+			min: 1000,
+			max: 10000,
+			step: 500,
+			value: plugin.settings.summarize.maxContentLength,
+			showTicks: true,
+			onChange: async (value) => {
+				plugin.settings.summarize.maxContentLength = value;
+				await plugin.saveSettings();
+			},
+		},
+	);
+
+	new Setting(summarizeBody)
+		.setName('Custom prompt')
+		.setDesc('Override the default summarization prompt (leave empty for default)')
+		.addTextArea((text) =>
+			text
+				.setPlaceholder('Custom summarization instructions...')
+				.setValue(plugin.settings.summarize.customPrompt)
+				.onChange(async (value) => {
+					plugin.settings.summarize.customPrompt = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(summarizeBody)
+		.setName('Excluded folders')
+		.setDesc('Comma-separated list of folders to skip for summarization')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.summarize.excludeFolders.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.summarize.excludeFolders =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(summarizeBody)
+		.setName('Excluded tags')
+		.setDesc('Notes with these tags will skip summarization')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.summarize.excludeTags.join(', '))
+				.onChange(async (value) => {
+					plugin.settings.summarize.excludeTags =
+						value.split(',').map((s) => s.trim()).filter(Boolean);
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(summarizeBody)
+		.setName('Auto-organize after summarize')
+		.setDesc('Automatically organize the current note after summarization completes (single-note only, not vault-wide)')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.summarize.autoOrganizeOnSummarize)
+				.onChange(async (value) => {
+					plugin.settings.summarize.autoOrganizeOnSummarize = value;
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -177,3 +177,6 @@ export class TidyModule {
 	}
 
 }
+
+// Settings section renderer (#243)
+export { renderTidySettings } from './settings-section';

--- a/src/tidy/settings-section.test.ts
+++ b/src/tidy/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderTidySettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Spelling correction and markdown formatting (no content changes)';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderTidySettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.tidy.enabled = true; });
+		renderTidySettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.tidy.enabled = true; });
+		renderTidySettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.tidy.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/tidy/settings-section.ts
+++ b/src/tidy/settings-section.ts
@@ -1,0 +1,22 @@
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Note Tidy settings accordion (#243). Tidy has no configurable
+ * options — just an empty-note placeholder in the body.
+ */
+export function renderTidySettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const tidyBody = ctx.featureSection(
+		'tidy',
+		'Note Tidy',
+		() => plugin.settings.tidy.enabled,
+		(v) => { plugin.settings.tidy.enabled = v; },
+		'Spelling correction and markdown formatting (no content changes)',
+	);
+
+	tidyBody.createDiv({
+		cls: 'setting-item-description synapse-accordion-empty-note',
+		text: 'Tidy applies spelling correction and markdown formatting without changing content. No additional options.',
+	});
+}

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -345,3 +345,6 @@ export class VideoModule {
 		}
 	}
 }
+
+// Settings section renderer (#243)
+export { renderVideoSettings } from './settings-section';

--- a/src/video/settings-section.test.ts
+++ b/src/video/settings-section.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderVideoSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP = 'Enable video transcription';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderVideoSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the feature header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.video.enabled = true; });
+		renderVideoSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.video.enabled = true; });
+		renderVideoSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.video.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+});

--- a/src/video/settings-section.ts
+++ b/src/video/settings-section.ts
@@ -1,0 +1,69 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Render the Video Transcription settings accordion (#243).
+ *
+ * NOTE: This feature is desktop-only (requires yt-dlp + ffmpeg). The
+ * `Platform.isDesktop` gate lives in the orchestrator (`settings-tab.ts`),
+ * which only invokes this renderer on desktop — keep it that way.
+ */
+export function renderVideoSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const videoBody = ctx.featureSection(
+		'video',
+		'Video Transcription',
+		() => plugin.settings.video.enabled,
+		(v) => { plugin.settings.video.enabled = v; },
+		'Enable video transcription',
+	);
+
+	new Setting(videoBody)
+		.setName('yt-dlp path')
+		.setDesc('Path to yt-dlp binary')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.video.ytDlpPath)
+				.onChange(async (value) => {
+					plugin.settings.video.ytDlpPath = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(videoBody)
+		.setName('ffmpeg path')
+		.setDesc('Path to ffmpeg binary')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.video.ffmpegPath)
+				.onChange(async (value) => {
+					plugin.settings.video.ffmpegPath = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(videoBody)
+		.setName('Video download folder')
+		.setDesc('Where to save downloaded video files in the vault')
+		.addText((text) =>
+			text
+				.setValue(plugin.settings.video.downloadFolder)
+				.onChange(async (value) => {
+					plugin.settings.video.downloadFolder = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(videoBody)
+		.setName('Embed video in note')
+		.setDesc('Add an embed link to the downloaded video file in the note')
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.video.embedInNote)
+				.onChange(async (value) => {
+					plugin.settings.video.embedInNote = value;
+					await plugin.saveSettings();
+				})
+		);
+}


### PR DESCRIPTION
## Summary

Decompose the ~1,218-line `src/settings-tab.ts` (single `display()` rendering every feature inline) into a **thin orchestrator** plus a uniform **per-feature settings renderer**.

closes #243

> ⚠️ **Stacked PR** — base is `feat/issue-242-disable-autoaccept-toggles` (PR #247), **not** `main`. This PR's diff contains only the #243 refactor. **Merge after #247.**

## What changed
- **Shared accordion plumbing** lifted into `src/shared/settings-section.ts`: a `SettingsSectionContext` type + `createSettingsSectionContext()` factory carrying `containerEl`, `plugin`, `featureSection`/`configSection` helpers, `isSectionCollapsed`, `persistCollapse`, a `rerender` hook, and an `onFeatureToggle` hook. Re-exported from `src/shared/index.ts` (beside `addCollapsibleSection`, `addEnhancedSlider`).
- **Per-feature renderers**: each feature exposes `renderXSettings(ctx)` in `src/<feature>/settings-section.ts`, re-exported from its `index.ts` public API. Extracted: elaboration, intake, image, audio, video, enrichment, summarize, tidy, organize, deep-dive, rem.
- **Thin orchestrator**: `settings-tab.ts` (1283 → 337 lines) keeps only cross-cutting concerns — version heading, section order, Video's `Platform.isDesktop` gate, and the orchestrator-owned **AI Configuration** and **Auto-Accept Proposals** sections. `display()` iterates the ordered renderer list.

## Architecture
- Dependency direction respected: feature modules → `shared` only. The tab imports each feature's `index.ts`; **no feature imports from `settings-tab.ts`** (verified). No circular runtime deps (the shared helper's `SynapsePlugin` import is type-only).
- kebab-case filenames, named exports, uniform renderer signature.

## Behavior preserved exactly (no functional change)
- Section render order identical: AI Configuration, Note Elaboration, Intake Folder, Image, Audio Transcription, Video Transcription, Note Enrichment, Summarize, Note Tidy, Note Organize, Deep Dive, REM, Auto-Accept Proposals.
- Collapse-persistence keys (`ui.collapsedSections[...]`), default-collapse logic, and the `deep-dive` → `deepDive` settings-key nuance.
- **#242 preserved**: auto-accept rows still grey out when their feature is disabled, stored values never reset, and feature-header toggles update the rows live (via the context's `onFeatureToggle` → `refreshAutoAcceptDisabledState()`) without a full re-render.

## Tests
- Added co-located `src/<feature>/settings-section.test.ts` (11 files, 25 tests) rendering each section in isolation against `src/__mocks__/obsidian.ts`.
- Existing `src/settings-tab.test.ts` (#242 auto-accept disable behavior) stays green.

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ — 85 files, 1059 tests
- `node esbuild.config.mjs production` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)