### PR TITLE
fix: classify network errors in the transcription pipeline

### DIFF
--- a/src/audio/transcriber.test.ts
+++ b/src/audio/transcriber.test.ts
@@ -206,6 +206,46 @@ describe('Transcriber', () => {
 			const result = await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
 			expect(result.timestamps).toBeUndefined();
 		});
+
+		describe('network failures', () => {
+			it('classifies a persistent connection-refused failure and names the Whisper API', async () => {
+				mockRequestUrl.mockRejectedValue(new Error('net::ERR_CONNECTION_REFUSED'));
+
+				const rejection = transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+				await expect(rejection).rejects.toThrow(/Whisper transcription API/);
+				await expect(rejection).rejects.toThrow(/connection refused/i);
+			});
+
+			it('retries a transient connection failure and succeeds on the second attempt', async () => {
+				mockRequestUrl
+					.mockRejectedValueOnce(new Error('net::ERR_CONNECTION_REFUSED'))
+					.mockResolvedValueOnce({
+						status: 200,
+						json: { text: 'Recovered', language: 'en', duration: 1 },
+						text: '',
+						headers: {},
+					});
+
+				const result = await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+
+				expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+				expect(result.raw).toBe('Recovered');
+			});
+
+			it('does not reclassify a 503 HTTP response as a network error', async () => {
+				mockRequestUrl.mockResolvedValue({
+					status: 503,
+					json: { error: { message: 'Service unavailable' } },
+					text: '',
+					headers: {},
+				});
+
+				await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+					.rejects.toThrow('Whisper API request failed (status 503)');
+				// A real HTTP response is not retried — single call.
+				expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+			});
+		});
 	});
 
 	describe('Deepgram API (requestUrl)', () => {
@@ -287,6 +327,52 @@ describe('Transcriber', () => {
 
 			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
 				.rejects.toThrow('Deepgram API request failed (status 401)');
+		});
+
+		describe('network failures', () => {
+			it('classifies a persistent connection-refused failure and names the Deepgram API', async () => {
+				mockRequestUrl.mockRejectedValue(new Error('net::ERR_CONNECTION_REFUSED'));
+
+				const rejection = transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
+				await expect(rejection).rejects.toThrow(/Deepgram transcription API/);
+				await expect(rejection).rejects.toThrow(/connection refused/i);
+			});
+
+			it('retries a transient connection failure and succeeds on the second attempt', async () => {
+				mockRequestUrl
+					.mockRejectedValueOnce(new Error('net::ERR_CONNECTION_REFUSED'))
+					.mockResolvedValueOnce({
+						status: 200,
+						json: {
+							results: {
+								channels: [{
+									alternatives: [{ transcript: 'recovered text' }],
+									detected_language: 'en',
+								}],
+							},
+						},
+						text: '',
+						headers: {},
+					});
+
+				const result = await transcriber.transcribe(new ArrayBuffer(8), 'audio.wav');
+
+				expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+				expect(result.raw).toBe('recovered text');
+			});
+
+			it('does not reclassify a 503 HTTP response as a network error', async () => {
+				mockRequestUrl.mockResolvedValue({
+					status: 503,
+					json: { error: 'Service unavailable' },
+					text: '',
+					headers: {},
+				});
+
+				await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
+					.rejects.toThrow('Deepgram API request failed (status 503)');
+				expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 });

--- a/src/audio/transcriber.ts
+++ b/src/audio/transcriber.ts
@@ -20,8 +20,9 @@
 //
 // Migration: native fetch -> requestUrl (completed in issue #88)
 
-import { requestUrl } from 'obsidian';
+import { requestUrl, RequestUrlParam, RequestUrlResponse } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { withRetry, classifyNetworkError, describeNetworkError } from '../shared';
 import { TranscriptionResult } from './types';
 
 /** Timeout for transcription API requests (5 minutes for large audio files). */
@@ -84,6 +85,26 @@ export function buildMultipartBody(
 export class Transcriber {
 	constructor(private getSettings: () => SynapseSettings) {}
 
+	// Retry connection-level failures only — NOT the 5-min app timeout (would mean up to 15 min).
+	private static readonly retryableNetwork = (e: unknown) => {
+		const k = classifyNetworkError(e);
+		return k === 'connection-refused' || k === 'dns' || k === 'offline';
+	};
+
+	private async requestTranscription(resource: string, params: RequestUrlParam): Promise<RequestUrlResponse> {
+		const send = () => Promise.race([
+			requestUrl(params),
+			new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error(`${resource} request timed out`)), TRANSCRIPTION_TIMEOUT_MS)),
+		]);
+		try {
+			return await withRetry(send, 2, 1000, Transcriber.retryableNetwork); // 2 attempts, 1s→2s backoff
+		} catch (error) {
+			const networkMsg = describeNetworkError(error, resource);
+			throw networkMsg ? new Error(networkMsg) : error;
+		}
+	}
+
 	async transcribe(
 		audioData: ArrayBuffer,
 		fileName: string
@@ -138,23 +159,16 @@ export class Transcriber {
 			data: audioData,
 		});
 
-		const timeout = new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error('Whisper API request timed out')), TRANSCRIPTION_TIMEOUT_MS)
-		);
-
-		const response = await Promise.race([
-			requestUrl({
-				url: 'https://api.openai.com/v1/audio/transcriptions',
-				method: 'POST',
-				headers: {
-					'Authorization': `Bearer ${apiKey}`,
-					'Content-Type': contentType,
-				},
-				body,
-				throw: false,
-			}),
-			timeout,
-		]);
+		const response = await this.requestTranscription('the Whisper transcription API', {
+			url: 'https://api.openai.com/v1/audio/transcriptions',
+			method: 'POST',
+			headers: {
+				'Authorization': `Bearer ${apiKey}`,
+				'Content-Type': contentType,
+			},
+			body,
+			throw: false,
+		});
 
 		if (response.status >= 400) {
 			throw new Error(`Whisper API request failed (status ${response.status})`);
@@ -197,23 +211,16 @@ export class Transcriber {
 			params.set('language', settings.language);
 		}
 
-		const timeout = new Promise<never>((_, reject) =>
-			setTimeout(() => reject(new Error('Deepgram API request timed out')), TRANSCRIPTION_TIMEOUT_MS)
-		);
-
-		const response = await Promise.race([
-			requestUrl({
-				url: `https://api.deepgram.com/v1/listen?${params}`,
-				method: 'POST',
-				headers: {
-					'Authorization': `Token ${settings.deepgramApiKey}`,
-					'Content-Type': 'audio/*',
-				},
-				body: audioData,
-				throw: false,
-			}),
-			timeout,
-		]);
+		const response = await this.requestTranscription('the Deepgram transcription API', {
+			url: `https://api.deepgram.com/v1/listen?${params}`,
+			method: 'POST',
+			headers: {
+				'Authorization': `Token ${settings.deepgramApiKey}`,
+				'Content-Type': 'audio/*',
+			},
+			body: audioData,
+			throw: false,
+		});
 
 		if (response.status >= 400) {
 			throw new Error(`Deepgram API request failed (status ${response.status})`);

--- a/src/shared/api-utils.test.ts
+++ b/src/shared/api-utils.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	classifyNetworkError,
+	describeNetworkError,
+	isTransientNetworkError,
+	withRetry,
+} from './api-utils';
+
+describe('classifyNetworkError', () => {
+	it('classifies Electron net::ERR_CONNECTION_REFUSED as connection-refused', () => {
+		expect(classifyNetworkError(new Error('net::ERR_CONNECTION_REFUSED'))).toBe('connection-refused');
+	});
+
+	it('classifies Node ECONNREFUSED as connection-refused', () => {
+		expect(classifyNetworkError(new Error('connect ECONNREFUSED 127.0.0.1:443'))).toBe('connection-refused');
+	});
+
+	it('classifies ENOTFOUND as dns', () => {
+		expect(classifyNetworkError(new Error('ENOTFOUND api.openai.com'))).toBe('dns');
+	});
+
+	it('classifies getaddrinfo ENOTFOUND as dns', () => {
+		expect(classifyNetworkError(new Error('getaddrinfo ENOTFOUND api.deepgram.com'))).toBe('dns');
+	});
+
+	it('classifies ETIMEDOUT as timeout', () => {
+		expect(classifyNetworkError(new Error('connect ETIMEDOUT 1.2.3.4:443'))).toBe('timeout');
+	});
+
+	it('classifies net::ERR_CONNECTION_TIMED_OUT as timeout', () => {
+		expect(classifyNetworkError(new Error('net::ERR_CONNECTION_TIMED_OUT'))).toBe('timeout');
+	});
+
+	it('returns null for a plain HTTP 500 string', () => {
+		expect(classifyNetworkError('HTTP 500')).toBeNull();
+	});
+
+	it('accepts a bare string message, not only Error instances', () => {
+		expect(classifyNetworkError('Connection refused')).toBe('connection-refused');
+	});
+});
+
+describe('isTransientNetworkError', () => {
+	it('is true for a network error', () => {
+		expect(isTransientNetworkError(new Error('ECONNREFUSED'))).toBe(true);
+	});
+
+	it('is false for a non-network error', () => {
+		expect(isTransientNetworkError(new Error('HTTP 500'))).toBe(false);
+	});
+});
+
+describe('describeNetworkError', () => {
+	it('returns a non-null message naming the resource for a network error', () => {
+		const msg = describeNetworkError(new Error('net::ERR_CONNECTION_REFUSED'), 'the Whisper transcription API');
+		expect(msg).not.toBeNull();
+		expect(msg).toContain('the Whisper transcription API');
+		expect(msg!.toLowerCase()).toContain('connection refused');
+	});
+
+	it('returns null for a non-network error', () => {
+		expect(describeNetworkError(new Error('HTTP 500'), 'the API')).toBeNull();
+	});
+});
+
+describe('withRetry', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('calls fn exactly once and rethrows when shouldRetry returns false', async () => {
+		const err = new Error('non-retryable');
+		const fn = vi.fn().mockRejectedValue(err);
+
+		await expect(withRetry(fn, 3, 0, () => false)).rejects.toThrow('non-retryable');
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries up to maxRetries when shouldRetry returns true', async () => {
+		const err = new Error('always fails');
+		const fn = vi.fn().mockRejectedValue(err);
+
+		const promise = withRetry(fn, 3, 0, () => true);
+		// Attach a rejection handler immediately so the rejection is observed.
+		const expectation = expect(promise).rejects.toThrow('always fails');
+		await vi.runAllTimersAsync();
+		await expectation;
+		expect(fn).toHaveBeenCalledTimes(3);
+	});
+
+	it('succeeds on a later attempt after transient failures', async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('transient 1'))
+			.mockRejectedValueOnce(new Error('transient 2'))
+			.mockResolvedValue('ok');
+
+		const promise = withRetry(fn, 3, 1000, () => true);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toBe('ok');
+		expect(fn).toHaveBeenCalledTimes(3);
+	});
+
+	it('defaults to retrying everything when no predicate is supplied (backward compatible)', async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('transient'))
+			.mockResolvedValue('done');
+
+		const promise = withRetry(fn, 2, 0);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toBe('done');
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/shared/api-utils.ts
+++ b/src/shared/api-utils.ts
@@ -1,19 +1,46 @@
 import { Notice } from 'obsidian';
 
+export type NetworkErrorKind = 'connection-refused' | 'dns' | 'timeout' | 'offline' | null;
+
+/** Classify an error/message into a network failure category (Electron net::, Node errno, common phrasings). */
+export function classifyNetworkError(error: unknown): NetworkErrorKind {
+	const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+	if (/econnrefused|err_connection_refused|connection refused/.test(msg)) return 'connection-refused';
+	if (/enotfound|err_name_not_resolved|getaddrinfo|eai_again/.test(msg)) return 'dns';
+	if (/etimedout|err_(connection_)?timed_out|timed out|timeout/.test(msg)) return 'timeout';
+	if (/enetunreach|err_internet_disconnected|network is unreachable|offline/.test(msg)) return 'offline';
+	return null;
+}
+
+export function isTransientNetworkError(error: unknown): boolean {
+	return classifyNetworkError(error) !== null;
+}
+
+/** User-facing explanation for a network failure reaching `resource`. Null for non-network errors. */
+export function describeNetworkError(error: unknown, resource: string): string | null {
+	switch (classifyNetworkError(error)) {
+		case 'connection-refused': return `Could not connect to ${resource} (connection refused). You may be offline, or a firewall/VPN/proxy is blocking the request.`;
+		case 'dns':                return `Could not resolve the address for ${resource} (DNS lookup failed). Check your internet connection.`;
+		case 'timeout':            return `Connection to ${resource} timed out — the service may be slow or unreachable.`;
+		case 'offline':            return `No network connection while reaching ${resource}. Check that you are online.`;
+		default:                   return null;
+	}
+}
+
 export async function withRetry<T>(
 	fn: () => Promise<T>,
 	maxRetries = 3,
-	delayMs = 1000
+	delayMs = 1000,
+	shouldRetry: (error: unknown) => boolean = () => true,
 ): Promise<T> {
-	let lastError: Error | undefined;
+	let lastError: unknown;
 	for (let attempt = 0; attempt < maxRetries; attempt++) {
 		try {
 			return await fn();
 		} catch (error) {
-			lastError = error as Error;
-			if (attempt < maxRetries - 1) {
-				await sleep(delayMs * Math.pow(2, attempt));
-			}
+			lastError = error;
+			if (attempt >= maxRetries - 1 || !shouldRetry(error)) break; // stop early on last attempt or non-retryable error
+			await sleep(delayMs * Math.pow(2, attempt));
 		}
 	}
 	throw lastError;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,6 +1,13 @@
 export { AIClient } from './ai-client';
 export type { ChatMessage, ContentBlock, TextContentBlock, ImageContentBlock } from './types';
-export { withRetry, sleep, notifyError } from './api-utils';
+export {
+	withRetry,
+	sleep,
+	notifyError,
+	classifyNetworkError,
+	isTransientNetworkError,
+	describeNetworkError,
+} from './api-utils';
 export {
 	ensureFolder,
 	readNote,

--- a/src/video/audio-extractor.test.ts
+++ b/src/video/audio-extractor.test.ts
@@ -124,4 +124,23 @@ describe('AudioExtractor.runCommand error classification', () => {
 		await expect(rejection).rejects.toThrow(/not found/i);
 		await expect(rejection).rejects.toThrow(/yt-dlp/);
 	});
+
+	it('reports a timeout when execFile kills the child via signal (no ETIMEDOUT code)', async () => {
+		// execFile's `timeout` option SIGTERMs the child: killed=true, signal set,
+		// code null. This must be detected before stderr classification.
+		const error = Object.assign(new Error('Command failed'), {
+			killed: true,
+			signal: 'SIGTERM',
+			code: null,
+		});
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string, s: string) => void) =>
+				cb(error, '', '')
+		);
+
+		const ex = makeExtractor();
+		const rejection = ex.extractFromUrl('https://www.tiktok.com/@user/video/123');
+		await expect(rejection).rejects.toThrow(/timed out after 5 minutes/);
+		await expect(rejection).rejects.toThrow(/yt-dlp/);
+	});
 });

--- a/src/video/audio-extractor.test.ts
+++ b/src/video/audio-extractor.test.ts
@@ -78,3 +78,50 @@ describe('AudioExtractor.concatAudio', () => {
 		expect(execFileMock).not.toHaveBeenCalled();
 	});
 });
+
+describe('AudioExtractor.runCommand error classification', () => {
+	beforeEach(() => {
+		execFileMock.mockReset();
+	});
+
+	function makeExtractor(): AudioExtractor {
+		const ex = new AudioExtractor(() => structuredClone(DEFAULT_SETTINGS));
+		// Inject node deps so no real process is spawned.
+		(ex as unknown as { _node: unknown })._node = { os, path, execFile: execFileMock };
+		return ex;
+	}
+
+	it('classifies a yt-dlp connection-refused failure from full stderr and names the tool', async () => {
+		// yt-dlp surfaces the network failure on a stderr line that is NOT the last line.
+		const stderr = [
+			'ERROR: unable to download video data: <urlopen error [Errno 61] Connection refused>',
+			'(Some trailing yt-dlp diagnostic line)',
+		].join('\n');
+		const error = Object.assign(new Error('Command failed'), { code: 1 });
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string, s: string) => void) =>
+				cb(error, '', stderr)
+		);
+
+		const ex = makeExtractor();
+		await expect(ex.extractFromUrl('https://www.tiktok.com/@user/video/123')).rejects.toThrow(
+			/connection refused/i
+		);
+		await expect(ex.extractFromUrl('https://www.tiktok.com/@user/video/123')).rejects.toThrow(
+			/yt-dlp/
+		);
+	});
+
+	it('reports a not-found message when the binary is missing (ENOENT)', async () => {
+		const error = Object.assign(new Error('spawn yt-dlp ENOENT'), { code: 'ENOENT' });
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string, s: string) => void) =>
+				cb(error, '', '')
+		);
+
+		const ex = makeExtractor();
+		const rejection = ex.extractFromUrl('https://www.tiktok.com/@user/video/123');
+		await expect(rejection).rejects.toThrow(/not found/i);
+		await expect(rejection).rejects.toThrow(/yt-dlp/);
+	});
+});

--- a/src/video/audio-extractor.ts
+++ b/src/video/audio-extractor.ts
@@ -195,17 +195,22 @@ export class AudioExtractor {
 						reject(new Error(`${label} not found — install it or set the full path in settings`));
 						return;
 					}
+					// execFile's `timeout` kills the child with a signal (SIGTERM),
+					// leaving error.code null — so detect the kill via `killed`/`signal`
+					// rather than an ETIMEDOUT code. Check this BEFORE classifying
+					// stderr, so a genuine timeout is labeled as such instead of being
+					// misclassified from leftover output.
+					const errno = error as NodeJS.ErrnoException & { killed?: boolean; signal?: string | null };
+					if (errno.killed && !!errno.signal) {
+						reject(new Error(`${label} timed out after 5 minutes`));
+						return;
+					}
 					// Classify against the FULL stderr (not just the last line) so
 					// yt-dlp's "Connection refused"/"Failed to resolve host" lines are caught.
 					const stderrText = stderr?.trim() || '';
 					const networkMsg = describeNetworkError(error, label) ?? describeNetworkError(stderrText, label);
 					if (networkMsg) {
 						reject(new Error(networkMsg));
-						return;
-					}
-					const errno = error as NodeJS.ErrnoException & { killed?: boolean };
-					if (errno.killed && errno.code === 'ETIMEDOUT') {
-						reject(new Error(`${label} timed out after 5 minutes`));
 						return;
 					}
 					const detail = stderrText.split('\n').pop() || '';

--- a/src/video/audio-extractor.ts
+++ b/src/video/audio-extractor.ts
@@ -1,6 +1,6 @@
 import { SynapseSettings } from '../settings';
 import { ExtractionResult, VideoMetadata } from './types';
-import { sanitizePath, sanitizeUrl } from '../shared';
+import { sanitizePath, sanitizeUrl, describeNetworkError } from '../shared';
 
 /**
  * Obsidian's Electron process has a minimal PATH that often excludes
@@ -59,7 +59,7 @@ export class AudioExtractor {
 			'-x', '--audio-format', 'mp3',
 			'-o', outputPath,
 			sanitizedUrl,
-		]);
+		], 'yt-dlp');
 
 		return { audioPath: outputPath, metadata };
 	}
@@ -73,7 +73,7 @@ export class AudioExtractor {
 			'-i', sanitizedPath,
 			'-vn', '-acodec', 'libmp3lame',
 			outputPath,
-		]);
+		], 'ffmpeg');
 
 		const fileName = sanitizedPath.split('/').pop() || 'video';
 		return {
@@ -95,7 +95,7 @@ export class AudioExtractor {
 			'-f', 'mp4/best',
 			'-o', outputPath,
 			sanitizedUrl,
-		]);
+		], 'yt-dlp');
 
 		return outputPath;
 	}
@@ -113,7 +113,7 @@ export class AudioExtractor {
 			'-to', String(endSeconds),
 			'-vn', '-acodec', 'libmp3lame',
 			outputPath,
-		]);
+		], 'ffmpeg');
 		return outputPath;
 	}
 
@@ -146,7 +146,7 @@ export class AudioExtractor {
 			outputPath,
 		);
 
-		await this.runCommand(sanitizePath(settings.ffmpegPath), args);
+		await this.runCommand(sanitizePath(settings.ffmpegPath), args, 'ffmpeg');
 		return outputPath;
 	}
 
@@ -167,7 +167,7 @@ export class AudioExtractor {
 		try {
 			const output = await this.runCommand(sanitizePath(settings.ytDlpPath), [
 				'--dump-json', '--no-download', url,
-			]);
+			], 'yt-dlp');
 			const data = JSON.parse(output);
 			return {
 				title: data.title || 'Untitled',
@@ -183,7 +183,7 @@ export class AudioExtractor {
 		}
 	}
 
-	private runCommand(cmd: string, args: string[]): Promise<string> {
+	private runCommand(cmd: string, args: string[], label = cmd): Promise<string> {
 		return new Promise((resolve, reject) => {
 			this.node.execFile(cmd, args, {
 				env: shellEnv(),
@@ -191,12 +191,27 @@ export class AudioExtractor {
 				timeout: 300_000, // 5 minute timeout for long downloads/conversions
 			}, (error, stdout, stderr) => {
 				if (error) {
-					const code = error.code || 'unknown';
-					const detail = stderr?.trim().split('\n').pop() || '';
-					const msg = code === 'ENOENT'
-						? `"${cmd}" not found — install it or set the full path in settings`
-						: `Command failed (exit code ${code})${detail ? ': ' + detail : ''}`;
-					reject(new Error(msg));
+					if (error.code === 'ENOENT') {
+						reject(new Error(`${label} not found — install it or set the full path in settings`));
+						return;
+					}
+					// Classify against the FULL stderr (not just the last line) so
+					// yt-dlp's "Connection refused"/"Failed to resolve host" lines are caught.
+					const stderrText = stderr?.trim() || '';
+					const networkMsg = describeNetworkError(error, label) ?? describeNetworkError(stderrText, label);
+					if (networkMsg) {
+						reject(new Error(networkMsg));
+						return;
+					}
+					const errno = error as NodeJS.ErrnoException & { killed?: boolean };
+					if (errno.killed && errno.code === 'ETIMEDOUT') {
+						reject(new Error(`${label} timed out after 5 minutes`));
+						return;
+					}
+					const detail = stderrText.split('\n').pop() || '';
+					reject(new Error(
+						`${label} failed (exit code ${error.code || 'unknown'})${detail ? ': ' + detail : ''}`
+					));
 				} else {
 					resolve(stdout);
 				}

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -81,7 +81,12 @@ export class VideoModule {
 		const update = parentOp?.update ?? (() => { /* no-op */ });
 
 		update(`Downloading ${platform} video...`);
-		const extraction = await this.extractor.extractFromUrl(validatedUrl);
+		let extraction;
+		try {
+			extraction = await this.extractor.extractFromUrl(validatedUrl);
+		} catch (e) {
+			throw new Error(`Download/audio extraction failed: ${e instanceof Error ? e.message : String(e)}`);
+		}
 
 		// Download the actual video file into the vault
 		let videoVaultPath: string | undefined;
@@ -114,11 +119,16 @@ export class VideoModule {
 		const audioData = fs.readFileSync(audioPath);
 
 		update('Transcribing...');
-		const result = await this.audioModule.transcribe(
-			audioData.buffer as ArrayBuffer,
-			extraction.metadata.title + '.mp3',
-			{ sourceName: extraction.metadata.title }
-		);
+		let result;
+		try {
+			result = await this.audioModule.transcribe(
+				audioData.buffer as ArrayBuffer,
+				extraction.metadata.title + '.mp3',
+				{ sourceName: extraction.metadata.title }
+			);
+		} catch (e) {
+			throw new Error(`Transcription failed: ${e instanceof Error ? e.message : String(e)}`);
+		}
 
 		// Clean up temp audio file
 		try {


### PR DESCRIPTION
## Summary

Transcribing a video URL (e.g. TikTok) failed with a bare, undiagnosable error like `net::ERR_CONNECTION_REFUSED` because the summarize -> video -> audio pipeline re-threw raw errors, so the user could not tell which step failed. This PR makes every failure name the step + resource in plain language, and auto-retries transient API connection failures with backoff (reusing the existing `withRetry`; no new setting, no `settings.ts` changes).

- **`src/shared/api-utils.ts`** — add `classifyNetworkError` / `isTransientNetworkError` / `describeNetworkError` (Electron `net::`, Node errno, common phrasings). Extend `withRetry` with an optional 4th `shouldRetry` predicate that defaults to retrying everything, so the existing `tweet-fetcher.ts` caller is unaffected.
- **`src/shared/index.ts`** — re-export the three new helpers.
- **`src/video/audio-extractor.ts`** — classify yt-dlp/ffmpeg failures in `runCommand` against the **full** stderr (so yt-dlp's "Connection refused"/"Failed to resolve host" lines are caught, not just the last line). Add a per-command `label` and surface ENOENT / network / 5-min-timeout / exit-code messages. No retry here (downloads are long).
- **`src/audio/transcriber.ts`** — route Whisper and Deepgram through a shared `requestTranscription` helper that retries connection-level failures only (NOT the 5-min app timeout) and translates them into user-facing messages naming the API. Removes the duplicated timeout-race logic from both methods.
- **`src/video/index.ts`** — wrap the download/extraction and transcription stages so the failing stage is named.
- **`src/summarize/index.ts`** — unchanged; its existing `Video transcription failed for ${url}: ${msg}` wrapper already surfaces the improved inner messages.

## Test plan

- New `src/shared/api-utils.test.ts`: `classifyNetworkError` string mapping, `describeNetworkError` null/non-null, and `withRetry` predicate behavior (called-once on non-retryable, retries to max, succeeds on a later attempt, backward-compatible default).
- Extended `src/video/audio-extractor.test.ts`: yt-dlp stderr with `Connection refused` -> message contains "connection refused" + "yt-dlp"; ENOENT -> "not found".
- Extended `src/audio/transcriber.test.ts` (both providers): persistent connection-refused names the API; reject-once-then-200 proves retry; a 503 HTTP response still reads "status 503" and is NOT reclassified as a network error.

Verification (all green on this branch):
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm test` — 86 files / 1083 tests passed
- [x] `node esbuild.config.mjs production` — exit 0

closes #62

Co-Authored-By: Claude <bot@wafflenet.io>