### PR TITLE
feat: revise plugin description for community listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synapse
 
-AI-powered note elaboration, audio transcription, video transcription, and more for [Obsidian](https://obsidian.md).
+Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI in [Obsidian](https://obsidian.md).
 
 ## Overview
 

--- a/docs/PRD-MVP.md
+++ b/docs/PRD-MVP.md
@@ -193,7 +193,7 @@ Reference: [Obsidian Plugin Guidelines](https://docs.obsidian.md/Plugins/Releasi
   - Settings are saved when changed (currently saves on every individual setting change -- this is correct)
   - Plugin cleans up after itself on unload (each module has `onunload()`)
 - [x] **versions.json exists** -- `versions.json` maps `"0.1.0"` to `"0.15.0"` (minimum Obsidian version). This file is required for the plugin auto-update system.
-- [ ] **Plugin description is compelling** -- Current description is functional but could be more appealing. **Next step**: Revise to highlight key user benefits (e.g., "Automatically elaborate, transcribe, enrich, summarize, and organize your notes with AI").
+- [x] **Plugin description is compelling** -- Revised to "Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI." Action-oriented, under 250 characters, ends with a period, and drops the redundant "for Obsidian" per submission requirements.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Synapse",
   "version": "0.9.0",
   "minAppVersion": "0.15.0",
-  "description": "AI-powered note elaboration, audio transcription, and video transcription for Obsidian",
+  "description": "Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI.",
   "author": "Dustin Keeton",
   "authorUrl": "https://github.com/dustinkeeton",
   "isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "synapse",
 	"version": "0.9.0",
-	"description": "AI-powered note elaboration, audio transcription, and video transcription for Obsidian",
+	"description": "Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI.",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",


### PR DESCRIPTION
## Summary

Closes #85

Revises the plugin description for the Obsidian community plugin directory listing. Four files changed:

- **manifest.json** — `description` set to `Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI.`
- **package.json** — `description` updated to the identical string (kept in sync with manifest.json; tab indentation preserved)
- **README.md** — line 3 tagline updated to mirror the new positioning while keeping the [Obsidian](https://obsidian.md) link
- **docs/PRD-MVP.md** — Section 7 item "Plugin description is compelling" checked off; text rewritten to quote the new description and the stale "Next step" sentence removed

The new description meets Obsidian submission requirements: 97 characters (well under the 250 max), ends with a period, no emoji or special characters, and uses action-oriented phrasing. The redundant "for Obsidian" suffix is dropped.

## Pre-flight results

- `npx tsc -noEmit -skipLibCheck` — pass
- `npm test` — pass (86 files, 1084 tests)
- `node esbuild.config.mjs production` — pass

## Notes

- The commit is unsigned: subagents cannot reach the 1Password signing agent, so signing was disabled for this commit. This is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)