### PR TITLE
feat: add brand identity — guidelines, assets, and brand agents

### DIFF
--- a/.claude/agents/brand-manager.md
+++ b/.claude/agents/brand-manager.md
@@ -1,0 +1,25 @@
+---
+name: brand-manager
+description: Brand manager for Synapse. Owns and enforces the brand guidelines — voice, tone, name treatment, visual identity rules, and asset usage. Reviews user-facing copy and visuals for brand consistency and writes creative briefs for the designer agent.
+skills:
+  - brand-guidelines
+  - issue
+allowed-tools: Read, Write, Edit, Glob, Grep
+---
+
+You are the brand manager for the Synapse Obsidian plugin. Your responsibilities:
+
+1. **Own the brand guidelines** — the `brand-guidelines` skill is the source of truth. You maintain it: voice and tone, name treatment, color palette, typography, and asset usage rules. Changes to the brand go through you.
+2. **Enforce brand consistency** — audit user-facing surfaces (README, manifest description, settings copy, notices, docs, release notes) for adherence to voice, tone, and name treatment. Fix violations or flag them for the responsible agent.
+3. **Direct design work** — when visual assets are needed, write a clear creative brief (concept, constraints, deliverables, sizes) for the `designer` agent to execute. Review the result against the guidelines before it ships.
+4. **Guard the brand essence** — every brand decision must serve the core idea: *firing synapses — more connected, higher quality thoughts*. Reject work that drifts into generic AI clichés (circuit-board brains, sparkle motifs, stock neural-network art).
+
+When auditing, check for:
+
+- Name treatment violations (see the guidelines for correct casing and usage of "Synapse")
+- Copy that breaks voice/tone (overpromising AI hype, passive hedging, jargon without payoff)
+- Colors or visual elements outside the brand palette
+- Assets used at sizes or on backgrounds they were not designed for
+- New user-facing surfaces shipping with no brand review
+
+You do not produce visual assets yourself — that is the `designer` agent's job. You define what should exist, judge what comes back, and keep the written record in the `brand-guidelines` skill current.

--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -1,0 +1,36 @@
+---
+name: designer
+description: Visual designer for Synapse. Produces brand-consistent visual assets — logos, icons, banners, diagrams — as hand-written SVG with local render verification. Works from creative briefs, ideally directed by the brand-manager agent.
+skills:
+  - brand-guidelines
+  - git-workflow
+  - issue
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
+---
+
+You are the visual designer for the Synapse Obsidian plugin. Your responsibilities:
+
+1. **Produce visual assets** — logos, icons, banners, social images, and diagram styling, all as hand-written SVG. Canonical assets live in `assets/brand/`.
+2. **Follow the brand guidelines** — the `brand-guidelines` skill defines the palette, typography, mark anatomy, and usage rules. Use only palette colors. Never redesign the mark on your own initiative; refinements to the core identity go through the `brand-manager` agent.
+3. **Verify by rendering** — never ship an SVG you have not looked at. Render and inspect every asset before finishing.
+4. **Keep assets honest** — small-size legibility first. A mark that muddies at 16px fails, no matter how good it looks large.
+
+## SVG production rules
+
+- Hand-written, minimal SVG: inline attributes, no `<style>` blocks or CSS classes, no external refs, no embedded raster.
+- Icon-class assets (anything that may render at small sizes): no `<text>`, bold silhouettes, minimum stroke weight ~8 units in a 256-unit viewBox, no detail smaller than ~10 units.
+- Banner/hero assets: `<text>` is allowed, but font-family must be a stack of widely-available fonts ending in `sans-serif`.
+- Marks must work on both dark (#1e1e1e) and white backgrounds — verify both.
+- Round coordinates to at most 1 decimal; keep files small.
+
+## Render verification loop
+
+On macOS, render with Quick Look (no extra dependencies):
+
+```sh
+qlmanage -t -s 1024 -o <output-dir> <asset>.svg   # produces <asset>.svg.png
+```
+
+Then Read the PNG and critique it honestly: balance, concept legibility, small-size survival, dark/light performance. Iterate — do not settle for the first attempt. To judge small-size legibility, include a 48px copy of the mark inside a preview composition rather than trusting a tiny thumbnail render.
+
+If `qlmanage` is unavailable, try `rsvg-convert` or `npx --yes sharp-cli`, and note in your report which renderer verified the asset.

--- a/.claude/skills/brand-guidelines/SKILL.md
+++ b/.claude/skills/brand-guidelines/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: brand-guidelines
+description: Brand guidelines for Synapse — brand essence, voice and tone, name treatment, color palette, typography, mark anatomy, and asset usage rules. Source of truth for all user-facing copy and visual assets. Use when writing or reviewing README/docs/UI copy, producing visual assets, or auditing brand consistency.
+user-invocable: false
+---
+
+# Synapse Brand Guidelines
+
+## Brand essence
+
+**Firing synapses — more connected, higher quality thoughts.**
+
+Synapse is the firing layer of the vault: the instant a stub becomes a real note, a recording becomes linked text, an orphan note jumps the gap and connects. And like a real synapse, nothing fires without crossing a threshold — every change is a proposal, and **the user is the threshold**. Signals sum; the user decides whether the neuron fires.
+
+**Tagline:** *More connections. Brighter thoughts.*
+Support line for hero moments only (not the standing tagline): *The spark between your notes.*
+
+## Voice & tone
+
+1. **Charged, not hyped** — energy comes from kinetic verbs (fire, jump, connect, surface); never exclamation points, superlatives, or sparkle-speak.
+2. **Precise** — speak in mechanism and exact counts ("Review 3 proposed links", "proximity-weighted scoring"); never "AI magic" or "enhancing your knowledge".
+3. **Deferential at the threshold** — every statement about changing the vault is framed as a proposal: *Synapse proposes, you decide*. Undo is as visible as accept.
+4. **Neuro- and systems-literate** — real vocabulary (impulse, threshold, edge weight, potentiation) used accurately as working metaphor, grounded in the user's own notes; never decorative jargon or brain-emoji whimsy.
+5. **Dry warmth** — short sentences, front-loaded verbs, understated wit in release notes and empty states; never memes, emoji, or anthropomorphizing the AI.
+
+## Name treatment
+
+- In all prose, UI copy, and documentation: **Synapse** — capital S, rest lowercase, one word, set in the body face.
+- Outside the Obsidian ecosystem (README intro, directory listing, social), first reference is **Synapse for Obsidian**.
+- Lowercase `synapse` is correct only in code, repo names, and the plugin manifest id.
+- The wordmark — and only the wordmark — is set all-lowercase "synapse" in Space Grotesk 500 at -0.02em tracking, with one deliberately widened letterspace between "n" and "a": the synaptic cleft. The cleft exists only in the official wordmark lockup; never type it manually in prose.
+
+**Incorrect:** SYNAPSE in running text; SynApse or any internal caps; "Synapse AI" / "SynapseAI" / "Synapse.ai" (never append AI — the deferential safety model is the point, not the AI); "the Synapse"; "Obsidian Synapse" as a product name (the repo slug is exempt); hyphenating or line-breaking the name; full letterspaced treatments (S Y N A P S E).
+
+## Color palette
+
+| Name | Hex | Role |
+|------|-----|------|
+| Gap Black | `#131019` | Primary brand surface; ink for text on white (18.8:1). Violet-cast near-black that sits natively beside Obsidian's `#1e1e1e`. Never pure `#000`. |
+| Dendrite | `#2A2140` | Elevated dark surface — cards, code blocks, panels. On light backgrounds: the fill of dark chips that carry the volt spark. |
+| Synapse Violet | `#8b5cf6` | Primary accent on dark surfaces — links, edge strokes, UI accents (4.4:1 on Gap Black; small violet text on dark uses Violet Glow instead). Bridges to Obsidian's accent family. |
+| Threshold Violet | `#5b21b6` | Light-surface twin — wordmark fill, headings, links, badges on white (9.0:1, AAA). Never on dark surfaces. |
+| Violet Glow | `#A78BFA` | Dark-mode small-text violet — links, icon strokes, emphasis on Gap Black/Dendrite (6.9:1). Gradient endpoint with Synapse Violet for hero art ≥128px only — gradients never enter the mark. |
+| Impulse Volt | `#CCFF00` | The firing moment — sole electric accent and the accepted-proposal state (16:1 on Gap Black). Only 1.2:1 on white, so on light backgrounds it appears only inside a Dendrite/Gap Black chip or with a 1.5px Gap Black outline — never as text or thin strokes on white. **One volt element per composition, ever.** |
+| Ion White | `#F4F2FB` | Primary text on dark surfaces (17:1 on Gap Black); the brand's light-mode page tint. |
+
+## Typography
+
+- **Wordmark:** Space Grotesk 500, all-lowercase, -0.02em tracking (plus the engineered n–a cleft). SVG-safe stack: `'Space Grotesk', 'Helvetica Neue', Arial, sans-serif`.
+- **Body:** Inter 400/500/600 — visually continuous with Obsidian's default UI font. Stack: `'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`. Avoid 700+ except in the tagline.
+- **Mono:** JetBrains Mono for code, hotkeys, file paths, frontmatter. Stack: `'JetBrains Mono', ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace`.
+
+## The mark: "The S-Signal"
+
+The mark is the path of a single impulse. Two Synapse Violet arc segments — the pre- and post-synaptic paths — are interrupted by a charged cleft, with one Impulse Volt spark (teardrop comet, traveling left-to-right) mid-jump across the gap. The geometry happens to trace an "S" (monogram utility at small sizes), but the letter emerges from synapse anatomy, not a font glyph:
+
+- **Filled ball** (top terminal) — the source note.
+- **Open, unfilled ring** (bottom terminal) — the proposed connection, not yet accepted. The receptor closes only on "accept" (state/animation variants): the proposal-approval safety model drawn as geometry.
+- **Volt spark in the cleft** — the firing moment, carried in its Gap Black chip so it survives white backgrounds.
+
+### Mark principles
+
+1. **Depict the cleft, not the cell** — never a whole brain, neuron silhouette, network globe, or generic node-and-edge graph. Banned: circuit traces, hexagons, chips-on-brains, chat bubbles, four-point sparkle glyphs, lightning-bolt-in-a-circle.
+2. **One spark only** — a single Impulse Volt element; no particle fields, scattered sparkles, or radiating lines. One bright element per layout, including marketing.
+3. **Directionality encodes the product** — the impulse travels left-to-right toward the open receptor. Motion is implied by offset, taper, and asymmetry — never blur or glow.
+4. **Weighted asymmetry on a strict grid** — the two terminals differ in size and form, like real weighted connections. Stroke weight never below 1.5px at a 24px artboard.
+5. **Survives 16px monochrome** — must read as a single-color `currentColor` silhouette at 16×16 (Obsidian ribbon icons strip color). Reduce detail at small sizes rather than thinning strokes.
+6. **Dark-first, both-proof, flat-only** — designed on Gap Black, verified on white. The canonical mark is flat fills and strokes; the one permitted violet→glow gradient lives only in marketing art ≥128px.
+
+## Assets & usage
+
+Canonical assets live in `assets/brand/` (see its README for inventory and regeneration). Quick rules:
+
+- `icon.svg` — the mark, transparent background, works on dark and white. Use for plugin icon contexts, avatars, favicons. Do not recolor, rotate, add glow, or detach the spark.
+- `banner.svg` — README hero, self-contained dark background; safe on both GitHub themes. Do not place text over it or crop it.
+- Clear space around the mark: at least the diameter of the open receptor ring.
+- On white at small sizes the spark reads as a dark dot — acceptable; never remove the chip outline to "fix" it.
+
+## Known gaps (future work)
+
+- A dedicated ≤24px optical-size variant that enlarges the cleft and spark (at 16px the S is crisp but the spark merges into the spine).
+- A monochrome `currentColor` ribbon-icon variant for Obsidian's UI.
+- Accept-state variant (receptor ring closes) for animations and UI states.
+- Run a confusion screen against existing S-arc marks (e.g. legacy Skype, Sketch-class letterforms) before community-directory launch.

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -37,6 +37,8 @@ For each issue, determine the best specialist agent using content-based matching
 | AGENTS.md, machine docs, module registry | `docs-agent` |
 | DECISIONS.md, STATUS.md, ARCHITECTURE.md | `docs-human` |
 | architecture, structure, naming, dependency, circular | `architect` |
+| `assets/brand/`, logo, icon, banner, visual asset, SVG | `designer` |
+| brand, branding, voice, tone, name treatment, brand audit | `brand-manager` |
 
 **Label fallback** — if no keyword match:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/brand/banner.svg" alt="Synapse — More connections. Brighter thoughts." width="100%">
+</p>
+
 # Synapse
 
 Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI in [Obsidian](https://obsidian.md).

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,38 @@
+# Synapse brand assets
+
+Canonical visual assets for Synapse. The full brand guidelines — palette, typography, voice/tone, name treatment, and mark usage rules — live in [`.claude/skills/brand-guidelines/SKILL.md`](../../.claude/skills/brand-guidelines/SKILL.md); read that before using or modifying anything here.
+
+## Inventory
+
+| Asset | Description | Use for |
+|-------|-------------|---------|
+| `icon.svg` | "The S-Signal" mark — 256×256 viewBox, transparent background, flat palette colors only | Plugin icon contexts, avatars, favicons, anywhere square |
+| `banner.svg` | README hero — 1280×320, self-contained dark background, mark + wordmark + tagline | Top of README; safe on both GitHub light and dark themes |
+
+## The mark in one sentence
+
+An "S" traced by a neural impulse: two violet synaptic arcs broken by a charged cleft, one Impulse Volt spark (`#CCFF00`) firing left-to-right across the gap, from a filled source ball toward an open receptor ring that closes only on accept.
+
+## Hard rules
+
+- Use only palette colors (see guidelines). Never recolor the mark or detach the spark.
+- **One volt element per composition** — the spark is the only bright accent, ever.
+- On white backgrounds the spark keeps its Gap Black outline/chip; never remove it.
+- The mark is flat — no glows, blurs, drop shadows, or gradients in the mark itself.
+- Don't place text over the banner or crop it.
+
+## Verifying changes
+
+Assets are hand-written SVG. After any edit, render and inspect before committing (macOS, no dependencies):
+
+```sh
+qlmanage -t -s 1024 -o /tmp <asset>.svg   # writes /tmp/<asset>.svg.png — open and check
+```
+
+Check dark (`#131019`) and white backgrounds, plus a ~48px copy for small-size legibility. The `designer` agent (`.claude/agents/designer.md`) does this loop automatically.
+
+## Wanted (not yet produced)
+
+- ≤24px optical-size icon variant (larger cleft + spark)
+- Monochrome `currentColor` variant for the Obsidian ribbon
+- Accept-state variant (receptor ring closed) for UI states and animation

--- a/assets/brand/banner.svg
+++ b/assets/brand/banner.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 320">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#131019"/>
+      <stop offset="1" stop-color="#1D1630"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="1280" height="320" rx="16" fill="url(#bg)"/>
+
+  <!-- faint synaptic-edge motif: filled sender dot, gapped edge, open receptor ring -->
+  <g stroke="#8b5cf6" fill="none" opacity="0.16">
+    <circle cx="898" cy="104" r="5" fill="#8b5cf6" stroke="none"/>
+    <path d="M906 103 Q990 84 1066 88" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M1088 90 Q1110 92 1128 96" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="1148" cy="99" r="8.5" stroke-width="3"/>
+  </g>
+  <g stroke="#8b5cf6" fill="none" opacity="0.10">
+    <circle cx="964" cy="232" r="4" fill="#8b5cf6" stroke="none"/>
+    <path d="M972 231 Q1040 222 1102 226" stroke-width="2" stroke-linecap="round"/>
+    <path d="M1120 227 Q1136 229 1148 231" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="1166" cy="234" r="7" stroke-width="3"/>
+  </g>
+
+  <!-- the mark -->
+  <g transform="translate(72,56) scale(0.8125)">
+    <path d="M179.3 64.4 A42 42 0 1 0 108.3 108.2" fill="none" stroke="#8b5cf6" stroke-width="26" stroke-linecap="round"/>
+    <circle cx="179.3" cy="64.4" r="20" fill="#8b5cf6"/>
+    <path d="M177.4 141.9 A46 46 0 0 1 107.0 200.9" fill="none" stroke="#8b5cf6" stroke-width="26" stroke-linecap="round"/>
+    <circle cx="85.7" cy="177.8" r="22.5" fill="none" stroke="#8b5cf6" stroke-width="14"/>
+    <path d="M124.0 120.1 L143.1 113.9 A14 14 0 1 1 136.4 135.9 Z" fill="#CCFF00" stroke="#131019" stroke-width="5" stroke-linejoin="round"/>
+  </g>
+
+  <!-- wordmark: all-lowercase, Space Grotesk 500, -0.02em tracking, engineered n-a cleft -->
+  <text x="336" y="168" font-family="'Space Grotesk', 'Helvetica Neue', Arial, sans-serif" font-size="88" font-weight="500" letter-spacing="-1.76" fill="#F4F2FB">syn<tspan dx="6">apse</tspan></text>
+
+  <!-- tagline -->
+  <text x="340" y="220" font-family="'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="26" font-weight="500" fill="#A78BFA">More connections. Brighter thoughts.</text>
+</svg>

--- a/assets/brand/icon.svg
+++ b/assets/brand/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <path d="M179.3 64.4 A42 42 0 1 0 108.3 108.2" fill="none" stroke="#8b5cf6" stroke-width="26" stroke-linecap="round"/>
+  <circle cx="179.3" cy="64.4" r="20" fill="#8b5cf6"/>
+  <path d="M177.4 141.9 A46 46 0 0 1 107.0 200.9" fill="none" stroke="#8b5cf6" stroke-width="26" stroke-linecap="round"/>
+  <circle cx="85.7" cy="177.8" r="22.5" fill="none" stroke="#8b5cf6" stroke-width="14"/>
+  <path d="M124.0 120.1 L143.1 113.9 A14 14 0 1 1 136.4 135.9 Z" fill="#CCFF00" stroke="#131019" stroke-width="5" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Establishes the Synapse brand identity per the creative direction: *"synapse, brain, firing synapses. More connected, higher quality thoughts."*

The identity was produced by a 13-agent design workflow: 3 brand strategists → synthesized brief → 5 independent SVG logo concepts (each self-rendered and critiqued) → a 3-judge panel scoring scalability, brand fit, and distinctiveness → refinement of the winner.

### The mark: "The S-Signal" (won 92/120 vs 85 for runner-up)

An "S" traced by a neural impulse: two violet synaptic arcs broken by a charged cleft, one Impulse Volt (`#CCFF00`) spark firing left-to-right across the gap, from a filled source ball toward an **open receptor ring that closes only on accept** — the proposal-approval safety model drawn as geometry.

### Deliverables

| Sub-task (#116) | Delivered |
|---|---|
| Brand-manager agent | `.claude/agents/brand-manager.md` — owns/enforces guidelines, audits copy, writes creative briefs |
| Designer agent | `.claude/agents/designer.md` — SVG production with qlmanage render-verify loop |
| Brand guidelines | `.claude/skills/brand-guidelines/SKILL.md` — essence, voice/tone (5 rules), name treatment, 7-color palette with verified contrast ratios, typography (Space Grotesk / Inter / JetBrains Mono), mark anatomy + principles |
| Plugin logo/icon | `assets/brand/icon.svg` (256×256, transparent, flat, palette-only, legible at 16px) |
| README banner | `assets/brand/banner.svg` (1280×320, self-contained dark bg, safe on both GitHub themes) + embedded at top of README |
| Asset documentation | `assets/brand/README.md` — inventory, hard rules, verification workflow |

Also routes future branding/design issues to the new agents via the delegate skill classification table.

**Tagline:** *More connections. Brighter thoughts.* (tightened from the owner's phrase)

### Follow-up work (documented in guidelines "Known gaps")

- ≤24px optical-size icon variant (at 16px the S is crisp but the spark merges into the spine)
- Monochrome `currentColor` ribbon-icon variant for Obsidian UI
- Accept-state variant (receptor closed) for UI states/animation
- Confusion screen vs existing S-arc marks before community-directory launch

### Verification

- `npx tsc --noEmit --skipLibCheck` clean, 1084/1084 tests pass, production build OK (no source changes)
- All SVGs render-verified via qlmanage on dark `#131019` and white, large and 48px

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)