### PR TITLE
feat: add ≤24px optical-size variant of the S-Signal icon

### DIFF
--- a/.claude/skills/brand-guidelines/SKILL.md
+++ b/.claude/skills/brand-guidelines/SKILL.md
@@ -71,14 +71,15 @@ The mark is the path of a single impulse. Two Synapse Violet arc segments — th
 
 Canonical assets live in `assets/brand/` (see its README for inventory and regeneration). Quick rules:
 
-- `icon.svg` — the mark, transparent background, works on dark and white. Use for plugin icon contexts, avatars, favicons. Do not recolor, rotate, add glow, or detach the spark.
+- `icon.svg` — the canonical mark, transparent background, works on dark and white. Use for plugin icon contexts, avatars, favicons, and any render **above ~24px**. Do not recolor, rotate, add glow, or detach the spark.
+- `icon-small.svg` — optical-size cut of the S-Signal for renders **at or below ~24px** (16px favicons, 16–24px list/UI icons). Same palette and silhouette, but the cleft is widened, the volt bead enlarged with a thinned Gap Black chip so the lime survives on white, and the receptor is a plain open terminal (the ring detail closes up at small sizes, so it is dropped). Do not use it above ~24px — its sacrificed letterform polish only pays off small.
 - `banner.svg` — README hero, self-contained dark background; safe on both GitHub themes. Do not place text over it or crop it.
+- **Size cutover:** at ~24px and below, use `icon-small.svg`; above ~24px, use canonical `icon.svg`. The cut exists because the canonical spark merges into the spine below ~24px while the small cut keeps one visible lime point in the gap.
 - Clear space around the mark: at least the diameter of the open receptor ring.
-- On white at small sizes the spark reads as a dark dot — acceptable; never remove the chip outline to "fix" it.
+- On white at small sizes the spark reads as a dark dot — acceptable; never remove the chip outline to "fix" it. (`icon-small.svg` thins, but never removes, that chip.)
 
 ## Known gaps (future work)
 
-- A dedicated ≤24px optical-size variant that enlarges the cleft and spark (at 16px the S is crisp but the spark merges into the spine).
 - A monochrome `currentColor` ribbon-icon variant for Obsidian's UI.
 - Accept-state variant (receptor ring closes) for animations and UI states.
 - Run a confusion screen against existing S-arc marks (e.g. legacy Skype, Sketch-class letterforms) before community-directory launch.

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -6,8 +6,13 @@ Canonical visual assets for Synapse. The full brand guidelines — palette, typo
 
 | Asset | Description | Use for |
 |-------|-------------|---------|
-| `icon.svg` | "The S-Signal" mark — 256×256 viewBox, transparent background, flat palette colors only | Plugin icon contexts, avatars, favicons, anywhere square |
+| `icon.svg` | "The S-Signal" mark — 256×256 viewBox, transparent background, flat palette colors only | Plugin icon contexts, avatars, favicons, anywhere square **above ~24px** |
+| `icon-small.svg` | Optical-size cut of the S-Signal — 256×256 viewBox, transparent, flat palette only. Widened cleft, enlarged volt bead on a thinned Gap Black chip, plain open receptor terminal (ring dropped) | Renders **at or below ~24px**: 16px favicons, 16–24px list/UI icons |
 | `banner.svg` | README hero — 1280×320, self-contained dark background, mark + wordmark + tagline | Top of README; safe on both GitHub light and dark themes |
+
+### Size cutover: canonical vs small cut
+
+Use **`icon.svg`** above ~24px and **`icon-small.svg`** at ~24px and below. Below ~24px the canonical spark — the firing moment that carries the whole brand story — merges into the S spine and disappears. `icon-small.svg` deliberately sacrifices letterform polish (wider cleft, fatter bead, plainer receptor) to keep one clearly visible lime point in the gap down to 16px. Above ~24px that trade is unnecessary and the canonical mark's full directional comet and open receptor ring read cleanly — use it there.
 
 ## The mark in one sentence
 
@@ -33,6 +38,5 @@ Check dark (`#131019`) and white backgrounds, plus a ~48px copy for small-size l
 
 ## Wanted (not yet produced)
 
-- ≤24px optical-size icon variant (larger cleft + spark)
 - Monochrome `currentColor` variant for the Obsidian ribbon
 - Accept-state variant (receptor ring closed) for UI states and animation

--- a/assets/brand/icon-small.svg
+++ b/assets/brand/icon-small.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <path d="M162.2 63.0 A42 42 0 1 0 91.9 107.7" fill="none" stroke="#8b5cf6" stroke-width="26" stroke-linecap="round"/>
+  <circle cx="162.2" cy="63.0" r="20" fill="#8b5cf6"/>
+  <path d="M170.1 158.3 A42 42 0 1 1 94.6 195.1" fill="none" stroke="#8b5cf6" stroke-width="26" stroke-linecap="round"/>
+  <path d="M108.0 113.0 L128.9 111.1 A23 23 0 1 1 108.0 134.0 Z" fill="#CCFF00" stroke="#131019" stroke-width="3" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Closes #256

## Summary

Adds `assets/brand/icon-small.svg` — an optical-size cut of the S-Signal mark for renders at or below ~24px. The canonical mark reads as a crisp "S" at 16px, but the Impulse Volt spark (the firing moment that carries the entire brand story) merges into the spine below ~24px. This variant rescues that one lime point per the #116 scalability judge's refinement.

## Design decisions

- **Widened cleft** — pulled the two violet arc terminals further apart, opening a clear violet-free channel for the spark.
- **Enlarged volt bead** — the teardrop bulb grows to r=23 (vs r=14 canonical) relative to the 26-unit stroke, so the lime survives downsampling.
- **Thinned the Gap Black chip ring** — outline cut to 3 units (vs 5 canonical). On white at 16px a thicker chip swallows the `#CCFF00` core into a dark dot; thinning keeps the lime dominant — without ever removing the chip (it's still required for white-bg legibility).
- **Plain open receptor terminal** — dropped the open ring (which closes to a featureless blob below ~24px) in favor of a plain rounded stroke terminal. Weighted asymmetry is preserved by the filled source ball up top vs. the plain taper at the bottom.
- Kept every brand constraint: palette-only (`#8b5cf6` / `#CCFF00` / `#131019`), flat (no glow/gradient), transparent background, **one** volt element, coordinates rounded to ≤1 decimal.

The canonical `icon.svg` is unchanged and remains the mark for all renders above ~24px — the two cuts split at ~24px.

## Render verification

Verified with the designer render loop (`qlmanage` at true 16px and 24px, then upscaled for inspection) on three surfaces:

| Surface | 16px | 24px |
|---------|------|------|
| `#131019` (brand) | ✅ clear lime point | ✅ clear lime point |
| White | ✅ clear lime point | ✅ clear lime point |
| `#1e1e1e` (Obsidian) | ✅ clear lime point | ✅ clear lime point |

Iterated through three versions: v1 (baseline) lost the lime on white at 16px; v2 (bigger bead + thinner chip) recovered it; v3 (further enlarged core) made it an unambiguous point. **Verdict: one clearly visible lime point in the gap at every target size on every surface.** The S silhouette still reads at 16px.

## Docs

- Documented the canonical-vs-small **size cutover (~24px)** in `.claude/skills/brand-guidelines/SKILL.md` and `assets/brand/README.md` (added `icon-small.svg` to the inventory).
- Cleared the corresponding "Known gaps" / "Wanted" entries now that the variant ships.

## Checks

- `npx tsc --noEmit --skipLibCheck` — clean
- `npm test` — 1084 passed (86 files)
- `node esbuild.config.mjs production` — exit 0

Note: the commit is unsigned — subagents can't reach the 1Password SSH signing agent in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)