### PR TITLE
feat: add monochrome currentColor ribbon icon, drop banned sparkles glyph

### DIFF
--- a/.claude/skills/brand-guidelines/SKILL.md
+++ b/.claude/skills/brand-guidelines/SKILL.md
@@ -73,6 +73,7 @@ Canonical assets live in `assets/brand/` (see its README for inventory and regen
 
 - `icon.svg` — the canonical mark, transparent background, works on dark and white. Use for plugin icon contexts, avatars, favicons, and any render **above ~24px**. Do not recolor, rotate, add glow, or detach the spark.
 - `icon-small.svg` — optical-size cut of the S-Signal for renders **at or below ~24px** (16px favicons, 16–24px list/UI icons). Same palette and silhouette, but the cleft is widened, the volt bead enlarged with a thinned Gap Black chip so the lime survives on white, and the receptor is a plain open terminal (the ring detail closes up at small sizes, so it is dropped). Do not use it above ~24px — its sacrificed letterform polish only pays off small.
+- `icon-mono.svg` — single-color **`currentColor`** silhouette of the S-Signal for surfaces that strip color: the Obsidian ribbon and UI (registered as the `synapse` icon via `addIcon` in `src/main.ts`), and any monochrome context. Authored on a `0 0 100 100` viewBox (Obsidian's `addIcon` convention) so the asset body doubles as the registered icon string. **Never assign it palette colors** — its color comes from the host UI via `currentColor`; and never use it where full color is available (use `icon.svg` / `icon-small.svg` there). This is the one variant where the cleft is *tightened*, not widened: in monochrome the spark bead bridges the cleft and completes the S spine, so the one-color silhouette stays whole down to 16px. It keeps the weighted asymmetry (filled source ball, plain open receptor terminal) but the spark is no longer a distinct accent — by design, it becomes the connective tissue of the spine.
 - `banner.svg` — README hero, self-contained dark background; safe on both GitHub themes. Do not place text over it or crop it.
 - **Size cutover:** at ~24px and below, use `icon-small.svg`; above ~24px, use canonical `icon.svg`. The cut exists because the canonical spark merges into the spine below ~24px while the small cut keeps one visible lime point in the gap.
 - Clear space around the mark: at least the diameter of the open receptor ring.
@@ -80,6 +81,5 @@ Canonical assets live in `assets/brand/` (see its README for inventory and regen
 
 ## Known gaps (future work)
 
-- A monochrome `currentColor` ribbon-icon variant for Obsidian's UI.
 - Accept-state variant (receptor ring closes) for animations and UI states.
 - Run a confusion screen against existing S-arc marks (e.g. legacy Skype, Sketch-class letterforms) before community-directory launch.

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -8,11 +8,20 @@ Canonical visual assets for Synapse. The full brand guidelines — palette, typo
 |-------|-------------|---------|
 | `icon.svg` | "The S-Signal" mark — 256×256 viewBox, transparent background, flat palette colors only | Plugin icon contexts, avatars, favicons, anywhere square **above ~24px** |
 | `icon-small.svg` | Optical-size cut of the S-Signal — 256×256 viewBox, transparent, flat palette only. Widened cleft, enlarged volt bead on a thinned Gap Black chip, plain open receptor terminal (ring dropped) | Renders **at or below ~24px**: 16px favicons, 16–24px list/UI icons |
+| `icon-mono.svg` | Single-color `currentColor` silhouette of the S-Signal — **`0 0 100 100` viewBox**, transparent, no palette colors. Tightened cleft; the spark bead bridges the cleft so the one-color spine stays whole at 16px | Color-stripping surfaces: Obsidian ribbon/UI (registered as the `synapse` icon), and any monochrome context |
 | `banner.svg` | README hero — 1280×320, self-contained dark background, mark + wordmark + tagline | Top of README; safe on both GitHub light and dark themes |
 
 ### Size cutover: canonical vs small cut
 
 Use **`icon.svg`** above ~24px and **`icon-small.svg`** at ~24px and below. Below ~24px the canonical spark — the firing moment that carries the whole brand story — merges into the S spine and disappears. `icon-small.svg` deliberately sacrifices letterform polish (wider cleft, fatter bead, plainer receptor) to keep one clearly visible lime point in the gap down to 16px. Above ~24px that trade is unnecessary and the canonical mark's full directional comet and open receptor ring read cleanly — use it there.
+
+Both color variants are for surfaces that **keep** color. For surfaces that strip it, use `icon-mono.svg` (below).
+
+### Monochrome variant (`icon-mono.svg`)
+
+Obsidian's ribbon and UI render icons as a single `currentColor` silhouette — gradients and palette colors are discarded. `icon-mono.svg` is the S-Signal built for exactly that: every stroke and fill is `currentColor`, so the host UI's text color drives it (Ion White on dark, Gap Black on white — verified on both). Where the colored cuts *widen* the cleft to keep the lime spark distinct, the mono cut *tightens* it: in one color the spark bead bridges the cleft and completes the S spine, so the silhouette stays whole down to 16px.
+
+It is authored on a **`0 0 100 100`** viewBox (not the family's 256) because that is Obsidian's `addIcon` convention — the body of this file is the literal string registered as the `synapse` icon in `src/main.ts` (`SYNAPSE_ICON_SVG`). **Keep the two in sync:** if you edit the asset, update the constant (and vice-versa). Use it only on color-stripping or monochrome surfaces; anywhere color survives, use `icon.svg` / `icon-small.svg`.
 
 ## The mark in one sentence
 
@@ -20,7 +29,7 @@ An "S" traced by a neural impulse: two violet synaptic arcs broken by a charged 
 
 ## Hard rules
 
-- Use only palette colors (see guidelines). Never recolor the mark or detach the spark.
+- Use only palette colors (see guidelines). Never recolor the mark or detach the spark. **Exception:** `icon-mono.svg` is intentionally single-color `currentColor` — no palette colors, no lime accent, no Gap Black chip. It is the only color-agnostic variant; the rules below about the volt spark and its chip do not apply to it.
 - **One volt element per composition** — the spark is the only bright accent, ever.
 - On white backgrounds the spark keeps its Gap Black outline/chip; never remove it.
 - The mark is flat — no glows, blurs, drop shadows, or gradients in the mark itself.
@@ -38,5 +47,4 @@ Check dark (`#131019`) and white backgrounds, plus a ~48px copy for small-size l
 
 ## Wanted (not yet produced)
 
-- Monochrome `currentColor` variant for the Obsidian ribbon
 - Accept-state variant (receptor ring closed) for UI states and animation

--- a/assets/brand/icon-mono.svg
+++ b/assets/brand/icon-mono.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <path d="M70 25.2 A16.4 16.4 0 1 0 42.3 42.3" fill="none" stroke="currentColor" stroke-width="10.5" stroke-linecap="round"/>
+  <circle cx="70" cy="25.2" r="7.8" fill="currentColor"/>
+  <path d="M69.3 55.4 A18 18 0 0 1 41.8 78.5" fill="none" stroke="currentColor" stroke-width="10.5" stroke-linecap="round"/>
+  <ellipse cx="55.8" cy="48.9" rx="16.5" ry="7.2" fill="currentColor" transform="rotate(26 55.8 48.9)"/>
+</svg>

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -375,6 +375,9 @@ export class SliderComponent {
 
 // --- Utility functions ---
 
+/** Registers a custom icon by id (real Obsidian: addIcon(id, svgContent)). */
+export const addIcon = vi.fn();
+
 export function normalizePath(path: string): string {
 	return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }

--- a/src/elaboration/proposal-view.ts
+++ b/src/elaboration/proposal-view.ts
@@ -32,7 +32,9 @@ export class ProposalReviewView extends ItemView {
 	}
 
 	getIcon(): string {
-		return 'sparkles';
+		// Brand S-Signal mark (registered via addIcon in main.ts), not the
+		// banned 'sparkles' Lucide glyph.
+		return 'synapse';
 	}
 
 	async onOpen(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Platform, Plugin } from 'obsidian';
+import { Notice, Platform, Plugin, addIcon } from 'obsidian';
 import { SynapseSettings, DEFAULT_SETTINGS } from './settings';
 import { SynapseSettingTab } from './settings-tab';
 import { ElaborationModule } from './elaboration';
@@ -28,6 +28,22 @@ import {
 } from './views';
 import type { UnifiedItem } from './views';
 
+/**
+ * Monochrome `currentColor` silhouette of the S-Signal mark, registered as the
+ * `synapse` icon for ribbon/UI surfaces (which strip color to a single
+ * currentColor fill). This is the inner body of `assets/brand/icon-mono.svg`,
+ * authored on the 0 0 100 100 viewBox Obsidian's `addIcon` expects. In
+ * monochrome the spark bead bridges the synaptic cleft and completes the S
+ * spine, so the silhouette stays whole down to 16px. Keep this in sync with the
+ * canonical asset; do not recolor (the brand mark only ever uses palette colors
+ * in its full-color variants — this variant is intentionally color-agnostic).
+ */
+const SYNAPSE_ICON_SVG =
+	'<path d="M70 25.2 A16.4 16.4 0 1 0 42.3 42.3" fill="none" stroke="currentColor" stroke-width="10.5" stroke-linecap="round"/>' +
+	'<circle cx="70" cy="25.2" r="7.8" fill="currentColor"/>' +
+	'<path d="M69.3 55.4 A18 18 0 0 1 41.8 78.5" fill="none" stroke="currentColor" stroke-width="10.5" stroke-linecap="round"/>' +
+	'<ellipse cx="55.8" cy="48.9" rx="16.5" ry="7.2" fill="currentColor" transform="rotate(26 55.8 48.9)"/>';
+
 export default class SynapsePlugin extends Plugin {
 	settings!: SynapseSettings;
 	notifications!: NotificationManager;
@@ -51,6 +67,10 @@ export default class SynapsePlugin extends Plugin {
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
+
+		// Register the brand mark as a custom icon so ribbon/UI surfaces can use
+		// it. Must run before any addRibbonIcon('synapse', …) call below.
+		addIcon('synapse', SYNAPSE_ICON_SVG);
 
 		// Migrate legacy .auto-notes folder to .synapse (one-time, backward compat)
 		await this.migrateDataFolder();
@@ -255,12 +275,17 @@ export default class SynapsePlugin extends Plugin {
 			};
 		}
 
-		// Single ribbon icon + command for the unified view
-		this.addRibbonIcon('sparkles', 'Review proposals', () => {
+		// Single ribbon icon + command for the unified view. Uses the brand
+		// S-Signal mark (registered above) rather than a stock Lucide glyph —
+		// the previous 'sparkles' icon is on the brand's banned inventory.
+		this.addRibbonIcon('synapse', 'Review proposals', () => {
 			this.activateUnifiedView();
 		});
 
-		// Unified transcription ribbon icon (desktop only — mic icon implies video support)
+		// Unified transcription ribbon icon (desktop only — mic icon implies video
+		// support). 'mic' stays a functional Lucide glyph: it communicates the
+		// transcribe action better than the brand mark, and only sparkle glyphs
+		// are banned, not all Lucide icons.
 		if (Platform.isDesktop) {
 			this.addRibbonIcon('mic', 'Transcribe media', () => {
 				this.openUnifiedModal();

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -57,7 +57,10 @@ export class UnifiedProposalView extends ItemView {
 	}
 
 	getIcon(): string {
-		return 'sparkles';
+		// Brand S-Signal mark (registered via addIcon in main.ts), matching the
+		// "Review proposals" ribbon that opens this view. Not 'sparkles' — that
+		// Lucide glyph is on the brand's banned inventory.
+		return 'synapse';
 	}
 
 	async onOpen(): Promise<void> {


### PR DESCRIPTION
Closes #257

## What

Adds the monochrome `currentColor` variant of the S-Signal and removes the banned `sparkles` Lucide glyph from the plugin's visible surfaces.

### New asset — `assets/brand/icon-mono.svg`
A single-color silhouette of the S-Signal for surfaces that strip color (Obsidian's ribbon/UI render every icon as one `currentColor` fill).

- **`currentColor` only** — no palette colors; the host UI's text color drives it.
- **Authored on a `0 0 100 100` viewBox** (Obsidian's `addIcon` convention) so the asset body doubles as the literal string registered in code. One source of truth.
- **The spark bead completes the spine.** Where `icon.svg` / `icon-small.svg` *widen* the cleft to keep the lime spark a distinct point, the mono cut *tightens* it: in one color the bead bridges the cleft so the silhouette stays whole down to 16px (mark principle 5). The spark is no longer a distinct accent — by design, it becomes the connective tissue of the spine.
- Keeps the weighted asymmetry (mark principle 4): filled source ball top-right, plain open receptor terminal bottom-left (ring dropped, as in `icon-small`).
- Stroke 10.5 on the 100-grid = ~2.5px at a 24px artboard (≥1.5px floor). No `<text>`, no sub-10-unit detail.

I evaluated three silhouettes (a condensed letterform, the chosen open-C-bowls cut, and a hooked variant) and picked the one that stays unmistakably the S-Signal at 16px rather than reading as a generic italic "s".

### Code — `src/main.ts`
- Import `addIcon` from `obsidian`; register the mark via `addIcon('synapse', SYNAPSE_ICON_SVG)` at the top of `onload()` (before any ribbon uses it). `SYNAPSE_ICON_SVG` is the inner body of `icon-mono.svg`, kept in sync with the asset.
- The **"Review proposals" ribbon** now uses `'synapse'` instead of `'sparkles'` (sparkles is on the brand's explicit banned inventory).
- **`mic` stays** on the transcribe ribbon. It's a *functional* glyph — a microphone communicates the transcribe action better than a brand mark — and the guidelines ban only sparkle glyphs, not all Lucide icons.

### Also swapped the banned glyph off the proposal view tabs
The issue's motivation is that the banned glyph sits on the plugin's most visible surface. The "Review proposals" ribbon opens `UnifiedProposalView`, whose tab icon was also `sparkles`; its `getIcon()` now returns `'synapse'` so the tab matches its ribbon. `ProposalReviewView` (legacy/unregistered) carried the same glyph and was swapped too, fully purging `sparkles` from the source. *(These two view files are beyond the literal "ribbon" scope but squarely serve the issue's stated goal — flagging for review.)*

### Tests / mocks
- Added a module-level `addIcon` stub to the centralized `obsidian` mock (`src/__mocks__/obsidian.ts`). No existing test asserted the ribbon icon name, so nothing else needed updating.

### Docs
- `.claude/skills/brand-guidelines/SKILL.md`: documented the mono variant + usage rule in *Assets & usage*; removed it from *Known gaps*.
- `assets/brand/README.md`: added the inventory row, a *Monochrome variant* subsection (incl. the "keep asset and `SYNAPSE_ICON_SVG` in sync" rule), and a palette-rule exception note; removed it from *Wanted*.

## Render verification

`qlmanage` (Quick Look) — no extra deps. `currentColor` was substituted with the theme color for rendering (Quick Look has no theme context):

- **16 / 24 / 48px** and a simulated **~18px ribbon button**, on Obsidian-dark (`#1e1e1e`, icon `#F4F2FB`) and white (icon `#131019`): reads as a clear, **whole** S at every size — no broken gaps, the bead bridges the spine.
- Large render of the committed asset confirms the source ball / open receptor asymmetry and a continuous spine.
- Verified the `currentColor` mechanism resolves correctly on both backgrounds (this is exactly how Obsidian drives the ribbon icon).

## Pre-flight

- `npx tsc --noEmit --skipLibCheck` ✓
- `npm test` ✓ (86 files, 1084 tests)
- `node esbuild.config.mjs production` ✓ (`addIcon` + icon path present in `main.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
