### PR TITLE
test: verify intake organize-move E2E and guard breadcrumb collisions

### DIFF
--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -426,6 +426,15 @@ export class IntakeModule {
 	 * (isInIntakeFolder), but the stamp guarantees it is skipped even if that
 	 * exclusion were ever bypassed.
 	 *
+	 * Collision policy (#227): the breadcrumb filename is `<date> — <sanitized
+	 * title>.md`, so two DIFFERENT notes that sanitize to the same title and are
+	 * organized on the same day would otherwise resolve to the same path — and
+	 * `writeNote` overwrites, silently losing one capture-log entry. To avoid
+	 * that data loss we disambiguate cross-note collisions with a uniqueness
+	 * suffix (` (2)`, ` (3)`, …) — see {@link resolveBreadcrumbPath}.
+	 * Re-processing the SAME note (same destination) deliberately reuses and
+	 * overwrites its own breadcrumb rather than suffix-spamming.
+	 *
 	 * `movedPath` is the note's current (organized) path; `originalPath` its
 	 * pre-processing path inside the intake folder.
 	 */
@@ -441,9 +450,6 @@ export class IntakeModule {
 
 		const date = new Date().toISOString().split('T')[0];
 		const title = this.sanitizeTitle(this.basenameOf(movedPath));
-		const breadcrumbPath = normalizePath(
-			`${logFolder}/${date} — ${title}.md`,
-		);
 
 		const body = [
 			this.wikiLink(movedPath),
@@ -459,7 +465,67 @@ export class IntakeModule {
 		);
 
 		await ensureFolder(this.plugin.app, logFolder);
+		const breadcrumbPath = await this.resolveBreadcrumbPath(
+			logFolder,
+			date,
+			title,
+			movedPath,
+		);
 		await writeNote(this.plugin.app, breadcrumbPath, content);
+	}
+
+	/**
+	 * Resolve a non-clobbering path for a breadcrumb (#227). The base path is
+	 * `‹logFolder›/‹date› — ‹title›.md`; if that is free we use it. If a file
+	 * already lives there we keep it ONLY when it is this same note's breadcrumb
+	 * (its `moved to:` trail equals `movedPath`), so re-processing a note
+	 * overwrites its own breadcrumb idempotently. Otherwise a DIFFERENT note
+	 * sanitized to the same dated title — we bump a uniqueness suffix (` (2)`,
+	 * ` (3)`, …) until we find a free slot or this note's own breadcrumb, so two
+	 * distinct captures never clobber each other.
+	 */
+	private async resolveBreadcrumbPath(
+		logFolder: string,
+		date: string,
+		title: string,
+		movedPath: string,
+	): Promise<string> {
+		const base = `${logFolder}/${date} — ${title}`;
+		for (let n = 1; ; n++) {
+			const candidate = normalizePath(
+				n === 1 ? `${base}.md` : `${base} (${n}).md`,
+			);
+			const existing =
+				this.plugin.app.vault.getAbstractFileByPath(candidate);
+			if (!(existing instanceof TFile)) {
+				return candidate; // free slot
+			}
+			if (await this.breadcrumbTargets(existing, movedPath)) {
+				return candidate; // this note's own breadcrumb → overwrite in place
+			}
+			// A different note collided on the same dated title — try the next
+			// suffix so its capture-log entry is never lost.
+		}
+	}
+
+	/**
+	 * True when an existing breadcrumb file points at `movedPath` — i.e. it is
+	 * the breadcrumb for this same moved note (its `- moved to:` trail matches).
+	 * Used to distinguish an idempotent re-process of the same note (overwrite)
+	 * from a genuine cross-note title collision (suffix). Reads defensively:
+	 * any read failure is treated as "not ours" so we fall through to a suffix
+	 * rather than risk clobbering another note's breadcrumb.
+	 */
+	private async breadcrumbTargets(
+		file: TFile,
+		movedPath: string,
+	): Promise<boolean> {
+		try {
+			const content = await this.plugin.app.vault.read(file);
+			return content.includes(`- moved to: ${movedPath}\n`);
+		} catch {
+			return false;
+		}
 	}
 
 	/** Basename (no extension) of a vault path, e.g. `A/B/note.md` → `note`. */

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -670,6 +670,93 @@ describe('IntakeModule', () => {
 		});
 	});
 
+	// #227 — two DIFFERENT notes that sanitize to the same dated breadcrumb
+	// title must never clobber each other; the same note re-processed must
+	// overwrite its own breadcrumb rather than spawn suffixed duplicates.
+	describe('capture log breadcrumb collisions (#227)', () => {
+		beforeEach(async () => {
+			await module.onload();
+		});
+
+		it('disambiguates two distinct notes that sanitize to the same dated title', async () => {
+			// "Meeting (Q1)" and "Meeting [Q1]" both sanitize to "Meeting Q1".
+			organizeMovesTo('Articles/Meeting (Q1).md');
+			emit('create', 'Inbox/Meeting (Q1).md', 'first note');
+			await flushDebounce();
+
+			organizeMovesTo('Refs/Meeting [Q1].md');
+			emit('create', 'Inbox/Meeting [Q1].md', 'second note');
+			await flushDebounce();
+
+			const first = 'Inbox/_captured/2026-06-05 — Meeting Q1.md';
+			const second = 'Inbox/_captured/2026-06-05 — Meeting Q1 (2).md';
+
+			// BOTH breadcrumbs survive — neither was overwritten.
+			expect(store.has(first)).toBe(true);
+			expect(store.has(second)).toBe(true);
+
+			// Each points at its own moved note (no clobber).
+			expect(store.get(first)).toContain('moved to: Articles/Meeting (Q1).md');
+			expect(store.get(first)).toContain('[[Meeting (Q1)]]');
+			expect(store.get(second)).toContain('moved to: Refs/Meeting [Q1].md');
+			expect(store.get(second)).toContain('[[Meeting [Q1]]]');
+
+			const captured = [...store.keys()].filter((p) =>
+				p.startsWith('Inbox/_captured/'),
+			);
+			expect(captured).toHaveLength(2);
+		});
+
+		it('escalates the suffix for a third same-titled collision', async () => {
+			organizeMovesTo('A/Report.md');
+			emit('create', 'Inbox/Report.md', 'one');
+			await flushDebounce();
+
+			organizeMovesTo('B/Report!.md');
+			emit('create', 'Inbox/Report!.md', 'two');
+			await flushDebounce();
+
+			organizeMovesTo('C/Report?.md');
+			emit('create', 'Inbox/Report?.md', 'three');
+			await flushDebounce();
+
+			expect(store.has('Inbox/_captured/2026-06-05 — Report.md')).toBe(true);
+			expect(store.has('Inbox/_captured/2026-06-05 — Report (2).md')).toBe(true);
+			expect(store.has('Inbox/_captured/2026-06-05 — Report (3).md')).toBe(true);
+
+			const captured = [...store.keys()].filter((p) =>
+				p.startsWith('Inbox/_captured/'),
+			);
+			expect(captured).toHaveLength(3);
+		});
+
+		it('overwrites a note\'s OWN breadcrumb on re-process (no suffix spam)', async () => {
+			// markProcessed off so the same logical note can be re-ingested and
+			// re-organized to the same destination, exercising the same-note path.
+			settings.intake.markProcessed = false;
+
+			organizeMovesTo('Articles/Recurring.md');
+			emit('create', 'Inbox/Recurring.md', 'v1');
+			await flushDebounce();
+
+			const crumb = 'Inbox/_captured/2026-06-05 — Recurring.md';
+			expect(store.has(crumb)).toBe(true);
+
+			// Re-ingest the same note → same destination → same breadcrumb. It is
+			// the note's OWN breadcrumb (matching `moved to:`), so it is reused.
+			organizeMovesTo('Articles/Recurring.md');
+			emit('create', 'Inbox/Recurring.md', 'v2');
+			await flushDebounce();
+
+			// No "(2)" duplicate — exactly one breadcrumb for this note.
+			expect(store.has('Inbox/_captured/2026-06-05 — Recurring.md (2).md')).toBe(false);
+			const captured = [...store.keys()].filter((p) =>
+				p.startsWith('Inbox/_captured/'),
+			);
+			expect(captured).toHaveLength(1);
+		});
+	});
+
 	describe('flush resilience', () => {
 		beforeEach(async () => {
 			await module.onload();

--- a/src/intake/intake-organize-e2e.test.ts
+++ b/src/intake/intake-organize-e2e.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IntakeModule } from './index';
+import { OrganizeModule } from '../organize';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile, TFolder } from '../__mocks__/obsidian';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+/**
+ * Integration test for the intake → organize handshake (#227).
+ *
+ * Unlike intake-module.test.ts — which stubs `fireOnFile` to simulate organize
+ * — this wires the REAL {@link OrganizeModule} into intake's `fireOnFile`. The
+ * ONLY mocked boundary is the AI: {@link ContentAnalyzer} (which wraps the
+ * network-bound AIClient) is replaced with a controllable topic/confidence
+ * source. The real DirectoryMatcher, OrganizeStore, and `vault.rename` mover all
+ * run, so this confirms the production organize → intake contract end-to-end:
+ *
+ *   1. High-confidence note with a matching directory → organize's `vault.rename`
+ *      moves it out of Inbox (mutating `TFile.path` IN PLACE) → intake detects
+ *      the move (originalPath !== file.path) → breadcrumb written → the
+ *      `moveWhenDone` fallback is NOT applied (no double move).
+ *   2. Low-confidence note → organize keeps it in Inbox (no-op / would-be
+ *      proposal) → with no `moveWhenDone`, the note stays put and NO breadcrumb
+ *      is written; with `moveWhenDone` set, intake's fallback relocates it.
+ *   3. The `originalPath !== file.path` detection holds against the REAL module
+ *      because `vault.rename` mutates the same TFile object in place.
+ */
+
+// The mocked AI boundary. `vi.hoisted` so the mock factory (hoisted above
+// imports) can safely reference this holder; tests mutate it per-case.
+const ai = vi.hoisted(() => ({
+	topics: [] as Array<{ label: string; confidence: number }>,
+	tags: [] as string[],
+}));
+
+vi.mock('../organize/content-analyzer', () => ({
+	ContentAnalyzer: class MockContentAnalyzer {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		// Mirrors the real analyzer's shape but returns controlled topics so the
+		// REAL DirectoryMatcher makes the move/keep decision deterministically.
+		analyze = vi.fn(async (file: { path: string }) => ({
+			notePath: file.path,
+			topics: ai.topics,
+			tags: ai.tags,
+			links: [] as string[],
+		}));
+	},
+}));
+
+const SETTLE_MS = 5000;
+
+function makeFile(path: string): TFile {
+	const file = new TFile(path);
+	const slash = path.lastIndexOf('/');
+	if (slash >= 0) {
+		file.parent = new TFolder(path.slice(0, slash));
+	}
+	return file;
+}
+
+/** Build a TFolder tree (for vault.getRoot) from flat directory paths. */
+function buildFolderTree(directories: string[]): TFolder {
+	const root = new TFolder('/');
+	root.isRoot = () => true;
+	const map = new Map<string, TFolder>([['/', root]]);
+
+	for (const dir of directories) {
+		let current = root;
+		let accumulated = '';
+		for (const part of dir.split('/').filter(Boolean)) {
+			accumulated = accumulated ? `${accumulated}/${part}` : part;
+			if (!map.has(accumulated)) {
+				const folder = new TFolder(accumulated);
+				folder.parent = current;
+				map.set(accumulated, folder);
+				current.children.push(folder);
+			}
+			current = map.get(accumulated)!;
+		}
+	}
+	return root;
+}
+
+function createMockNotifications() {
+	return {
+		startOperation: vi.fn().mockReturnValue({
+			update: vi.fn(),
+			progress: vi.fn(),
+			finish: vi.fn(),
+			error: vi.fn(),
+			cancelled: false,
+		}),
+		info: vi.fn(),
+		success: vi.fn(),
+		notifyError: vi.fn(),
+		confirm: vi.fn().mockResolvedValue(true),
+	};
+}
+
+describe('intake → real organize handshake (#227)', () => {
+	let settings: SynapseSettings;
+	let store: Map<string, string>;
+	let adapterFiles: Map<string, string>;
+	let handlers: Record<string, (file: any) => void>;
+	let vault: any;
+	let fileManager: any;
+	let organize: OrganizeModule;
+	let intake: IntakeModule;
+	let deps: {
+		fireOnFile: ReturnType<typeof vi.fn>;
+		transcribeUrlToNote: ReturnType<typeof vi.fn>;
+	};
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-05T12:00:00.000Z'));
+		vi.stubGlobal('window', globalThis);
+
+		settings = structuredClone(DEFAULT_SETTINGS);
+		settings.intake.enabled = true;
+		settings.intake.intakeFolder = 'Inbox';
+		settings.intake.markProcessed = true;
+		settings.intake.moveWhenDone = '';
+		settings.intake.settleSeconds = SETTLE_MS / 1000;
+		// captureLog/captureLogFolder keep their defaults (true / '_captured').
+		settings.organize.enabled = true;
+
+		ai.topics = [];
+		ai.tags = [];
+
+		store = new Map();
+		adapterFiles = new Map();
+		handlers = {};
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	/**
+	 * Build the shared in-memory vault + both REAL modules over a folder tree.
+	 * `vault.rename` and `fileManager.renameFile` both mutate `TFile.path` IN
+	 * PLACE, exactly as Obsidian does — this is the behaviour intake's move
+	 * detection (`originalPath !== file.path`) relies on.
+	 */
+	async function setup(directories: string[]): Promise<void> {
+		const folderRoot = buildFolderTree(directories);
+
+		const adapter = {
+			read: vi.fn(async (path: string) => {
+				if (!adapterFiles.has(path)) throw new Error(`ENOENT: ${path}`);
+				return adapterFiles.get(path)!;
+			}),
+			write: vi.fn(async (path: string, content: string) => {
+				adapterFiles.set(path, content);
+			}),
+			exists: vi.fn(async (path: string) => {
+				if (adapterFiles.has(path)) return true;
+				for (const k of adapterFiles.keys()) if (k.startsWith(path + '/')) return true;
+				return false;
+			}),
+			remove: vi.fn(async (path: string) => {
+				adapterFiles.delete(path);
+			}),
+			list: vi.fn(async (folder: string) => ({
+				files: [...adapterFiles.keys()].filter((k) => k.startsWith(folder + '/')),
+				folders: [],
+			})),
+		};
+
+		const moveInPlace = (file: any, newPath: string) => {
+			const content = store.get(file.path);
+			store.delete(file.path);
+			if (content !== undefined) store.set(newPath, content);
+			// Obsidian mutates the live TFile on rename — mirror that exactly.
+			file.path = newPath;
+			file.name = newPath.split('/').pop() ?? newPath;
+			file.basename = file.name.replace(/\.[^.]+$/, '');
+		};
+
+		vault = {
+			on: vi.fn((event: string, cb: (file: any) => void) => {
+				handlers[event] = cb;
+				return { event };
+			}),
+			read: vi.fn(async (file: any) => store.get(file.path) ?? ''),
+			process: vi.fn(async (file: any, fn: (data: string) => string) => {
+				const result = fn(store.get(file.path) ?? '');
+				store.set(file.path, result);
+				return result;
+			}),
+			create: vi.fn(async (path: string, content: string) => {
+				store.set(path, content);
+				return makeFile(path);
+			}),
+			createFolder: vi.fn().mockResolvedValue(undefined),
+			getRoot: () => folderRoot,
+			getAbstractFileByPath: vi.fn((path: string) =>
+				store.has(path) ? makeFile(path) : null,
+			),
+			// Organize's primary mover.
+			rename: vi.fn(async (file: any, newPath: string) => moveInPlace(file, newPath)),
+			adapter,
+		};
+
+		fileManager = {
+			// Intake's fallback mover.
+			renameFile: vi.fn(async (file: any, newPath: string) => moveInPlace(file, newPath)),
+		};
+
+		const metadataCache = {
+			getFileCache: vi.fn().mockReturnValue(null),
+			getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+		};
+
+		const plugin: any = {
+			app: { vault, fileManager, metadataCache },
+			registerEvent: vi.fn(),
+			addCommand: vi.fn(),
+		};
+
+		organize = new OrganizeModule(
+			plugin,
+			() => settings,
+			createMockNotifications() as never,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(plugin),
+			() => false, // auto-accept off (default): a proposal never moves the note
+		);
+		await organize.onload();
+
+		deps = {
+			// THE handshake: intake's pipeline phase IS the real organize module.
+			fireOnFile: vi.fn(async (file: any) => {
+				await organize.organizeNote(file);
+			}),
+			transcribeUrlToNote: vi.fn().mockResolvedValue(undefined),
+		};
+
+		intake = new IntakeModule(plugin, () => settings, createMockNotifications() as never, deps as never);
+		await intake.onload();
+	}
+
+	function emit(event: string, path: string, content = ''): TFile {
+		store.set(path, content);
+		const file = makeFile(path);
+		handlers[event](file);
+		return file;
+	}
+
+	function flushDebounce() {
+		return vi.runOnlyPendingTimersAsync();
+	}
+
+	function capturedBreadcrumbs(): string[] {
+		return [...store.keys()].filter((p) => p.startsWith('Inbox/_captured/'));
+	}
+
+	describe('high-confidence note with a matching directory', () => {
+		beforeEach(async () => {
+			await setup(['Inbox', 'Machine Learning']);
+			// Confidence 0.95 (≥ 0.9) + an exact existing-directory match → the
+			// real DirectoryMatcher scores a direct move out of Inbox.
+			ai.topics = [{ label: 'machine learning', confidence: 0.95 }];
+			ai.tags = ['#machine-learning'];
+		});
+
+		it('moves the note out of Inbox via organize, writes a breadcrumb, applies NO fallback', async () => {
+			settings.intake.moveWhenDone = 'Processed'; // would fire only if organize did NOT move it
+
+			emit('create', 'Inbox/note.md', 'A deep dive into neural networks and gradient descent.');
+			await flushDebounce();
+
+			// Organize relocated it (the real module called vault.rename).
+			expect(vault.rename).toHaveBeenCalledWith(expect.anything(), 'Machine Learning/note.md');
+			expect(store.has('Inbox/note.md')).toBe(false);
+			expect(store.has('Machine Learning/note.md')).toBe(true);
+			expect(store.get('Machine Learning/note.md')).toContain('synapse-processed: true');
+
+			// The moveWhenDone fallback did NOT run — organize already moved it out.
+			expect(fileManager.renameFile).not.toHaveBeenCalled();
+			expect(store.has('Processed/note.md')).toBe(false);
+
+			// A breadcrumb traces the capture, linking to the organized note.
+			const crumb = 'Inbox/_captured/2026-06-05 — note.md';
+			expect(store.has(crumb)).toBe(true);
+			expect(store.get(crumb)).toContain('[[note]]');
+			expect(store.get(crumb)).toContain('from: Inbox/note.md');
+			expect(store.get(crumb)).toContain('moved to: Machine Learning/note.md');
+		});
+
+		it('does not double-fire fireOnFile and leaves exactly one breadcrumb', async () => {
+			emit('create', 'Inbox/note.md', 'Neural networks, transformers, and attention.');
+			await flushDebounce();
+
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
+			expect(capturedBreadcrumbs()).toHaveLength(1);
+		});
+	});
+
+	describe('low-confidence note (organize keeps it in Inbox)', () => {
+		beforeEach(async () => {
+			// No directory matches the topic, and confidence is well below the 0.9
+			// new-directory threshold → the real matcher returns "keep in place".
+			ai.topics = [{ label: 'random musings', confidence: 0.4 }];
+			ai.tags = [];
+		});
+
+		it('stays in Inbox with NO breadcrumb when moveWhenDone is unset', async () => {
+			await setup(['Inbox', 'Projects', 'Archive']);
+			settings.intake.moveWhenDone = '';
+
+			emit('create', 'Inbox/thoughts.md', 'Some unstructured stream-of-consciousness notes.');
+			await flushDebounce();
+
+			// Neither mover ran; the note is browsable in place, just stamped.
+			expect(vault.rename).not.toHaveBeenCalled();
+			expect(fileManager.renameFile).not.toHaveBeenCalled();
+			expect(store.has('Inbox/thoughts.md')).toBe(true);
+			expect(store.get('Inbox/thoughts.md')).toContain('synapse-processed: true');
+
+			// Still in Inbox → nothing to log.
+			expect(capturedBreadcrumbs()).toHaveLength(0);
+		});
+
+		it('applies the moveWhenDone fallback when organize left it in Inbox', async () => {
+			await setup(['Inbox', 'Projects']);
+			settings.intake.moveWhenDone = 'Processed';
+
+			emit('create', 'Inbox/thoughts.md', 'Some unstructured stream-of-consciousness notes.');
+			await flushDebounce();
+
+			// Organize did NOT move it (its mover was never called)…
+			expect(vault.rename).not.toHaveBeenCalled();
+			// …so intake's fallback relocates it out of Inbox.
+			expect(fileManager.renameFile).toHaveBeenCalledWith(expect.anything(), 'Processed/thoughts.md');
+			expect(store.has('Processed/thoughts.md')).toBe(true);
+			expect(store.get('Processed/thoughts.md')).toContain('synapse-processed: true');
+
+			// The note left Inbox via the fallback, so per the shipped #224 design
+			// ("breadcrumb whenever the note leaves the intake folder") a trace is
+			// still written — the breadcrumb is mover-agnostic by design.
+			const crumb = 'Inbox/_captured/2026-06-05 — thoughts.md';
+			expect(store.has(crumb)).toBe(true);
+			expect(store.get(crumb)).toContain('moved to: Processed/thoughts.md');
+		});
+	});
+
+	describe('TFile.path in-place mutation against the real organize module', () => {
+		it('mutates the SAME TFile object in place when organize moves it', async () => {
+			await setup(['Inbox', 'Machine Learning']);
+			ai.topics = [{ label: 'machine learning', confidence: 0.95 }];
+			ai.tags = ['#machine-learning'];
+
+			store.set('Inbox/note.md', 'Neural networks and backpropagation.');
+			const file = makeFile('Inbox/note.md');
+			const originalPath = file.path; // exactly how intake snapshots it pre-pipeline
+
+			await organize.organizeNote(file as never);
+
+			// The real module mutated this very object — so intake's
+			// `originalPath !== file.path` detection holds against production code.
+			expect(originalPath).toBe('Inbox/note.md');
+			expect(file.path).toBe('Machine Learning/note.md');
+			expect(originalPath).not.toBe(file.path);
+			expect(vault.rename).toHaveBeenCalledWith(file, 'Machine Learning/note.md');
+		});
+
+		it('does NOT mutate the TFile when organize keeps the note in place', async () => {
+			await setup(['Inbox', 'Projects']);
+			ai.topics = [{ label: 'random musings', confidence: 0.4 }];
+			ai.tags = [];
+
+			store.set('Inbox/keep.md', 'unstructured notes');
+			const file = makeFile('Inbox/keep.md');
+
+			await organize.organizeNote(file as never);
+
+			expect(file.path).toBe('Inbox/keep.md'); // unchanged
+			expect(vault.rename).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
closes #227

Resolves the two items flagged during review of Intake Processing v2 (PR #226, epic #221) before v0.9.0.

## Item 1 — verify the real organize → intake handshake (integration test)

Previously, intake's `movedOutOfIntake` signal and the `moveWhenDone` fallback were only verified against a **stub** that simulated organize by renaming in the in-memory store. The real organize module (`fireOnFile`'s last phase) was never exercised against intake.

New file **`src/intake/intake-organize-e2e.test.ts`** wires the **real `OrganizeModule`** into intake's `fireOnFile` and mocks **only the AI boundary** (`ContentAnalyzer`, which wraps the network-bound `AIClient`) to return controlled topic/confidence values. The real `DirectoryMatcher`, `OrganizeStore`, and `vault.rename` mover all run. Covered scenarios:

- **High-confidence note + matching directory** → the real matcher scores a direct move → `vault.rename` relocates the note out of `Inbox` → breadcrumb written → `moveWhenDone` fallback **not** applied (no double move). Verified even with `moveWhenDone` set.
- **Low-confidence note** → matcher returns "keep in place":
  - with `moveWhenDone` unset → note stays in `Inbox`, stamped, **no breadcrumb**.
  - with `moveWhenDone` set → organize's mover is never called; intake's fallback (`fileManager.renameFile`) relocates it.
- **`TFile.path` in-place mutation** → an explicit test drives the real module directly and asserts the **same** `TFile` object's `.path` is mutated in place by `vault.rename` (and is left untouched when organize keeps the note). This confirms intake's `originalPath !== file.path` detection holds against production code, not just the stub. The test harness's `vault.rename` / `fileManager.renameFile` mocks mutate `TFile.path`/`name`/`basename` in place to match real Obsidian behavior.

### Note on the low-confidence + `moveWhenDone` breadcrumb
The shipped #224 design writes a breadcrumb **whenever the note leaves the intake folder**, regardless of which mover (organize or the `moveWhenDone` fallback) relocated it — the breadcrumb is mover-agnostic by design (see the `writeCaptureBreadcrumb` doc comment and `execute`). The issue text implied "no breadcrumb" on the fallback path, but that reading conflicts with the implemented/documented behavior. The test therefore pins the **actual** behavior: a fallback move still leaves a trace, while the clean "no breadcrumb" case is when the note genuinely **stays** in `Inbox`. Flagging this as a deliberate-decision point in case the fallback should be treated differently — it would be a behavior change beyond this issue's scope.

## Item 2 — breadcrumb collision policy: disambiguate, never overwrite

Capture-log breadcrumbs are named `<YYYY-MM-DD> — <sanitized title>.md` and written with `writeNote` (which overwrites). Two **different** notes that sanitize to the same title and are organized on the same day silently clobbered each other — one capture-log entry lost.

Per the team-lead decision direction, `writeCaptureBreadcrumb` now disambiguates rather than overwriting:

- It detects an existing breadcrumb at the target path before `writeNote` and appends a uniqueness suffix (` (2)`, ` (3)`, …) for **cross-note** collisions, so two distinct captures never overwrite each other.
- Re-processing the **same** note (same `moved to:` destination) deliberately **reuses/overwrites its own** breadcrumb rather than suffix-spamming — identity is matched on the breadcrumb's `- moved to:` trail (`breadcrumbTargets`). This honors "re-processing the same note overwriting its own breadcrumb is fine; two DIFFERENT notes must never clobber each other."

## Tests added
- `intake-organize-e2e.test.ts` (new, 6 tests): high-confidence move + breadcrumb + no fallback (×2), low-confidence stay/no-breadcrumb + fallback (×2), in-place `TFile.path` mutation (×2).
- `intake-module.test.ts` (+3 tests, "capture log breadcrumb collisions (#227)"): two distinct same-titled notes get suffixed; third collision escalates to ` (3)`; same-note re-process overwrites its own breadcrumb (no suffix spam).

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` — clean
- `npm test` — 1132 passed (89 files)
- `node esbuild.config.mjs production` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)