### PR TITLE
chore: improve test coverage for critical paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1778 +1,2068 @@
 {
-  "name": "synapse",
-  "version": "0.1.0",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "synapse",
-      "version": "0.1.0",
-      "license": "AGPL-3.0-only",
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "builtin-modules": "^4.0.0",
-        "esbuild": "^0.27.4",
-        "obsidian": "latest",
-        "tslib": "^2.7.0",
-        "typescript": "^5.6.0",
-        "vitest": "^4.1.0"
-      }
-    },
-    "node_modules/@codemirror/state": {
-      "version": "6.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@marijn/find-cluster-break": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/view": {
-      "version": "6.38.6",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^6.5.0",
-        "crelt": "^1.0.6",
-        "style-mod": "^4.1.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@oxc-project/runtime": {
-      "version": "0.115.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.115.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.9",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*",
-        "assertion-error": "^2.0.1"
-      }
-    },
-    "node_modules/@types/codemirror": {
-      "version": "5.60.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/tern": "*"
-      }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "22.19.15",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/tern": {
-      "version": "0.23.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.0",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/builtin-modules": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/expect-type": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/obsidian": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/codemirror": "5.60.8",
-        "moment": "2.29.4"
-      },
-      "peerDependencies": {
-        "@codemirror/state": "6.5.0",
-        "@codemirror/view": "6.38.6"
-      }
-    },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.8",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/rolldown": {
-      "version": "1.0.0-rc.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.115.0",
-        "@rolldown/pluginutils": "1.0.0-rc.9"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
-      }
-    },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/std-env": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/style-mod": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinybench": {
-      "version": "2.9.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vitest": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.0",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@oxc-project/runtime": "0.115.0",
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.9",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.0.0-alpha.31",
-        "esbuild": "^0.27.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/why-is-node-running": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    }
-  }
+	"name": "synapse",
+	"version": "0.9.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "synapse",
+			"version": "0.9.0",
+			"license": "AGPL-3.0-only",
+			"devDependencies": {
+				"@types/node": "^22.0.0",
+				"@vitest/coverage-v8": "^4.1.8",
+				"builtin-modules": "^4.0.0",
+				"esbuild": "^0.27.4",
+				"obsidian": "latest",
+				"tslib": "^2.7.0",
+				"typescript": "^5.6.0",
+				"vitest": "^4.1.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.7"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.5.0",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.38.6",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/codemirror": {
+			"version": "5.60.8",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/tern": "*"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.19.15",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/tern": {
+			"version": "0.23.9",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+			"integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.8",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.1.8",
+				"vitest": "4.1.8"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+			"integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/builtin-modules": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.4",
+				"@esbuild/android-arm": "0.27.4",
+				"@esbuild/android-arm64": "0.27.4",
+				"@esbuild/android-x64": "0.27.4",
+				"@esbuild/darwin-arm64": "0.27.4",
+				"@esbuild/darwin-x64": "0.27.4",
+				"@esbuild/freebsd-arm64": "0.27.4",
+				"@esbuild/freebsd-x64": "0.27.4",
+				"@esbuild/linux-arm": "0.27.4",
+				"@esbuild/linux-arm64": "0.27.4",
+				"@esbuild/linux-ia32": "0.27.4",
+				"@esbuild/linux-loong64": "0.27.4",
+				"@esbuild/linux-mips64el": "0.27.4",
+				"@esbuild/linux-ppc64": "0.27.4",
+				"@esbuild/linux-riscv64": "0.27.4",
+				"@esbuild/linux-s390x": "0.27.4",
+				"@esbuild/linux-x64": "0.27.4",
+				"@esbuild/netbsd-arm64": "0.27.4",
+				"@esbuild/netbsd-x64": "0.27.4",
+				"@esbuild/openbsd-arm64": "0.27.4",
+				"@esbuild/openbsd-x64": "0.27.4",
+				"@esbuild/openharmony-arm64": "0.27.4",
+				"@esbuild/sunos-x64": "0.27.4",
+				"@esbuild/win32-arm64": "0.27.4",
+				"@esbuild/win32-ia32": "0.27.4",
+				"@esbuild/win32-x64": "0.27.4"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.3",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.29.4",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/obsidian": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "5.60.8",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
+			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.12",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.133.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.3",
+				"@rolldown/binding-darwin-arm64": "1.0.3",
+				"@rolldown/binding-darwin-x64": "1.0.3",
+				"@rolldown/binding-freebsd-x64": "1.0.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
+				"@rolldown/binding-linux-arm64-musl": "1.0.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-musl": "1.0.3",
+				"@rolldown/binding-openharmony-arm64": "1.0.3",
+				"@rolldown/binding-wasm32-wasi": "1.0.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
+				"@rolldown/binding-win32-x64-msvc": "1.0.3"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/style-mod": {
+			"version": "4.1.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vite": {
+			"version": "8.0.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.3",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.18",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,31 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+			"integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+			"integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -107,6 +132,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -584,7 +610,8 @@
 		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.5",
@@ -966,7 +993,6 @@
 			"version": "22.19.15",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -985,7 +1011,6 @@
 			"integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.8",
@@ -1177,7 +1202,8 @@
 		"node_modules/crelt": {
 			"version": "1.0.6",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
@@ -1201,7 +1227,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -1721,7 +1746,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -1833,7 +1857,8 @@
 		"node_modules/style-mod": {
 			"version": "4.1.3",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -1914,7 +1939,6 @@
 			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -1993,7 +2017,6 @@
 			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.8",
 				"@vitest/mocker": "4.1.8",
@@ -2081,7 +2104,8 @@
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -836,6 +836,40 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"license": "AGPL-3.0-only",
 	"devDependencies": {
 		"@types/node": "^22.0.0",
+		"@vitest/coverage-v8": "^4.1.8",
 		"builtin-modules": "^4.0.0",
 		"esbuild": "^0.27.4",
 		"obsidian": "latest",

--- a/src/audio/post-processor.test.ts
+++ b/src/audio/post-processor.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PostProcessor } from './post-processor';
+import { AIClient } from '../shared';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+
+function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
+	const s = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(s);
+	return s;
+}
+
+describe('PostProcessor', () => {
+	let completeSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		completeSpy = vi.spyOn(AIClient.prototype, 'complete').mockResolvedValue('processed');
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	it('returns the raw transcript untouched when post-processing is disabled', async () => {
+		const settings = makeSettings((s) => {
+			s.audio.postProcessing.enabled = false;
+		});
+		const pp = new PostProcessor(() => settings);
+
+		const result = await pp.process('um raw text');
+		expect(result).toBe('um raw text');
+		expect(completeSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns the raw transcript when enabled but no instructions are active', async () => {
+		const settings = makeSettings((s) => {
+			s.audio.postProcessing.enabled = true;
+			s.audio.postProcessing.removeFiller = false;
+			s.audio.postProcessing.addStructure = false;
+			s.audio.postProcessing.extractKeyPoints = false;
+			s.audio.postProcessing.customPrompt = '';
+		});
+		const pp = new PostProcessor(() => settings);
+
+		const result = await pp.process('raw');
+		expect(result).toBe('raw');
+		expect(completeSpy).not.toHaveBeenCalled();
+	});
+
+	it('builds an instruction list from the enabled toggles and sends it to the AI', async () => {
+		const settings = makeSettings((s) => {
+			s.audio.postProcessing.enabled = true;
+			s.audio.postProcessing.removeFiller = true;
+			s.audio.postProcessing.addStructure = true;
+			s.audio.postProcessing.extractKeyPoints = true;
+			s.audio.postProcessing.customPrompt = 'Use British spelling';
+		});
+		const pp = new PostProcessor(() => settings);
+
+		await pp.process('the transcript');
+
+		expect(completeSpy).toHaveBeenCalledTimes(1);
+		const [prompt, systemPrompt] = completeSpy.mock.calls[0];
+		expect(prompt).toContain('Remove filler words');
+		expect(prompt).toContain('Add proper punctuation');
+		expect(prompt).toContain('Key Points');
+		expect(prompt).toContain('Use British spelling');
+		expect(prompt).toContain('the transcript');
+		expect(systemPrompt).toContain('transcription editor');
+	});
+
+	it('sanitizes the AI response before returning it', async () => {
+		completeSpy.mockResolvedValue('clean text<script>alert(1)</script> here');
+		const settings = makeSettings((s) => {
+			s.audio.postProcessing.enabled = true;
+			s.audio.postProcessing.removeFiller = true;
+		});
+		const pp = new PostProcessor(() => settings);
+
+		const result = await pp.process('raw');
+		// sanitizeAIResponse strips injected <script> content
+		expect(result).toBe('clean text here');
+		expect(result).not.toContain('<script>');
+	});
+});

--- a/src/enrichment/enrichment-applier.test.ts
+++ b/src/enrichment/enrichment-applier.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EnrichmentApplier } from './enrichment-applier';
+import { EnrichmentProposal, AcceptedItems } from './types';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { createMockApp, mockFile } from '../__test-utils__/mock-factories';
+import { CALLOUT_TYPES } from '../shared';
+import type { App } from 'obsidian';
+
+function makeSettings(): SynapseSettings {
+	return structuredClone(DEFAULT_SETTINGS);
+}
+
+function emptyResult(): EnrichmentProposal['result'] {
+	return { tags: [], internalLinks: [], externalLinks: [], frontmatter: [] };
+}
+
+function makeProposal(overrides: Partial<EnrichmentProposal> = {}): EnrichmentProposal {
+	return {
+		id: 'prop-1',
+		sourceNotePath: 'notes/Test.md',
+		createdAt: '2026-06-11T00:00:00.000Z',
+		triggerSource: 'manual',
+		result: emptyResult(),
+		status: 'pending',
+		...overrides,
+	};
+}
+
+function emptyAccepted(): AcceptedItems {
+	return { tags: [], internalLinks: [], externalLinks: [], frontmatter: [] };
+}
+
+describe('EnrichmentApplier', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let applier: EnrichmentApplier;
+	let settings: SynapseSettings;
+
+	beforeEach(() => {
+		app = createMockApp();
+		settings = makeSettings();
+		applier = new EnrichmentApplier(app as unknown as App, () => settings);
+	});
+
+	/** Run apply() and return the content the atomic process() transform produced. */
+	async function runApply(
+		content: string,
+		proposal: EnrichmentProposal,
+		accepted: AcceptedItems,
+		path = proposal.sourceNotePath
+	): Promise<string> {
+		const file = mockFile(path);
+		app.vault.getAbstractFileByPath.mockReturnValue(file);
+		app.vault.read.mockResolvedValue(content);
+		await applier.apply(proposal, accepted);
+		return app.vault.process.mock.results[0].value as Promise<string> as unknown as string;
+	}
+
+	describe('apply', () => {
+		it('does nothing when the source note is not a TFile', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(null);
+			await applier.apply(makeProposal(), emptyAccepted());
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+
+		it('merges accepted tags into frontmatter (stripping the leading #)', async () => {
+			const proposal = makeProposal();
+			const accepted: AcceptedItems = { ...emptyAccepted(), tags: ['#ml', '#ai'] };
+			const result = await runApply('# Note body\n', proposal, accepted);
+
+			expect(result).toContain('tags:');
+			expect(result).toContain('- ml');
+			expect(result).toContain('- ai');
+			expect(result).not.toContain('#ml');
+		});
+
+		it('does not duplicate tags already present in frontmatter', async () => {
+			const proposal = makeProposal();
+			const accepted: AcceptedItems = { ...emptyAccepted(), tags: ['#ml'] };
+			const result = await runApply('---\ntags: [ml]\n---\nBody\n', proposal, accepted);
+
+			const occurrences = result.split('\n').filter((l) => l.trim() === '- ml');
+			expect(occurrences).toHaveLength(1);
+		});
+
+		it('adds a Related Notes enrichment callout for accepted internal links', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					internalLinks: [
+						{ targetPath: 'notes/Other.md', displayText: 'Other', relevanceScore: 0.9, reason: 'shares 3 tags' },
+					],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), internalLinks: ['notes/Other.md'] };
+			const result = await runApply('Body text\n', proposal, accepted);
+
+			expect(result).toContain(`> [!${CALLOUT_TYPES.enrichment}] Related Notes`);
+			expect(result).toContain('[[Other]] — shares 3 tags');
+		});
+
+		it('only includes internal links whose targetPath was accepted', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					internalLinks: [
+						{ targetPath: 'notes/Yes.md', displayText: 'Yes', relevanceScore: 0.9, reason: 'r1' },
+						{ targetPath: 'notes/No.md', displayText: 'No', relevanceScore: 0.8, reason: 'r2' },
+					],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), internalLinks: ['notes/Yes.md'] };
+			const result = await runApply('Body\n', proposal, accepted);
+
+			expect(result).toContain('[[Yes]]');
+			expect(result).not.toContain('[[No]]');
+		});
+
+		it('sanitizes wikilink/markdown metacharacters out of link display text and reason', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					internalLinks: [
+						{ targetPath: 'notes/Evil.md', displayText: 'Ev[il]|x', relevanceScore: 0.9, reason: 'a (b) c' },
+					],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), internalLinks: ['notes/Evil.md'] };
+			const result = await runApply('Body\n', proposal, accepted);
+
+			expect(result).toContain('[[Evilx]] — a b c');
+		});
+
+		it('adds a References callout for accepted external links', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					externalLinks: [
+						{ url: 'https://example.com', title: 'Example', reason: 'authoritative' },
+					],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), externalLinks: ['https://example.com'] };
+			const result = await runApply('Body\n', proposal, accepted);
+
+			expect(result).toContain(`> [!${CALLOUT_TYPES.enrichment}] References`);
+			expect(result).toContain('[Example](https://example.com) — authoritative');
+		});
+
+		it('skips external links with non-HTTP(S) schemes', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					externalLinks: [
+						{ url: 'javascript:alert(1)', title: 'Bad', reason: 'evil' },
+						{ url: 'not a url', title: 'Invalid', reason: 'broken' },
+						{ url: 'https://ok.com', title: 'Good', reason: 'fine' },
+					],
+				},
+			});
+			const accepted: AcceptedItems = {
+				...emptyAccepted(),
+				externalLinks: ['javascript:alert(1)', 'not a url', 'https://ok.com'],
+			};
+			const result = await runApply('Body\n', proposal, accepted);
+
+			expect(result).toContain('[Good](https://ok.com)');
+			expect(result).not.toContain('javascript:');
+			expect(result).not.toContain('Invalid');
+		});
+
+		it('merges frontmatter array values without overwriting existing entries', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					frontmatter: [{ key: 'topics', value: ['b', 'c'], action: 'merge' }],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), frontmatter: ['topics'] };
+			const result = await runApply('---\ntopics: [a]\n---\nBody\n', proposal, accepted);
+
+			expect(result).toContain('- a');
+			expect(result).toContain('- b');
+			expect(result).toContain('- c');
+		});
+
+		it('adds a scalar frontmatter attribute when the key does not already exist', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					frontmatter: [{ key: 'category', value: 'reference', action: 'add' }],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), frontmatter: ['category'] };
+			const result = await runApply('Body\n', proposal, accepted);
+
+			expect(result).toContain('category: reference');
+		});
+
+		it('never overwrites an existing frontmatter key on an add action', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					frontmatter: [{ key: 'category', value: 'new', action: 'add' }],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), frontmatter: ['category'] };
+			const result = await runApply('---\ncategory: original\n---\nBody\n', proposal, accepted);
+
+			expect(result).toContain('category: original');
+			expect(result).not.toContain('category: new');
+		});
+
+		it('ignores frontmatter enrichments whose key was not accepted', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					frontmatter: [{ key: 'status', value: 'draft', action: 'add' }],
+				},
+			});
+			const result = await runApply('Body\n', proposal, emptyAccepted());
+
+			expect(result).not.toContain('status: draft');
+		});
+
+		it('is idempotent — re-applying replaces the previous enrichment callout rather than stacking', async () => {
+			const proposal = makeProposal({
+				result: {
+					...emptyResult(),
+					internalLinks: [
+						{ targetPath: 'notes/Other.md', displayText: 'Other', relevanceScore: 0.9, reason: 'reason' },
+					],
+				},
+			});
+			const accepted: AcceptedItems = { ...emptyAccepted(), internalLinks: ['notes/Other.md'] };
+			const first = await runApply('Body\n', proposal, accepted);
+
+			// Feed the already-enriched content back in.
+			app.vault.read.mockResolvedValue(first);
+			await applier.apply(proposal, accepted);
+			const second = (await app.vault.process.mock.results[1].value) as unknown as string;
+
+			const headerCount = second
+				.split('\n')
+				.filter((l) => l.includes(`[!${CALLOUT_TYPES.enrichment}] Related Notes`)).length;
+			expect(headerCount).toBe(1);
+		});
+	});
+
+	describe('undo', () => {
+		it('does nothing when the proposal has no acceptedItems', async () => {
+			await applier.undo(makeProposal());
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+
+		it('does nothing when the source note is not a TFile', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(null);
+			await applier.undo(makeProposal({ acceptedItems: emptyAccepted() }));
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+
+		it('removes accepted tags, frontmatter keys, and the enrichment callout', async () => {
+			const proposal = makeProposal({
+				acceptedItems: {
+					tags: ['#ml'],
+					internalLinks: [],
+					externalLinks: [],
+					frontmatter: ['category'],
+				},
+			});
+			const enriched =
+				'---\ntags: [ml, keep]\ncategory: reference\n---\n' +
+				'Body\n\n' +
+				`> [!${CALLOUT_TYPES.enrichment}] Related Notes\n> - [[Other]] — reason\n`;
+
+			const file = mockFile(proposal.sourceNotePath);
+			app.vault.getAbstractFileByPath.mockReturnValue(file);
+			app.vault.read.mockResolvedValue(enriched);
+			await applier.undo(proposal);
+			const result = (await app.vault.process.mock.results[0].value) as unknown as string;
+
+			expect(result).not.toContain('- ml');
+			expect(result).toContain('- keep');
+			expect(result).not.toContain('category: reference');
+			expect(result).not.toContain(`[!${CALLOUT_TYPES.enrichment}]`);
+		});
+	});
+});

--- a/src/enrichment/link-resolver.test.ts
+++ b/src/enrichment/link-resolver.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { LinkResolver } from './link-resolver';
 import { InternalLinkCandidate } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
+import { mockFile as rawFile } from '../__test-utils__/mock-factories';
+
+// Mock TFile vs the real obsidian TFile type differ structurally; tests only
+// need the runtime instance, so widen to `any` at the boundary.
+const mockFile = (path: string): any => rawFile(path);
 
 vi.mock('./weight-calculator', () => ({
 	computeProximityWeight: () => 0.8,
@@ -137,5 +142,128 @@ describe('LinkResolver.mergeTopicCandidates', () => {
 		expect(result[0].targetPath).toBe('High.md');
 		expect(result[1].targetPath).toBe('Mid.md');
 		expect(result[2].targetPath).toBe('Low.md');
+	});
+});
+
+// ── findInternalLinks ──
+// These use the centralized obsidian-mock TFile so the resolver's
+// `targetFile instanceof TFile` guard passes (the makeMockApp above uses a
+// local TFile class, which is fine for mergeTopicCandidates but not here).
+
+/** App whose getAbstractFileByPath resolves every path to a real mock TFile. */
+function makeTFileApp(markdownPaths: string[] = []) {
+	return {
+		vault: {
+			getMarkdownFiles: () => markdownPaths.map((p) => mockFile(p)),
+			getAbstractFileByPath: (path: string) => mockFile(path),
+		},
+		metadataCache: {
+			fileToLinktext: (file: any) => file.basename,
+		},
+	} as any;
+}
+
+describe('LinkResolver.findInternalLinks', () => {
+	function settingsWith(overrides?: Partial<typeof DEFAULT_SETTINGS.enrichment>) {
+		return makeSettings({ internalLinkThreshold: 0, ...overrides });
+	}
+
+	it('surfaces files that share two or more tags', () => {
+		const app = makeTFileApp();
+		const analyzer = makeMockAnalyzer({
+			tags: ['#x', '#y'],
+			tagIndex: new Map([
+				['#x', { count: 1, files: ['folder/B.md'] }],
+				['#y', { count: 1, files: ['folder/B.md'] }],
+			]),
+		});
+		const resolver = new LinkResolver(app, analyzer, settingsWith());
+
+		const result = resolver.findInternalLinks(mockFile('folder/A.md'), []);
+		const b = result.find((r) => r.targetPath === 'folder/B.md');
+		expect(b).toBeDefined();
+		expect(b!.reason).toContain('shares 2 tags');
+		expect(b!.displayText).toBe('B');
+	});
+
+	it('ignores files sharing only a single tag', () => {
+		const app = makeTFileApp();
+		const analyzer = makeMockAnalyzer({
+			tags: ['#x', '#y'],
+			tagIndex: new Map([
+				['#x', { count: 1, files: ['folder/B.md'] }],
+				['#y', { count: 1, files: ['folder/C.md'] }],
+			]),
+		});
+		const resolver = new LinkResolver(app, analyzer, settingsWith());
+
+		expect(resolver.findInternalLinks(mockFile('folder/A.md'), [])).toEqual([]);
+	});
+
+	it('surfaces same-folder files as proximity candidates', () => {
+		const app = makeTFileApp(['folder/A.md', 'folder/B.md']);
+		const resolver = new LinkResolver(app, makeMockAnalyzer(), settingsWith());
+
+		const result = resolver.findInternalLinks(mockFile('folder/A.md'), []);
+		const b = result.find((r) => r.targetPath === 'folder/B.md');
+		expect(b).toBeDefined();
+		expect(b!.reason).toContain('nearby folder');
+	});
+
+	it('surfaces 2-hop link-graph neighbors', () => {
+		const app = makeTFileApp();
+		const analyzer = makeMockAnalyzer({
+			outgoing: new Map([
+				['A.md', ['B.md']],
+				['B.md', ['C.md']],
+			]),
+		});
+		const resolver = new LinkResolver(app, analyzer, settingsWith());
+
+		const result = resolver.findInternalLinks(mockFile('A.md'), []);
+		const c = result.find((r) => r.targetPath === 'C.md');
+		expect(c).toBeDefined();
+		expect(c!.reason).toContain('2-hop link neighbor');
+	});
+
+	it('excludes already-linked paths', () => {
+		const app = makeTFileApp(['folder/A.md', 'folder/B.md']);
+		const resolver = new LinkResolver(app, makeMockAnalyzer(), settingsWith());
+
+		const result = resolver.findInternalLinks(mockFile('folder/A.md'), ['folder/B.md']);
+		expect(result).toEqual([]);
+	});
+
+	it('filters out candidates that fall below the threshold', () => {
+		const app = makeTFileApp(['folder/A.md', 'folder/B.md']);
+		const resolver = new LinkResolver(
+			app,
+			makeMockAnalyzer(),
+			settingsWith({ internalLinkThreshold: 0.9 })
+		);
+
+		expect(resolver.findInternalLinks(mockFile('folder/A.md'), [])).toEqual([]);
+	});
+
+	it('caps results at maxInternalLinks, highest score first', () => {
+		const app = makeTFileApp();
+		const analyzer = makeMockAnalyzer({
+			tags: ['#x', '#y', '#z'],
+			tagIndex: new Map([
+				['#x', { count: 2, files: ['folder/B.md', 'folder/C.md'] }],
+				['#y', { count: 2, files: ['folder/B.md', 'folder/C.md'] }],
+				['#z', { count: 1, files: ['folder/B.md'] }],
+			]),
+		});
+		const resolver = new LinkResolver(
+			app,
+			analyzer,
+			settingsWith({ maxInternalLinks: 1 })
+		);
+
+		const result = resolver.findInternalLinks(mockFile('folder/A.md'), []);
+		expect(result).toHaveLength(1);
+		// B shares 3 tags, C shares 2 → B ranks first
+		expect(result[0].targetPath).toBe('folder/B.md');
 	});
 });

--- a/src/enrichment/prompt-builder.test.ts
+++ b/src/enrichment/prompt-builder.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PromptBuilder } from './prompt-builder';
+import { AIClient } from '../shared';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+
+function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
+	const s = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(s);
+	return s;
+}
+
+describe('PromptBuilder', () => {
+	let settings: SynapseSettings;
+	let completeSpy: ReturnType<typeof vi.spyOn>;
+	let builder: PromptBuilder;
+
+	beforeEach(() => {
+		settings = makeSettings();
+		completeSpy = vi.spyOn(AIClient.prototype, 'complete');
+		builder = new PromptBuilder(() => settings);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	describe('suggestExternalLinks', () => {
+		it('returns an empty array without calling the AI when maxExternalLinks is 0', async () => {
+			settings.enrichment.maxExternalLinks = 0;
+			const result = await builder.suggestExternalLinks('content', []);
+			expect(result).toEqual([]);
+			expect(completeSpy).not.toHaveBeenCalled();
+		});
+
+		it('parses a valid JSON array and sanitizes title/reason fields', async () => {
+			settings.enrichment.maxExternalLinks = 3;
+			completeSpy.mockResolvedValue(
+				JSON.stringify([
+					{ url: 'https://en.wikipedia.org/wiki/X', title: 'X [page]', reason: 'auth (src)' },
+				])
+			);
+
+			const result = await builder.suggestExternalLinks('note text', []);
+			expect(result).toHaveLength(1);
+			expect(result[0].url).toBe('https://en.wikipedia.org/wiki/X');
+			expect(result[0].title).toBe('X page');
+			expect(result[0].reason).toBe('auth src');
+		});
+
+		it('strips a ```json fence before parsing', async () => {
+			settings.enrichment.maxExternalLinks = 3;
+			completeSpy.mockResolvedValue(
+				'```json\n[{"url":"https://ok.com","title":"Ok","reason":"good"}]\n```'
+			);
+
+			const result = await builder.suggestExternalLinks('text', []);
+			expect(result).toHaveLength(1);
+			expect(result[0].url).toBe('https://ok.com');
+		});
+
+		it('filters out entries with invalid URLs or missing fields', async () => {
+			settings.enrichment.maxExternalLinks = 5;
+			completeSpy.mockResolvedValue(
+				JSON.stringify([
+					{ url: 'javascript:alert(1)', title: 'bad', reason: 'evil' },
+					{ url: 'https://good.com', title: 'good', reason: 'fine' },
+					{ url: 'https://nofields.com', title: 'missing reason' },
+				])
+			);
+
+			const result = await builder.suggestExternalLinks('text', []);
+			expect(result).toHaveLength(1);
+			expect(result[0].url).toBe('https://good.com');
+		});
+
+		it('caps the result count at maxExternalLinks', async () => {
+			settings.enrichment.maxExternalLinks = 2;
+			completeSpy.mockResolvedValue(
+				JSON.stringify([
+					{ url: 'https://a.com', title: 'a', reason: 'r' },
+					{ url: 'https://b.com', title: 'b', reason: 'r' },
+					{ url: 'https://c.com', title: 'c', reason: 'r' },
+				])
+			);
+
+			const result = await builder.suggestExternalLinks('text', []);
+			expect(result).toHaveLength(2);
+		});
+
+		it('includes existing links in the prompt context', async () => {
+			settings.enrichment.maxExternalLinks = 3;
+			completeSpy.mockResolvedValue('[]');
+
+			await builder.suggestExternalLinks('text', ['https://existing.com']);
+			const prompt = completeSpy.mock.calls[0][0] as string;
+			expect(prompt).toContain('https://existing.com');
+		});
+
+		it('returns an empty array when the AI response is not valid JSON', async () => {
+			settings.enrichment.maxExternalLinks = 3;
+			completeSpy.mockResolvedValue('totally not json');
+			const result = await builder.suggestExternalLinks('text', []);
+			expect(result).toEqual([]);
+		});
+
+		it('returns an empty array when the AI throws', async () => {
+			settings.enrichment.maxExternalLinks = 3;
+			completeSpy.mockRejectedValue(new Error('boom'));
+			const result = await builder.suggestExternalLinks('text', []);
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('suggestFrontmatter', () => {
+		it('parses valid suggestions and filters out keys that already exist', async () => {
+			completeSpy.mockResolvedValue(
+				JSON.stringify([
+					{ key: 'category', value: 'reference', action: 'add' },
+					{ key: 'status', value: 'draft', action: 'add' },
+				])
+			);
+
+			const result = await builder.suggestFrontmatter('text', { status: 'published' });
+			expect(result).toHaveLength(1);
+			expect(result[0].key).toBe('category');
+		});
+
+		it('never suggests the reserved tags key', async () => {
+			completeSpy.mockResolvedValue(
+				JSON.stringify([{ key: 'tags', value: ['a'], action: 'merge' }])
+			);
+
+			const result = await builder.suggestFrontmatter('text', {});
+			expect(result).toEqual([]);
+		});
+
+		it('rejects prototype-pollution and malformed frontmatter keys', async () => {
+			completeSpy.mockResolvedValue(
+				JSON.stringify([
+					{ key: '__proto__', value: 'x', action: 'add' },
+					{ key: 'Invalid Key', value: 'x', action: 'add' },
+					{ key: 'valid-key', value: 'x', action: 'add' },
+				])
+			);
+
+			const result = await builder.suggestFrontmatter('text', {});
+			expect(result).toHaveLength(1);
+			expect(result[0].key).toBe('valid-key');
+		});
+
+		it('drops entries with an invalid action or missing value', async () => {
+			completeSpy.mockResolvedValue(
+				JSON.stringify([
+					{ key: 'a', value: 'x', action: 'replace' },
+					{ key: 'b', action: 'add' },
+					{ key: 'c', value: 'ok', action: 'merge' },
+				])
+			);
+
+			const result = await builder.suggestFrontmatter('text', {});
+			expect(result.map((r) => r.key)).toEqual(['c']);
+		});
+
+		it('returns an empty array when the AI throws', async () => {
+			completeSpy.mockRejectedValue(new Error('nope'));
+			const result = await builder.suggestFrontmatter('text', {});
+			expect(result).toEqual([]);
+		});
+	});
+});

--- a/src/image/index.test.ts
+++ b/src/image/index.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ImageModule } from './index';
+import { ImageExtractor } from './extractor';
+import { ImageEmbed } from './types';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { createMockApp, mockFile as rawFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+
+// Mock TFile vs the real obsidian TFile type differ structurally; tests only
+// need the runtime instance, so widen to `any` at the boundary.
+const mockFile = (path: string): any => rawFile(path);
+
+function makeSettings(): SynapseSettings {
+	return structuredClone(DEFAULT_SETTINGS);
+}
+
+/** A stub OperationHandle. `cancelled` is mutable so cancellation can be simulated. */
+function makeOp(cancelled = false) {
+	return {
+		progress: vi.fn(),
+		finish: vi.fn(),
+		error: vi.fn(),
+		cancelled,
+	};
+}
+
+describe('ImageModule', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let notifications: any;
+	let checkpointManager: ReturnType<typeof createMockCheckpointManager>;
+	let op: ReturnType<typeof makeOp>;
+	let extractSpy: ReturnType<typeof vi.spyOn>;
+	let module: ImageModule;
+
+	beforeEach(() => {
+		app = createMockApp();
+		(app.workspace as any).getActiveFile = vi.fn().mockReturnValue(null);
+		plugin = { app } as unknown as Plugin;
+		op = makeOp();
+		notifications = {
+			info: vi.fn(),
+			notifyError: vi.fn(),
+			startOperation: vi.fn().mockReturnValue(op),
+		};
+		checkpointManager = createMockCheckpointManager();
+		extractSpy = vi.spyOn(ImageExtractor.prototype, 'extract').mockResolvedValue({
+			text: 'extracted text',
+			fileName: 'img.png',
+		} as any);
+		module = new ImageModule(plugin, () => makeSettings(), notifications, checkpointManager as any);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	describe('extractFromFile', () => {
+		it('shows an info notice and does nothing when no note is active', async () => {
+			(app.workspace as any).getActiveFile.mockReturnValue(null);
+
+			await module.extractFromFile(mockFile('images/img.png'));
+
+			expect(notifications.info).toHaveBeenCalledWith(
+				expect.stringContaining('Open a note first')
+			);
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+
+		it('extracts OCR text and appends an OCR callout to the active note', async () => {
+			const active = mockFile('notes/Active.md');
+			(app.workspace as any).getActiveFile.mockReturnValue(active);
+			app.vault.read.mockResolvedValue('existing body');
+			const onComplete = vi.fn();
+			module.onExtractionComplete = onComplete;
+
+			await module.extractFromFile(mockFile('images/img.png'));
+
+			expect(app.vault.readBinary).toHaveBeenCalled();
+			expect(extractSpy).toHaveBeenCalled();
+			const written = (await app.vault.process.mock.results[0].value) as unknown as string;
+			expect(written).toContain('existing body');
+			expect(written).toContain('[!synapse-ocr]');
+			expect(written).toContain('extracted text');
+			expect(onComplete).toHaveBeenCalledWith('notes/Active.md');
+			expect(op.finish).toHaveBeenCalled();
+		});
+
+		it('reports an error notice when extraction throws', async () => {
+			const active = mockFile('notes/Active.md');
+			(app.workspace as any).getActiveFile.mockReturnValue(active);
+			app.vault.read.mockResolvedValue('body');
+			extractSpy.mockRejectedValue(new Error('vision API down'));
+
+			await module.extractFromFile(mockFile('images/img.png'));
+
+			expect(op.error).toHaveBeenCalledWith(expect.stringContaining('vision API down'));
+		});
+	});
+
+	describe('extractAndInsert', () => {
+		const embed = (fileName: string, line: number): ImageEmbed => ({
+			fileName,
+			file: mockFile(`images/${fileName}`),
+			line,
+		});
+
+		it('creates a checkpoint, inserts OCR blocks, and completes the checkpoint', async () => {
+			const note = mockFile('notes/Doc.md');
+			app.vault.read.mockResolvedValue('line0\nline1\nline2');
+			const onComplete = vi.fn();
+			module.onExtractionComplete = onComplete;
+
+			await module.extractAndInsert(note, [embed('a.png', 0)]);
+
+			expect(checkpointManager.create).toHaveBeenCalledWith(
+				expect.objectContaining({ module: 'image' })
+			);
+			expect(checkpointManager.addDeferredTask).toHaveBeenCalled();
+			expect(checkpointManager.completeItem).toHaveBeenCalled();
+			const written = (await app.vault.process.mock.results[0].value) as unknown as string;
+			expect(written).toContain('[!synapse-ocr]');
+			expect(written).toContain('extracted text');
+			expect(checkpointManager.complete).toHaveBeenCalledWith('mockcheckpoint');
+			expect(onComplete).toHaveBeenCalledWith('notes/Doc.md');
+			expect(op.finish).toHaveBeenCalled();
+		});
+
+		it('continues the batch and reports per-image errors without aborting', async () => {
+			const note = mockFile('notes/Doc.md');
+			app.vault.read.mockResolvedValue('a\nb');
+			extractSpy.mockRejectedValueOnce(new Error('one failed'));
+
+			await module.extractAndInsert(note, [embed('bad.png', 0)]);
+
+			expect(notifications.notifyError).toHaveBeenCalledWith(
+				expect.stringContaining('bad.png'),
+				expect.any(Error)
+			);
+			// Nothing completed → no write, checkpoint still completed (not cancelled)
+			expect(app.vault.process).not.toHaveBeenCalled();
+			expect(checkpointManager.complete).toHaveBeenCalled();
+		});
+
+		it('discards the checkpoint when the operation is cancelled before any work', async () => {
+			op = makeOp(true);
+			notifications.startOperation.mockReturnValue(op);
+			const note = mockFile('notes/Doc.md');
+
+			await module.extractAndInsert(note, [embed('a.png', 0)]);
+
+			expect(checkpointManager.discard).toHaveBeenCalledWith('mockcheckpoint');
+			expect(checkpointManager.complete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('resumeFromCheckpoint', () => {
+		it('informs the user and discards the checkpoint', async () => {
+			const checkpoint = { id: 'cp-1', remainingItems: [{ id: 'x' }, { id: 'y' }] } as any;
+
+			await module.resumeFromCheckpoint(checkpoint);
+
+			expect(notifications.info).toHaveBeenCalledWith(expect.stringContaining('2 remaining'));
+			expect(checkpointManager.discard).toHaveBeenCalledWith('cp-1');
+		});
+	});
+
+	it('onload and onunload are no-ops that do not throw', async () => {
+		await expect(module.onload()).resolves.toBeUndefined();
+		expect(() => module.onunload()).not.toThrow();
+	});
+});

--- a/src/rem/index.test.ts
+++ b/src/rem/index.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RemModule } from './index';
+import { RemStore } from './rem-store';
+import { MentionScanner } from './mention-scanner';
+import { SemanticMatcher } from './semantic-matcher';
+import { RemProposal, RemLinkCandidate } from './types';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { createMockApp, mockFile as rawFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+
+// Mock TFile vs the real obsidian TFile type differ structurally; tests only
+// need the runtime instance, so widen to `any` at the boundary.
+const mockFile = (path: string): any => rawFile(path);
+
+function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
+	const s = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(s);
+	return s;
+}
+
+function makeOp(cancelled = false) {
+	return { progress: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+}
+
+function candidate(matchedText: string, line = 0): RemLinkCandidate {
+	return {
+		targetPath: `notes/${matchedText}.md`,
+		targetDisplayName: matchedText,
+		matchedText,
+		matchType: 'title',
+		occurrences: [{ lineNumber: line, lineText: matchedText, startOffset: 0, endOffset: matchedText.length }],
+		confidence: 1,
+	};
+}
+
+describe('RemModule', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let notifications: any;
+	let checkpointManager: ReturnType<typeof createMockCheckpointManager>;
+	let registrar: any;
+	let settings: SynapseSettings;
+
+	// Collaborator spies
+	let initSpy: ReturnType<typeof vi.spyOn>;
+	let saveSpy: ReturnType<typeof vi.spyOn>;
+	let loadSpy: ReturnType<typeof vi.spyOn>;
+	let updateStatusSpy: ReturnType<typeof vi.spyOn>;
+	let scanSpy: ReturnType<typeof vi.spyOn>;
+	let matchSpy: ReturnType<typeof vi.spyOn>;
+	let loadPendingSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		app = createMockApp();
+		(app.metadataCache as any).getFileCache = vi.fn().mockReturnValue(null);
+		plugin = { app } as unknown as Plugin;
+		settings = makeSettings();
+		notifications = {
+			info: vi.fn(),
+			success: vi.fn(),
+			notifyError: vi.fn(),
+			startOperation: vi.fn().mockReturnValue(makeOp()),
+		};
+		checkpointManager = createMockCheckpointManager();
+		registrar = { register: vi.fn() };
+
+		initSpy = vi.spyOn(RemStore.prototype, 'init').mockResolvedValue(undefined);
+		saveSpy = vi.spyOn(RemStore.prototype, 'save').mockResolvedValue(undefined);
+		loadSpy = vi.spyOn(RemStore.prototype, 'load').mockResolvedValue(null);
+		updateStatusSpy = vi.spyOn(RemStore.prototype, 'updateStatus').mockResolvedValue(undefined);
+		scanSpy = vi.spyOn(MentionScanner.prototype, 'scan').mockReturnValue([]);
+		matchSpy = vi.spyOn(SemanticMatcher.prototype, 'match').mockResolvedValue([]);
+		loadPendingSpy = vi.spyOn(RemStore.prototype, 'loadPending').mockResolvedValue([]);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	async function loadedModule(shouldAutoAccept?: () => boolean): Promise<RemModule> {
+		const module = new RemModule(
+			plugin,
+			() => settings,
+			notifications,
+			checkpointManager as any,
+			registrar,
+			shouldAutoAccept
+		);
+		await module.onload();
+		return module;
+	}
+
+	describe('onload', () => {
+		it('initializes the store and registers both REM commands', async () => {
+			await loadedModule();
+			expect(initSpy).toHaveBeenCalled();
+			const ids = registrar.register.mock.calls.map((c: any[]) => c[0]);
+			expect(ids).toContain('synapse:rem-current-note');
+			expect(ids).toContain('synapse:rem-directory');
+		});
+	});
+
+	describe('remScanNote', () => {
+		it('returns null and notifies when the file does not exist', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(null);
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('missing.md');
+			expect(result).toBeNull();
+			expect(notifications.info).toHaveBeenCalledWith('File not found');
+		});
+
+		it('returns null when the note is in an excluded folder', async () => {
+			settings.enrichment.excludeFolders = ['Archive'];
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('Archive/Old.md'));
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('Archive/Old.md');
+			expect(result).toBeNull();
+			expect(notifications.info).toHaveBeenCalledWith('Note is excluded from REM scanning');
+		});
+
+		it('saves a proposal built from literal mention candidates', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('mentions Foo and Bar');
+			scanSpy.mockReturnValue([candidate('Foo'), candidate('Bar')]);
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('notes/A.md');
+			expect(result).not.toBeNull();
+			expect(result!.candidates).toHaveLength(2);
+			expect(result!.status).toBe('pending');
+			expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({ sourceNotePath: 'notes/A.md' }));
+			expect(notifications.success).toHaveBeenCalledWith(expect.stringContaining('2 linkable mentions'));
+		});
+
+		it('returns null when no linkable mentions are found', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('nothing here');
+			scanSpy.mockReturnValue([]);
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('notes/A.md');
+			expect(result).toBeNull();
+			expect(notifications.info).toHaveBeenCalledWith('No linkable mentions found');
+			expect(saveSpy).not.toHaveBeenCalled();
+		});
+
+		it('augments literal candidates with semantic matches above the confidence threshold', async () => {
+			settings.rem.semanticMatching = true;
+			settings.rem.confidenceThreshold = 0.5;
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('deep learning content');
+			scanSpy.mockReturnValue([]);
+			matchSpy.mockResolvedValue([
+				{ ...candidate('ML'), matchType: 'semantic', confidence: 0.9 },
+				{ ...candidate('Weak'), matchType: 'semantic', confidence: 0.2 },
+			]);
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('notes/A.md');
+			expect(matchSpy).toHaveBeenCalled();
+			expect(result!.candidates.map((c) => c.matchedText)).toEqual(['ML']);
+		});
+	});
+
+	describe('acceptProposal', () => {
+		const pendingProposal = (): RemProposal => ({
+			id: 'p1',
+			sourceNotePath: 'notes/A.md',
+			createdAt: '2026-06-11T00:00:00.000Z',
+			candidates: [candidate('Foo', 0), candidate('Bar', 1)],
+			status: 'pending',
+		});
+
+		it('applies accepted links to the note and marks the proposal accepted', async () => {
+			loadSpy.mockResolvedValue(pendingProposal());
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('Foo line\nBar line');
+			const module = await loadedModule();
+
+			await module.acceptProposal('p1', ['Foo', 'Bar']);
+
+			const written = (await app.vault.process.mock.results[0].value) as unknown as string;
+			expect(written).toContain('[[Foo]]');
+			expect(written).toContain('[[Bar]]');
+			expect(updateStatusSpy).toHaveBeenCalledWith('p1', 'accepted', ['Foo', 'Bar'], 'Foo line\nBar line');
+			expect(notifications.success).toHaveBeenCalled();
+		});
+
+		it('marks the proposal partially-accepted when only some links are accepted', async () => {
+			loadSpy.mockResolvedValue(pendingProposal());
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('Foo line\nBar line');
+			const module = await loadedModule();
+
+			await module.acceptProposal('p1', ['Foo']);
+
+			expect(updateStatusSpy).toHaveBeenCalledWith(
+				'p1',
+				'partially-accepted',
+				['Foo'],
+				expect.any(String)
+			);
+		});
+
+		it('rejects the proposal when no candidate matches the accepted texts', async () => {
+			loadSpy.mockResolvedValue(pendingProposal());
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			const module = await loadedModule();
+
+			await module.acceptProposal('p1', ['Nonexistent']);
+
+			expect(updateStatusSpy).toHaveBeenCalledWith('p1', 'rejected');
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+
+		it('does nothing for an already-accepted proposal (double-accept guard)', async () => {
+			loadSpy.mockResolvedValue({ ...pendingProposal(), status: 'accepted' });
+			const module = await loadedModule();
+
+			await module.acceptProposal('p1', ['Foo']);
+			expect(app.vault.process).not.toHaveBeenCalled();
+			expect(updateStatusSpy).not.toHaveBeenCalled();
+		});
+
+		it('returns early when the proposal cannot be loaded', async () => {
+			loadSpy.mockResolvedValue(null);
+			const module = await loadedModule();
+
+			await module.acceptProposal('missing', ['Foo']);
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('auto-accept', () => {
+		it('auto-accepts a freshly scanned proposal when the flag is on', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('Foo here');
+			scanSpy.mockReturnValue([candidate('Foo')]);
+			// load() is consulted by acceptProposal (invoked via maybeAutoAccept)
+			loadSpy.mockImplementation(async () => ({
+				id: 'x',
+				sourceNotePath: 'notes/A.md',
+				createdAt: '2026-06-11T00:00:00.000Z',
+				candidates: [candidate('Foo')],
+				status: 'pending',
+			}));
+			const module = await loadedModule(() => true);
+
+			await module.remScanNote('notes/A.md');
+			// acceptProposal path writes to the note and updates status
+			expect(updateStatusSpy).toHaveBeenCalledWith(
+				expect.any(String),
+				'accepted',
+				['Foo'],
+				expect.any(String)
+			);
+		});
+	});
+
+	describe('rejectProposal / undoProposal', () => {
+		it('rejectProposal sets the status to rejected', async () => {
+			const module = await loadedModule();
+			await module.rejectProposal('p1');
+			expect(updateStatusSpy).toHaveBeenCalledWith('p1', 'rejected');
+		});
+
+		it('undoProposal restores the original content snapshot and resets to pending', async () => {
+			loadSpy.mockResolvedValue({
+				id: 'p1',
+				sourceNotePath: 'notes/A.md',
+				createdAt: '2026-06-11T00:00:00.000Z',
+				candidates: [candidate('Foo')],
+				status: 'accepted',
+				originalContent: 'pristine content',
+			});
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('linked [[Foo]] content');
+			const module = await loadedModule();
+
+			await module.undoProposal('p1');
+
+			const written = (await app.vault.process.mock.results[0].value) as unknown as string;
+			expect(written).toBe('pristine content');
+			expect(updateStatusSpy).toHaveBeenCalledWith('p1', 'pending', undefined, undefined);
+			expect(notifications.success).toHaveBeenCalled();
+		});
+
+		it('undoProposal bails out when there is no snapshot', async () => {
+			loadSpy.mockResolvedValue({
+				id: 'p1',
+				sourceNotePath: 'notes/A.md',
+				createdAt: '2026-06-11T00:00:00.000Z',
+				candidates: [],
+				status: 'accepted',
+			});
+			const module = await loadedModule();
+
+			await module.undoProposal('p1');
+			expect(notifications.info).toHaveBeenCalledWith(expect.stringContaining('Cannot undo'));
+			expect(app.vault.process).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('remScanDirectory', () => {
+		it('notifies and returns 0 when no eligible files are found', async () => {
+			app.vault.getMarkdownFiles.mockReturnValue([]);
+			const module = await loadedModule();
+
+			const created = await module.remScanDirectory('notes');
+			expect(created).toBe(0);
+			expect(notifications.info).toHaveBeenCalledWith('No eligible files found');
+		});
+
+		it('scans each eligible note, saves proposals, and completes the checkpoint', async () => {
+			app.vault.getMarkdownFiles.mockReturnValue([mockFile('notes/A.md'), mockFile('notes/B.md')]);
+			app.vault.read.mockResolvedValue('Foo content');
+			scanSpy.mockReturnValue([candidate('Foo')]);
+			const module = await loadedModule();
+
+			const created = await module.remScanDirectory();
+			expect(created).toBe(2);
+			expect(saveSpy).toHaveBeenCalledTimes(2);
+			expect(checkpointManager.create).toHaveBeenCalledWith(
+				expect.objectContaining({ module: 'rem' })
+			);
+			expect(checkpointManager.complete).toHaveBeenCalled();
+		});
+
+		it('discards the checkpoint and reverts when cancelled before any work', async () => {
+			app.vault.getMarkdownFiles.mockReturnValue([mockFile('notes/A.md')]);
+			notifications.startOperation.mockReturnValue(makeOp(true));
+			const module = await loadedModule();
+
+			const created = await module.remScanDirectory();
+			expect(created).toBe(0);
+			expect(checkpointManager.discard).toHaveBeenCalled();
+			expect(checkpointManager.complete).not.toHaveBeenCalled();
+		});
+
+		it('narrows the scan to a single note when onlyFile is provided', async () => {
+			app.vault.getMarkdownFiles.mockReturnValue([mockFile('notes/A.md'), mockFile('notes/B.md')]);
+			app.vault.read.mockResolvedValue('Foo content');
+			scanSpy.mockReturnValue([candidate('Foo')]);
+			const module = await loadedModule();
+
+			const created = await module.remScanDirectory(undefined, false, mockFile('notes/B.md'));
+			expect(created).toBe(1);
+			expect(saveSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ sourceNotePath: 'notes/B.md' })
+			);
+		});
+	});
+
+	describe('getPendingProposals', () => {
+		it('delegates to the store', async () => {
+			const pending = [{ id: 'p1' }] as any;
+			loadPendingSpy.mockResolvedValue(pending);
+			const module = await loadedModule();
+
+			expect(await module.getPendingProposals()).toBe(pending);
+		});
+	});
+
+	describe('isExcluded via exclude tags', () => {
+		it('excludes a note carrying an excluded frontmatter tag', async () => {
+			settings.enrichment.excludeTags = ['#private'];
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/Secret.md'));
+			(app.metadataCache as any).getFileCache.mockReturnValue({
+				frontmatter: { tags: ['private'] },
+			});
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('notes/Secret.md');
+			expect(result).toBeNull();
+			expect(notifications.info).toHaveBeenCalledWith('Note is excluded from REM scanning');
+		});
+	});
+});

--- a/src/rem/rem-applier.test.ts
+++ b/src/rem/rem-applier.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { RemApplier } from './rem-applier';
+import type { RemLinkCandidate, RemOccurrence } from './types';
+
+function occ(lineNumber: number, lineText: string, startOffset: number, endOffset: number): RemOccurrence {
+	return { lineNumber, lineText, startOffset, endOffset };
+}
+
+function candidate(overrides: Partial<RemLinkCandidate> = {}): RemLinkCandidate {
+	return {
+		targetPath: 'notes/Target.md',
+		targetDisplayName: 'Target',
+		matchedText: 'Target',
+		matchType: 'title',
+		occurrences: [],
+		confidence: 1,
+		...overrides,
+	};
+}
+
+describe('RemApplier', () => {
+	const applier = new RemApplier();
+
+	it('returns content unchanged when there are no candidates', () => {
+		const content = 'Just some text\nover two lines';
+		expect(applier.apply(content, [])).toBe(content);
+	});
+
+	it('inserts a bare wikilink when matched text equals the display name', () => {
+		const content = 'I love Target very much';
+		const c = candidate({
+			matchedText: 'Target',
+			targetDisplayName: 'Target',
+			occurrences: [occ(0, content, 7, 13)],
+		});
+		expect(applier.apply(content, [c])).toBe('I love [[Target]] very much');
+	});
+
+	it('inserts an aliased wikilink when matched text differs from the display name', () => {
+		const content = 'study of machine learning today';
+		const c = candidate({
+			matchedText: 'machine learning',
+			targetDisplayName: 'ML Fundamentals',
+			occurrences: [occ(0, content, 9, 25)],
+		});
+		expect(applier.apply(content, [c])).toBe(
+			'study of [[ML Fundamentals|machine learning]] today'
+		);
+	});
+
+	it('treats the matched/display equality check case-insensitively', () => {
+		const content = 'the TARGET note';
+		const c = candidate({
+			matchedText: 'TARGET',
+			targetDisplayName: 'Target',
+			occurrences: [occ(0, content, 4, 10)],
+		});
+		// matchedText differs in case but is considered equal → bare link, keeping display name casing
+		expect(applier.apply(content, [c])).toBe('the [[Target]] note');
+	});
+
+	it('applies multiple occurrences on the same line without corrupting offsets', () => {
+		const content = 'foo foo foo';
+		const c = candidate({
+			matchedText: 'foo',
+			targetDisplayName: 'Foobar',
+			occurrences: [occ(0, content, 0, 3), occ(0, content, 4, 7), occ(0, content, 8, 11)],
+		});
+		expect(applier.apply(content, [c])).toBe('[[Foobar|foo]] [[Foobar|foo]] [[Foobar|foo]]');
+	});
+
+	it('applies replacements across multiple lines and multiple candidates', () => {
+		const lines = ['alpha here', 'and beta there'];
+		const content = lines.join('\n');
+		const a = candidate({
+			matchedText: 'alpha',
+			targetDisplayName: 'Alpha',
+			occurrences: [occ(0, lines[0], 0, 5)],
+		});
+		const b = candidate({
+			targetPath: 'notes/Beta.md',
+			matchedText: 'beta',
+			targetDisplayName: 'Beta',
+			occurrences: [occ(1, lines[1], 4, 8)],
+		});
+		// matchedText equals displayName case-insensitively → bare links
+		expect(applier.apply(content, [a, b])).toBe('[[Alpha]] here\nand [[Beta]] there');
+	});
+
+	it('skips occurrences whose line number is out of range', () => {
+		const content = 'single line';
+		const c = candidate({
+			matchedText: 'single',
+			targetDisplayName: 'Single',
+			occurrences: [occ(5, 'phantom', 0, 6)],
+		});
+		expect(applier.apply(content, [c])).toBe(content);
+	});
+});

--- a/src/rem/semantic-matcher.test.ts
+++ b/src/rem/semantic-matcher.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SemanticMatcher } from './semantic-matcher';
+import { AIClient } from '../shared';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { createMockApp, mockFile as rawFile } from '../__test-utils__/mock-factories';
+import type { App } from 'obsidian';
+
+// Mock TFile vs the real obsidian TFile type differ structurally; tests only
+// need the runtime instance, so widen to `any` at the boundary.
+const mockFile = (path: string): any => rawFile(path);
+
+function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
+	const s = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(s);
+	return s;
+}
+
+describe('SemanticMatcher', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let settings: SynapseSettings;
+	let completeSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		app = createMockApp();
+		settings = makeSettings((s) => {
+			s.rem.confidenceThreshold = 0.5;
+		});
+		completeSpy = vi.spyOn(AIClient.prototype, 'complete');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function makeMatcher(): SemanticMatcher {
+		return new SemanticMatcher(app as unknown as App, () => settings);
+	}
+
+	it('returns an empty array when the vault has no other notes', async () => {
+		const source = mockFile('notes/Source.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source]);
+
+		const result = await makeMatcher().match(source, 'content', new Set(), 10);
+
+		expect(result).toEqual([]);
+		expect(completeSpy).not.toHaveBeenCalled();
+	});
+
+	it('excludes the source note and already-matched notes from the candidate title list', async () => {
+		const source = mockFile('notes/Source.md');
+		const matched = mockFile('notes/Already.md');
+		const candidateNote = mockFile('notes/Neural Networks.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, matched, candidateNote]);
+		completeSpy.mockResolvedValue('[]');
+
+		await makeMatcher().match(source, 'about deep learning', new Set(['notes/Already.md']), 10);
+
+		const userPrompt = completeSpy.mock.calls[0][0] as string;
+		expect(userPrompt).toContain('Neural Networks');
+		expect(userPrompt).not.toContain('Already');
+		expect(userPrompt).not.toContain('Source');
+	});
+
+	it('builds candidates from a valid AI response and locates the concept in the text', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/ML Fundamentals.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		completeSpy.mockResolvedValue(
+			JSON.stringify([
+				{ title: 'ML Fundamentals', matchedConcept: 'machine learning', confidence: 0.9 },
+			])
+		);
+
+		const content = 'This note discusses machine learning in depth.\nMore machine learning here.';
+		const result = await makeMatcher().match(source, content, new Set(), 10);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].targetPath).toBe('notes/ML Fundamentals.md');
+		expect(result[0].targetDisplayName).toBe('ML Fundamentals');
+		expect(result[0].matchType).toBe('semantic');
+		expect(result[0].confidence).toBe(0.9);
+		expect(result[0].occurrences).toHaveLength(2);
+		expect(result[0].occurrences[0]).toMatchObject({ lineNumber: 0, startOffset: 20 });
+	});
+
+	it('strips ```json code fences before parsing', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/Topic.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		completeSpy.mockResolvedValue(
+			'```json\n[{"title":"Topic","matchedConcept":"topic","confidence":0.8}]\n```'
+		);
+
+		const result = await makeMatcher().match(source, 'a topic line', new Set(), 10);
+		expect(result).toHaveLength(1);
+		expect(result[0].targetDisplayName).toBe('Topic');
+	});
+
+	it('drops matches below the configured confidence threshold', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/Topic.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		settings.rem.confidenceThreshold = 0.7;
+		completeSpy.mockResolvedValue(
+			JSON.stringify([{ title: 'Topic', matchedConcept: 'topic', confidence: 0.6 }])
+		);
+
+		const result = await makeMatcher().match(source, 'topic', new Set(), 10);
+		expect(result).toEqual([]);
+	});
+
+	it('ignores AI-suggested titles that do not correspond to a real note', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/Real.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		completeSpy.mockResolvedValue(
+			JSON.stringify([{ title: 'Hallucinated', matchedConcept: 'x', confidence: 0.9 }])
+		);
+
+		const result = await makeMatcher().match(source, 'x', new Set(), 10);
+		expect(result).toEqual([]);
+	});
+
+	it('sorts by confidence descending and caps results at maxLinks', async () => {
+		const source = mockFile('notes/Source.md');
+		const a = mockFile('notes/A.md');
+		const b = mockFile('notes/B.md');
+		const c = mockFile('notes/C.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, a, b, c]);
+		completeSpy.mockResolvedValue(
+			JSON.stringify([
+				{ title: 'A', matchedConcept: 'a', confidence: 0.6 },
+				{ title: 'B', matchedConcept: 'b', confidence: 0.95 },
+				{ title: 'C', matchedConcept: 'c', confidence: 0.8 },
+			])
+		);
+
+		const result = await makeMatcher().match(source, 'a b c', new Set(), 2);
+		expect(result.map((r) => r.targetDisplayName)).toEqual(['B', 'C']);
+	});
+
+	it('returns an empty array when the AI client throws', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/Topic.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		completeSpy.mockRejectedValue(new Error('network down'));
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const result = await makeMatcher().match(source, 'topic', new Set(), 10);
+		expect(result).toEqual([]);
+		expect(warn).toHaveBeenCalled();
+	});
+
+	it('returns an empty array when the AI response is not valid JSON', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/Topic.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		completeSpy.mockResolvedValue('not json at all');
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const result = await makeMatcher().match(source, 'topic', new Set(), 10);
+		expect(result).toEqual([]);
+	});
+
+	it('returns an empty array when the AI response is valid JSON but not an array', async () => {
+		const source = mockFile('notes/Source.md');
+		const target = mockFile('notes/Topic.md');
+		app.vault.getMarkdownFiles.mockReturnValue([source, target]);
+		completeSpy.mockResolvedValue('{"not":"an array"}');
+
+		const result = await makeMatcher().match(source, 'topic', new Set(), 10);
+		expect(result).toEqual([]);
+	});
+});

--- a/src/shared/ai-client.test.ts
+++ b/src/shared/ai-client.test.ts
@@ -218,3 +218,264 @@ describe('AIClient — Gemini provider', () => {
 		expect(err.message).not.toContain('AIzaSyBadKey');
 	});
 });
+
+/** A minimal successful OpenAI chat-completions response. */
+function openAIResponse(content: string) {
+	return {
+		status: 200,
+		json: { choices: [{ message: { role: 'assistant', content } }] },
+		text: '',
+		headers: {},
+	};
+}
+
+/** A minimal successful Anthropic messages response. */
+function anthropicResponse(text: string) {
+	return {
+		status: 200,
+		json: { content: [{ type: 'text', text }] },
+		text: '',
+		headers: {},
+	};
+}
+
+/** A minimal successful Ollama chat response. */
+function ollamaResponse(content: string) {
+	return {
+		status: 200,
+		json: { message: { role: 'assistant', content } },
+		text: '',
+		headers: {},
+	};
+}
+
+describe('AIClient — OpenAI provider', () => {
+	let settings: SynapseSettings;
+	let client: AIClient;
+
+	beforeEach(() => {
+		settings = makeSettings((s) => {
+			s.ai.provider = 'openai';
+			s.ai.model = 'gpt-4o';
+			s.ai.apiKey = 'sk-test123456789012345';
+			s.ai.maxTokens = 512;
+			s.ai.temperature = 0.5;
+		});
+		client = new AIClient(() => settings);
+		mockRequestUrl.mockReset();
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	it('POSTs to the chat completions endpoint with a Bearer auth header', async () => {
+		mockRequestUrl.mockResolvedValue(openAIResponse('hello'));
+
+		const result = await client.complete('Hi', 'Be brief.');
+
+		const call = mockRequestUrl.mock.calls[0][0] as any;
+		expect(call.url).toBe('https://api.openai.com/v1/chat/completions');
+		expect(call.method).toBe('POST');
+		expect(call.headers['Authorization']).toBe('Bearer sk-test123456789012345');
+		const body = lastRequestBody();
+		expect(body.model).toBe('gpt-4o');
+		expect(body.max_tokens).toBe(512);
+		expect(body.temperature).toBe(0.5);
+		// system prompt is preserved as a system-role message for OpenAI
+		expect(body.messages[0]).toEqual({ role: 'system', content: 'Be brief.' });
+		expect(body.messages[1]).toEqual({ role: 'user', content: 'Hi' });
+		expect(result).toBe('hello');
+	});
+
+	it('serializes vision content blocks into image_url parts', async () => {
+		mockRequestUrl.mockResolvedValue(openAIResponse('a dog'));
+		const blocks: ContentBlock[] = [
+			{ type: 'text', text: 'describe' },
+			{ type: 'image', mediaType: 'image/jpeg', data: 'Zm9v' },
+		];
+
+		await client.chat([{ role: 'user', content: blocks }]);
+
+		const body = lastRequestBody();
+		expect(body.messages[0].content).toEqual([
+			{ type: 'text', text: 'describe' },
+			{ type: 'image_url', image_url: { url: 'data:image/jpeg;base64,Zm9v' } },
+		]);
+	});
+});
+
+describe('AIClient — Anthropic provider', () => {
+	let settings: SynapseSettings;
+	let client: AIClient;
+
+	beforeEach(() => {
+		settings = makeSettings((s) => {
+			s.ai.provider = 'anthropic';
+			s.ai.model = 'sonnet';
+			s.ai.apiKey = 'anthropic-key-1234567890';
+			s.ai.maxTokens = 2048;
+			s.ai.temperature = 0.2;
+		});
+		client = new AIClient(() => settings);
+		mockRequestUrl.mockReset();
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	it('resolves the short model name to a full Anthropic model id and sets version headers', async () => {
+		mockRequestUrl.mockResolvedValue(anthropicResponse('hi'));
+
+		const result = await client.complete('Hello', 'You are terse.');
+
+		const call = mockRequestUrl.mock.calls[0][0] as any;
+		expect(call.url).toBe('https://api.anthropic.com/v1/messages');
+		expect(call.headers['x-api-key']).toBe('anthropic-key-1234567890');
+		expect(call.headers['anthropic-version']).toBe('2023-06-01');
+		const body = lastRequestBody();
+		expect(body.model).toBe('claude-sonnet-4-6');
+		// system message is lifted out of messages into the top-level system field
+		expect(body.system).toBe('You are terse.');
+		expect(body.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+		expect(result).toBe('hi');
+	});
+
+	it('omits the system field when no system message is supplied', async () => {
+		mockRequestUrl.mockResolvedValue(anthropicResponse('ok'));
+
+		await client.chat([{ role: 'user', content: 'Hi' }]);
+
+		const body = lastRequestBody();
+		expect(body.system).toBeUndefined();
+	});
+
+	it('serializes vision content blocks into base64 image source parts', async () => {
+		mockRequestUrl.mockResolvedValue(anthropicResponse('seen'));
+		const blocks: ContentBlock[] = [
+			{ type: 'text', text: 'look' },
+			{ type: 'image', mediaType: 'image/png', data: 'YmFy' },
+		];
+
+		await client.chat([{ role: 'user', content: blocks }]);
+
+		const body = lastRequestBody();
+		expect(body.messages[0].content).toEqual([
+			{ type: 'text', text: 'look' },
+			{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'YmFy' } },
+		]);
+	});
+});
+
+describe('AIClient — Ollama provider', () => {
+	let settings: SynapseSettings;
+	let client: AIClient;
+
+	beforeEach(() => {
+		settings = makeSettings((s) => {
+			s.ai.provider = 'ollama';
+			s.ai.model = 'llama3';
+			s.ai.ollamaEndpoint = 'http://localhost:11434';
+		});
+		client = new AIClient(() => settings);
+		mockRequestUrl.mockReset();
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	it('POSTs to the {endpoint}/api/chat path with streaming disabled', async () => {
+		mockRequestUrl.mockResolvedValue(ollamaResponse('local reply'));
+
+		const result = await client.complete('Hi');
+
+		const call = mockRequestUrl.mock.calls[0][0] as any;
+		expect(call.url).toBe('http://localhost:11434/api/chat');
+		const body = lastRequestBody();
+		expect(body.model).toBe('llama3');
+		expect(body.stream).toBe(false);
+		expect(result).toBe('local reply');
+	});
+
+	it('splits vision content blocks into content text and an images array', async () => {
+		mockRequestUrl.mockResolvedValue(ollamaResponse('ok'));
+		const blocks: ContentBlock[] = [
+			{ type: 'text', text: 'first' },
+			{ type: 'text', text: 'second' },
+			{ type: 'image', mediaType: 'image/png', data: 'aW1n' },
+		];
+
+		await client.chat([{ role: 'user', content: blocks }]);
+
+		const body = lastRequestBody();
+		expect(body.messages[0]).toEqual({
+			role: 'user',
+			content: 'first\nsecond',
+			images: ['aW1n'],
+		});
+	});
+
+	it('rejects an unparseable endpoint URL without making a request', async () => {
+		settings.ai.ollamaEndpoint = 'not a url';
+		await expect(client.complete('Hi')).rejects.toThrow(/Invalid Ollama endpoint/);
+		expect(mockRequestUrl).not.toHaveBeenCalled();
+	});
+
+	it('rejects a non-localhost HTTP endpoint (requires HTTPS off-localhost)', async () => {
+		settings.ai.ollamaEndpoint = 'http://example.com:11434';
+		await expect(client.complete('Hi')).rejects.toThrow(/must use HTTPS/);
+		expect(mockRequestUrl).not.toHaveBeenCalled();
+	});
+
+	it('allows an HTTPS endpoint on a remote host', async () => {
+		settings.ai.ollamaEndpoint = 'https://ollama.example.com';
+		mockRequestUrl.mockResolvedValue(ollamaResponse('secure'));
+
+		const result = await client.complete('Hi');
+		expect(result).toBe('secure');
+		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('AIClient — shared error handling and routing', () => {
+	let settings: SynapseSettings;
+	let client: AIClient;
+
+	beforeEach(() => {
+		settings = makeSettings((s) => {
+			s.ai.provider = 'openai';
+			s.ai.model = 'gpt-4o';
+			s.ai.apiKey = 'sk-test';
+		});
+		client = new AIClient(() => settings);
+		mockRequestUrl.mockReset();
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	it('throws on a >= 400 status, surfacing the structured error message', async () => {
+		mockRequestUrl.mockResolvedValue({
+			status: 429,
+			json: { error: { message: 'rate limited' } },
+			text: '',
+			headers: {},
+		});
+
+		await expect(client.complete('Hi')).rejects.toThrow('API error (429): rate limited');
+	});
+
+	it('falls back to the response text when the error body has no structured message', async () => {
+		mockRequestUrl.mockResolvedValue({
+			status: 500,
+			get json(): unknown {
+				throw new Error('no body');
+			},
+			text: 'upstream exploded',
+			headers: {},
+		});
+
+		await expect(client.complete('Hi')).rejects.toThrow('API error (500): upstream exploded');
+	});
+
+	it('throws for an unsupported provider', async () => {
+		settings.ai.provider = 'mystery' as SynapseSettings['ai']['provider'];
+		await expect(client.complete('Hi')).rejects.toThrow(/Unsupported AI provider: mystery/);
+		expect(mockRequestUrl).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Improves test coverage for critical paths, with priority on the **write paths** (the appliers that modify user notes) and untested integration points. Raises statement coverage from **58.71% to 65.71%**, clearing the 65% goal with all must-have items (1–3) covered.

`closes #91`

## Coverage: before → after

`npm run test:coverage`, full suite (95 files, 1222 tests passing).

| Metric | Before | After |
| --- | --- | --- |
| Statements | 58.71% (4113/7005) | **65.71% (4603/7005)** |
| Branches | 52.90% (1650/3119) | **59.12% (1844/3119)** |
| Functions | 57.09% (732/1282) | **63.10% (809/1282)** |
| Lines | 60.14% (3881/6453) | **67.02% (4325/6453)** |

## Files tested

Per-file statement coverage (before → after):

**Priority 1 — write paths (highest risk):**
- `enrichment/enrichment-applier.ts` — **0% → 91%** (new file): tag merge, Related Notes / References callouts, frontmatter add/merge (no-overwrite), idempotent re-apply, URL-scheme skipping, sanitization, undo
- `rem/rem-applier.ts` — **0% → 100%** (new file): bare vs aliased wikilink insertion, case-insensitive equality, multi-occurrence offset integrity, out-of-range guards

**Priority 2 — rem write path + matcher:**
- `rem/semantic-matcher.ts` — **0% → ~95%** (new file): candidate-list construction, code-fence stripping, confidence-threshold filtering, hallucinated-title rejection, AI-error / non-array / invalid-JSON fallbacks

**Priority 3 — AIClient (all four providers + error handling):**
- `shared/ai-client.ts` — **48% → 97%** (extended existing): OpenAI / Anthropic / Ollama provider paths (Gemini already covered), multimodal content-block serialization per provider, Anthropic short-name → model-id resolution, Ollama endpoint validation (invalid URL / non-localhost HTTP rejection / remote HTTPS), shared `safeRequest` error handling with structured + text fallbacks, unsupported-provider guard

**Priority 4 — module orchestrators:**
- `image/index.ts` — **0% → ~78%** (new file): single-image OCR insert, batch OCR with checkpoints, per-image error tolerance, checkpoint cancel/discard, `resumeFromCheckpoint`
- `rem/index.ts` — **30% → ~80%** (new file): `remScanNote`, `remScanDirectory` (incl. `onlyFile` scoping + cancellation), `acceptProposal` (accepted / partial / rejected / double-accept guard), `undoProposal`, auto-accept, folder/tag exclusions, `getPendingProposals`

**Priority 5 — small low-coverage modules:**
- `audio/post-processor.ts` — **0%** (new file): instruction assembly from toggles, disabled / no-instruction short-circuits, response sanitization
- `enrichment/prompt-builder.ts` — **5%** (new file): external-link + frontmatter suggestion parsing, URL validation, prototype-pollution / malformed-key rejection, max-count capping, AI-failure fallbacks
- `enrichment/link-resolver.ts` — **17% → 79%** (extended existing): `findInternalLinks` shared-tag, proximity, and 2-hop link-graph candidates; threshold filtering and `maxInternalLinks` capping

> Note on `transcription/duration-detector.ts`: the `detectLocalFileDuration` / `detectUrlDuration` paths invoke `require('child_process')` at runtime, which `vi.mock` does not intercept (the real binaries execute). Cleanly testing the success branch would require injecting the exec dependency — out of scope for a test-only change. The pure helpers (`formatTimestamp`, `MIN_SLIDER_DURATION`) remain covered by the pre-existing tests.

## Testability refactors

**None.** No production source behavior was changed. Tests use the centralized Obsidian mocks (`src/__mocks__/obsidian.ts`) and `src/__test-utils__/mock-factories.ts`; collaborators are isolated via prototype spies. The only non-test change is adding `@vitest/coverage-v8` to devDependencies (pinned `^4`, matching vitest), committed separately.

## Notes
- Did not touch `src/intake/` (sibling PR #267).
- Commits are **unsigned** — the 1Password SSH signing agent isn't reachable from this environment (`commit.gpgsign=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
