### PR TITLE
feat: add first-run onboarding experience

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { TitleModule } from './title';
 import { RemModule } from './rem';
 import { IntakeModule } from './intake';
 import { CommandRegistrar, auditCommands } from './commands';
+import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
 import { FolderPickerModal, NotificationManager, CheckpointManager } from './shared';
@@ -64,6 +65,12 @@ export default class SynapsePlugin extends Plugin {
 	private audioExtractor: AudioExtractor | undefined;
 	private ffmpegAvailable: boolean | null = null;
 	private startupTimeout: ReturnType<typeof setTimeout> | null = null;
+	/**
+	 * True when `loadData()` returned no persisted settings — i.e. a genuine
+	 * fresh install rather than an existing user upgrading. Drives first-run
+	 * onboarding (#89): only fresh installs are greeted with the welcome notice.
+	 */
+	private isFreshInstall = false;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -369,6 +376,11 @@ export default class SynapsePlugin extends Plugin {
 		// Surface command-registry drift: active entries with no handler, or
 		// registered handlers missing from the registry. Asserted by a Vitest test too.
 		auditCommands(registrar.getAttempted()).forEach(w => console.warn('[Synapse] ' + w));
+
+		// First-run onboarding (#89): a one-time welcome notice for fresh installs.
+		// Runs last so it never delays core setup, and after the notification
+		// manager is ready. Non-blocking — failure here must not break load.
+		await this.runFirstRunOnboarding();
 	}
 
 	onunload(): void {
@@ -391,14 +403,38 @@ export default class SynapsePlugin extends Plugin {
 	}
 
 	async loadSettings(): Promise<void> {
-		this.settings = this.deepMerge(
-			DEFAULT_SETTINGS,
-			(await this.loadData()) || {}
-		);
+		const data = await this.loadData();
+		// No persisted data (null) or an empty object means this is the plugin's
+		// first run in this vault — used to gate the first-run welcome (#89).
+		this.isFreshInstall = !data || Object.keys(data).length === 0;
+		this.settings = this.deepMerge(DEFAULT_SETTINGS, data || {});
 	}
 
 	async saveSettings(): Promise<void> {
 		await this.saveData(this.settings);
+	}
+
+	/**
+	 * First-run onboarding (#89). Greets a genuine fresh install once with a
+	 * welcome notice pointing at the settings tab to configure an API key, then
+	 * persists `onboarding.hasSeenWelcome` so it never fires again. An existing
+	 * user upgrading into this version is marked seen silently (no notice). Any
+	 * failure is swallowed — onboarding must never break plugin load.
+	 */
+	private async runFirstRunOnboarding(): Promise<void> {
+		try {
+			const plan = planFirstRun(this.settings, this.isFreshInstall);
+			if (!plan.markSeen) return;
+
+			this.settings.onboarding.hasSeenWelcome = true;
+			await this.saveSettings();
+
+			if (plan.showWelcome) {
+				this.notifications.info(WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS);
+			}
+		} catch (error) {
+			console.warn('[Synapse] First-run onboarding failed:', error);
+		}
 	}
 
 	private openUnifiedModal(): void {

--- a/src/onboarding.test.ts
+++ b/src/onboarding.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from './settings';
+import type { SynapseSettings, AIProvider } from './settings';
+import {
+	needsApiKey,
+	planFirstRun,
+	applyApiKeyEmphasis,
+	WELCOME_MESSAGE,
+	REQUIRED_FIELD_CLASS,
+	API_KEY_DESC,
+	API_KEY_REQUIRED_DESC,
+} from './onboarding';
+
+function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	return settings;
+}
+
+describe('needsApiKey (#89)', () => {
+	it('is true for a hosted provider with no key', () => {
+		const s = makeSettings((s) => {
+			s.ai.provider = 'openai';
+			s.ai.apiKey = '';
+		});
+		expect(needsApiKey(s)).toBe(true);
+	});
+
+	it('treats a whitespace-only key as missing', () => {
+		const s = makeSettings((s) => {
+			s.ai.provider = 'anthropic';
+			s.ai.apiKey = '   ';
+		});
+		expect(needsApiKey(s)).toBe(true);
+	});
+
+	it('is false once a hosted provider has a key', () => {
+		const s = makeSettings((s) => {
+			s.ai.provider = 'gemini';
+			s.ai.apiKey = 'real-key';
+		});
+		expect(needsApiKey(s)).toBe(false);
+	});
+
+	it('is false for Ollama even with no key (runs locally)', () => {
+		const s = makeSettings((s) => {
+			s.ai.provider = 'ollama';
+			s.ai.apiKey = '';
+		});
+		expect(needsApiKey(s)).toBe(false);
+	});
+
+	it('flags every hosted provider but never Ollama when the key is empty', () => {
+		const hosted: AIProvider[] = ['openai', 'anthropic', 'gemini'];
+		for (const provider of hosted) {
+			expect(needsApiKey(makeSettings((s) => { s.ai.provider = provider; s.ai.apiKey = ''; }))).toBe(true);
+		}
+		expect(needsApiKey(makeSettings((s) => { s.ai.provider = 'ollama'; s.ai.apiKey = ''; }))).toBe(false);
+	});
+});
+
+describe('planFirstRun (#89)', () => {
+	it('greets a genuine fresh install that has not seen the welcome', () => {
+		const s = makeSettings((s) => { s.onboarding.hasSeenWelcome = false; });
+		expect(planFirstRun(s, true)).toEqual({ showWelcome: true, markSeen: true });
+	});
+
+	it('marks an upgrading user seen WITHOUT greeting them (has saved data)', () => {
+		const s = makeSettings((s) => { s.onboarding.hasSeenWelcome = false; });
+		expect(planFirstRun(s, false)).toEqual({ showWelcome: false, markSeen: true });
+	});
+
+	it('does nothing once the welcome has already been seen', () => {
+		const s = makeSettings((s) => { s.onboarding.hasSeenWelcome = true; });
+		expect(planFirstRun(s, true)).toEqual({ showWelcome: false, markSeen: false });
+		expect(planFirstRun(s, false)).toEqual({ showWelcome: false, markSeen: false });
+	});
+});
+
+describe('applyApiKeyEmphasis (#89)', () => {
+	function makeTarget() {
+		return {
+			settingEl: { toggleClass: vi.fn() },
+			setDesc: vi.fn(),
+		};
+	}
+
+	it('adds the required class and emphasised desc when a key is needed', () => {
+		const target = makeTarget();
+		applyApiKeyEmphasis(target, makeSettings((s) => { s.ai.provider = 'openai'; s.ai.apiKey = ''; }));
+		expect(target.settingEl.toggleClass).toHaveBeenCalledWith(REQUIRED_FIELD_CLASS, true);
+		expect(target.setDesc).toHaveBeenCalledWith(API_KEY_REQUIRED_DESC);
+	});
+
+	it('clears the required class and restores the neutral desc when satisfied', () => {
+		const target = makeTarget();
+		applyApiKeyEmphasis(target, makeSettings((s) => { s.ai.provider = 'openai'; s.ai.apiKey = 'sk-123'; }));
+		expect(target.settingEl.toggleClass).toHaveBeenCalledWith(REQUIRED_FIELD_CLASS, false);
+		expect(target.setDesc).toHaveBeenCalledWith(API_KEY_DESC);
+	});
+
+	it('never emphasises for the local Ollama provider', () => {
+		const target = makeTarget();
+		applyApiKeyEmphasis(target, makeSettings((s) => { s.ai.provider = 'ollama'; s.ai.apiKey = ''; }));
+		expect(target.settingEl.toggleClass).toHaveBeenCalledWith(REQUIRED_FIELD_CLASS, false);
+	});
+});
+
+describe('WELCOME_MESSAGE copy (#89)', () => {
+	it('omits the "Synapse" brand name (NotificationManager prefixes it)', () => {
+		expect(WELCOME_MESSAGE).not.toMatch(/synapse/i);
+	});
+
+	it('points the user at the settings and the API key, charged but unhyped', () => {
+		expect(WELCOME_MESSAGE.toLowerCase()).toContain('api key');
+		expect(WELCOME_MESSAGE.toLowerCase()).toContain('settings');
+		// Brand voice: no exclamation points, no emoji (an em dash is fine).
+		expect(WELCOME_MESSAGE).not.toContain('!');
+		expect(WELCOME_MESSAGE).not.toMatch(/\p{Extended_Pictographic}/u);
+	});
+});

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,0 +1,102 @@
+// First-run onboarding (#89). A deliberately minimal, non-intrusive experience:
+// a one-time welcome notice that points new users at the settings tab, plus a
+// "required" emphasis on the AI provider API key field while it is still unset.
+//
+// This module is pure TypeScript with no Obsidian runtime import — the side
+// effects (showing the notice, touching the DOM) live in the caller. The DOM
+// helper takes a small structural target so both Obsidian's `Setting` and the
+// test stub satisfy it. Keeping the logic here makes every branch unit-testable
+// without rendering a full settings tab.
+
+import type { SynapseSettings } from './settings';
+
+/**
+ * Duration (ms) of the first-run welcome notice. Longer than a routine info
+ * toast so a brand-new user has time to read it and act before it dismisses.
+ */
+export const WELCOME_NOTICE_DURATION_MS = 12000;
+
+/**
+ * Copy for the first-run welcome notice. `NotificationManager.info` prefixes
+ * `Synapse: `, so this string intentionally omits the brand name to avoid
+ * doubling it. Brand voice: charged ("fire"), precise ("AI provider API key"),
+ * deferential at the threshold ("proposals" — the user decides).
+ */
+export const WELCOME_MESSAGE =
+	'Welcome — add your AI provider API key in the settings tab to fire your first proposals.';
+
+/** CSS class that draws the "required" emphasis on a setting row. */
+export const REQUIRED_FIELD_CLASS = 'synapse-setting-required';
+
+/** Neutral description for the API key field once a key is set (or not needed). */
+export const API_KEY_DESC = 'API key for OpenAI, Anthropic, or Google Gemini';
+
+/** Emphasised description shown while the active provider still needs a key. */
+export const API_KEY_REQUIRED_DESC =
+	'Required — add your provider API key to activate AI features.';
+
+/**
+ * Whether the configured provider still needs an API key. Ollama runs locally
+ * and authenticates against a URL endpoint, so it never counts as missing — only
+ * the hosted providers (OpenAI, Anthropic, Gemini) require a key here.
+ */
+export function needsApiKey(settings: SynapseSettings): boolean {
+	return settings.ai.provider !== 'ollama' && settings.ai.apiKey.trim() === '';
+}
+
+/**
+ * The outcome of evaluating first-run onboarding. The caller performs the side
+ * effects so this stays pure and testable.
+ *
+ * - `markSeen`  — persist `onboarding.hasSeenWelcome = true` (so it never fires
+ *   again). False only when it was already seen.
+ * - `showWelcome` — actually surface the welcome notice.
+ */
+export interface FirstRunPlan {
+	showWelcome: boolean;
+	markSeen: boolean;
+}
+
+/**
+ * Decide what first-run onboarding to perform.
+ *
+ * The welcome only greets a *genuine* fresh install (no persisted plugin data).
+ * An existing user upgrading into this version has saved data but has never had
+ * the flag set — we silently mark them as seen rather than greeting them with a
+ * "configure your API key" notice they neither need nor expect. Once the flag is
+ * set, this is a no-op forever.
+ */
+export function planFirstRun(
+	settings: SynapseSettings,
+	isFreshInstall: boolean,
+): FirstRunPlan {
+	if (settings.onboarding.hasSeenWelcome) {
+		return { showWelcome: false, markSeen: false };
+	}
+	return { showWelcome: isFreshInstall, markSeen: true };
+}
+
+/**
+ * Minimal structural view of an Obsidian `Setting` needed to toggle the
+ * required-field emphasis. Both the real `Setting` and the test stub satisfy it.
+ */
+export interface EmphasisTarget {
+	settingEl: { toggleClass(cls: string, on: boolean): void };
+	setDesc(desc: string): unknown;
+}
+
+/**
+ * Apply (or clear) the "required" emphasis on the API key setting row to mirror
+ * whether the active provider still needs a key. Safe to call repeatedly — it is
+ * idempotent and reflects only the current settings, so it doubles as the live
+ * update handler as the user types a key in (the emphasis clears the moment the
+ * field is non-empty, without a full settings re-render that would steal focus).
+ */
+export function applyApiKeyEmphasis(
+	target: EmphasisTarget,
+	settings: SynapseSettings,
+): void {
+	const needed = needsApiKey(settings);
+	target.settingEl.toggleClass(REQUIRED_FIELD_CLASS, needed);
+	target.setDesc(needed ? API_KEY_REQUIRED_DESC : API_KEY_DESC);
+}

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -20,6 +20,7 @@ import { renderTidySettings } from './tidy';
 import { renderOrganizeSettings } from './organize';
 import { renderDeepDiveSettings } from './deep-dive';
 import { renderRemSettings } from './rem';
+import { applyApiKeyEmphasis } from './onboarding';
 
 /**
  * Per-kind display copy for the Auto-Accept Proposals section (#228). MUTATING
@@ -205,9 +206,12 @@ export class SynapseSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(aiBody)
+		// The description and a violet "required" accent are driven by
+		// applyApiKeyEmphasis so a brand-new user sees the one field that gates
+		// every AI feature highlighted until they fill it (#89). Toggled live as
+		// they type — no full re-render, so the field keeps focus.
+		const apiKeySetting = new Setting(aiBody)
 			.setName('API Key')
-			.setDesc('API key for OpenAI, Anthropic, or Google Gemini')
 			.addText((text) => {
 				text
 					.setPlaceholder('sk-...')
@@ -215,10 +219,12 @@ export class SynapseSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.ai.apiKey = value;
 						await this.plugin.saveSettings();
+						applyApiKeyEmphasis(apiKeySetting, this.plugin.settings);
 					});
 				text.inputEl.type = 'password';
 				text.inputEl.autocomplete = 'off';
 			});
+		applyApiKeyEmphasis(apiKeySetting, this.plugin.settings);
 
 		if (this.plugin.settings.ai.provider === 'ollama') {
 			new Setting(aiBody)

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -50,3 +50,9 @@ describe('Gemini provider settings (#251)', () => {
 		expect(DEFAULT_SETTINGS.audio.geminiApiKey).toBe('');
 	});
 });
+
+describe('onboarding settings (#89)', () => {
+	it('defaults hasSeenWelcome to false so the first run is greeted', () => {
+		expect(DEFAULT_SETTINGS.onboarding.hasSeenWelcome).toBe(false);
+	});
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -248,6 +248,20 @@ export interface UISettings {
 }
 
 /**
+ * First-run onboarding state (#89). Persisted so the welcome experience fires
+ * exactly once. Nested as its own group (rather than a bare top-level flag) so
+ * future onboarding signals can join it without widening the settings root.
+ */
+export interface OnboardingSettings {
+	/**
+	 * Set once the first-run welcome notice has been shown (or silently marked
+	 * for an upgrading user who already has saved data). Gates the notice so it
+	 * never appears twice.
+	 */
+	hasSeenWelcome: boolean;
+}
+
+/**
  * Per-proposal-type auto-accept flags (#228). When a kind's flag is `true`,
  * every *future* proposal of that kind is accepted automatically as generated
  * (the unedited draft), so it lands accepted — not pending — in the unified
@@ -273,6 +287,7 @@ export interface SynapseSettings {
 	intake: IntakeSettings;
 	ui: UISettings;
 	autoAccept: AutoAcceptSettings;
+	onboarding: OnboardingSettings;
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
@@ -434,5 +449,8 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		'deep-dive': false,
 		title: false,
 		rem: false,
+	},
+	onboarding: {
+		hasSeenWelcome: false,
 	},
 };

--- a/styles.css
+++ b/styles.css
@@ -976,3 +976,17 @@
   background: var(--interactive-accent);
   transition: width 0.2s ease;
 }
+
+/* ── First-run: required-field emphasis (API key, #89) ──
+ * Marks the one field that gates every AI feature while it is still unset.
+ * The accent is drawn with an inset box-shadow (not a border) so it adds no
+ * layout box and never reflows the row; it clears live the moment a key is
+ * entered. Uses the user's accent (violet by default — bridges the brand). */
+.synapse-setting-required {
+  box-shadow: inset 3px 0 0 0 var(--interactive-accent);
+  padding-left: 12px;
+  border-radius: 2px;
+}
+.synapse-setting-required .setting-item-name {
+  font-weight: var(--font-semibold);
+}


### PR DESCRIPTION
## Summary

Adds a minimal, non-intrusive first-run experience for new users (#89):

- **Welcome notice** — a one-time Obsidian notice on a genuine fresh install, pointing users to the settings tab to configure their AI provider API key.
- **`onboarding.hasSeenWelcome` flag** — persisted in settings so the welcome fires *exactly once*.
- **Required-field emphasis** — the API Key setting gets a violet accent + "Required" description whenever the active hosted provider has no key. It clears live as the user types (no re-render, so the field keeps focus). Ollama runs locally and is never flagged.

The optional Getting Started modal was intentionally **skipped** — per the issue's "non-intrusive, not a wizard" guidance, a notice + settings emphasis covers the goal (orient the user, surface the API-key requirement) without the added surface area of a modal.

## Reassessment (issue carried the `reassess` label)

Verified before implementing:
- **No onboarding/first-run logic exists** anywhere in `src/` (grepped `onboard`, `hasSeen*`, `welcome`, `first-run`, `getting started`). The issue is still valid.
- The proposed structure fits the current codebase: settings live in nested groups (`src/settings.ts`), the API key field is rendered in `SynapseSettingTab.renderAIConfiguration` (`src/settings-tab.ts`), and notices flow through `NotificationManager.info`.

Adjustments (minor, within scope):
- Named the flag `onboarding.hasSeenWelcome` (nested group, not a bare top-level `hasSeenOnboarding`) for consistency with the existing nested-settings convention and future extensibility.
- Added **fresh-install vs. upgrade** detection in `loadSettings`. Without it, every existing user upgrading into this version would see a "configure your API key" notice once — wrong and annoying. Upgraders (who already have saved data) are marked seen silently; only genuine fresh installs are greeted.
- Made the API-key emphasis reflect "key currently missing" rather than literally "first open of settings" — strictly more useful, and self-correcting if a key is later cleared.

## Brand

User-facing copy was written against the `brand-guidelines` skill: charged but unhyped ("fire your first proposals"), precise ("AI provider API key"), deferential at the threshold ("proposals"), no exclamation points or emoji. The welcome string omits the "Synapse" name because `NotificationManager.info` already prefixes `Synapse: `.

## Tests

- New `src/onboarding.test.ts` — covers `needsApiKey` (every provider incl. Ollama + whitespace key), `planFirstRun` (fresh / upgrade / already-seen), `applyApiKeyEmphasis` (on / off / Ollama), and welcome-copy brand invariants.
- `src/settings.test.ts` — default `hasSeenWelcome === false`.

Pre-flight: `tsc --noEmit --skipLibCheck` clean · `npm test` 1245 passed · `node esbuild.config.mjs production` succeeds.

closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)