### PR TITLE
feat: add funding files for pre-release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [dustinkeeton]
+custom: ["https://www.buymeacoffee.com/dustinkeeton"]

--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ ln -s /path/to/obsidian-synapse .obsidian/plugins/synapse
 
 Then run `npm run dev` to rebuild automatically on changes. Reload Obsidian (Cmd+R / Ctrl+R) to pick up changes.
 
+## Support
+
+Synapse is free and open source. If it has earned a place in your workflow,
+you can support continued development:
+
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-GitHub-8b5cf6?logo=github)](https://github.com/sponsors/dustinkeeton)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-5b21b6?logo=buymeacoffee&logoColor=white)](https://www.buymeacoffee.com/dustinkeeton)
+
 ## License
 
 [AGPL-3.0](LICENSE)

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,9 @@
   "description": "Automatically elaborate, transcribe, enrich, summarize, organize, and connect your notes with AI.",
   "author": "Dustin Keeton",
   "authorUrl": "https://github.com/dustinkeeton",
+  "fundingUrl": {
+    "GitHub Sponsors": "https://github.com/sponsors/dustinkeeton",
+    "Buy Me a Coffee": "https://www.buymeacoffee.com/dustinkeeton"
+  },
   "isDesktopOnly": false
 }

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -50,6 +50,15 @@ function lastSetDisabledArg(row: Setting): boolean {
 	return calls[calls.length - 1][0] as boolean;
 }
 
+/** Recursively collect all anchor elements rendered into a stub element tree. */
+function findAnchors(el: any, out: any[] = []): any[] {
+	for (const child of el?.children ?? []) {
+		if (child.tagName === 'A') out.push(child);
+		findAnchors(child, out);
+	}
+	return out;
+}
+
 describe('SynapseSettingTab — Auto-Accept disabled state', () => {
 	beforeEach(() => {
 		ToggleComponent.instances.length = 0;
@@ -130,5 +139,24 @@ describe('SynapseSettingTab — Auto-Accept disabled state', () => {
 
 		// A disable→re-enable cycle must not flip the stored OFF value to ON.
 		expect(plugin.settings.autoAccept.rem).toBe(false);
+	});
+});
+
+describe('SynapseSettingTab — About support links (#274)', () => {
+	it('renders static GitHub Sponsors and Buy Me a Coffee links', () => {
+		const { tab } = makeTab();
+		tab.display();
+
+		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+		const anchors = findAnchors(containerEl);
+		const byHref = new Map(
+			anchors.map((a) => [a.getAttribute('href'), a.textContent]),
+		);
+		expect(byHref.get('https://github.com/sponsors/dustinkeeton')).toBe(
+			'GitHub Sponsors',
+		);
+		expect(byHref.get('https://www.buymeacoffee.com/dustinkeeton')).toBe(
+			'Buy Me a Coffee',
+		);
 	});
 });

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -173,6 +173,9 @@ export class SynapseSettingTab extends PluginSettingTab {
 
 		// ── Auto-Accept Proposals (global, non-feature) ──
 		this.renderAutoAccept(ctx);
+
+		// ── About (static support links, always last) ──
+		this.renderAbout(ctx);
 	}
 
 	/**
@@ -340,5 +343,28 @@ export class SynapseSettingTab extends PluginSettingTab {
 			setting.setDisabled(!this.isFeatureEnabled(kind));
 			this.autoAcceptSettings[kind] = setting;
 		}
+	}
+
+	/**
+	 * About — one static support line below all functional settings (#274).
+	 * Set once, never animated, never usage-triggered. Obsidian also renders the
+	 * manifest `fundingUrl` links natively; this row is the in-tab mirror, and
+	 * its links must stay in sync with `manifest.json` and `.github/FUNDING.yml`.
+	 */
+	private renderAbout(ctx: SettingsSectionContext): void {
+		const aboutBody = ctx.configSection('about', 'About');
+		const line = aboutBody.createDiv({ cls: 'setting-item-description' });
+		line.createSpan({
+			text: 'Synapse is free and open source. Support development → ',
+		});
+		line.createEl('a', {
+			text: 'GitHub Sponsors',
+			attr: { href: 'https://github.com/sponsors/dustinkeeton' },
+		});
+		line.createSpan({ text: ' · ' });
+		line.createEl('a', {
+			text: 'Buy Me a Coffee',
+			attr: { href: 'https://www.buymeacoffee.com/dustinkeeton' },
+		});
 	}
 }


### PR DESCRIPTION
## Summary

Implements the approved donation/sponsorship plan (`docs/plans/donation-sponsorship-plan.md`, §3/§4/§7) now that both accounts exist. closes #274

- **`.github/FUNDING.yml`** (§3a) — `github: [dustinkeeton]` + Buy Me a Coffee custom link; enables the repo "Sponsor" button
- **`manifest.json` `fundingUrl`** (§3b) — object form with labeled "GitHub Sponsors" and "Buy Me a Coffee" entries, rendered natively by Obsidian in both the community-plugin list and the plugin's settings. No version bump — `fundingUrl` changes no compatibility surface; `versions.json` untouched.
- **README "Support" section** (§3c) — placed near the bottom (after Development, before License), exact plan copy with the real handle substituted, badges in brand violets (`#8b5cf6` Synapse Violet, `#5b21b6` Threshold Violet)
- **Settings "About" section** (§3d, optional — implemented) — it dropped in cleanly as one more `configSection` accordion at the very bottom of the existing settings-tab orchestrator, mirroring the Auto-Accept section. A single static line: "Synapse is free and open source. Support development → GitHub Sponsors · Buy Me a Coffee". No banners, no animation, no usage triggers. Covered by a new test in `src/settings-tab.test.ts` following the existing stub-element patterns.

Platform lists are identical across all four surfaces (FUNDING.yml, fundingUrl, README, settings line), per plan §6.

## Maintainer action before merge

Please confirm ownership of https://www.buymeacoffee.com/dustinkeeton — the page exists, but the handle should be verified as yours before these links go live. The GitHub Sponsors listing (https://github.com/sponsors/dustinkeeton) was verified live per the issue.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] `npm test` — 97 files, 1246 tests passed (includes new About-links test)
- [x] `node esbuild.config.mjs production` — build succeeds
- [x] `manifest.json` parses; `fundingUrl` object verified via `node -e require(...)`
- [ ] "Sponsor" button renders on the repo page (visible once merged to the default branch)
- [ ] Obsidian renders the two labeled support links from `fundingUrl`

Co-Authored-By: Claude <bot@wafflenet.io>