### PR TITLE
fix: drop plugin-id prefix from command ids

### DIFF
--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -12,16 +12,16 @@ import type { CommandDefinition } from './types';
 
 /** The 23 real, user-invocable command ids (excludes the synthetic pipeline entry). */
 const EXPECTED_COMMAND_IDS = [
-	'synapse:review-proposals', 'synapse:manage-checkpoints', 'synapse:transcribe-media',
-	'synapse:transcribe-note-media', 'synapse:fire',
-	'synapse:scan-vault', 'synapse:scan-current-note', 'synapse:clear-proposals',
-	'synapse:enrich-current-note', 'synapse:scan-vault-enrichment', 'synapse:undo-enrichment',
-	'synapse:organize-current-note', 'synapse:scan-directory-organize', 'synapse:undo-organize',
-	'synapse:deep-dive', 'synapse:clear-deep-dive',
-	'synapse:summarize-current-note', 'synapse:scan-vault-summarize',
-	'synapse:tidy-current-note', 'synapse:undo-tidy',
-	'synapse:rem-current-note', 'synapse:rem-directory',
-	'synapse:check-dependencies',
+	'review-proposals', 'manage-checkpoints', 'transcribe-media',
+	'transcribe-note-media', 'fire',
+	'scan-vault', 'scan-current-note', 'clear-proposals',
+	'enrich-current-note', 'scan-vault-enrichment', 'undo-enrichment',
+	'organize-current-note', 'scan-directory-organize', 'undo-organize',
+	'deep-dive', 'clear-deep-dive',
+	'summarize-current-note', 'scan-vault-summarize',
+	'tidy-current-note', 'undo-tidy',
+	'rem-current-note', 'rem-directory',
+	'check-dependencies',
 ];
 
 describe('COMMAND_REGISTRY', () => {
@@ -30,7 +30,7 @@ describe('COMMAND_REGISTRY', () => {
 		for (const id of EXPECTED_COMMAND_IDS) {
 			expect(REGISTRY_BY_ID.has(id)).toBe(true);
 		}
-		expect(REGISTRY_BY_ID.has('synapse:tidy-vault')).toBe(true);
+		expect(REGISTRY_BY_ID.has('tidy-vault')).toBe(true);
 	});
 
 	it('has no duplicate ids', () => {
@@ -50,12 +50,12 @@ describe('COMMAND_REGISTRY', () => {
 			.map(c => c.id)
 			.sort();
 		expect(disabled).toEqual([
-			'synapse:clear-deep-dive',
-			'synapse:clear-proposals',
-			'synapse:transcribe-media',
-			'synapse:undo-enrichment',
-			'synapse:undo-organize',
-			'synapse:undo-tidy',
+			'clear-deep-dive',
+			'clear-proposals',
+			'transcribe-media',
+			'undo-enrichment',
+			'undo-organize',
+			'undo-tidy',
 		]);
 	});
 
@@ -66,14 +66,14 @@ describe('COMMAND_REGISTRY', () => {
 	});
 
 	it('keeps the synthetic tidy-vault entry out of the palette', () => {
-		const tidyVault = REGISTRY_BY_ID.get('synapse:tidy-vault')!;
+		const tidyVault = REGISTRY_BY_ID.get('tidy-vault')!;
 		expect(tidyVault.flows).not.toContain('palette');
 		expect(tidyVault.flows).toContain('fire-synapse');
 	});
 
 	it('marks exactly scan-vault as a startup flow command', () => {
 		const startupCommands = COMMAND_REGISTRY.filter(c => c.flows.includes('startup'));
-		expect(startupCommands.map(c => c.id)).toEqual(['synapse:scan-vault']);
+		expect(startupCommands.map(c => c.id)).toEqual(['scan-vault']);
 	});
 
 	it('gives every entry a non-empty name', () => {
@@ -110,18 +110,18 @@ describe('pipeline mapping', () => {
 
 describe('isInFlow', () => {
 	it('is true for an active command in the requested flow', () => {
-		expect(isInFlow('synapse:scan-vault', 'palette')).toBe(true);
-		expect(isInFlow('synapse:scan-vault', 'fire-synapse')).toBe(true);
-		expect(isInFlow('synapse:scan-vault', 'startup')).toBe(true);
+		expect(isInFlow('scan-vault', 'palette')).toBe(true);
+		expect(isInFlow('scan-vault', 'fire-synapse')).toBe(true);
+		expect(isInFlow('scan-vault', 'startup')).toBe(true);
 	});
 
 	it('is false for a flow the command does not participate in', () => {
-		expect(isInFlow('synapse:scan-current-note', 'fire-synapse')).toBe(false);
-		expect(isInFlow('synapse:scan-current-note', 'startup')).toBe(false);
+		expect(isInFlow('scan-current-note', 'fire-synapse')).toBe(false);
+		expect(isInFlow('scan-current-note', 'startup')).toBe(false);
 	});
 
 	it('is false for an unknown id', () => {
-		expect(isInFlow('synapse:does-not-exist', 'palette')).toBe(false);
+		expect(isInFlow('does-not-exist', 'palette')).toBe(false);
 	});
 });
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -14,45 +14,45 @@ import { CommandDefinition, CommandFlow } from './types';
 
 export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	// --- main (src/main.ts) ---
-	{ id: 'synapse:review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:transcribe-media', name: 'Transcribe media', feature: 'main', status: 'disabled', flows: ['palette'] },
-	{ id: 'synapse:transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:fire', name: 'Fire Synapse: run all features on a directory', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'transcribe-media', name: 'Transcribe media', feature: 'main', status: 'disabled', flows: ['palette'] },
+	{ id: 'transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'fire', name: 'Fire Synapse: run all features on a directory', feature: 'main', status: 'active', flows: ['palette'] },
 
 	// --- elaboration (src/elaboration/index.ts) ---
-	{ id: 'synapse:scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], pipelineKey: 'elaboration' },
-	{ id: 'synapse:scan-current-note', name: 'Scan current note for elaboration', feature: 'elaboration', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:clear-proposals', name: 'Clear all pending proposals', feature: 'elaboration', status: 'disabled', flows: ['palette'] },
+	{ id: 'scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], pipelineKey: 'elaboration' },
+	{ id: 'scan-current-note', name: 'Scan current note for elaboration', feature: 'elaboration', status: 'active', flows: ['palette'] },
+	{ id: 'clear-proposals', name: 'Clear all pending proposals', feature: 'elaboration', status: 'disabled', flows: ['palette'] },
 
 	// --- enrichment (src/enrichment/index.ts) ---
-	{ id: 'synapse:enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'enrichment' },
-	{ id: 'synapse:undo-enrichment', name: 'Undo last enrichment on current note', feature: 'enrichment', status: 'disabled', flows: ['palette'] },
+	{ id: 'enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'] },
+	{ id: 'scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'enrichment' },
+	{ id: 'undo-enrichment', name: 'Undo last enrichment on current note', feature: 'enrichment', status: 'disabled', flows: ['palette'] },
 
 	// --- organize (src/organize/index.ts) ---
-	{ id: 'synapse:organize-current-note', name: 'Organize current note', feature: 'organize', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:scan-directory-organize', name: 'Scan directory for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'organize' },
-	{ id: 'synapse:undo-organize', name: 'Undo last organize on current note', feature: 'organize', status: 'disabled', flows: ['palette'] },
+	{ id: 'organize-current-note', name: 'Organize current note', feature: 'organize', status: 'active', flows: ['palette'] },
+	{ id: 'scan-directory-organize', name: 'Scan directory for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'organize' },
+	{ id: 'undo-organize', name: 'Undo last organize on current note', feature: 'organize', status: 'disabled', flows: ['palette'] },
 
 	// --- deep-dive (src/deep-dive/index.ts) ---
-	{ id: 'synapse:deep-dive', name: 'Deep dive into current note', feature: 'deep-dive', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:clear-deep-dive', name: 'Clear deep dive proposals', feature: 'deep-dive', status: 'disabled', flows: ['palette'] },
+	{ id: 'deep-dive', name: 'Deep dive into current note', feature: 'deep-dive', status: 'active', flows: ['palette'] },
+	{ id: 'clear-deep-dive', name: 'Clear deep dive proposals', feature: 'deep-dive', status: 'disabled', flows: ['palette'] },
 
 	// --- summarize (src/summarize/index.ts) ---
-	{ id: 'synapse:summarize-current-note', name: 'Summarize current note', feature: 'summarize', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:scan-vault-summarize', name: 'Scan vault for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'summarize' },
+	{ id: 'summarize-current-note', name: 'Summarize current note', feature: 'summarize', status: 'active', flows: ['palette'] },
+	{ id: 'scan-vault-summarize', name: 'Scan vault for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'summarize' },
 
 	// --- tidy (src/tidy/index.ts) ---
-	{ id: 'synapse:tidy-current-note', name: 'Tidy current note', feature: 'tidy', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:undo-tidy', name: 'Undo last tidy on current note', feature: 'tidy', status: 'disabled', flows: ['palette'] },
+	{ id: 'tidy-current-note', name: 'Tidy current note', feature: 'tidy', status: 'active', flows: ['palette'] },
+	{ id: 'undo-tidy', name: 'Undo last tidy on current note', feature: 'tidy', status: 'disabled', flows: ['palette'] },
 
 	// --- rem (src/rem/index.ts) ---
-	{ id: 'synapse:rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'] },
-	{ id: 'synapse:rem-directory', name: 'REM: Discover links in directory', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'rem' },
+	{ id: 'rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'] },
+	{ id: 'rem-directory', name: 'REM: Discover links in directory', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'rem' },
 
 	// --- video (src/video/index.ts) ---
-	{ id: 'synapse:check-dependencies', name: 'Check external tool availability', feature: 'video', status: 'active', flows: ['palette'] },
+	{ id: 'check-dependencies', name: 'Check external tool availability', feature: 'video', status: 'active', flows: ['palette'] },
 
 	// --- synthetic, pipeline-only ---
 	// Tidy is the only Fire Synapse phase with no matching palette command: the
@@ -60,7 +60,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	// palette command runs `tidy()` on a single note — a different operation. This
 	// entry carries `pipelineKey: 'tidy'` so the tidy pipeline phase is controlled
 	// independently of the palette command. It is never passed to registrar.register().
-	{ id: 'synapse:tidy-vault', name: 'Tidy vault (Fire Synapse)', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
+	{ id: 'tidy-vault', name: 'Tidy vault (Fire Synapse)', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
 ];
 
 /** Lookup by command id. */

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -27,7 +27,11 @@ export type FeatureKey =
 
 /** A single declarative command entry. */
 export interface CommandDefinition {
-	/** Obsidian command id, e.g. `synapse:scan-vault`. */
+	/**
+	 * Command id WITHOUT the plugin-id prefix, e.g. `scan-vault`. Obsidian prepends
+	 * the manifest id automatically, so the user-facing id becomes `synapse:scan-vault`.
+	 * Including `synapse:` here would double-prefix it (`synapse:synapse:scan-vault`).
+	 */
 	id: string;
 	/** Display name shown in the command palette. */
 	name: string;

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -85,7 +85,7 @@ export class DeepDiveModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.registrar.register('synapse:deep-dive', this.getSettings().deepDive.enabled, {
+		this.registrar.register('deep-dive', this.getSettings().deepDive.enabled, {
 			name: 'Deep dive into current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -94,7 +94,7 @@ export class DeepDiveModule {
 			},
 		});
 
-		this.registrar.register('synapse:clear-deep-dive', this.getSettings().deepDive.enabled, {
+		this.registrar.register('clear-deep-dive', this.getSettings().deepDive.enabled, {
 			name: 'Clear deep dive proposals',
 			callback: async () => {
 				await this.clearProposals();

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -50,7 +50,7 @@ export class ElaborationModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.registrar.register('synapse:scan-vault', this.getSettings().elaboration.enabled, {
+		this.registrar.register('scan-vault', this.getSettings().elaboration.enabled, {
 			name: 'Scan vault for stub notes',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
@@ -62,7 +62,7 @@ export class ElaborationModule {
 			},
 		});
 
-		this.registrar.register('synapse:scan-current-note', this.getSettings().elaboration.enabled, {
+		this.registrar.register('scan-current-note', this.getSettings().elaboration.enabled, {
 			name: 'Scan current note for elaboration',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -71,17 +71,17 @@ export class ElaborationModule {
 			},
 		});
 
-		this.registrar.register('synapse:clear-proposals', this.getSettings().elaboration.enabled, {
+		this.registrar.register('clear-proposals', this.getSettings().elaboration.enabled, {
 			name: 'Clear all pending proposals',
 			callback: () => this.clearProposals(),
 		});
 
 		const settings = this.getSettings().elaboration;
-		if (settings.scanOnStartup && isInFlow('synapse:scan-vault', 'startup')) {
+		if (settings.scanOnStartup && isInFlow('scan-vault', 'startup')) {
 			this.startupTimeout = window.setTimeout(() => this.scanVault(), 5000);
 		}
 
-		if (settings.autoScanInterval > 0 && isInFlow('synapse:scan-vault', 'startup')) {
+		if (settings.autoScanInterval > 0 && isInFlow('scan-vault', 'startup')) {
 			this.scanInterval = window.setInterval(
 				() => this.scanVault(),
 				settings.autoScanInterval * 60 * 1000

--- a/src/elaboration/startup-flow.test.ts
+++ b/src/elaboration/startup-flow.test.ts
@@ -64,6 +64,6 @@ describe('ElaborationModule — startup flow gate', () => {
 		await makeModule().onload();
 		expect(setTimeoutFn).not.toHaveBeenCalled();
 		expect(setIntervalFn).not.toHaveBeenCalled();
-		expect(isInFlowMock).toHaveBeenCalledWith('synapse:scan-vault', 'startup');
+		expect(isInFlowMock).toHaveBeenCalledWith('scan-vault', 'startup');
 	});
 });

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -74,7 +74,7 @@ export class EnrichmentModule {
 			})
 		);
 
-		this.registrar.register('synapse:enrich-current-note', this.getSettings().enrichment.enabled, {
+		this.registrar.register('enrich-current-note', this.getSettings().enrichment.enabled, {
 			name: 'Enrich current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -83,7 +83,7 @@ export class EnrichmentModule {
 			},
 		});
 
-		this.registrar.register('synapse:scan-vault-enrichment', this.getSettings().enrichment.enabled, {
+		this.registrar.register('scan-vault-enrichment', this.getSettings().enrichment.enabled, {
 			name: 'Scan vault for enrichment',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
@@ -95,7 +95,7 @@ export class EnrichmentModule {
 			},
 		});
 
-		this.registrar.register('synapse:undo-enrichment', this.getSettings().enrichment.enabled, {
+		this.registrar.register('undo-enrichment', this.getSettings().enrichment.enabled, {
 			name: 'Undo last enrichment on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -299,12 +299,12 @@ export default class SynapsePlugin extends Plugin {
 			});
 		}
 
-		registrar.register('synapse:review-proposals', true, {
+		registrar.register('review-proposals', true, {
 			name: 'Open proposal review sidebar',
 			callback: () => this.activateUnifiedView(),
 		});
 
-		registrar.register('synapse:manage-checkpoints', true, {
+		registrar.register('manage-checkpoints', true, {
 			name: 'Manage interrupted operations',
 			callback: () => this.manageCheckpoints(),
 		});
@@ -315,12 +315,12 @@ export default class SynapsePlugin extends Plugin {
 		// Unified transcription commands (audio on any platform, video on desktop only, image OCR).
 		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
 		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
-		registrar.register('synapse:transcribe-media', !!hasTranscription, {
+		registrar.register('transcribe-media', !!hasTranscription, {
 			name: 'Transcribe media',
 			callback: () => this.openUnifiedModal(),
 		});
 
-		registrar.register('synapse:transcribe-note-media', !!hasTranscription, {
+		registrar.register('transcribe-note-media', !!hasTranscription, {
 			name: 'Transcribe media from current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -361,7 +361,7 @@ export default class SynapsePlugin extends Plugin {
 			await this.intake.onload();
 		}
 
-		registrar.register('synapse:fire', true, {
+		registrar.register('fire', true, {
 			name: 'Fire Synapse: run all features on a directory',
 			callback: () => {
 				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -57,7 +57,7 @@ export class OrganizeModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.registrar.register('synapse:organize-current-note', this.getSettings().organize.enabled, {
+		this.registrar.register('organize-current-note', this.getSettings().organize.enabled, {
 			name: 'Organize current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -66,7 +66,7 @@ export class OrganizeModule {
 			},
 		});
 
-		this.registrar.register('synapse:scan-directory-organize', this.getSettings().organize.enabled, {
+		this.registrar.register('scan-directory-organize', this.getSettings().organize.enabled, {
 			name: 'Scan directory for organization',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
@@ -78,7 +78,7 @@ export class OrganizeModule {
 			},
 		});
 
-		this.registrar.register('synapse:undo-organize', this.getSettings().organize.enabled, {
+		this.registrar.register('undo-organize', this.getSettings().organize.enabled, {
 			name: 'Undo last organize on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {

--- a/src/rem/index.test.ts
+++ b/src/rem/index.test.ts
@@ -93,8 +93,8 @@ describe('RemModule', () => {
 			await loadedModule();
 			expect(initSpy).toHaveBeenCalled();
 			const ids = registrar.register.mock.calls.map((c: any[]) => c[0]);
-			expect(ids).toContain('synapse:rem-current-note');
-			expect(ids).toContain('synapse:rem-directory');
+			expect(ids).toContain('rem-current-note');
+			expect(ids).toContain('rem-directory');
 		});
 	});
 

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -52,7 +52,7 @@ export class RemModule {
 		await this.store.init();
 
 		// Command: scan current note
-		this.registrar.register('synapse:rem-current-note', this.getSettings().rem.enabled, {
+		this.registrar.register('rem-current-note', this.getSettings().rem.enabled, {
 			name: 'REM: Discover links in current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -62,7 +62,7 @@ export class RemModule {
 		});
 
 		// Command: scan directory
-		this.registrar.register('synapse:rem-directory', this.getSettings().rem.enabled, {
+		this.registrar.register('rem-directory', this.getSettings().rem.enabled, {
 			name: 'REM: Discover links in directory',
 			callback: () => {
 				new FolderPickerModal(

--- a/src/summarize/audio-summarize.test.ts
+++ b/src/summarize/audio-summarize.test.ts
@@ -140,7 +140,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -158,7 +158,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -180,7 +180,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -212,7 +212,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -245,7 +245,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await moduleNoAudio.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -276,7 +276,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -299,7 +299,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -319,7 +319,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/test.md');
@@ -362,7 +362,7 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = makeTFile('notes/lecture.md');

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -96,7 +96,7 @@ export class SummarizeModule {
 	}
 
 	async onload(): Promise<void> {
-		this.registrar.register('synapse:summarize-current-note', this.getSettings().summarize.enabled, {
+		this.registrar.register('summarize-current-note', this.getSettings().summarize.enabled, {
 			name: 'Summarize current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -105,7 +105,7 @@ export class SummarizeModule {
 			},
 		});
 
-		this.registrar.register('synapse:scan-vault-summarize', this.getSettings().summarize.enabled, {
+		this.registrar.register('scan-vault-summarize', this.getSettings().summarize.enabled, {
 			name: 'Scan vault for notes to summarize',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -123,7 +123,7 @@ describe('SummarizeModule organize scope', () => {
 		// Register commands so we can invoke the summarize command
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = new TFile('notes/test.md') as any;
@@ -141,7 +141,7 @@ describe('SummarizeModule organize scope', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = new TFile('notes/test.md') as any;
@@ -157,7 +157,7 @@ describe('SummarizeModule organize scope', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const file = new TFile('notes/test.md') as any;
@@ -176,7 +176,7 @@ describe('SummarizeModule organize scope', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 
 		const specificFile = new TFile('projects/research/my-note.md') as any;
@@ -254,7 +254,7 @@ describe('SummarizeModule content-aware templates', () => {
 	async function invokeCommand(file: any): Promise<void> {
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'synapse:summarize-current-note'
+			(c: any) => c[0].id === 'summarize-current-note'
 		)[0];
 		await summarizeCmd.editorCallback({}, { file });
 	}

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -46,7 +46,7 @@ export class TidyModule {
 	async onload(): Promise<void> {
 		await this.store.init();
 
-		this.registrar.register('synapse:tidy-current-note', this.getSettings().tidy.enabled, {
+		this.registrar.register('tidy-current-note', this.getSettings().tidy.enabled, {
 			name: 'Tidy current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
@@ -55,7 +55,7 @@ export class TidyModule {
 			},
 		});
 
-		this.registrar.register('synapse:undo-tidy', this.getSettings().tidy.enabled, {
+		this.registrar.register('undo-tidy', this.getSettings().tidy.enabled, {
 			name: 'Undo last tidy on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {

--- a/src/tidy/tidy-module.test.ts
+++ b/src/tidy/tidy-module.test.ts
@@ -83,12 +83,12 @@ describe('TidyModule', () => {
 		it('registers the tidy command (undo-tidy is gated off by the registry)', async () => {
 			await module.onload();
 
-			// `synapse:undo-tidy` ships as `status: 'disabled'` in COMMAND_REGISTRY, so
+			// `undo-tidy` ships as `status: 'disabled'` in COMMAND_REGISTRY, so
 			// the registrar gates it out — only the active tidy command registers.
 			expect(mockPlugin.addCommand).toHaveBeenCalledTimes(1);
 			const commands = mockPlugin.addCommand.mock.calls.map((c: any) => c[0].id);
-			expect(commands).toContain('synapse:tidy-current-note');
-			expect(commands).not.toContain('synapse:undo-tidy');
+			expect(commands).toContain('tidy-current-note');
+			expect(commands).not.toContain('undo-tidy');
 		});
 	});
 

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -47,7 +47,7 @@ export class VideoModule {
 			this.getSettings().video.tempFolder
 		);
 
-		this.registrar.register('synapse:check-dependencies', this.getSettings().video.enabled, {
+		this.registrar.register('check-dependencies', this.getSettings().video.enabled, {
 			name: 'Check external tool availability',
 			callback: () => this.checkDependencies(),
 		});


### PR DESCRIPTION
## Summary

Obsidian automatically prepends the plugin id (`synapse`, from `manifest.json`) to every command id passed to `addCommand()`. Because every entry in `COMMAND_REGISTRY` and each `registrar.register(...)` call site already carried a `synapse:` prefix, commands were being registered as `synapse:synapse:scan-vault` — a double prefix that fails community plugin review.

This drops the redundant `synapse:` prefix from every command id so Obsidian exposes them correctly as `synapse:scan-vault`, `synapse:fire`, etc.

## Changes

- **`src/commands/registry.ts`** — stripped `synapse:` from all 25 `id` values in `COMMAND_REGISTRY` (including the synthetic `tidy-vault` entry).
- **`src/commands/types.ts`** — clarified the `id` doc comment: the field holds the id *without* the plugin prefix (Obsidian adds it).
- **Call sites** — updated `registrar.register('synapse:...')` ids in `main.ts`, `video`, `deep-dive`, `organize`, `summarize`, `rem`, `tidy`, `elaboration`, `enrichment`, plus the two `isInFlow('synapse:scan-vault', 'startup')` calls in `elaboration`.
- **Tests** — updated id expectations in `commands/registry.test.ts`, `rem/index.test.ts`, `tidy/tidy-module.test.ts`, `summarize/*.test.ts`, and `elaboration/startup-flow.test.ts`.

Only command-id strings were changed; unrelated strings containing "synapse" (callout types, enrichment markers, etc.) were left untouched. The `registrar.test.ts` mock ids (`cmd:...`) are intentionally generic and not affected. Drift detection (`src/commands/audit.ts`) continues to pass unchanged.

## Pre-flight

- `npx tsc --noEmit --skipLibCheck` — pass
- `npm test` — 1246 passed (97 files)
- `node esbuild.config.mjs production` — pass

closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
