### PR TITLE
feat: replace sync fs calls in media pipelines with fs.promises

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -109,17 +109,17 @@ export class AudioModule {
 				const fs = require('fs') as typeof import('fs');
 
 				const tempPath = path.join(os.tmpdir(), `synapse-clip-src-${Date.now()}.mp3`);
-				fs.writeFileSync(tempPath, Buffer.from(data));
+				await fs.promises.writeFile(tempPath, Buffer.from(data));
 
 				const clippedPath = await this.extractor.clipAudio(
 					tempPath, timeRange.startSeconds, timeRange.endSeconds
 				);
 
-				data = fs.readFileSync(clippedPath).buffer as ArrayBuffer;
+				data = (await fs.promises.readFile(clippedPath)).buffer as ArrayBuffer;
 
 				// Clean up temp files
-				try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
-				try { fs.unlinkSync(clippedPath); } catch { /* ignore */ }
+				try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
+				try { await fs.promises.unlink(clippedPath); } catch { /* ignore */ }
 			} else if (timeRange && !this.extractor) {
 				this.notifications.info('Time-range clipping requires ffmpeg (desktop only). Transcribing full file.');
 			}
@@ -428,11 +428,11 @@ export class AudioModule {
 				const bin = await this.plugin.app.vault.readBinary(files[i]);
 				const ext = files[i].extension || 'audio';
 				const tempPath = path.join(os.tmpdir(), `synapse-combine-src-${Date.now()}-${i}.${ext}`);
-				fs.writeFileSync(tempPath, Buffer.from(bin));
+				await fs.promises.writeFile(tempPath, Buffer.from(bin));
 				tempInputs.push(tempPath);
 			}
 			combinedPath = await this.extractor.concatAudio(tempInputs);
-			const buf = fs.readFileSync(combinedPath);
+			const buf = await fs.promises.readFile(combinedPath);
 			const data = buf.buffer.slice(
 				buf.byteOffset,
 				buf.byteOffset + buf.byteLength
@@ -440,10 +440,10 @@ export class AudioModule {
 			return { data, sizeBytes: buf.byteLength };
 		} finally {
 			for (const t of tempInputs) {
-				try { fs.unlinkSync(t); } catch { /* ignore */ }
+				try { await fs.promises.unlink(t); } catch { /* ignore */ }
 			}
 			if (combinedPath) {
-				try { fs.unlinkSync(combinedPath); } catch { /* ignore */ }
+				try { await fs.promises.unlink(combinedPath); } catch { /* ignore */ }
 			}
 		}
 	}

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -38,7 +38,7 @@ export async function detectLocalFileDuration(
 		// crafted basename can never escape os.tmpdir().
 		const safeName = file.name.replace(/[^A-Za-z0-9._-]/g, '_');
 		const tempPath = path.join(os.tmpdir(), `synapse-probe-${Date.now()}-${safeName}`);
-		fs.writeFileSync(tempPath, Buffer.from(data));
+		await fs.promises.writeFile(tempPath, Buffer.from(data));
 
 		const ffmpegPath = sanitizePath(getSettings().video.ffmpegPath);
 		// Derive ffprobe path from ffmpeg path: replace "ffmpeg" with "ffprobe"
@@ -55,7 +55,10 @@ export async function detectLocalFileDuration(
 				],
 				{ env: shellEnv(), timeout: 15_000 },
 				(error, stdout) => {
-					try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
+					// Fire-and-forget cleanup: the execFile callback is sync, so we
+					// can't await here; unlink is a cheap metadata op and its result
+					// doesn't affect duration detection.
+					void fs.promises.unlink(tempPath).catch(() => { /* ignore */ });
 					if (error) {
 						resolve(undefined);
 						return;

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -112,11 +112,11 @@ export class VideoModule {
 			update('Clipping audio to time range...');
 			const clippedPath = await this.extractor.clipAudio(audioPath, startSeconds, endSeconds);
 			// Clean up the original unclipped audio
-			try { fs.unlinkSync(audioPath); } catch { /* ignore */ }
+			try { await fs.promises.unlink(audioPath); } catch { /* ignore */ }
 			audioPath = clippedPath;
 		}
 
-		const audioData = fs.readFileSync(audioPath);
+		const audioData = await fs.promises.readFile(audioPath);
 
 		update('Transcribing...');
 		let result;
@@ -132,7 +132,7 @@ export class VideoModule {
 
 		// Clean up temp audio file
 		try {
-			fs.unlinkSync(audioPath);
+			await fs.promises.unlink(audioPath);
 		} catch {
 			// Ignore cleanup errors
 		}
@@ -322,12 +322,12 @@ export class VideoModule {
 		const tempPath = await this.extractor.downloadVideo(url);
 
 		// Read the downloaded file and write it into the vault
-		const videoData = fs.readFileSync(tempPath);
+		const videoData = await fs.promises.readFile(tempPath);
 		const vaultPath = `${settings.downloadFolder}/${fileName}`;
 		await this.plugin.app.vault.adapter.writeBinary(vaultPath, videoData.buffer as ArrayBuffer);
 
 		// Clean up temp video file
-		try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
+		try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
 
 		return vaultPath;
 	}


### PR DESCRIPTION
## Summary

The plugin guidelines warn against blocking the main thread with synchronous operations. The desktop media pipelines used synchronous Node `fs` calls on whole media files, freezing the Obsidian UI for the duration of the read/write — noticeable for multi-hundred-MB videos.

This swaps every listed call site to the awaitable `fs.promises` API. The enclosing functions are already `async`, so the migration is mechanical.

## Changes

- **`src/video/index.ts`** — extracted-audio readback + entire downloaded-video readback, plus the associated temp-file `unlink` cleanup.
- **`src/audio/index.ts`** — clip round-trip and combine round-trip `write`/`read`, plus their `unlink` cleanup (including the `finally`-block cleanup).
- **`src/transcription/duration-detector.ts`** — probe-buffer `write`. The ffprobe-callback `unlink` runs inside a synchronous `execFile` callback, so it becomes a fire-and-forget `void fs.promises.unlink(...).catch(...)` (a cheap metadata op whose result doesn't affect duration detection).

The lazy `require('fs')` pattern is preserved so `scripts/check-top-level-requires.mjs` (mobile-safety guard) still passes. No `adapter.writeBinary`/vault APIs were touched — that's issue #280, handled separately.

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (1246 passed / 97 files)
- `node esbuild.config.mjs production` ✅
- `node scripts/check-top-level-requires.mjs` ✅ (no top-level requires)

> Note: stacked PR — base is `fix/issue-276-command-id-prefix`, not `main`.

closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)