### PR TITLE
fix: use vault.createBinary for video downloads

### DIFF
--- a/src/video/index.test.ts
+++ b/src/video/index.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TFile } from '../__mocks__/obsidian';
+import { VideoModule } from './index';
+import type { VideoMetadata } from './types';
+
+/**
+ * Focused coverage for VideoModule.downloadVideoToVault — the Vault-API
+ * migration (#280). The method is private, so we reach it via bracket access.
+ * Real fs is used for the temp-file round-trip (mirrors the audio combine
+ * tests) so the pool-backed-Buffer slice path is genuinely exercised.
+ */
+
+const VIDEO_BYTES = Buffer.from('fake-mp4-payload-bytes');
+
+interface VaultStub {
+	createBinary: ReturnType<typeof vi.fn>;
+	getAbstractFileByPath: ReturnType<typeof vi.fn>;
+	createFolder: ReturnType<typeof vi.fn>;
+	adapter: { writeBinary: ReturnType<typeof vi.fn> };
+}
+
+function makeVault(
+	getAbstractFileByPath = vi.fn().mockReturnValue(null)
+): VaultStub {
+	return {
+		createBinary: vi.fn().mockResolvedValue(new TFile()),
+		getAbstractFileByPath,
+		createFolder: vi.fn().mockResolvedValue(undefined),
+		adapter: { writeBinary: vi.fn().mockResolvedValue(undefined) },
+	};
+}
+
+function makeModule(downloadFolder: string, vault: VaultStub, tempPath: string) {
+	const getSettings = () =>
+		({
+			video: {
+				enabled: true,
+				downloadFolder,
+				tempFolder: '.synapse/temp',
+				ffmpegPath: 'ffmpeg',
+			},
+		}) as never;
+	const plugin = { app: { vault } } as never;
+	const mod = new VideoModule(
+		plugin,
+		getSettings,
+		{} as never,
+		{} as never,
+		{} as never,
+		{} as never
+	);
+	// Replace the real extractor with a stub that "downloads" to our temp file.
+	(mod as unknown as { extractor: { downloadVideo: ReturnType<typeof vi.fn> } }).extractor = {
+		downloadVideo: vi.fn().mockResolvedValue(tempPath),
+	};
+	return mod;
+}
+
+function callDownload(mod: VideoModule, metadata: VideoMetadata): Promise<string> {
+	return (
+		mod as unknown as {
+			downloadVideoToVault: (url: string, m: VideoMetadata) => Promise<string>;
+		}
+	).downloadVideoToVault('https://example.com/v', metadata);
+}
+
+describe('VideoModule.downloadVideoToVault', () => {
+	let tempPath: string;
+	let counter = 0;
+
+	beforeEach(async () => {
+		tempPath = path.join(os.tmpdir(), `synapse-video-test-${counter++}.mp4`);
+		await fs.promises.writeFile(tempPath, VIDEO_BYTES);
+	});
+
+	afterEach(async () => {
+		try {
+			await fs.promises.unlink(tempPath);
+		} catch {
+			/* already cleaned up by the unit under test */
+		}
+	});
+
+	it('writes the video via vault.createBinary, not the adapter API', async () => {
+		const vault = makeVault();
+		const mod = makeModule('Media', vault, tempPath);
+
+		const result = await callDownload(mod, { title: 'My Test Video' });
+
+		expect(vault.createBinary).toHaveBeenCalledTimes(1);
+		expect(vault.adapter.writeBinary).not.toHaveBeenCalled();
+
+		const [writtenPath, writtenData] = vault.createBinary.mock.calls[0];
+		expect(writtenPath).toMatch(/^Media\/\d{4}-\d{2}-\d{2}-My Test Video\.mp4$/);
+		expect(result).toBe(writtenPath);
+
+		// Exact-bytes assertion: proves the pool-backed-Buffer slice is correct.
+		expect(writtenData).toBeInstanceOf(ArrayBuffer);
+		expect(Buffer.from(writtenData as ArrayBuffer).equals(VIDEO_BYTES)).toBe(true);
+	});
+
+	it('cleans up the temp download file after writing', async () => {
+		const vault = makeVault();
+		const mod = makeModule('Media', vault, tempPath);
+
+		await callDownload(mod, { title: 'Cleanup Video' });
+
+		expect(fs.existsSync(tempPath)).toBe(false);
+	});
+
+	it('normalizes the joined download-folder path (no double slashes)', async () => {
+		const vault = makeVault();
+		const mod = makeModule('Media//Sub/', vault, tempPath);
+
+		const result = await callDownload(mod, { title: 'Nested Video' });
+
+		expect(result).not.toContain('//');
+		expect(result).toMatch(/^Media\/Sub\/\d{4}-\d{2}-\d{2}-Nested Video\.mp4$/);
+		expect(vault.createBinary).toHaveBeenCalledWith(result, expect.any(ArrayBuffer));
+	});
+
+	it('suffixes the filename on collision instead of overwriting', async () => {
+		// The un-suffixed name is taken; the "-1" name is free.
+		const getAbstractFileByPath = vi.fn((p: string) =>
+			p.endsWith('Dupe Video.mp4') ? new TFile(p) : null
+		);
+		const vault = makeVault(getAbstractFileByPath);
+		const mod = makeModule('Media', vault, tempPath);
+
+		const result = await callDownload(mod, { title: 'Dupe Video' });
+
+		expect(result).toMatch(/^Media\/\d{4}-\d{2}-\d{2}-Dupe Video-1\.mp4$/);
+		expect(vault.createBinary).toHaveBeenCalledWith(result, expect.any(ArrayBuffer));
+	});
+
+	it('increments the suffix until a free name is found', async () => {
+		// Both the base name and "-1" are taken; "-2" is free.
+		const getAbstractFileByPath = vi.fn((p: string) =>
+			p.endsWith('Busy Video.mp4') || p.endsWith('Busy Video-1.mp4')
+				? new TFile(p)
+				: null
+		);
+		const vault = makeVault(getAbstractFileByPath);
+		const mod = makeModule('Media', vault, tempPath);
+
+		const result = await callDownload(mod, { title: 'Busy Video' });
+
+		expect(result).toMatch(/^Media\/\d{4}-\d{2}-\d{2}-Busy Video-2\.mp4$/);
+	});
+});

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFile } from 'obsidian';
+import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import { AudioModule, TranscriptionResult } from '../audio';
@@ -321,15 +321,57 @@ export class VideoModule {
 		// Download via extractor (uses correct PATH and ytDlpPath setting)
 		const tempPath = await this.extractor.downloadVideo(url);
 
-		// Read the downloaded file and write it into the vault
+		// Read the downloaded file and write it into the vault. Use the Vault
+		// API (createBinary) rather than the Adapter API so the file is a
+		// first-class vault citizen -- cached, indexed, and immediately visible
+		// to other plugins. createBinary() throws if the path is taken, so pick
+		// a non-colliding name first (same-day re-downloads share a name).
 		const videoData = await fs.promises.readFile(tempPath);
-		const vaultPath = `${settings.downloadFolder}/${fileName}`;
-		await this.plugin.app.vault.adapter.writeBinary(vaultPath, videoData.buffer as ArrayBuffer);
+		// Slice to the exact bytes: fs.readFile may return a Buffer backed by a
+		// shared pool whose underlying ArrayBuffer is larger than the file.
+		const data = videoData.buffer.slice(
+			videoData.byteOffset,
+			videoData.byteOffset + videoData.byteLength
+		) as ArrayBuffer;
+		const vaultPath = this.findAvailableVaultPath(
+			normalizePath(`${settings.downloadFolder}/${fileName}`)
+		);
+		await this.plugin.app.vault.createBinary(vaultPath, data);
 
 		// Clean up temp video file
 		try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
 
 		return vaultPath;
+	}
+
+	/**
+	 * Resolve a vault path that does not collide with an existing file.
+	 * Mirrors Obsidian's de-duplication: append `-1`, `-2`, ... before the
+	 * extension until an unused path is found. Unlike the Adapter API (which
+	 * silently overwrites), vault.createBinary() throws on an existing file,
+	 * and the generated `<date>-<title>.mp4` name can collide on same-day
+	 * re-downloads -- so suffix rather than clobber the user's existing file.
+	 */
+	private findAvailableVaultPath(desiredPath: string): string {
+		const vault = this.plugin.app.vault;
+		if (!vault.getAbstractFileByPath(desiredPath)) {
+			return desiredPath;
+		}
+
+		const slashIndex = desiredPath.lastIndexOf('/');
+		const dotIndex = desiredPath.lastIndexOf('.');
+		// Only treat a dot as an extension separator if it sits in the basename.
+		const hasExt = dotIndex > slashIndex;
+		const stem = hasExt ? desiredPath.slice(0, dotIndex) : desiredPath;
+		const ext = hasExt ? desiredPath.slice(dotIndex) : '';
+
+		let counter = 1;
+		let candidate = `${stem}-${counter}${ext}`;
+		while (vault.getAbstractFileByPath(candidate)) {
+			counter++;
+			candidate = `${stem}-${counter}${ext}`;
+		}
+		return candidate;
 	}
 
 	private async checkDependencies(): Promise<void> {


### PR DESCRIPTION
## Summary

The plugin guidelines say to prefer the **Vault API** over the **Adapter API** for files in the user's vault — the vault layer provides caching, safety, and immediate visibility to other plugins/indexers. `downloadVideoToVault()` writes the downloaded video (a user-visible file in the user-configured download folder) and was using `vault.adapter.writeBinary(...)`.

This switches that write to `vault.createBinary(normalizePath(...), data)`.

## Wrinkles handled

- **Collisions** — `vault.createBinary()` throws if the file already exists (the adapter call silently overwrote), and the generated `<date>-<title>.mp4` name collides on same-day re-downloads. Added `findAvailableVaultPath()`, which suffixes `-1`, `-2`, … before the extension (Obsidian-style dedup) so a re-download never clobbers the user's existing file.
- **Path normalization** — `normalizePath()` is now applied to the joined `downloadFolder`/`fileName` path.
- **Exact-bytes slice** — `fs.readFile` can return a Buffer backed by a shared pool whose underlying `ArrayBuffer` is larger than the file; the bytes are now sliced to `[byteOffset, byteOffset + byteLength)` before being handed to `createBinary` (matches the existing pattern in the audio module). Without this, small files would write trailing pool garbage.

## Tests

`src/video/index.ts` previously had **no** test coverage. Added `src/video/index.test.ts` (5 cases, real-fs temp-file round-trip):
- writes via `vault.createBinary`, **not** the adapter API; exact bytes preserved
- temp download file is cleaned up
- joined path is normalized (no `//`)
- collision → `-1` suffix instead of overwrite
- multiple collisions → increments to `-2`

## Pre-flight
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (1251 passed / 98 files — +5 new)
- `node esbuild.config.mjs production` ✅
- `node scripts/check-top-level-requires.mjs` ✅

> Note: stacked PR — base is `feat/issue-279-async-fs-media` (PR #284), not `main`. `closingIssuesReferences` for #280 stays empty until the stack collapses onto the default branch — expected, same as #284.

closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)