### PR TITLE
fix: sentence case in settings UI, drop top-level heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Open **Settings > Synapse** to configure the plugin. All features can be individ
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| AI Provider | OpenAI, Anthropic, or Ollama (local) | OpenAI |
-| API Key | Your API key for the selected provider | -- |
-| Ollama Endpoint | URL for local Ollama server (shown when Ollama selected) | `http://localhost:11434` |
+| AI provider | OpenAI, Anthropic, or Ollama (local) | OpenAI |
+| API key | Your API key for the selected provider | -- |
+| Ollama endpoint | URL for local Ollama server (shown when Ollama selected) | `http://localhost:11434` |
 | Model | AI model for the selected provider | GPT-4o |
 | Temperature | Controls randomness (0 = deterministic, 1 = creative) | 0.7 |
 

--- a/src/audio/settings-section.ts
+++ b/src/audio/settings-section.ts
@@ -14,7 +14,7 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 
 	const audioBody = ctx.featureSection(
 		'audio',
-		'Audio Transcription',
+		'Audio transcription',
 		() => plugin.settings.audio.enabled,
 		(v) => { plugin.settings.audio.enabled = v; },
 		'Enable audio transcription',
@@ -58,7 +58,7 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 		plugin.settings.ai.provider !== 'openai'
 	) {
 		new Setting(audioBody)
-			.setName('OpenAI API Key (Whisper)')
+			.setName('OpenAI API key (Whisper)')
 			.setDesc(
 				'Whisper uses the OpenAI API. Provide your OpenAI key here since your AI provider is set to ' +
 				plugin.settings.ai.provider.charAt(0).toUpperCase() +
@@ -84,7 +84,7 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 		plugin.settings.ai.provider !== 'gemini'
 	) {
 		new Setting(audioBody)
-			.setName('Google Gemini API Key')
+			.setName('Google Gemini API key')
 			.setDesc(
 				'Gemini transcription uses the Google AI API. Provide your Gemini key here since your AI provider is set to ' +
 				plugin.settings.ai.provider.charAt(0).toUpperCase() +
@@ -105,7 +105,7 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 
 	if (plugin.settings.audio.transcriptionProvider === 'deepgram') {
 		new Setting(audioBody)
-			.setName('Deepgram API Key')
+			.setName('Deepgram API key')
 			.setDesc('Required for Deepgram transcription provider')
 			.addText((text) => {
 				text

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -18,7 +18,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	{ id: 'manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'] },
 	{ id: 'transcribe-media', name: 'Transcribe media', feature: 'main', status: 'disabled', flows: ['palette'] },
 	{ id: 'transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'fire', name: 'Fire Synapse: run all features on a directory', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'fire', name: 'Run all features on a directory', feature: 'main', status: 'active', flows: ['palette'] },
 
 	// --- elaboration (src/elaboration/index.ts) ---
 	{ id: 'scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], pipelineKey: 'elaboration' },
@@ -60,7 +60,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	// palette command runs `tidy()` on a single note — a different operation. This
 	// entry carries `pipelineKey: 'tidy'` so the tidy pipeline phase is controlled
 	// independently of the palette command. It is never passed to registrar.register().
-	{ id: 'tidy-vault', name: 'Tidy vault (Fire Synapse)', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
+	{ id: 'tidy-vault', name: 'Tidy vault', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
 ];
 
 /** Lookup by command id. */

--- a/src/deep-dive/depth-selector-modal.ts
+++ b/src/deep-dive/depth-selector-modal.ts
@@ -28,7 +28,7 @@ export class DepthSelectorModal extends Modal {
 
 		addEnhancedSlider(
 			new Setting(sliderContainer)
-				.setName('Recursion Depth')
+				.setName('Recursion depth')
 				.setDesc('How many generations of topics to explore'),
 				{
 					min: MIN_DEPTH,

--- a/src/deep-dive/settings-section.ts
+++ b/src/deep-dive/settings-section.ts
@@ -14,7 +14,7 @@ export function renderDeepDiveSettings(ctx: SettingsSectionContext): void {
 
 	const deepDiveBody = ctx.featureSection(
 		'deepDive',
-		'Deep Dive',
+		'Deep dive',
 		() => plugin.settings.deepDive.enabled,
 		(v) => { plugin.settings.deepDive.enabled = v; },
 		'Recursively explore a note into a tree of interlinked child notes',

--- a/src/elaboration/proposal-modal.ts
+++ b/src/elaboration/proposal-modal.ts
@@ -37,7 +37,7 @@ export class ProposalDetailModal extends Modal {
 
 		contentEl.createEl('p', { text: `Detected: ${reasons}`, cls: 'synapse-detection-info' });
 
-		contentEl.createEl('h3', { text: 'Proposed Additions' });
+		contentEl.createEl('h3', { text: 'Proposed additions' });
 		contentEl.createEl('p', { text: 'Edit the content below before accepting:' });
 
 		const textarea = contentEl.createEl('textarea', {
@@ -45,8 +45,6 @@ export class ProposalDetailModal extends Modal {
 		});
 		textarea.value = this.proposal.proposedAdditions;
 		textarea.rows = 12;
-		textarea.style.width = '100%';
-		textarea.style.fontFamily = 'monospace';
 
 		const actions = contentEl.createDiv({ cls: 'synapse-modal-actions' });
 

--- a/src/elaboration/proposal-view.ts
+++ b/src/elaboration/proposal-view.ts
@@ -54,7 +54,7 @@ export class ProposalReviewView extends ItemView {
 		const { contentEl } = this;
 		contentEl.empty();
 
-		contentEl.createEl('h3', { text: 'Pending Proposals' });
+		contentEl.createEl('h3', { text: 'Pending proposals' });
 
 		const pending = this.proposals.filter(p => p.status === 'pending');
 		if (pending.length === 0) {

--- a/src/elaboration/settings-section.ts
+++ b/src/elaboration/settings-section.ts
@@ -10,7 +10,7 @@ export function renderElaborationSettings(ctx: SettingsSectionContext): void {
 
 	const elaborationBody = ctx.featureSection(
 		'elaboration',
-		'Note Elaboration',
+		'Note elaboration',
 		() => plugin.settings.elaboration.enabled,
 		(v) => { plugin.settings.elaboration.enabled = v; },
 		'Enable stub note detection and proposal generation',

--- a/src/enrichment/enrichment-modal.ts
+++ b/src/enrichment/enrichment-modal.ts
@@ -85,7 +85,7 @@ export class EnrichmentDetailModal extends Modal {
 		const actions = contentEl.createDiv({ cls: 'synapse-modal-actions' });
 
 		const acceptBtn = actions.createEl('button', {
-			text: 'Accept Selected',
+			text: 'Accept selected',
 			cls: 'mod-cta',
 		});
 		acceptBtn.addEventListener('click', () => {
@@ -98,19 +98,19 @@ export class EnrichmentDetailModal extends Modal {
 			this.close();
 		});
 
-		const selectAllBtn = actions.createEl('button', { text: 'Select All' });
+		const selectAllBtn = actions.createEl('button', { text: 'Select all' });
 		selectAllBtn.addEventListener('click', () => {
 			this.selectAll();
 			this.onOpen(); // Re-render
 		});
 
-		const deselectBtn = actions.createEl('button', { text: 'Deselect All' });
+		const deselectBtn = actions.createEl('button', { text: 'Deselect all' });
 		deselectBtn.addEventListener('click', () => {
 			this.deselectAll();
 			this.onOpen(); // Re-render
 		});
 
-		const rejectBtn = actions.createEl('button', { text: 'Reject All' });
+		const rejectBtn = actions.createEl('button', { text: 'Reject all' });
 		rejectBtn.addEventListener('click', () => {
 			this.onReject();
 			this.close();

--- a/src/enrichment/settings-section.test.ts
+++ b/src/enrichment/settings-section.test.ts
@@ -43,7 +43,7 @@ describe('renderEnrichmentSettings', () => {
 		expect(saveSettings).toHaveBeenCalled();
 	});
 
-	it('renders the Proximity Weights and Tag Vocabulary sub-sections without throwing', () => {
+	it('renders the Proximity weights and Tag vocabulary sub-sections without throwing', () => {
 		const { ctx } = makeCtx();
 		expect(() => renderEnrichmentSettings(ctx)).not.toThrow();
 	});

--- a/src/enrichment/settings-section.ts
+++ b/src/enrichment/settings-section.ts
@@ -12,7 +12,7 @@ export function renderEnrichmentSettings(ctx: SettingsSectionContext): void {
 
 	const enrichmentBody = ctx.featureSection(
 		'enrichment',
-		'Note Enrichment',
+		'Note enrichment',
 		() => plugin.settings.enrichment.enabled,
 		(v) => { plugin.settings.enrichment.enabled = v; },
 		'Add tags, links, references, and metadata to notes',
@@ -120,7 +120,7 @@ export function renderEnrichmentSettings(ctx: SettingsSectionContext): void {
 	);
 
 	// Weight settings (sub-section within enrichment)
-	new Setting(enrichmentBody).setHeading().setName('Proximity Weights');
+	new Setting(enrichmentBody).setHeading().setName('Proximity weights');
 
 	type WeightKey = keyof EnrichmentWeightSettings;
 	const weightFields: Array<{ key: WeightKey; name: string; desc: string }> = [
@@ -153,7 +153,7 @@ export function renderEnrichmentSettings(ctx: SettingsSectionContext): void {
 	}
 
 	// Tag Vocabulary (sub-section within enrichment)
-	new Setting(enrichmentBody).setHeading().setName('Tag Vocabulary').setDesc('Define metadata tag categories. Tags classify notes (status, type, source) — topics become [[links]] instead.');
+	new Setting(enrichmentBody).setHeading().setName('Tag vocabulary').setDesc('Define metadata tag categories. Tags classify notes (status, type, source) — topics become [[links]] instead.');
 
 	for (let i = 0; i < plugin.settings.enrichment.tagVocabulary.length; i++) {
 		const entry = plugin.settings.enrichment.tagVocabulary[i];

--- a/src/intake/settings-section.ts
+++ b/src/intake/settings-section.ts
@@ -9,7 +9,7 @@ export function renderIntakeSettings(ctx: SettingsSectionContext): void {
 
 	const intakeBody = ctx.featureSection(
 		'intake',
-		'Intake Folder',
+		'Intake folder',
 		() => plugin.settings.intake.enabled,
 		(v) => { plugin.settings.intake.enabled = v; },
 		'Watch the intake folder and run enabled Synapse features on new notes',

--- a/src/main.ts
+++ b/src/main.ts
@@ -362,7 +362,7 @@ export default class SynapsePlugin extends Plugin {
 		}
 
 		registrar.register('fire', true, {
-			name: 'Fire Synapse: run all features on a directory',
+			name: 'Run all features on a directory',
 			callback: () => {
 				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(

--- a/src/organize/settings-section.ts
+++ b/src/organize/settings-section.ts
@@ -10,7 +10,7 @@ export function renderOrganizeSettings(ctx: SettingsSectionContext): void {
 
 	const organizeBody = ctx.featureSection(
 		'organize',
-		'Note Organize',
+		'Note organize',
 		() => plugin.settings.organize.enabled,
 		(v) => { plugin.settings.organize.enabled = v; },
 		'AI-powered semantic directory structuring for notes',

--- a/src/rem/settings-section.ts
+++ b/src/rem/settings-section.ts
@@ -10,7 +10,7 @@ export function renderRemSettings(ctx: SettingsSectionContext): void {
 
 	const remBody = ctx.featureSection(
 		'rem',
-		'REM (Link Discovery)',
+		'REM (link discovery)',
 		() => plugin.settings.rem.enabled,
 		(v) => { plugin.settings.rem.enabled = v; },
 		'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions',

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -41,7 +41,7 @@ const AUTO_ACCEPT_LABELS: Record<ProposalKind, { name: string; desc: string }> =
 		desc: 'Caution: moves notes. Automatically accept organize proposals, relocating notes into the proposed folders without review.',
 	},
 	'deep-dive': {
-		name: 'Deep Dive',
+		name: 'Deep dive',
 		desc: 'Automatically accept every generated deep dive note in a run, creating all of them in the vault.',
 	},
 	title: {
@@ -49,7 +49,7 @@ const AUTO_ACCEPT_LABELS: Record<ProposalKind, { name: string; desc: string }> =
 		desc: 'Caution: renames files. Automatically accept title proposals, renaming notes without review.',
 	},
 	rem: {
-		name: 'REM (Link Discovery)',
+		name: 'REM (link discovery)',
 		desc: 'Caution: rewrites note body text. Automatically insert all discovered [[wikilinks]] without review.',
 	},
 };
@@ -145,8 +145,6 @@ export class SynapseSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		new Setting(containerEl).setHeading().setName(`Synapse v${this.plugin.manifest.version}`);
-
 		// Rebuilt each render; feature toggles flip Auto-Accept rows' disabled
 		// state live via the context's onFeatureToggle hook.
 		this.autoAcceptSettings = {};
@@ -176,6 +174,14 @@ export class SynapseSettingTab extends PluginSettingTab {
 
 		// ── About (static support links, always last) ──
 		this.renderAbout(ctx);
+
+		// Version as a muted footer line. The settings tab must not carry a
+		// top-level plugin-name heading (Obsidian community guidelines), so the
+		// version moves here, below everything else.
+		containerEl.createDiv({
+			cls: 'setting-item-description synapse-settings-footer',
+			text: `Synapse v${this.plugin.manifest.version}`,
+		});
 	}
 
 	/**
@@ -184,10 +190,10 @@ export class SynapseSettingTab extends PluginSettingTab {
 	 * not tied to any single feature.
 	 */
 	private renderAIConfiguration(ctx: SettingsSectionContext): void {
-		const aiBody = ctx.configSection('ai', 'AI Configuration');
+		const aiBody = ctx.configSection('ai', 'AI configuration');
 
 		new Setting(aiBody)
-			.setName('AI Provider')
+			.setName('AI provider')
 			.setDesc('Which AI service to use for elaboration and post-processing')
 			.addDropdown((dd) =>
 				dd
@@ -214,7 +220,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 		// every AI feature highlighted until they fill it (#89). Toggled live as
 		// they type — no full re-render, so the field keeps focus.
 		const apiKeySetting = new Setting(aiBody)
-			.setName('API Key')
+			.setName('API key')
 			.addText((text) => {
 				text
 					.setPlaceholder('sk-...')
@@ -231,7 +237,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 
 		if (this.plugin.settings.ai.provider === 'ollama') {
 			new Setting(aiBody)
-				.setName('Ollama Endpoint')
+				.setName('Ollama endpoint')
 				.setDesc('URL for local Ollama server (HTTPS required for non-localhost)')
 				.addText((text) =>
 					text
@@ -316,7 +322,7 @@ export class SynapseSettingTab extends PluginSettingTab {
 	private renderAutoAccept(ctx: SettingsSectionContext): void {
 		// Rendered like the AI Configuration section: a collapsible config
 		// section with no header toggle, persisting its own collapse state.
-		const autoAcceptBody = ctx.configSection('autoAccept', 'Auto-Accept Proposals');
+		const autoAcceptBody = ctx.configSection('autoAccept', 'Auto-accept proposals');
 
 		autoAcceptBody.createDiv({
 			cls: 'setting-item-description synapse-accordion-empty-note',

--- a/src/summarize/summarize-modal.ts
+++ b/src/summarize/summarize-modal.ts
@@ -21,20 +21,20 @@ export class SummarizeSelectionModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 
-		contentEl.createEl('h2', { text: 'Summarize Content' });
+		contentEl.createEl('h2', { text: 'Summarize content' });
 		contentEl.createEl('p', {
 			text: `Found ${this.targets.length} item(s) to summarize. Select which to process:`,
 		});
 
 		new Setting(contentEl)
 			.addButton((btn) => {
-				btn.setButtonText('Select All').onClick(() => {
+				btn.setButtonText('Select all').onClick(() => {
 					this.selected = new Set(this.targets.map(t => `${t.type}:${t.line}:${t.source}`));
 					this.renderCheckboxes(listEl);
 				});
 			})
 			.addButton((btn) => {
-				btn.setButtonText('Select None').onClick(() => {
+				btn.setButtonText('Select none').onClick(() => {
 					this.selected.clear();
 					this.renderCheckboxes(listEl);
 				});
@@ -58,7 +58,7 @@ export class SummarizeSelectionModal extends Modal {
 		this.renderCheckboxes(listEl);
 
 		new Setting(contentEl).addButton((btn) => {
-			btn.setButtonText('Summarize Selected')
+			btn.setButtonText('Summarize selected')
 				.setCta()
 				.onClick(async () => {
 					const keys = this.selected;

--- a/src/tidy/settings-section.ts
+++ b/src/tidy/settings-section.ts
@@ -9,7 +9,7 @@ export function renderTidySettings(ctx: SettingsSectionContext): void {
 
 	const tidyBody = ctx.featureSection(
 		'tidy',
-		'Note Tidy',
+		'Note tidy',
 		() => plugin.settings.tidy.enabled,
 		(v) => { plugin.settings.tidy.enabled = v; },
 		'Spelling correction and markdown formatting (no content changes)',

--- a/src/transcription/note-media-modal.ts
+++ b/src/transcription/note-media-modal.ts
@@ -31,7 +31,7 @@ export class NoteMediaModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 
-		contentEl.createEl('h2', { text: 'Process Media from Note' });
+		contentEl.createEl('h2', { text: 'Process media from note' });
 
 		const audioCount = this.audioEmbeds.length;
 		const videoCount = this.videoEmbeds.length;
@@ -47,7 +47,7 @@ export class NoteMediaModal extends Modal {
 		// Select all / none
 		new Setting(contentEl)
 			.addButton((btn) => {
-				btn.setButtonText('Select All').onClick(() => {
+				btn.setButtonText('Select all').onClick(() => {
 					this.selectedAudio = new Set(this.audioEmbeds.map(e => e.fileName));
 					this.selectedVideo = new Set(this.videoEmbeds.map(e => e.url));
 					this.selectedImage = new Set(this.imageEmbeds.map(e => e.fileName));
@@ -55,7 +55,7 @@ export class NoteMediaModal extends Modal {
 				});
 			})
 			.addButton((btn) => {
-				btn.setButtonText('Select None').onClick(() => {
+				btn.setButtonText('Select none').onClick(() => {
 					this.selectedAudio.clear();
 					this.selectedVideo.clear();
 					this.selectedImage.clear();
@@ -89,7 +89,7 @@ export class NoteMediaModal extends Modal {
 
 		// Process button
 		new Setting(contentEl).addButton((btn) => {
-			btn.setButtonText('Process Selected')
+			btn.setButtonText('Process selected')
 				.setCta()
 				.onClick(async () => {
 					const chosenAudio = this.audioEmbeds.filter(e => this.selectedAudio.has(e.fileName));
@@ -129,7 +129,7 @@ export class NoteMediaModal extends Modal {
 		imageContainer.empty();
 
 		if (this.audioEmbeds.length > 0) {
-			audioContainer.createEl('h4', { text: 'Audio Files' });
+			audioContainer.createEl('h4', { text: 'Audio files' });
 			for (const embed of this.audioEmbeds) {
 				new Setting(audioContainer)
 					.setName(embed.fileName)

--- a/src/transcription/time-range-toast.ts
+++ b/src/transcription/time-range-toast.ts
@@ -93,7 +93,7 @@ export function showTimeRangeToast(
 		const actions = el.createDiv({ cls: `${CLS}-actions` });
 
 		const selectionBtn = actions.createEl('button', {
-			text: 'Transcribe Selection',
+			text: 'Transcribe selection',
 			cls: 'mod-cta',
 		});
 		selectionBtn.addEventListener('click', (e) => {
@@ -111,7 +111,7 @@ export function showTimeRangeToast(
 		});
 
 		const fullBtn = actions.createEl('button', {
-			text: 'Full File',
+			text: 'Full file',
 			cls: 'mod-cancel',
 		});
 		fullBtn.addEventListener('click', (e) => {

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -31,7 +31,7 @@ export class UnifiedTranscriptionModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 
-		contentEl.createEl('h2', { text: 'Transcribe Media' });
+		contentEl.createEl('h2', { text: 'Transcribe media' });
 
 		// Local File section
 		if (this.enabledModules.audio || this.enabledModules.video) {
@@ -244,7 +244,7 @@ export class UnifiedTranscriptionModal extends Modal {
 			const actions = el.createDiv({ cls: 'synapse-notice-actions' });
 
 			const clipBtn = actions.createEl('button', {
-				text: 'Transcribe Selection',
+				text: 'Transcribe selection',
 				cls: 'mod-cta',
 			});
 			clipBtn.addEventListener('click', (e) => {
@@ -265,7 +265,7 @@ export class UnifiedTranscriptionModal extends Modal {
 			});
 
 			const fullBtn = actions.createEl('button', {
-				text: 'Full File',
+				text: 'Full file',
 				cls: 'mod-cancel',
 			});
 			fullBtn.addEventListener('click', (e) => {

--- a/src/video/settings-section.ts
+++ b/src/video/settings-section.ts
@@ -13,7 +13,7 @@ export function renderVideoSettings(ctx: SettingsSectionContext): void {
 
 	const videoBody = ctx.featureSection(
 		'video',
-		'Video Transcription',
+		'Video transcription',
 		() => plugin.settings.video.enabled,
 		(v) => { plugin.settings.video.enabled = v; },
 		'Enable video transcription',

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -337,7 +337,7 @@ export class UnifiedProposalView extends ItemView {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('synapse-view-root');
-		contentEl.createEl('h3', { text: 'Pending Proposals' });
+		contentEl.createEl('h3', { text: 'Pending proposals' });
 
 		const progressBar = contentEl.createDiv({ cls: 'synapse-accept-all-progress' });
 		progressBar.createEl('p', {
@@ -356,7 +356,7 @@ export class UnifiedProposalView extends ItemView {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass('synapse-view-root');
-		contentEl.createEl('h3', { text: 'Pending Proposals' });
+		contentEl.createEl('h3', { text: 'Pending proposals' });
 
 		// Render incomplete checkpoints banner
 		if (this.incompleteCheckpoints.length > 0) {
@@ -381,7 +381,7 @@ export class UnifiedProposalView extends ItemView {
 			const bulkInProgress = this.acceptAllInProgress || this.rejectAllInProgress;
 
 			const acceptAllBtn = bulkBar.createEl('button', {
-				text: 'Accept All',
+				text: 'Accept all',
 				cls: 'synapse-accept-all-btn mod-cta',
 			});
 			if (bulkInProgress) {
@@ -390,7 +390,7 @@ export class UnifiedProposalView extends ItemView {
 			acceptAllBtn.addEventListener('click', () => this.acceptAll());
 
 			const rejectAllBtn = bulkBar.createEl('button', {
-				text: 'Reject All',
+				text: 'Reject all',
 				cls: 'synapse-reject-all-btn',
 			});
 			if (bulkInProgress) {
@@ -510,7 +510,7 @@ export class UnifiedProposalView extends ItemView {
 			this.enterEnrichmentReview(proposal);
 		});
 
-		const acceptBtn = actions.createEl('button', { text: 'Accept All' });
+		const acceptBtn = actions.createEl('button', { text: 'Accept all' });
 		acceptBtn.addEventListener('click', () => {
 			const all: AcceptedItems = {
 				tags: result.tags.map(t => t.tag),
@@ -594,7 +594,7 @@ export class UnifiedProposalView extends ItemView {
 
 		const editorPane = contentEl.createDiv({ cls: 'synapse-review-pane' });
 		editorPane.createEl('div', {
-			text: 'Proposed Additions',
+			text: 'Proposed additions',
 			cls: 'synapse-review-pane-label synapse-review-pane-label--elaboration',
 		});
 		const textarea = editorPane.createEl('textarea', { cls: 'synapse-review-editor' });
@@ -686,7 +686,7 @@ export class UnifiedProposalView extends ItemView {
 		// Action bar
 		const actionBar = contentEl.createDiv({ cls: 'synapse-review-actions' });
 
-		const acceptBtn = actionBar.createEl('button', { text: 'Accept Selected', cls: 'mod-cta' });
+		const acceptBtn = actionBar.createEl('button', { text: 'Accept selected', cls: 'mod-cta' });
 		acceptBtn.addEventListener('click', () => {
 			const accepted: AcceptedItems = {
 				tags: [...this.selectedTags],
@@ -748,7 +748,7 @@ export class UnifiedProposalView extends ItemView {
 		// Proposed directory
 		const dirPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		dirPane.createEl('div', {
-			text: 'Proposed Directory',
+			text: 'Proposed directory',
 			cls: 'synapse-review-pane-label synapse-review-pane-label--organize',
 		});
 		dirPane.createEl('p', {
@@ -787,7 +787,7 @@ export class UnifiedProposalView extends ItemView {
 		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--deep-dive' });
 
 		const badgeRow = card.createDiv({ cls: 'synapse-badge-row' });
-		badgeRow.createEl('span', { text: 'Deep Dive', cls: 'synapse-badge synapse-badge--deep-dive' });
+		badgeRow.createEl('span', { text: 'Deep dive', cls: 'synapse-badge synapse-badge--deep-dive' });
 		badgeRow.createEl('span', {
 			text: `D${proposal.depth}`,
 			cls: 'synapse-depth-badge',
@@ -866,7 +866,7 @@ export class UnifiedProposalView extends ItemView {
 		// Proposed path
 		const pathPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		pathPane.createEl('div', {
-			text: 'Proposed Path',
+			text: 'Proposed path',
 			cls: 'synapse-review-pane-label synapse-review-pane-label--deep-dive',
 		});
 		pathPane.createEl('p', {
@@ -877,7 +877,7 @@ export class UnifiedProposalView extends ItemView {
 		// Content preview
 		const editorPane = contentEl.createDiv({ cls: 'synapse-review-pane' });
 		editorPane.createEl('div', {
-			text: 'Proposed Content',
+			text: 'Proposed content',
 			cls: 'synapse-review-pane-label synapse-review-pane-label--deep-dive',
 		});
 		const textarea = editorPane.createEl('textarea', { cls: 'synapse-review-editor synapse-review-editor--deep-dive' });
@@ -969,7 +969,7 @@ export class UnifiedProposalView extends ItemView {
 		// Current title
 		const currentPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		currentPane.createEl('div', {
-			text: 'Current Title',
+			text: 'Current title',
 			cls: 'synapse-review-pane-label synapse-review-pane-label--title',
 		});
 		currentPane.createEl('p', {
@@ -980,7 +980,7 @@ export class UnifiedProposalView extends ItemView {
 		// Proposed title
 		const proposedPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		proposedPane.createEl('div', {
-			text: 'Proposed Title',
+			text: 'Proposed title',
 			cls: 'synapse-review-pane-label synapse-review-pane-label--title',
 		});
 		proposedPane.createEl('p', {
@@ -1051,7 +1051,7 @@ export class UnifiedProposalView extends ItemView {
 			this.enterRemReview(proposal);
 		});
 
-		const acceptBtn = actions.createEl('button', { text: 'Accept All' });
+		const acceptBtn = actions.createEl('button', { text: 'Accept all' });
 		acceptBtn.addEventListener('click', () => {
 			const allTexts = candidates.map(c => c.matchedText);
 			this.callbacks.onRemAcceptSelected(proposal.id, allTexts);
@@ -1149,7 +1149,7 @@ export class UnifiedProposalView extends ItemView {
 		// Action bar
 		const actionBar = contentEl.createDiv({ cls: 'synapse-review-actions' });
 
-		const acceptBtn = actionBar.createEl('button', { text: 'Accept Selected', cls: 'mod-cta' });
+		const acceptBtn = actionBar.createEl('button', { text: 'Accept selected', cls: 'mod-cta' });
 		acceptBtn.addEventListener('click', () => {
 			const accepted = [...this.selectedRemLinks];
 			this.reviewingRem = null;
@@ -1180,7 +1180,7 @@ export class UnifiedProposalView extends ItemView {
 	private renderCheckpointBanner(container: HTMLElement): void {
 		const section = container.createDiv({ cls: 'synapse-checkpoint-banner' });
 		section.createEl('div', {
-			text: 'Interrupted Operations',
+			text: 'Interrupted operations',
 			cls: 'synapse-checkpoint-heading',
 		});
 

--- a/styles.css
+++ b/styles.css
@@ -103,8 +103,18 @@
 /* ── Proposal editor textarea ── */
 
 .synapse-proposal-editor {
+  width: 100%;
+  font-family: var(--font-monospace, monospace);
   max-height: 60vh;
   resize: vertical;
+}
+
+/* ── Settings tab version footer ── */
+
+.synapse-settings-footer {
+  margin-top: 24px;
+  text-align: center;
+  opacity: 0.7;
 }
 
 /* ── Dual-handle time-range slider ── */


### PR DESCRIPTION
## Summary

Obsidian's community plugin guidelines require **sentence case** for all UI text and forbid a **top-level heading** (plugin name or "Settings") at the top of a settings tab. The community-guidelines audit (#80) flagged both. This brings every user-facing label into compliance.

Stacked on top of #276 (`fix/issue-276-command-id-prefix`) — review/merge that first.

## Changes

**Top-level heading → muted footer**
- Removed the `Synapse v<version>` `setHeading()` at the top of the settings tab (`src/settings-tab.ts`); the version now renders as a muted, centered footer line at the very bottom via a new `.synapse-settings-footer` CSS class.

**Sentence case — settings tab & sections**
- AI config: `AI Configuration → AI configuration`, `AI Provider → AI provider`, `API Key → API key`, `Ollama Endpoint → Ollama endpoint`; `Auto-Accept Proposals → Auto-accept proposals`.
- Audio: `OpenAI API Key (Whisper) → OpenAI API key (Whisper)`, `Google Gemini API Key → … API key`, `Deepgram API Key → Deepgram API key` (product names kept capitalized).
- Enrichment: `Proximity Weights → Proximity weights`, `Tag Vocabulary → Tag vocabulary`.
- Deep dive: `Recursion Depth → Recursion depth`.
- All feature-section titles: `Video Transcription`, `Audio Transcription`, `Note Elaboration`, `Note Enrichment`, `Note Organize`, `Note Tidy`, `Intake Folder`, `Deep Dive`, `REM (Link Discovery)` → sentence case. (Section toggle tooltips come from the description arg, so unaffected.)
- Auto-accept row labels: `Deep Dive → Deep dive`, `REM (Link Discovery) → REM (link discovery)`.

**Sentence case — modals, views, buttons**
- Buttons: `Select All/None`, `Process Selected`, `Summarize Selected`, `Accept Selected`, `Accept All`, `Reject All`, `Deselect All`, `Transcribe Selection`, `Full File` → sentence case (across note-media, summarize, enrichment, transcription, time-range, and the unified proposal view).
- Headings/labels: `Process Media from Note`, `Transcribe Media`, `Summarize Content`, `Audio Files`, `Pending Proposals`, `Proposed Additions/Path/Content/Title/Directory`, `Current Title`, `Interrupted Operations` → sentence case. (`Video URLs`, `Images (OCR)` already compliant — acronyms kept.)

**Command names (drop plugin-name restatement)**
- `Fire Synapse: run all features on a directory → Run all features on a directory` (both the `registry.ts` declarative entry and the `main.ts` `addCommand` spec — the spec is what the palette shows).
- `Tidy vault (Fire Synapse) → Tidy vault` (synthetic pipeline-only entry).
- Note: the "Fire Synapse" branding is retained in the run-completion notification; only the command labels changed. Flagging for confirmation in case you'd prefer to keep a "Fire" verb in the command name.

**Inline styles → CSS**
- Moved the two inline styles on the elaboration proposal textarea (`width: 100%`, `font-family: monospace`) into the existing `.synapse-proposal-editor` class in `styles.css`.

**README**
- Updated only the three AI-configuration table name cells (`AI provider`, `API key`, `Ollama endpoint`). No other rows, the Overview, provider list, or Privacy section touched — keeps #283 merging cleanly.

**Tests**
- Updated one test description string referencing the renamed enrichment sub-sections. No assertions changed; the sweep was verified against the suite (no test asserts the changed labels).

## Pre-flight

- `npx tsc --noEmit --skipLibCheck` — pass
- `npm test` — 1246 passed (97 files)
- `node esbuild.config.mjs production` — pass

closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
