### PR TITLE
chore: full codebase audit — architecture, security, docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-11
 ---
 
 # Synapse — Agent Reference
@@ -54,13 +54,13 @@ main.ts
   |-- shared/     (base layer: depends on NO feature module; owns url-detector)
   |-- pipeline/ --> commands/ (isPipelineKeyInFlow); modules injected via PipelineModuleMap
   |-- views/unified-proposal-view.ts --> elaboration/types, enrichment/types, organize/types, deep-dive/types, title/types, rem/types, shared/checkpoint-types
-  |-- elaboration/ --> shared/, commands/, image/ (ImageAnalyzer uses shared/AIClient)
+  |-- elaboration/ --> shared/, commands/, image/ (ImageAnalyzer uses shared AIClient + image/preprocessImage)
   |-- audio/ --> shared/, commands/
   |-- video/ --> shared/ (CheckpointManager, url-detector), commands/, audio/ (reuses transcription pipeline)
   |-- image/ --> shared/ (CheckpointManager, AIClient, callouts, validation), commands/
   |-- transcription/ --> audio/ (types), video/ (types), image/ (types), shared/ (detectPlatform, TimeRange, validation)
   |-- enrichment/ --> shared/, commands/
-  |-- summarize/ --> shared/, commands/, video/ (transcribeUrl injection), audio/ (findAudioEmbeds)
+  |-- summarize/ --> shared/ (incl. isSupportedUrl/detectPlatform), commands/, audio/ (findAudioEmbeds); video.transcribeUrl injected at runtime (NO static video import edge)
   |-- tidy/ --> shared/, commands/
   |-- organize/ --> shared/, commands/
   |-- deep-dive/ --> shared/, commands/, organize/ (ContentAnalyzer, DirectoryMatcher)
@@ -78,7 +78,7 @@ Key constraints:
 - `intake` imports only `obsidian` + `src/shared/*`; all cross-module work goes through `IntakeDeps`.
 - `video` depends on `audio` (reuses transcription pipeline)
 - `transcription` is UI-only; delegates work to `audio`, `video`, and `image` modules
-- `summarize` receives `video.transcribeUrl` and audio transcribe callback via constructor injection
+- `summarize` has NO static import of `video`; URL-platform helpers (`isSupportedUrl`/`detectPlatform`) resolve from `shared/url-detector`. It receives `video.transcribeUrl` and an audio transcribe callback via constructor injection
 - `deep-dive` reuses `organize` for auto-organize nesting mode
 - `image` module uses multi-modal `AIClient.chat()` with `ContentBlock[]` for vision
 - `elaboration` module includes `ImageAnalyzer` for analyzing images in notes during proposal generation
@@ -153,10 +153,10 @@ All AI-generated content uses Obsidian callouts. Registry in `src/shared/callout
 ```ts
 SynapseSettings {
   ai: AISettings {
-    provider: 'openai' | 'anthropic' | 'ollama'   // default: 'openai'
+    provider: 'openai' | 'anthropic' | 'gemini' | 'ollama'   // AIProvider, default: 'openai'
     apiKey: string                                  // default: ''
     ollamaEndpoint: string                          // default: 'http://localhost:11434'
-    model: string                                   // default: 'gpt-4o'
+    model: string                                   // default: 'gpt-4o' (dropdown values per provider in MODEL_OPTIONS)
     maxTokens: number                               // default: 2048
     temperature: number                             // default: 0.7
   }
@@ -181,9 +181,10 @@ SynapseSettings {
   }
   audio: AudioSettings {
     enabled: boolean                                // default: true
-    transcriptionProvider: 'whisper-api' | 'deepgram' | 'local-whisper'
+    transcriptionProvider: 'whisper-api' | 'deepgram' | 'gemini' | 'local-whisper'  // default: 'whisper-api'
     whisperApiKey: string                           // default: '' (fallback: ai.apiKey)
     deepgramApiKey: string                          // default: ''
+    geminiApiKey: string                            // default: '' (fallback: ai.apiKey)
     whisperModel: string                            // default: 'whisper-1'
     localWhisperPath: string                        // default: ''
     language: string                                // default: ''
@@ -299,8 +300,16 @@ SynapseSettings {
     title: boolean                                  // default: false
     rem: boolean                                    // default: false (NOTE: rewrites note body)
   }
+  onboarding: OnboardingSettings {
+    hasSeenWelcome: boolean                         // default: false (first-run welcome gate, #89)
+  }
 }
 ```
+
+Provider model dropdowns: `MODEL_OPTIONS: Record<AIProvider, Record<id, label>>` in `src/settings.ts`.
+openai: gpt-4o, gpt-4o-mini, o3, o3-mini, o4-mini. anthropic: opus, sonnet, haiku (resolved to full
+IDs in `ai-client.ts`). gemini: gemini-3.5-flash, gemini-3.1-flash-lite, gemini-2.5-pro, gemini-2.5-flash.
+ollama: llama3, mistral, codellama, gemma.
 
 `ProposalKind` (`src/views/types.ts`) is the single source of truth for `PROPOSAL_KINDS` and keys of `autoAccept`:
 `'elaboration' | 'enrichment' | 'organize' | 'deep-dive' | 'title' | 'rem'`. A compile-time guard asserts it
@@ -404,9 +413,15 @@ interface ImageContentBlock { type: 'image'; data: string; mediaType: string }
 Provider-specific format conversion:
 - OpenAI: `image_url` with `data:` URI
 - Anthropic: `image` source with `base64` type
+- Gemini: `inline_data` with `mime_type` + base64 `data` (REST snake_case); system role routed to `system_instruction`
 - Ollama: separate `images` array on the message
 
 Used by: `image/extractor.ts` (OCR), `elaboration/image-analyzer.ts` (image analysis for proposals)
+
+Gemini responses are parsed via `extractGeminiResponseText()` (exported from `shared/ai-client.ts`),
+which throws descriptive errors for blocked/empty HTTP-200 shapes (`promptFeedback.blockReason`,
+`finishReason: MAX_TOKENS`) instead of crashing. Shared by `AIClient.callGemini()` and
+`audio/transcriber.ts` (Gemini transcription provider).
 
 ## External Dependencies (Runtime)
 
@@ -434,7 +449,9 @@ Framework: Vitest, globals enabled, node environment.
 - URLs validated via `sanitizeUrl()` before external tool invocation
 - Paths validated via `sanitizePath()` (rejects `..`, null bytes, shell metacharacters)
 - AI output sanitized via `sanitizeAIResponse()` before vault writes
-- API keys redacted from all error messages
+- Secret redaction centralized in `shared/redact.ts` (`redactSecrets`); both `ai-client.ts` (upstream error bodies) and `api-utils.ts:notifyError` (user/console errors) route through it — single source of truth, re-exported from `ai-client` and the `shared` barrel. Covers `sk-`/`sk-ant-`, `key-`, Deepgram `dg-`, `Bearer `/`Token ` headers, `anthropic-`, and Google `AIza` keys
+- Multipart transcription bodies (`audio/transcriber.ts:buildMultipartBody`) sanitize vault-/settings-derived field names and file names via `sanitizeMultipartHeaderValue` (strips CR/LF, replaces `"`/`\` with `_`) to block `Content-Disposition` header / multipart injection
+- Gemini audio transcription places its instruction in `system_instruction` (not the user turn beside the audio) so speech inside untrusted audio cannot override the prompt (prompt-injection hardening)
 - Ollama endpoint: HTTPS required (HTTP for localhost only)
 - External commands use `execFile` with argument arrays (no shell interpolation)
 - Frontmatter keys validated against allowlist pattern + forbidden keys blocklist

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,8 +50,8 @@ graph TB
     end
 
     subgraph External["External Services"]
-        AI["AI Providers<br/>OpenAI · Anthropic · Ollama"]
-        TransAPI["Transcription APIs<br/>Whisper · Deepgram"]
+        AI["AI Providers<br/>OpenAI · Anthropic · Gemini · Ollama"]
+        TransAPI["Transcription APIs<br/>Whisper · Deepgram · Gemini"]
         Tools["CLI Tools<br/>yt-dlp · ffmpeg"]
     end
 
@@ -130,10 +130,11 @@ src/
 │   └── index.ts            #   ElaborationModule orchestrator
 │
 ├── audio/                  # Audio transcription
-│   ├── transcriber.ts      #   Whisper API / Deepgram / local routing
+│   ├── transcriber.ts      #   Whisper / Deepgram / Gemini / local routing; manual multipart w/ sanitized headers
 │   ├── post-processor.ts   #   AI transcript cleanup
 │   ├── note-scanner.ts     #   Find audio embeds in note content
 │   └── index.ts            #   AudioModule orchestrator
+│                           #   NOTE: type-only `import type { AudioExtractor }` from video/ (no runtime cycle)
 │
 ├── video/                  # Video download + transcription
 │   ├── audio-extractor.ts  #   yt-dlp + ffmpeg via execFile
@@ -198,7 +199,9 @@ src/
 │   └── index.ts            #   Re-exports module, types, isUntitled
 │
 ├── shared/                 # Cross-cutting utilities (base layer)
-│   ├── ai-client.ts        #   Multi-provider AI (OpenAI, Anthropic, Ollama)
+│   ├── ai-client.ts        #   Multi-provider AI (OpenAI, Anthropic, Gemini, Ollama); re-exports redactSecrets
+│   ├── redact.ts           #   redactSecrets() — single source of truth for API-key/token redaction
+│   ├── encoding.ts         #   arrayBufferToBase64 / base64EncodedLength (shared by audio/image/elaboration)
 │   ├── url-detector.ts     #   YouTube/TikTok/Instagram URL parsing (moved here 2026-06-08)
 │   ├── checkpoint-manager.ts #  Checkpoint/resume for long-running operations
 │   ├── checkpoint-types.ts #   Checkpoint type definitions
@@ -266,12 +269,13 @@ graph TD
     Intake -. injected fireOnFile .-> Pipe
 
     Video --> Audio
+    Audio -. type only .-> Video
     Video --> Shared
     Elab -. ImageAnalyzer .-> Image
     Trans --> Audio
     Trans --> Video
     Trans --> Image
-    Summ -. transcribeUrl .-> Video
+    Summ -. transcribeUrl injected .-> Video
     Summ --> Audio
     DD --> Org
 
@@ -308,10 +312,12 @@ Key constraints:
 - **Acyclic graph.** `shared` and `commands` are base layers depending on no feature module. The former `shared ⇄ video` cycle was removed on 2026-06-08 by moving `url-detector.ts` into `shared` — the edge is now one-directional `video → shared`.
 - **`commands` imports nothing in `src/`.** `pipeline` imports `commands` (for flow gating) but never the feature modules — `main.ts` injects them via `PipelineModuleMap`.
 - **`intake` imports only `obsidian` + `shared`.** All cross-module work routes through an injected `IntakeDeps` (notably `fireOnFile`).
-- **Video depends on Audio** — reuses the transcription pipeline.
+- **Video depends on Audio** — reuses the transcription pipeline (runtime edge `video → audio`).
+- **Audio has a type-only back-edge to Video** — `audio/index.ts` does `import type { AudioExtractor } from '../video'` for time-range clipping. The type is erased at compile time, so there is **no runtime cycle**; it is a structural exception flagged for a future cleanup (move `AudioExtractor` to `shared/` or pass a structural interface).
 - **Transcription is UI-only** — delegates all work to Audio, Video, and Image via callbacks.
 - **Elaboration uses ImageAnalyzer** — analyzes embedded images during proposal generation (dotted line to Image).
-- **Summarize receives `video.transcribeUrl`** via constructor injection; also calls `audio.findAudioEmbeds`.
+- **Summarize receives `video.transcribeUrl`** via constructor injection **only** (no static `summarize → video` import); URL-platform helpers resolve from `shared`; also calls `audio.findAudioEmbeds`.
+- **Shared utilities are imported via the `../shared` barrel** — never through a sibling feature module or an internal `shared/` file. Canonical homes (`url-detector`, `redact`, `encoding`) live in `shared/` and re-export elsewhere only for back-compat.
 - **Deep Dive reuses Organize** for `auto-organize` nesting mode.
 - **Views imports types only** from feature modules (including REM).
 - **CheckpointManager is a singleton** — created in `main.ts`, injected into modules with resumable scans (elaboration, enrichment, audio, video, image, summarize, organize, deep-dive, rem). `tidy`, `title`, `transcription`, and `intake` do not use it.
@@ -692,9 +698,10 @@ graph TB
 
     AIC -->|"'openai'"| OAI["POST api.openai.com/v1/chat/completions<br/>Auth: Bearer {ai.apiKey}"]
     AIC -->|"'anthropic'"| ANT["POST api.anthropic.com/v1/messages<br/>Auth: x-api-key<br/>Models: opus->claude-opus-4-6, etc."]
+    AIC -->|"'gemini'"| GEM["POST generativelanguage.googleapis.com/v1beta/models/{model}:generateContent<br/>Auth: x-goog-api-key · system -> system_instruction"]
     AIC -->|"'ollama'"| OLL["POST {ollamaEndpoint}/api/chat<br/>HTTPS required (HTTP localhost only)"]
 
-    AIC --> Safe["safeRequest()<br/>Obsidian requestUrl · 2min timeout<br/>Error extraction · Key redaction"]
+    AIC --> Safe["safeRequest()<br/>Obsidian requestUrl · 2min timeout<br/>Error extraction · Secret redaction (shared/redact.ts)"]
 ```
 
 ### Multi-Modal Vision Support
@@ -709,13 +716,15 @@ ContentBlock = TextContentBlock { type: 'text', text: string }
 Provider-specific format conversion:
 - **OpenAI**: `image_url` with `data:` URI
 - **Anthropic**: `image` source with `base64` type
+- **Gemini**: `inline_data` with `mime_type` + base64 `data` (system role routed to `system_instruction`)
 - **Ollama**: separate `images` array on the message
 
 Used by: `image/extractor.ts` (OCR), `elaboration/image-analyzer.ts` (image analysis for proposals)
 
-Audio transcription uses separate APIs (not AIClient):
-- **Whisper**: OpenAI `/v1/audio/transcriptions` via native `fetch` + `FormData`
-- **Deepgram**: `/v1/listen` via native `fetch`
+Audio transcription uses provider-specific APIs over Obsidian `requestUrl` (not `AIClient`, not native `fetch`):
+- **Whisper**: OpenAI `/v1/audio/transcriptions` — manual `multipart/form-data` via `buildMultipartBody()` (sanitized headers; `requestUrl` has no `FormData`)
+- **Deepgram**: `/v1/listen` — raw `ArrayBuffer` body
+- **Gemini**: `…:generateContent` — inline base64 audio (≤ 15 MB); instruction in `system_instruction` (prompt-injection hardening)
 
 ---
 
@@ -777,13 +786,14 @@ Modules access settings via `getSettings()` closure -- always reads latest value
 | Output sanitization | `sanitizeAIResponse()` strips scripts, event handlers, dangerous URIs | `shared/validation.ts` |
 | Subprocess security | `execFile` with argument arrays (no shell) | `video/audio-extractor.ts`, `transcription/duration-detector.ts` |
 | Temp-path hardening | Vault-derived basenames sanitized before composing temp paths (2026-06-08) | `transcription/duration-detector.ts` |
-| API key protection | `redactSecrets()` in error messages, password-masked inputs; keys live only in gitignored `data.json` | `shared/ai-client.ts` |
+| Multipart header hardening | Vault-/settings-derived field + file names sanitized (`sanitizeMultipartHeaderValue`: strip CR/LF, replace `"`/`\`) before `Content-Disposition` lines — blocks multipart/header injection (2026-06-11) | `audio/transcriber.ts` |
+| API key protection | `redactSecrets()` — **single source of truth** scrubbing keys from error messages/console; covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Gemini `AIza`. Password-masked inputs; keys live only in gitignored `data.json` | `shared/redact.ts` (used by `ai-client.ts` + `api-utils.ts`) |
 | Frontmatter safety | Key validation regex + forbidden keys blocklist | `enrichment/enrichment-applier.ts` |
 | Network security | Ollama HTTPS required (HTTP for localhost only), 2min timeouts | `shared/ai-client.ts` |
 | Idempotent updates | `%% synapse-enrichment-start/end %%` markers | `enrichment/enrichment-applier.ts` |
 | Prototype pollution | `deepMerge` skips `__proto__`, `constructor`, `prototype` keys | `main.ts` |
 
-**Audit status (2026-06-08):** No critical or high vulnerabilities. `data.json` (live API keys) is gitignored and never committed.
+**Audit status:** The full audit (2026-06-08) found no critical or high vulnerabilities. The 2026-06-11 re-audit added two defense-in-depth hardenings — canonical secret redaction (now covering Gemini `AIza` keys everywhere) and multipart header-injection hardening. `data.json` (live API keys) is gitignored and never committed.
 
 **Known posture / not-yet-enforced:**
 - `ensureWithinVault()` exists in `shared/validation.ts` but is **not yet wired into write paths** — there is no active vault-boundary enforcement on writes today.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,56 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-06-11: Canonical secret-redaction module (`shared/redact.ts`)
+
+**Context**: Two code paths scrubbed API keys/tokens out of strings before they could reach a user-facing Notice, an error message, an echoed-back upstream error body, or the console: the AI client (`ai-client.ts`) and `notifyError` (`api-utils.ts`). Each kept its *own* inline copy of the redaction regex, and the two had drifted — the `notifyError` copy was missing the Google `AIza…` (Gemini) pattern. A leaked Gemini key surfaced through `notifyError` would have been shown to the user verbatim.
+
+**Decision**: Extract one canonical `redactSecrets()` into a new `shared/redact.ts` and make it the single source of truth. Both `ai-client.ts` (upstream error bodies) and `api-utils.ts:notifyError` (any error shown to the user/console) now route through it. It is re-exported from `ai-client.ts` and the `shared` barrel for back-compat. Covered shapes: `sk-`/`sk-ant-`, generic `key-`, Deepgram `dg-`, `Bearer `/`Token ` header values, `anthropic-` identifiers, and Google `AIza` keys.
+
+**Alternatives considered**:
+- **Keep two copies, just add the missing pattern to `notifyError`** — rejected. Fixes today's drift but not the cause; two regexes will drift again the next time a provider is added.
+- **A lint rule that bans raw key patterns in strings** — rejected as heavier and orthogonal; it doesn't give us one tested redactor to call.
+
+**Rationale**: One function, one regex, one place to extend when a new provider key shape appears — and one set of regression tests instead of two partial ones. The drift that exposed Gemini keys becomes structurally impossible once both callers share the module.
+
+**Impact**: New `src/shared/redact.ts`. Redaction is now consistent across both surfaces and covers Gemini `AIza` keys everywhere. Behavior-preserving except that `notifyError` now also redacts Gemini keys. Regression tests added (`ai-client.test.ts`, `api-utils.test.ts`).
+
+---
+
+## 2026-06-11: Harden multipart transcription bodies against header injection
+
+**Context**: Obsidian's `requestUrl` has no `FormData`, so `audio/transcriber.ts` hand-builds the `multipart/form-data` body for Whisper uploads (`buildMultipartBody`). The part field names and the uploaded file name are **vault-/settings-derived** — i.e. influenceable via a crafted note or embed file name — and were interpolated straight into `Content-Disposition` header lines. A file name containing CRLF or a quote (e.g. `x"\r\nContent-Disposition: ...`) could break out of the quoted parameter to inject extra headers or forge new multipart parts.
+
+**Decision**: Sanitize every untrusted value before it reaches a header line. A new internal `sanitizeMultipartHeaderValue()` strips all CR/LF and replaces `"` and `\` (the only characters that can escape a quoted header parameter) with `_`; field *values* additionally collapse CR/LF to spaces so they cannot start a new part. The binary file payload is appended raw and never interpreted as text.
+
+**Alternatives considered**:
+- **Reject file names containing suspicious characters** — rejected; would fail legitimate transcriptions for benign-but-unusual names. Sanitizing is non-destructive to the actual audio upload.
+- **Percent-encode header values (RFC 6266)** — rejected as overkill for a controlled internal body; strip-and-replace provably closes the break-out characters with less code.
+
+**Rationale**: Defense-in-depth on any vault-derived string that crosses into a wire-format header. The fix is local, has no effect on normal file names, and removes the only injection-capable characters.
+
+**Impact**: `audio/transcriber.ts` only (`buildMultipartBody` + new `sanitizeMultipartHeaderValue`). No user-visible change for normal transcriptions. Regression tests added.
+
+---
+
+## 2026-06-11: Shared utilities are imported through the `shared` barrel only
+
+**Context**: An architecture audit found shared utilities being reached inconsistently — through a *sibling feature module* or through an *internal `shared/` file* rather than the `shared` barrel. Concretely: base64 helpers pulled via `image/preprocess`, and an **undocumented static `summarize → video` import** had crept in even though `video.transcribeUrl` is supposed to arrive only by constructor injection. The static edge contradicted both the docs and the acyclic-graph rule.
+
+**Decision**: Establish and enforce one rule — **shared utilities are imported from the `../shared` barrel, never from a sibling feature module and never from an internal `shared/` file.** Normalize the offending imports (`image/preprocess.ts`, `summarize/index.ts`, `elaboration/image-analyzer.ts`) to the barrel, and remove the static `summarize → video` import (summarize keeps `video.transcribeUrl` strictly as an injected dependency; the URL-platform helpers `isSupportedUrl`/`detectPlatform` resolve from `shared`). Canonical homes (`url-detector.ts`, `redact.ts`, `encoding.ts`) live in `shared/` and may be re-exported elsewhere for back-compat, but consumers import the barrel.
+
+**Alternatives considered**:
+- **Allow re-export "convenience" imports through whichever module is nearest** — rejected; that is exactly what let the static `summarize → video` edge appear, and it makes the dependency graph ambiguous.
+- **Deep-import internal `shared/` files directly (e.g. `shared/encoding`)** — rejected; couples callers to `shared`'s internal file layout. The barrel is the stable contract.
+
+**Rationale**: A single import convention keeps the dependency graph legible and acyclic, prevents accidental feature-to-feature coupling, and lets `shared` reorganize its internals freely behind the barrel.
+
+**Impact**: Imports normalized in `image/preprocess.ts`, `summarize/index.ts`, `elaboration/image-analyzer.ts`; the static `summarize → video` edge is removed (now injection-only).
+
+**Known exception (flagged for cleanup)**: `audio/index.ts` keeps a **type-only** `import type { AudioExtractor } from '../video'` for time-range clipping. Because the type is erased at compile time it creates **no runtime cycle** (the runtime edge remains the correct `video → audio`), but it is a structural back-edge against the layering. A future cleanup could move `AudioExtractor` into `shared/` or pass it through a structural interface.
+
+---
+
 ## 2026-06-08: Eliminate the `shared ⇄ video` circular dependency
 
 **Context**: `shared/` is the base layer of the codebase — every feature module depends on it, and by design it must depend on *no* feature module. An audit found that `url-detector.ts` lived in `video/`, yet `shared/` code reached back into it for URL parsing. That inverted the layering and created a genuine import cycle: `shared → video → shared`. Cycles make the dependency graph non-deterministic to reason about, complicate testing in isolation, and risk subtle load-order bugs.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,9 @@
 # Project Status
 
-**Last updated**: 2026-06-08
+**Last updated**: 2026-06-11
 **Version**: 0.3.2
 **Branch**: `main`
-**Health**: Green — `tsc` clean, 1030/1030 tests passing, dependency graph acyclic, no critical/high security findings.
+**Health**: Green — `tsc` clean, 1256/1256 tests passing (98 files), dependency graph acyclic, no critical/high security findings.
 
 > Snapshot only. Decision history lives in `DECISIONS.md`; architecture in `ARCHITECTURE.md`.
 
@@ -23,7 +23,7 @@
 | Module | Path | Role | Status |
 |--------|------|------|--------|
 | elaboration | `src/elaboration/` | Detect stub notes, propose content (image-aware) | Working |
-| audio | `src/audio/` | Transcribe audio (Whisper / Deepgram) | Working (local-whisper not impl.) |
+| audio | `src/audio/` | Transcribe audio (Whisper / Deepgram / Gemini) | Working (local-whisper not impl.) |
 | video | `src/video/` | Download + transcribe YouTube/TikTok/Instagram | Working (local file + frames not impl.) |
 | image | `src/image/` | OCR via vision models, batch + checkpoints | Working |
 | transcription | `src/transcription/` | Unified transcription/OCR UI + time-range clipping | Working (desktop-only clipping) |
@@ -44,8 +44,8 @@
 
 ## Current Focus
 
-- **Codebase audit (in progress)** — architecture, machine + human docs, and security re-audit refreshed for the current tree.
-- **Decycling** — `shared ⇄ video` cycle eliminated; graph is now acyclic (see DECISIONS.md, 2026-06-08).
+- **Codebase audit (2026-06-11)** — architecture, machine + human docs refreshed; security re-audit in final pass. Changes: secret redaction consolidated into one canonical `shared/redact.ts` (now covers Gemini `AIza` keys); multipart transcription bodies hardened against header injection from vault-derived file names; shared-utility imports normalized to the `../shared` barrel and the stale static `summarize → video` import removed (injection-only now).
+- **Decycling** — `shared ⇄ video` cycle eliminated; graph is acyclic. One **type-only** `audio → video` back-edge remains (no runtime cycle; flagged for cleanup).
 
 ---
 
@@ -54,7 +54,9 @@
 - Full audit found **no critical or high vulnerabilities**; the codebase is security-mature.
 - API keys live in `data.json`, which is **gitignored and never committed** — no secrets in the repo.
 - Subprocess calls use `execFile` with argument arrays (no shell); API auth is header-based and HTTPS-only; AI responses are sanitized before being written to notes.
-- One low-severity hardening applied: sanitize a vault-derived basename before a temp path in `duration-detector.ts`.
+- Secret redaction now has a single source of truth (`shared/redact.ts`), used by both the AI client and `notifyError` — closes a drift where Gemini `AIza` keys could surface unredacted.
+- Multipart Whisper upload bodies sanitize vault-derived field/file names (`sanitizeMultipartHeaderValue`) to block header/multipart injection.
+- One low-severity hardening applied earlier: sanitize a vault-derived basename before a temp path in `duration-detector.ts`.
 - **Accepted risk**: `sanitizeUrl` permits arbitrary hosts (an SSRF surface on user-supplied URLs) — accepted because URLs are author-supplied within the user's own vault.
 - **Not yet wired**: an `ensureWithinVault` helper exists but is **not** yet enforced on write paths — there is no active vault-boundary check on writes today.
 
@@ -82,6 +84,7 @@
 | ffmpeg / ffprobe | Audio extraction, duration, clipping | User-installed; PATH auto-resolved |
 | OpenAI API key | Whisper, GPT models (incl. vision) | User-configured |
 | Anthropic API key | Claude models (incl. vision) | User-configured |
+| Gemini API key | Gemini models + Gemini audio transcription (optional) | User-configured |
 | Deepgram API key | Deepgram transcription (optional) | User-configured |
 
 ---
@@ -92,5 +95,5 @@
 |---------|---------|
 | `npm run dev` | esbuild watch (development) |
 | `npm run build` | `tsc -noEmit -skipLibCheck` + esbuild production bundle |
-| `npm test` | Vitest — **1030/1030 passing** |
+| `npm test` | Vitest — **1256/1256 passing** (98 files) |
 | `npm run test:coverage` | Vitest with coverage |

--- a/src/audio/AGENTS.md
+++ b/src/audio/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-11
 ---
 
 # Audio Module
 
-Transcribes audio files from the vault using configurable providers, with optional AI post-processing. Exposes public methods for unified transcription UI.
+Transcribes audio files from the vault using configurable providers (Whisper API, Deepgram, Gemini, local Whisper stub), with optional AI post-processing. Exposes public methods for unified transcription UI. All HTTP goes through Obsidian `requestUrl` (CSP-safe on mobile), not native `fetch`.
 
 ## Public API
 
@@ -23,6 +23,17 @@ class AudioModule {
 }
 
 function findAudioEmbeds(content: string, sourcePath: string, metadataCache: MetadataCache): AudioEmbed[]
+
+// transcriber.ts (exported for reuse + tests)
+function buildMultipartBody(
+  fields: { name: string; value: string }[],
+  file: { name: string; fieldName: string; data: ArrayBuffer }
+): { contentType: string; body: ArrayBuffer }   // manual multipart/form-data (requestUrl has no FormData); header values sanitized
+const GEMINI_MAX_INLINE_AUDIO_BYTES: number      // 15 MB raw ceiling for Gemini inline transcription (20 MB request cap / ~4/3 base64 inflation)
+class Transcriber {
+  constructor(getSettings: () => SynapseSettings)
+  transcribe(audioData: ArrayBuffer, fileName: string): Promise<TranscriptionResult>   // routes by audio.transcriptionProvider
+}
 
 const AUDIO_EXTENSIONS: RegExp   // /\.(mp3|wav|m4a|ogg|flac|webm|aac)$/i
 const AUDIO_EMBED_REGEX: RegExp  // /!\[\[([^\]]+\.(?:mp3|wav|m4a|ogg|flac|webm|aac))\]\]/gi
@@ -46,8 +57,10 @@ interface AudioEmbed { fileName: string; file: TFile; line: number }
 | File | Class/Export | Purpose |
 |------|-------------|---------|
 | `types.ts` | `TranscriptionResult`, `TimestampEntry`, `TranscribeOptions`, `AudioEmbed` | Types |
-| `transcriber.ts` | `Transcriber` | Provider-routed transcription (Whisper, Deepgram, local) |
+| `transcriber.ts` | `Transcriber`, `buildMultipartBody`, `GEMINI_MAX_INLINE_AUDIO_BYTES` | Provider-routed transcription (Whisper, Deepgram, Gemini, local stub) over `requestUrl`; manual multipart with sanitized headers (internal `sanitizeMultipartHeaderValue`, `geminiMimeType`); Gemini text via shared `extractGeminiResponseText` |
+| `transcriber.test.ts` | Tests | Transcriber + multipart + provider routing tests |
 | `post-processor.ts` | `PostProcessor` | AI transcript cleanup via `AIClient` |
+| `settings-section.ts` | `renderAudioSettings` | Audio settings UI section |
 | `note-scanner.ts` | `findAudioEmbeds`, `hasTranscriptionBelow`, `AUDIO_EXTENSIONS`, `AUDIO_EMBED_REGEX` | Scan note content for audio embeds |
 | `note-scanner.test.ts` | Tests | Note scanner tests |
 | `index.ts` | `AudioModule` | Orchestrator, public transcription methods |
@@ -66,10 +79,16 @@ interface AudioEmbed { fileName: string; file: TFile; line: number }
    |  Cancellable via NotificationManager operation handle
    |
 3. Transcriber.transcribe(audioData, fileName)
-   |  Routes by transcriptionProvider:
-   |  'whisper-api' --> OpenAI /v1/audio/transcriptions (fetch + FormData, 5min timeout)
+   |  Routes by transcriptionProvider (all via requestUrl, 5min timeout, retry on connection/dns/offline only):
+   |  'whisper-api' --> OpenAI /v1/audio/transcriptions
+   |       Body: buildMultipartBody() manual multipart/form-data (requestUrl has no FormData)
    |       Key: audio.whisperApiKey || ai.apiKey
-   |  'deepgram' --> Deepgram /v1/listen (fetch, 5min timeout)
+   |  'deepgram' --> Deepgram /v1/listen (raw ArrayBuffer body)
+   |       Key: audio.deepgramApiKey
+   |  'gemini' --> generativelanguage /v1beta/models/gemini-3.5-flash:generateContent
+   |       Inline base64 audio (rejects > GEMINI_MAX_INLINE_AUDIO_BYTES = 15 MB)
+   |       Instruction in system_instruction (prompt-injection hardening); text via extractGeminiResponseText()
+   |       Key: audio.geminiApiKey || ai.apiKey
    |  'local-whisper' --> throws (not implemented)
    |
 4. PostProcessor.process(rawTranscript)  [if postProcess !== false]
@@ -95,9 +114,10 @@ All under `settings.audio`:
 
 | Key | Controls |
 |-----|----------|
-| `transcriptionProvider` | Backend selection |
+| `transcriptionProvider` | Backend: `whisper-api` \| `deepgram` \| `gemini` \| `local-whisper` |
 | `whisperApiKey` | Dedicated OpenAI key (fallback: `ai.apiKey`) |
 | `deepgramApiKey` | Deepgram API key |
+| `geminiApiKey` | Dedicated Gemini key (fallback: `ai.apiKey`) |
 | `whisperModel` | Whisper model name |
 | `language` | Language hint |
 | `postProcessing.*` | AI cleanup flags |
@@ -110,6 +130,18 @@ When `timeRange` is provided to `transcribeFileToActiveNote()`:
 3. Clipped audio data passed to `transcribe()`
 4. Callout title includes time range: "Transcription of file.mp3 [01:30 - 05:00]"
 5. Falls back to full-file transcription on mobile (no AudioExtractor)
+
+## Multipart Construction & Hardening
+
+`buildMultipartBody(fields, file)` assembles a `multipart/form-data` body as an `ArrayBuffer` (Obsidian
+`requestUrl` does not accept `FormData`). Random boundary: `----SynapseFormBoundary{base36}`.
+
+Untrusted input safety: field names and the file name are vault-/settings-derived, so they pass through
+`sanitizeMultipartHeaderValue()` before interpolation into `Content-Disposition` header lines — it strips
+all CR/LF and replaces `"`/`\` with `_`, the only characters that can break out of a quoted header
+parameter. Field values strip CR/LF to ` ` so they cannot start a new part. This blocks header/multipart
+injection from filenames like `x"\r\nContent-Disposition: ...`. The binary file payload is appended raw and
+never interpreted as text.
 
 ## Video Module Integration
 

--- a/src/audio/transcriber.test.ts
+++ b/src/audio/transcriber.test.ts
@@ -68,6 +68,44 @@ describe('buildMultipartBody', () => {
 		const b2 = r2.contentType.split('boundary=')[1];
 		expect(b1).not.toBe(b2);
 	});
+
+	// Core security invariant for header/multipart injection: untrusted input
+	// (vault-derived file names, settings-derived field values) must contribute
+	// ZERO CR/LF characters to the assembled body. A CRLF is the only way to
+	// terminate a header line early and forge a new header or multipart part, so
+	// if the attacker payload adds no CRLFs versus a benign build, it is inert.
+	const crlfCount = (body: ArrayBuffer): number =>
+		(new TextDecoder().decode(body).match(/\r\n/g) || []).length;
+
+	it('neutralizes CRLF/quote injection in a vault-derived file name', () => {
+		const fileData = new Uint8Array([0x01]).buffer as ArrayBuffer;
+		// A maliciously named note/audio file trying to break out of the quoted
+		// filename param and inject an extra multipart header/part.
+		const evilName =
+			'a.mp3"\r\nContent-Disposition: form-data; name="model"\r\n\r\nwhisper-evil\r\n--x--';
+
+		const benign = buildMultipartBody([], { name: 'clean.mp3', fieldName: 'file', data: fileData });
+		const evil = buildMultipartBody([], { name: evilName, fieldName: 'file', data: fileData });
+
+		// The crafted name adds no structural CRLFs and cannot break out of the quote.
+		expect(crlfCount(evil.body)).toBe(crlfCount(benign.body));
+		const decoded = new TextDecoder().decode(evil.body);
+		expect(decoded).not.toContain('filename="a.mp3"');
+	});
+
+	it('strips CRLF from field values so they cannot start a new part', () => {
+		const fileData = new Uint8Array([0x02]).buffer as ArrayBuffer;
+		const benign = buildMultipartBody(
+			[{ name: 'language', value: 'en' }],
+			{ name: 'a.mp3', fieldName: 'file', data: fileData }
+		);
+		const evil = buildMultipartBody(
+			[{ name: 'language', value: 'en\r\n--injected\r\nContent-Disposition: x' }],
+			{ name: 'a.mp3', fieldName: 'file', data: fileData }
+		);
+		// Same number of structural CRLFs → the value's embedded CRLFs were stripped.
+		expect(crlfCount(evil.body)).toBe(crlfCount(benign.body));
+	});
 });
 
 describe('Transcriber', () => {

--- a/src/audio/transcriber.ts
+++ b/src/audio/transcriber.ts
@@ -70,10 +70,29 @@ function geminiMimeType(fileName: string): string {
 }
 
 /**
+ * Sanitize a value before it is interpolated into a multipart header line.
+ *
+ * The file name is vault-derived (and field values can be settings-derived), so
+ * a CR/LF or a stray double-quote in one of them could otherwise terminate the
+ * `Content-Disposition` line early and inject arbitrary multipart headers or
+ * extra body parts (header/multipart injection). Strip CR/LF entirely and
+ * replace double-quotes/backslashes, which are the only characters that can
+ * break out of a quoted header parameter.
+ */
+function sanitizeMultipartHeaderValue(value: string): string {
+	return value.replace(/[\r\n]/g, '').replace(/["\\]/g, '_');
+}
+
+/**
  * Build a multipart/form-data body manually from field definitions.
  *
  * Obsidian's requestUrl does not support FormData, so we construct the
  * multipart body as an ArrayBuffer with a random boundary string.
+ *
+ * Field names, field values, and the file name are sanitized before being
+ * interpolated into header lines so untrusted (vault- or settings-derived)
+ * input cannot inject multipart headers. The binary file payload itself is
+ * never interpreted as text.
  *
  * @returns An object with the Content-Type header (including boundary) and the body ArrayBuffer.
  */
@@ -89,17 +108,24 @@ export function buildMultipartBody(
 
 	// Add text fields
 	for (const field of fields) {
+		const safeName = sanitizeMultipartHeaderValue(field.name);
+		// CR/LF in a value would also break the body framing; strip it. (Values
+		// are emitted in the body, not a header, but a bare CRLF here could still
+		// be read as the start of a new part.)
+		const safeValue = field.value.replace(/[\r\n]/g, ' ');
 		const header =
 			`--${boundary}${crlf}` +
-			`Content-Disposition: form-data; name="${field.name}"${crlf}${crlf}` +
-			`${field.value}${crlf}`;
+			`Content-Disposition: form-data; name="${safeName}"${crlf}${crlf}` +
+			`${safeValue}${crlf}`;
 		parts.push(encoder.encode(header));
 	}
 
 	// Add file field
+	const safeFieldName = sanitizeMultipartHeaderValue(file.fieldName);
+	const safeFileName = sanitizeMultipartHeaderValue(file.name);
 	const fileHeader =
 		`--${boundary}${crlf}` +
-		`Content-Disposition: form-data; name="${file.fieldName}"; filename="${file.name}"${crlf}` +
+		`Content-Disposition: form-data; name="${safeFieldName}"; filename="${safeFileName}"${crlf}` +
 		`Content-Type: application/octet-stream${crlf}${crlf}`;
 	parts.push(encoder.encode(fileHeader));
 	parts.push(new Uint8Array(file.data));

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-11
 ---
 
 # Elaboration Module
@@ -134,6 +134,7 @@ const MAX_IMAGES_PER_NOTE = 5
 - Caps at 5 images per note to avoid token overflow
 - Uses `image.visionModel` override if configured (same pattern as `ImageExtractor`)
 - Graceful degradation: skips individual image failures
+- Imports `AIClient` and `arrayBufferToBase64` from the `shared` barrel and reuses `image/preprocessImage` (from the `image` barrel) to downscale oversized images before they reach the API — no duplicate base64/encoding logic
 
 ## Error Handling
 

--- a/src/elaboration/image-analyzer.ts
+++ b/src/elaboration/image-analyzer.ts
@@ -1,8 +1,8 @@
 import { App, Notice, TFile } from 'obsidian';
-import { AIClient } from '../shared';
+import { AIClient, arrayBufferToBase64 } from '../shared';
 import type { ContentBlock } from '../shared';
 import { SynapseSettings } from '../settings';
-import { arrayBufferToBase64, preprocessImage } from '../image';
+import { preprocessImage } from '../image';
 
 export interface ImageAnalysis {
 	/** Original reference as it appears in the note */

--- a/src/image/AGENTS.md
+++ b/src/image/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-11
 ---
 
 # Image Module
@@ -24,8 +24,10 @@ class ImageModule {
 function findImageEmbeds(content: string, sourcePath: string, metadataCache: MetadataCache): ImageEmbed[]
 
 // preprocess.ts (also exported from index.ts)
-function arrayBufferToBase64(buffer: ArrayBuffer): string
 function preprocessImage(data: ArrayBuffer, mediaType: string, maxSizeMb: number): Promise<{ data: string; mediaType: string }>
+// re-exported from shared/encoding.ts for back-compat (canonical home is shared):
+function arrayBufferToBase64(buffer: ArrayBuffer): string
+function base64EncodedLength(byteLength: number): number
 
 const IMAGE_EXTENSIONS: RegExp   // /\.(png|jpg|jpeg|gif|webp|bmp|tiff)$/i
 const IMAGE_EMBED_REGEX: RegExp  // /!\[\[([^\]]+\.(?:png|jpg|jpeg|gif|webp|bmp|tiff))\]\]/gi
@@ -48,7 +50,7 @@ interface OCRResult {
 |------|-------------|---------|
 | `types.ts` | `ImageEmbed`, `OCRResult` | Type definitions |
 | `extractor.ts` | `ImageExtractor` | Multi-modal AI OCR via `AIClient.chat()` with `ContentBlock[]` |
-| `preprocess.ts` | `arrayBufferToBase64`, `preprocessImage` | Base64 encoding + auto-downscale when payload exceeds `maxImageSizeMb` |
+| `preprocess.ts` | `preprocessImage`; re-exports `arrayBufferToBase64`, `base64EncodedLength` | Auto-downscale/re-encode when payload exceeds `maxImageSizeMb`. Base64 helpers now live in `shared/encoding.ts` (imported via the `shared` barrel, not `shared/encoding` directly) and are re-exported here for back-compat |
 | `note-scanner.ts` | `findImageEmbeds`, `hasExtractionBelow`, `IMAGE_EXTENSIONS`, `IMAGE_EMBED_REGEX` | Scan note content for image embeds |
 | `note-scanner.test.ts`, `extractor.test.ts`, `preprocess.test.ts` | Tests | |
 | `index.ts` | `ImageModule` | Orchestrator, public extraction methods, checkpoint management |
@@ -116,14 +118,17 @@ No commands registered directly. Image OCR is accessible via:
 
 ## Dependencies
 
+All imports resolve through the `shared` barrel (`../shared`), never an internal `shared/*` file.
+
 | Import | From |
 |--------|------|
-| `AIClient`, `ContentBlock` | `shared/` |
-| `NotificationManager` | `shared/notifications` |
-| `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `shared/checkpoint-*` |
-| `buildCallout`, `CALLOUT_TYPES` | `shared/callouts` |
-| `sanitizeAIResponse` | `shared/validation` |
-| `generateId` | `shared/id-utils` |
+| `AIClient`, `ContentBlock` | `shared` |
+| `base64EncodedLength` (preprocess) | `shared` (canonical: `shared/encoding`) |
+| `NotificationManager` | `shared` |
+| `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `shared` |
+| `buildCallout`, `CALLOUT_TYPES` | `shared` |
+| `sanitizeAIResponse` | `shared` |
+| `generateId` | `shared` |
 
 ## Supported Image Formats
 

--- a/src/image/preprocess.ts
+++ b/src/image/preprocess.ts
@@ -8,11 +8,13 @@
  * they fit under the limit before they ever reach the API.
  */
 
-import { base64EncodedLength } from '../shared/encoding';
+import { base64EncodedLength } from '../shared';
 
 // Canonical home of the encoding helpers is now shared/encoding.ts (#251) so
-// the audio module can reuse them; re-exported here for back-compat.
-export { arrayBufferToBase64, base64EncodedLength } from '../shared/encoding';
+// the audio module can reuse them; re-exported here for back-compat. Imported
+// through the shared barrel (not shared/encoding directly) so this module obeys
+// the "import from a module's index, never its internal files" rule.
+export { arrayBufferToBase64, base64EncodedLength } from '../shared';
 
 /** Lossless source formats that benefit from JPEG re-encoding when downscaling. */
 const LOSSLESS_MEDIA_TYPES = new Set(['image/png', 'image/bmp', 'image/tiff']);

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -1,14 +1,15 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-11
 ---
 
 # Shared Module
 
-Cross-cutting base layer used by all feature modules: AI client, file operations, notifications, validation, frontmatter parsing, checkpoint management, ID generation, URL platform detection / classification, and web content fetching. Depends on NO feature module — this is the bottom of the dependency graph.
+Cross-cutting base layer used by all feature modules: AI client, secret redaction, file operations, base64 encoding, notifications, validation, frontmatter parsing, checkpoint management, ID generation, URL platform detection / classification, and web content fetching. Depends on NO feature module — this is the bottom of the dependency graph.
 
-Note: `url-detector.ts` (`detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult`) was moved here
-from `src/video/` to break the former shared⇄video import cycle. The canonical home for these symbols and the
-`Platform`/`UrlDetectionResult` types is now `shared`; `video` re-exports them for back-compat.
+Canonical homes (re-exported elsewhere for back-compat — import from the `shared` barrel, never an internal file):
+- `url-detector.ts` (`detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult`) — moved here from `src/video/` to break the former shared⇄video import cycle; `video` re-exports for back-compat.
+- `redact.ts` (`redactSecrets`) — single source of truth for API-key/token redaction; `ai-client.ts` re-exports it. Previously `ai-client` and `notifyError` each kept inline copies that drifted (the `notifyError` copy lacked the Google `AIza` pattern).
+- `encoding.ts` (`arrayBufferToBase64`, `base64EncodedLength`) — base64 helpers; `image/preprocess.ts` re-exports them so audio + image + elaboration share one implementation.
 
 ## Public API
 
@@ -19,8 +20,17 @@ Exported from `index.ts`:
 class AIClient {
   constructor(getSettings: () => SynapseSettings)
   complete(prompt: string, systemPrompt?: string): Promise<string>
-  chat(messages: ChatMessage[]): Promise<string>
+  chat(messages: ChatMessage[]): Promise<string>   // providers: openai | anthropic | gemini | ollama
 }
+function extractGeminiResponseText(json: GeminiResponseJson): string  // throws on blocked/empty 200 shapes
+export { redactSecrets }                              // re-export of redact.ts (back-compat)
+
+// redact.ts (single source of truth for secret redaction)
+function redactSecrets(text: string): string         // replaces sk-/key-/dg-/Bearer/Token/anthropic-/AIza secrets with [REDACTED]
+
+// encoding.ts
+function arrayBufferToBase64(buffer: ArrayBuffer): string
+function base64EncodedLength(byteLength: number): number   // exact base64 char count for a byte length
 
 // types.ts
 interface TextContentBlock { type: 'text'; text: string }
@@ -54,9 +64,12 @@ function getMarkdownFiles(app: App, folder?: string): TFile[]
 function wordCount(text: string): number
 
 // api-utils.ts
-function withRetry<T>(fn: () => Promise<T>, maxRetries?: number, delayMs?: number): Promise<T>
+function withRetry<T>(fn: () => Promise<T>, maxRetries?: number, delayMs?: number, shouldRetry?: (error: unknown) => boolean): Promise<T>
 function sleep(ms: number): Promise<void>
-function notifyError(context: string, error: unknown): void
+function notifyError(context: string, error: unknown): void   // redacts secrets via redactSecrets() before Notice/console
+function classifyNetworkError(error: unknown): NetworkErrorKind   // 'connection-refused' | 'dns' | 'timeout' | 'offline' | null
+function isTransientNetworkError(error: unknown): boolean
+function describeNetworkError(error: unknown, resource: string): string | null   // user-facing explanation, null for non-network
 
 // validation.ts
 function sanitizeUrl(url: string): string
@@ -168,12 +181,15 @@ interface Checkpoint {
 
 | File | Exports | Purpose |
 |------|---------|---------|
-| `ai-client.ts` | `AIClient` | Multi-provider AI completion with multi-modal support; `safeRequest`, `redactSecrets`, `resolveModelId`, `toOpenAIContent`, `toAnthropicContent`, `toOllamaMessage` (internal) |
+| `ai-client.ts` | `AIClient`, `extractGeminiResponseText`, re-export `redactSecrets` | Multi-provider AI completion (openai/anthropic/gemini/ollama) with multi-modal support; `safeRequest`, `resolveModelId`, `toOpenAIContent`, `toAnthropicContent`, `toGeminiContent`, `toOllamaMessage` (internal). Imports `redactSecrets` from `redact.ts` |
+| `redact.ts` | `redactSecrets` | Single source of truth for API-key/token redaction (sk-/key-/dg-/Bearer/Token/anthropic-/AIza). Consumed by `ai-client.ts` + `api-utils.ts`; redaction behavior covered by `ai-client.test.ts` + `api-utils.test.ts` |
+| `encoding.ts` | `arrayBufferToBase64`, `base64EncodedLength` | Base64 encode + exact encoded-length calc; canonical home reused by audio/image/elaboration |
+| `encoding.test.ts` | Tests | Encoding tests |
 | `types.ts` | `ChatMessage`, `ContentBlock`, `TextContentBlock`, `ImageContentBlock` | Shared types including multi-modal content blocks |
 | `notifications.ts` | `NotificationManager`, `OperationHandle`, `NoticeLevel` | Centralized notifications with cancellation, progress, confirmation snackbars |
 | `notifications.test.ts` | Tests | NotificationManager tests |
 | `file-utils.ts` | `ensureFolder`, `readNote`, `writeNote`, `getMarkdownFiles`, `wordCount` | Vault file operations |
-| `api-utils.ts` | `withRetry`, `sleep`, `notifyError` | Retry with exponential backoff, error display |
+| `api-utils.ts` | `withRetry`, `sleep`, `notifyError`, `classifyNetworkError`, `isTransientNetworkError`, `describeNetworkError` | Retry with exponential backoff, network-error classification/disclosure, redacted error display (via `redactSecrets`) |
 | `validation.ts` | `sanitizeUrl`, `sanitizePath`, `ensureWithinVault`, `sanitizeAIResponse`, `stripCodeFences`, `blockquoteOriginal`, `parseTimestamp`, `validateTimeRange`, `formatTimeRange`, `TimeRange` | Input validation, output sanitization, time-range parsing |
 | `validation.test.ts` | Tests | Validation tests |
 | `url-detector.ts` | `detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult` | Regex platform detection (moved here from video/) |
@@ -213,10 +229,13 @@ AIClient.chat(messages)
 |                   Auth: Bearer {ai.apiKey}
 |-- 'anthropic' --> POST api.anthropic.com/v1/messages
 |                   Auth: x-api-key, system message extracted to top-level field
+|-- 'gemini'    --> POST generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+|                   Auth: x-goog-api-key; system routed to system_instruction; 'assistant'->'model';
+|                   response parsed via extractGeminiResponseText() (throws on blocked/empty 200)
 |-- 'ollama'    --> POST {ollamaEndpoint}/api/chat
 |                   HTTPS required (HTTP for localhost only)
 |
-All use Obsidian requestUrl via safeRequest() (handles errors, redacts secrets)
+All use Obsidian requestUrl via safeRequest() (120s timeout, redacts secrets in error bodies via redactSecrets)
 ```
 
 ## CheckpointManager Lifecycle
@@ -276,6 +295,10 @@ Write concurrency: per-checkpoint mutex via `withLock()` prevents concurrent rea
 | Utility | Used By |
 |---------|---------|
 | `AIClient` | elaboration/proposer, elaboration/image-analyzer, audio/post-processor, image/extractor, enrichment/metadata-classifier, enrichment/topic-extractor, enrichment/prompt-builder, tidy/index |
+| `redactSecrets` | ai-client (safeRequest error bodies), api-utils/notifyError (user/console errors) |
+| `extractGeminiResponseText` | ai-client (callGemini), audio/transcriber (Gemini provider) |
+| `arrayBufferToBase64` / `base64EncodedLength` | image/preprocess (re-exports), audio/transcriber (Gemini inline audio), elaboration/image-analyzer |
+| `classifyNetworkError` / `describeNetworkError` | audio/transcriber (retry gating + failure disclosure) |
 | `NotificationManager` | all feature modules (injected via constructor) |
 | `CheckpointManager` | main (creates), elaboration, audio, video, image, enrichment, summarize, organize, deep-dive, rem (all injected via constructor) |
 | `fetchArticleContent` / `fetchPageContent` | summarize/index, intake/index |

--- a/src/shared/ai-client.ts
+++ b/src/shared/ai-client.ts
@@ -1,18 +1,12 @@
 import { requestUrl, RequestUrlParam, RequestUrlResponse } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { ChatMessage, ContentBlock, TextContentBlock } from './types';
+import { redactSecrets } from './redact';
 
-/**
- * Redact API keys/tokens that may appear in API error response bodies.
- * Covers OpenAI/Deepgram-style prefixed keys, bearer tokens, Anthropic keys,
- * and Google `AIza…` API keys. Exported for tests.
- */
-export function redactSecrets(text: string): string {
-	return text.replace(
-		/(?:sk-|key-|dg-|Bearer\s+|Token\s+|anthropic-|AIza)[A-Za-z0-9_-]{8,}/g,
-		'[REDACTED]'
-	);
-}
+// Re-exported for back-compat: existing callers and tests import `redactSecrets`
+// from this module. The implementation now lives in ./redact (single source of
+// truth) so the AI client and `notifyError` can't drift apart.
+export { redactSecrets };
 
 /** Default timeout for AI API requests (2 minutes). */
 const AI_REQUEST_TIMEOUT_MS = 120_000;

--- a/src/shared/api-utils.test.ts
+++ b/src/shared/api-utils.test.ts
@@ -3,6 +3,7 @@ import {
 	classifyNetworkError,
 	describeNetworkError,
 	isTransientNetworkError,
+	notifyError,
 	withRetry,
 } from './api-utils';
 
@@ -115,5 +116,39 @@ describe('withRetry', () => {
 		await vi.runAllTimersAsync();
 		await expect(promise).resolves.toBe('done');
 		expect(fn).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('notifyError redaction', () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	const loggedMessage = () => String(errorSpy.mock.calls[0]?.[1] ?? '');
+
+	it('redacts Google AIza… keys (the gap the old inline regex missed)', () => {
+		notifyError('Gemini call failed', new Error('API key not valid: AIzaSyBadKey1234567890123456789012345'));
+		const msg = loggedMessage();
+		expect(msg).toContain('[REDACTED]');
+		expect(msg).not.toContain('AIzaSyBadKey');
+	});
+
+	it('redacts OpenAI sk- keys and Bearer tokens', () => {
+		notifyError('OpenAI call failed', new Error('rejected key sk-abcdef1234567890 via Bearer abcdefgh12345678'));
+		const msg = loggedMessage();
+		expect(msg).not.toContain('sk-abcdef1234567890');
+		expect(msg).not.toContain('abcdefgh12345678');
+		expect(msg).toContain('[REDACTED]');
+	});
+
+	it('leaves non-secret error text intact', () => {
+		notifyError('Parse failed', new Error('Unexpected token at position 12'));
+		expect(loggedMessage()).toContain('Unexpected token at position 12');
 	});
 });

--- a/src/shared/api-utils.ts
+++ b/src/shared/api-utils.ts
@@ -1,4 +1,5 @@
 import { Notice } from 'obsidian';
+import { redactSecrets } from './redact';
 
 export type NetworkErrorKind = 'connection-refused' | 'dns' | 'timeout' | 'offline' | null;
 
@@ -52,11 +53,11 @@ export function sleep(ms: number): Promise<void> {
 
 export function notifyError(context: string, error: unknown): void {
 	const message = error instanceof Error ? error.message : String(error);
-	// Redact potential API keys/tokens from error messages shown to users
-	const redacted = message.replace(
-		/(?:sk-|key-|dg-|anthropic-|Bearer\s+|Token\s+)[A-Za-z0-9_-]{8,}/g,
-		'[REDACTED]'
-	);
+	// Redact potential API keys/tokens before showing the error to the user or
+	// logging it. Uses the shared canonical redactor (./redact) so this stays in
+	// sync with the AI client — an earlier inline copy here omitted the Google
+	// `AIza…` pattern and would have leaked Gemini keys.
+	const redacted = redactSecrets(message);
 	new Notice(`Synapse: ${context} - ${redacted}`);
 	console.error(`[Synapse] ${context}:`, redacted);
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -16,6 +16,7 @@ export {
 	wordCount,
 } from './file-utils';
 export { arrayBufferToBase64, base64EncodedLength } from './encoding';
+export { redactSecrets } from './redact';
 export { NotificationManager } from './notifications';
 export type { OperationHandle } from './notifications';
 export { FolderPickerModal } from './folder-picker-modal';

--- a/src/shared/redact.ts
+++ b/src/shared/redact.ts
@@ -1,0 +1,29 @@
+/**
+ * Redaction of API keys / auth tokens before they can reach a user-facing
+ * Notice, an error message, an API error body echoed back to us, or the
+ * console.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for secret redaction. It is consumed by
+ * both the AI client (redacting upstream error bodies) and `notifyError`
+ * (redacting any error surfaced to the user/console). Previously each kept its
+ * own inline copy of the pattern and they drifted — the `notifyError` copy was
+ * missing the Google `AIza…` pattern, so a leaked Gemini key would have been
+ * shown to the user verbatim. Keep all redaction going through here.
+ *
+ * Covered shapes:
+ *  - OpenAI / Anthropic `sk-…` (and `sk-ant-…`) keys
+ *  - Generic `key-…` and Deepgram `dg-…` prefixed keys
+ *  - `Bearer …` and `Token …` Authorization header values
+ *  - `anthropic-…` prefixed identifiers
+ *  - Google `AIza…` API keys (x-goog-api-key)
+ */
+const SECRET_PATTERN =
+	/(?:sk-|key-|dg-|Bearer\s+|Token\s+|anthropic-|AIza)[A-Za-z0-9_-]{8,}/g;
+
+/**
+ * Replace any recognized secret in `text` with `[REDACTED]`.
+ * Safe to call on arbitrary strings; non-secret text is returned unchanged.
+ */
+export function redactSecrets(text: string): string {
+	return text.replace(SECRET_PATTERN, '[REDACTED]');
+}

--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-11
 ---
 
 # Summarize Module
@@ -42,8 +42,7 @@ Exported types: `SummarizeTarget`, `SummarizeSettings`, `TranscribeUrlFn`, `Tran
 |------|---------------|------|
 | `summarizer.ts` | `Summarizer` | AI summarization with style (bullets/paragraph/key-points) |
 | `summarizer.test.ts` | Tests | Summarizer tests |
-| `content-fetcher.ts` | `fetchPageContent` | HTTP fetch + HTML-to-text extraction for URLs |
-| `content-fetcher.test.ts` | Tests | Content fetcher tests |
+| `settings-section.ts` | `renderSummarizeSettings` | Summarize settings UI section |
 | `note-scanner.ts` | `findSummarizeTargets`, `hasSummaryBelow` | Finds URLs, transcription blocks, and audio embed summary gaps in note content |
 | `note-scanner.test.ts` | Tests | Note scanner tests |
 | `summarize-modal.ts` | `SummarizeSelectionModal` | Selection modal when multiple targets found |
@@ -123,9 +122,9 @@ interface SummarizeTarget {
 ## Video URL Auto-Transcription
 
 When `transcribeUrl` is injected (from `VideoModule.transcribeUrl`):
-- `fetchContentForUrl()` checks `isSupportedUrl(url)` first
-- If video URL detected, transcribes via video pipeline instead of HTTP fetch
-- Falls back to `fetchPageContent()` for non-video URLs
+- `fetchContentForUrl()` checks `isSupportedUrl(url)` first (`isSupportedUrl` from `shared/url-detector`)
+- If video URL detected, transcribes via the injected `transcribeUrl` callback instead of HTTP fetch
+- Falls back to `fetchPageContent()` (from `shared/content-fetcher`) for non-video URLs
 
 ## Audio Embed Summarization
 
@@ -150,10 +149,10 @@ this.summarize = new SummarizeModule(
 
 ## Dependencies
 
-- `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, OperationHandle, buildCallout, CALLOUT_TYPES, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask)
-- `video/` (isSupportedUrl -- used in fetchContentForUrl)
+- `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, OperationHandle, buildCallout, CALLOUT_TYPES, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask, fetchPageContent, fetchTweetContent, isSupportedUrl, detectPlatform)
 - `audio/` (findAudioEmbeds -- used in collectTargets)
 - `settings.ts` (SynapseSettings, SummarizeSettings)
+- NO static `video/` import. URL-platform helpers (`isSupportedUrl`/`detectPlatform`) and content fetchers (`fetchPageContent`/`fetchTweetContent`) resolve from `shared`. Video transcription happens only through the injected `transcribeUrl` callback (`TranscribeUrlFn`).
 
 ## Content-Aware Templates
 
@@ -179,7 +178,6 @@ Enrichment targets (standalone notes) always use `COMPREHENSIVE_SUMMARY_PROMPT` 
 ## Tests
 
 - `summarizer.test.ts`
-- `content-fetcher.test.ts`
 - `note-scanner.test.ts`
 - `summarize-module.test.ts`
 - `templates.test.ts`

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -7,7 +7,7 @@ import {
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { OperationHandle } from '../shared';
-import { isSupportedUrl, detectPlatform } from '../video';
+import { isSupportedUrl, detectPlatform } from '../shared';
 import { findAudioEmbeds } from '../audio';
 import { fetchPageContent, fetchTweetContent } from '../shared';
 import { findSummarizeTargets } from './note-scanner';

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -39,6 +39,10 @@ vi.mock('../shared', () => ({
 	FolderPickerModal: vi.fn(),
 	getMarkdownFiles: vi.fn().mockReturnValue([]),
 	NotificationManager: vi.fn(),
+	// URL detection helpers live in shared/url-detector; the summarize module
+	// imports them from the shared barrel (not via the video module's re-export).
+	isSupportedUrl: vi.fn().mockReturnValue(false),
+	detectPlatform: vi.fn().mockReturnValue(null),
 	CALLOUT_TYPES: { transcription: 'synapse-transcription', summary: 'synapse-summary' },
 	buildCallout: vi.fn((_type: string, _title: string, content: string) => `> ${content}`),
 	ENRICHMENT_START: '%% synapse-enrichment-start %%',


### PR DESCRIPTION
## Summary

Five-stage audit chain (architect → security → agent docs → human docs → security re-check) run over the full codebase. All fixes applied directly; final security pass came back clean.

### Architecture (3 fixes)
- Shared utilities are now always imported through the `../shared` barrel — never via a sibling feature or a shared internal file (`src/image/preprocess.ts`, `src/summarize/index.ts`, `src/elaboration/image-analyzer.ts`).
- Removes an undocumented static `summarize → video` import edge (`isSupportedUrl`/`detectPlatform` live in `shared/url-detector`; video only re-exported them).

### Security (2 fixes + 5 regression tests)
- **Secret-redaction drift (medium):** new `src/shared/redact.ts` is the single source of truth for secret redaction. `notifyError` previously kept its own inline regex that was missing the Google `AIza…` pattern — a leaked Gemini key would have reached user-facing Notices and the console unredacted. Both `ai-client.ts` and `api-utils.ts` now route through the canonical redactor (re-exported from `ai-client` for back-compat).
- **Multipart header injection (low-med):** `buildMultipartBody()` in `src/audio/transcriber.ts` interpolated vault-derived file names and settings-derived field values raw into `Content-Disposition` lines; embedded CRLF/quotes could forge multipart headers or extra parts. Now sanitized via `sanitizeMultipartHeaderValue`.
- Re-verified clean: child_process (execFile-only), secrets scan, .gitignore coverage (`data.json` with live keys confirmed untracked), HTTPS-only APIs with header auth + timeouts, input validation, AI-response sanitization.

### Docs
- Root `AGENTS.md` + feature `AGENTS.md` (shared, audio, summarize, image, elaboration): dependency graph corrections, new redact/encoding entries, multipart-hardening notes, and previously undocumented Gemini provider wiring (settings, routing, audio path).
- `DECISIONS.md`: 3 new decision entries (canonical redactor, multipart hardening, shared-barrel import convention).
- `STATUS.md` / `ARCHITECTURE.md`: refreshed to current state (incl. the type-only `audio → video` `AudioExtractor` back-edge, flagged for future cleanup).

Pre-existing local lockfile churn (`package-lock.json`, untracked `pnpm-lock.yaml`/`pnpm-workspace.yaml`) intentionally excluded.

## Test plan
- [x] Types pass (`npx tsc --noEmit --skipLibCheck`)
- [x] Tests pass (`npx vitest run` — 98 files, 1256/1256, incl. 5 new redaction/injection regression tests)
- [x] Build passes (`node esbuild.config.mjs production`)

Co-Authored-By: Claude <bot@wafflenet.io>