### PR TITLE
fix: remove banned and undescribed eslint-disable directives

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,15 @@ const SYNAPSE_ICON_SVG =
 	'<path d="M69.3 55.4 A18 18 0 0 1 41.8 78.5" fill="none" stroke="currentColor" stroke-width="10.5" stroke-linecap="round"/>' +
 	'<ellipse cx="55.8" cy="48.9" rx="16.5" ry="7.2" fill="currentColor" transform="rotate(26 55.8 48.9)"/>';
 
+/**
+ * Narrows a value to a plain object record (a non-null, non-array object) so
+ * `deepMerge` can recurse into nested settings groups without falling back to
+ * `any` casts. Arrays and primitives are treated as leaf values to overwrite.
+ */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export default class SynapsePlugin extends Plugin {
 	settings!: SynapseSettings;
 	notifications!: NotificationManager;
@@ -755,28 +764,19 @@ export default class SynapsePlugin extends Plugin {
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	private deepMerge<T>(target: T, source: any): T {
-		const output: any = { ...target };
+	private deepMerge<T extends object>(target: T, source: Record<string, unknown>): T {
+		const output: Record<string, unknown> = { ...(target as Record<string, unknown>) };
 		for (const key of Object.keys(source)) {
 			// Guard against prototype pollution
 			if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
 				continue;
 			}
-			if (
-				source[key] &&
-				typeof source[key] === 'object' &&
-				!Array.isArray(source[key]) &&
-				key in (target as any) &&
-				typeof (target as any)[key] === 'object' &&
-				!Array.isArray((target as any)[key])
-			) {
-				output[key] = this.deepMerge(
-					(target as any)[key],
-					source[key]
-				);
+			const sourceValue = source[key];
+			const targetValue = output[key];
+			if (isPlainRecord(sourceValue) && isPlainRecord(targetValue)) {
+				output[key] = this.deepMerge(targetValue, sourceValue);
 			} else {
-				output[key] = source[key];
+				output[key] = sourceValue;
 			}
 		}
 		return output as T;

--- a/src/video/audio-extractor.ts
+++ b/src/video/audio-extractor.ts
@@ -33,12 +33,13 @@ export class AudioExtractor {
 
 	private get node() {
 		if (!this._node) {
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			/* eslint-disable @typescript-eslint/no-var-requires -- lazy-load Node builtins at first use so the bundle can load on mobile (isDesktopOnly: false) */
 			this._node = {
 				os: require('os'),
 				path: require('path'),
 				execFile: require('child_process').execFile,
 			};
+			/* eslint-enable @typescript-eslint/no-var-requires -- re-enable the rule now that the lazy Node-builtin loads are done */
 		}
 		return this._node;
 	}


### PR DESCRIPTION
## Summary

The official Obsidian community-plugin review (`docs/reviews/obsidian-review-20260612.md`) flagged two hard **Errors** that block community-plugin acceptance:

- **Error**: Disabling `@typescript-eslint/no-explicit-any` is not allowed — `src/main.ts:758`
- **Error**: Unexpected undescribed directive comment — `src/main.ts:758`, `src/video/audio-extractor.ts:36`

This PR removes the banned directive (by typing the code properly) and makes the remaining required directive compliant.

## Changes

### `src/main.ts` — delete the banned `no-explicit-any` directive, type `deepMerge` properly
- New signature: `private deepMerge<T extends object>(target: T, source: Record<string, unknown>): T`. The call site at line 410 already passes untyped JSON (`data || {}`), which fits `Record<string, unknown>`.
- Added a module-level type guard `isPlainRecord(value: unknown): value is Record<string, unknown>` (non-null, non-array object) that replaces the old `typeof x === 'object' && !Array.isArray(x)` checks **and** every `(target as any)` cast.
- `output` is built as `Record<string, unknown>` and cast once at `return output as T`. No `any` (explicit or via casts) remains in the block.
- **Merge semantics preserved** — every user's persisted settings flow through this on plugin load. The prototype-pollution guard is unchanged and the full test suite passes unchanged.

### `src/video/audio-extractor.ts` — keep the load-bearing lazy-require, fix the directive
- The lazy `require()` of `os`/`path`/`child_process` is intentional: the manifest declares `isDesktopOnly: false`, so the bundle must load on mobile without touching Node builtins at import time. The pattern is kept.
- Replaced the single `// eslint-disable-next-line @typescript-eslint/no-var-requires` (which, as written, only covered line 37 — not the actual `require()` calls on lines 38-40) with a described `/* eslint-disable */` … `/* eslint-enable */` block spanning all three requires, using eslint's `--` description syntax to justify it.

### Out of scope (owned by sibling issues — untouched)
- The remaining unsafe-assignment `any` warnings at `audio-extractor.ts:38-40` and the `JSON.parse()` accesses in `getMetadata()` (#296).
- The Node-builtin import style at lines 38-40 (#299).

## Verification
- `npx tsc --noEmit --skipLibCheck` → exit 0
- `npm test` → 98 files, 1256 tests passed
- `node esbuild.config.mjs production` → exit 0
- Confirmed no `eslint-disable` of `no-explicit-any` remains anywhere in `src/`, every remaining directive comment in the touched files carries a `--` description, and the `deepMerge` block contains no `any`.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
