### PR TITLE
ci: add build provenance attestations for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -56,6 +58,14 @@ jobs:
 
       - name: Build
         run: node esbuild.config.mjs production
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -6,11 +6,15 @@ on:
     paths: ['manifest.json']
 
 # Required so the `tag` job can push the tag, and so the reusable `release`
-# workflow call can be granted `contents: write`. A called workflow cannot have
-# more permissions than its caller; without this the run fails at startup when
-# the repo default workflow permission is read-only.
+# workflow call can be granted the permissions it needs. A called workflow
+# cannot have more permissions than its caller, so the `id-token`/`attestations`
+# scopes the release uses to attest build provenance must be granted here too;
+# without this the run fails at startup when the repo default workflow
+# permission is read-only.
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   tag:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ For video transcription, you need these tools installed and available on your PA
 
 Use the command **Synapse: Check dependencies** to verify these are available.
 
+### Verifying releases
+
+Release assets are signed with [GitHub artifact attestations](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), letting you cryptographically confirm they were built from this repository. After downloading a release, verify an asset with the [GitHub CLI](https://cli.github.com/):
+
+```sh
+gh attestation verify main.js --repo dustinkeeton/obsidian-synapse
+```
+
+Repeat for `manifest.json` and `styles.css` as needed.
+
 ## Configuration
 
 Open **Settings > Synapse** to configure the plugin. All features can be individually enabled or disabled.


### PR DESCRIPTION
## Summary

Adds GitHub artifact attestations to the release workflow so release assets can be cryptographically verified as built from this repository, addressing the Obsidian community-plugin review flag for missing attestations under "Releases".

- **`.github/workflows/release.yml`**
  - Added `id-token: write` and `attestations: write` to the `permissions` block (alongside existing `contents: write`).
  - Added an `actions/attest-build-provenance@v2` step after the Build step and before the Release/upload step, with `subject-path` covering `main.js`, `manifest.json`, and `styles.css` (the review listed only main.js/styles.css, but manifest.json is also uploaded, so it is attested too).
- **`.github/workflows/tag-on-version-bump.yml`**
  - `release.yml` is invoked as a reusable workflow via `workflow_call` from this caller. A called workflow cannot have more permissions than its caller, so the same `id-token: write` and `attestations: write` scopes were added to the caller's `permissions` block (and the explanatory comment updated) — otherwise the version-bump-triggered release path would fail at startup.
- **`README.md`**
  - Added a concise "Verifying releases" subsection under Installation documenting `gh attestation verify main.js --repo dustinkeeton/obsidian-synapse`.

## Verification

- Both edited workflow YAML files parse cleanly.
- No plugin source changed — only CI workflow YAML and the README.

## Post-merge follow-up

The 5th sub-issue (attestations appear on the repo's Attestations page / `gh attestation verify` passes) is runtime verification that can only happen on an actual tagged release. It remains to be verified on the next release; no release was triggered here.

closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)