### PR TITLE
fix: use window-scoped timer and DOM APIs for popout compatibility

### DIFF
--- a/src/__test-utils__/setup.ts
+++ b/src/__test-utils__/setup.ts
@@ -1,3 +1,31 @@
 // Global test setup — runs before each test file
 // The obsidian module is resolved via the alias in vitest.config.ts
 // pointing to src/__mocks__/obsidian.ts, so no vi.mock() call is needed.
+
+// Vitest runs in a `node` environment, which has no DOM globals. Production
+// code uses the window-scoped timer/DOM APIs that Obsidian exposes in its
+// Electron renderer (`window`, `activeWindow`, `activeDocument`) for popout-
+// window compatibility. In a real browser/Electron renderer `window` is the
+// global object and `window.setTimeout === setTimeout`, so aliasing them to
+// `globalThis` here faithfully mirrors runtime and keeps Vitest fake timers
+// (which patch the global timer functions) working transparently.
+const g = globalThis as Record<string, unknown>;
+
+if (typeof g.window === 'undefined') {
+	g.window = globalThis;
+}
+if (typeof g.activeWindow === 'undefined') {
+	g.activeWindow = globalThis;
+}
+
+// `activeDocument` tracks the focused window's document. Expose it as a live
+// getter so tests that stub `document` (e.g. canvas mocks) flow through to
+// `activeDocument` automatically, including stubbing it to `undefined`.
+if (!Object.getOwnPropertyDescriptor(globalThis, 'activeDocument')) {
+	Object.defineProperty(globalThis, 'activeDocument', {
+		configurable: true,
+		get() {
+			return g.document;
+		},
+	});
+}

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -201,7 +201,7 @@ export class AudioModule {
 			const embed = sorted[i];
 			// Delay between requests to avoid API rate limits
 			if (i > 0) {
-				await new Promise(resolve => setTimeout(resolve, 2000));
+				await new Promise(resolve => window.setTimeout(resolve, 2000));
 			}
 			try {
 				op.progress(completed + 1, total, 'Transcribing audio');
@@ -395,7 +395,7 @@ export class AudioModule {
 		for (let i = 0; i < files.length; i++) {
 			if (op?.cancelled) break;
 			if (i > 0 && this.interFileDelayMs > 0) {
-				await new Promise(resolve => setTimeout(resolve, this.interFileDelayMs));
+				await new Promise(resolve => window.setTimeout(resolve, this.interFileDelayMs));
 			}
 			op?.progress(i + 1, files.length, 'Transcribing audio');
 			const data = await this.plugin.app.vault.readBinary(files[i]);

--- a/src/audio/transcriber.ts
+++ b/src/audio/transcriber.ts
@@ -162,7 +162,7 @@ export class Transcriber {
 		const send = () => Promise.race([
 			requestUrl(params),
 			new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error(`${resource} request timed out`)), TRANSCRIPTION_TIMEOUT_MS)),
+				window.setTimeout(() => reject(new Error(`${resource} request timed out`)), TRANSCRIPTION_TIMEOUT_MS)),
 		]);
 		try {
 			return await withRetry(send, 2, 1000, Transcriber.retryableNetwork); // 2 attempts, 1s→2s backoff

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -117,7 +117,7 @@ export class ImageModule {
 			const embed = sorted[i];
 			// Delay between requests to avoid API rate limits
 			if (i > 0) {
-				await new Promise(resolve => setTimeout(resolve, 2000));
+				await new Promise(resolve => window.setTimeout(resolve, 2000));
 			}
 			try {
 				op.progress(completed + 1, total, 'Extracting text from image');

--- a/src/image/preprocess.ts
+++ b/src/image/preprocess.ts
@@ -82,8 +82,8 @@ export async function preprocessImage(
 
 function canUseCanvas(): boolean {
 	return (
-		typeof document !== 'undefined' &&
-		typeof document.createElement === 'function' &&
+		typeof activeDocument !== 'undefined' &&
+		typeof activeDocument.createElement === 'function' &&
 		(typeof createImageBitmap === 'function' || typeof Image !== 'undefined')
 	);
 }
@@ -195,7 +195,7 @@ async function rasterizeToBuffer(
 	outputType: string,
 	quality: number
 ): Promise<ArrayBuffer | null> {
-	const canvas = document.createElement('canvas');
+	const canvas = activeDocument.createElement('canvas');
 	canvas.width = width;
 	canvas.height = height;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ export default class SynapsePlugin extends Plugin {
 	private intake!: IntakeModule;
 	private audioExtractor: AudioExtractor | undefined;
 	private ffmpegAvailable: boolean | null = null;
-	private startupTimeout: ReturnType<typeof setTimeout> | null = null;
+	private startupTimeout: number | null = null;
 	/**
 	 * True when `loadData()` returned no persisted settings — i.e. a genuine
 	 * fresh install rather than an existing user upgrading. Drives first-run
@@ -319,7 +319,7 @@ export default class SynapsePlugin extends Plugin {
 		});
 
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
-		this.startupTimeout = setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
+		this.startupTimeout = window.setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
 
 		// Unified transcription commands (audio on any platform, video on desktop only, image OCR).
 		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
@@ -394,7 +394,7 @@ export default class SynapsePlugin extends Plugin {
 
 	onunload(): void {
 		if (this.startupTimeout !== null) {
-			clearTimeout(this.startupTimeout);
+			window.clearTimeout(this.startupTimeout);
 			this.startupTimeout = null;
 		}
 		this.elaboration?.onunload();

--- a/src/shared/ai-client.ts
+++ b/src/shared/ai-client.ts
@@ -14,7 +14,7 @@ const AI_REQUEST_TIMEOUT_MS = 120_000;
 async function safeRequest(options: RequestUrlParam): Promise<RequestUrlResponse> {
 	// Race the request against a timeout to prevent indefinite hangs
 	const timeout = new Promise<never>((_, reject) =>
-		setTimeout(() => reject(new Error('AI request timed out')), AI_REQUEST_TIMEOUT_MS)
+		window.setTimeout(() => reject(new Error('AI request timed out')), AI_REQUEST_TIMEOUT_MS)
 	);
 
 	// Don't use throw mode — Obsidian strips the response body on error

--- a/src/shared/api-utils.ts
+++ b/src/shared/api-utils.ts
@@ -48,7 +48,7 @@ export async function withRetry<T>(
 }
 
 export function sleep(ms: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, ms));
+	return new Promise(resolve => window.setTimeout(resolve, ms));
 }
 
 export function notifyError(context: string, error: unknown): void {

--- a/src/shared/content-fetcher.ts
+++ b/src/shared/content-fetcher.ts
@@ -39,7 +39,7 @@ async function fetchHtml(url: string): Promise<string> {
 	const validatedUrl = sanitizeUrl(url);
 
 	const timeout = new Promise<never>((_, reject) =>
-		setTimeout(() => reject(new Error('Page fetch timed out')), FETCH_TIMEOUT_MS)
+		window.setTimeout(() => reject(new Error('Page fetch timed out')), FETCH_TIMEOUT_MS)
 	);
 
 	const response = await Promise.race([

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -27,7 +27,7 @@ interface TrackedOperation {
 	/** Fixed-width span that holds the animated dots, preventing layout reflow */
 	dotsEl: HTMLElement;
 	state: 'running' | 'done' | 'error' | 'cancelled';
-	ellipsisInterval: ReturnType<typeof setInterval> | null;
+	ellipsisInterval: number | null;
 }
 
 /**
@@ -81,17 +81,17 @@ function stripTrailingDots(msg: string): string {
  * so that changing dot count does not cause the parent to reflow.
  * Returns an interval handle for cleanup.
  */
-function startEllipsisOnEl(dotsEl: HTMLElement): ReturnType<typeof setInterval> {
+function startEllipsisOnEl(dotsEl: HTMLElement): number {
 	let dotCount = 1;
-	return globalThis.setInterval(() => {
+	return window.setInterval(() => {
 		dotCount = (dotCount % 3) + 1;
 		dotsEl.textContent = '.'.repeat(dotCount);
 	}, 400);
 }
 
-function stopEllipsis(intervalId: ReturnType<typeof setInterval> | null): void {
+function stopEllipsis(intervalId: number | null): void {
 	if (intervalId !== null) {
-		globalThis.clearInterval(intervalId);
+		window.clearInterval(intervalId);
 	}
 }
 

--- a/src/shared/tweet-fetcher.ts
+++ b/src/shared/tweet-fetcher.ts
@@ -72,7 +72,7 @@ async function fetchViaOEmbed(url: string, endpoint: string): Promise<TweetConte
 	const oembedUrl = `${endpoint}?url=${encodeURIComponent(url)}`;
 
 	const timeout = new Promise<never>((_, reject) =>
-		setTimeout(() => reject(new Error('Tweet fetch timed out')), FETCH_TIMEOUT_MS)
+		window.setTimeout(() => reject(new Error('Tweet fetch timed out')), FETCH_TIMEOUT_MS)
 	);
 
 	const response = await Promise.race([
@@ -121,7 +121,7 @@ async function fetchViaVxTwitter(url: string): Promise<TweetContent> {
 	const apiUrl = `https://api.vxtwitter.com/Twitter/status/${idMatch[1]}`;
 
 	const timeout = new Promise<never>((_, reject) =>
-		setTimeout(() => reject(new Error('Tweet fetch timed out')), FETCH_TIMEOUT_MS)
+		window.setTimeout(() => reject(new Error('Tweet fetch timed out')), FETCH_TIMEOUT_MS)
 	);
 
 	const response = await Promise.race([

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -238,7 +238,7 @@ export class VideoModule {
 			if (op.cancelled) break;
 			const embed = sorted[i];
 			if (i > 0) {
-				await new Promise(resolve => setTimeout(resolve, 2000));
+				await new Promise(resolve => window.setTimeout(resolve, 2000));
 			}
 			try {
 				op.progress(completed + 1, total, 'Transcribing video');


### PR DESCRIPTION
## Summary
Resolves the four Warning-level popout-window compatibility findings from the Obsidian community-plugin review. In a popout window, bare globals like `document` resolve against the MAIN window, and in Obsidian's Electron renderer bare `setTimeout`/`setInterval`/`globalThis.setInterval` can resolve to Node's timers (typed `NodeJS.Timeout`). Window-scoping pins to the focused window and to the DOM timer overload (handle type `number`).

### Changes (mechanical, no behavior change)
- **11 `setTimeout` -> `window.setTimeout`**: `main.ts` (1), `audio/index.ts` (2), `audio/transcriber.ts` (1), `image/index.ts` (1), `video/index.ts` (1), `shared/ai-client.ts` (1), `shared/api-utils.ts` (1), `shared/content-fetcher.ts` (1), `shared/tweet-fetcher.ts` (2).
- **1 `clearTimeout` -> `window.clearTimeout`**: `main.ts`.
- **2 `document` -> `activeDocument`**: `image/preprocess.ts` `canUseCanvas()` capability check and `rasterizeToBuffer()` canvas creation, so canvas work follows the focused window. Capability-check semantics preserved.
- **2 `globalThis.*` -> `window.*`**: `shared/notifications.ts` `setInterval`/`clearInterval` (status bar lives in the main window).
- **Handle type annotations -> `number`**: `main.ts` `startupTimeout` field, and `notifications.ts` `ellipsisInterval` field + `startEllipsisOnEl` return + `stopEllipsis` param (these store the same handle, so all three move to `number` together to keep tsc happy).

### Tests
Vitest runs in a `node` environment with no DOM globals, so the shared `setup.ts` now aliases `window`/`activeWindow` to `globalThis` and exposes `activeDocument` as a live getter over `document` (matching real Electron/browser semantics, where `window` is the global object and Vitest fake timers patch the global timer functions). This lets the existing suite exercise the new window-scoped APIs unchanged.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm test` (1256 passed)
- [x] `node esbuild.config.mjs production`

closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)