### PR TITLE
chore: remove dead code and unnecessary regex escapes

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -5,7 +5,6 @@ import {
 	CheckpointManager, generateId, formatTimeRange,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask, TimeRange } from '../shared';
-import { findAudioEmbeds } from './note-scanner';
 import { AudioEmbed } from './types';
 import { PostProcessor } from './post-processor';
 import { Transcriber, GEMINI_MAX_INLINE_AUDIO_BYTES } from './transcriber';

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -2,7 +2,7 @@ import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings, DeepDiveNestingMode } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
-	NotificationManager, ensureFolder, readNote, writeNote, wordCount,
+	NotificationManager, readNote, writeNote, wordCount,
 	CheckpointManager, generateId,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';

--- a/src/enrichment/metadata-classifier.ts
+++ b/src/enrichment/metadata-classifier.ts
@@ -2,7 +2,7 @@ import { SynapseSettings, TagVocabularyEntry } from '../settings';
 import { AIClient, sanitizeAIResponse } from '../shared';
 import { TagCandidate } from './types';
 
-const TAG_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_/\-]{0,49}$/;
+const TAG_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_/-]{0,49}$/;
 
 /**
  * Classifies notes using a user-defined metadata tag vocabulary.

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -5,7 +5,6 @@ import {
 	CheckpointManager, generateId,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
-import { findImageEmbeds } from './note-scanner';
 import { ImageEmbed } from './types';
 import { ImageExtractor } from './extractor';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onb
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
 import { FolderPickerModal, NotificationManager, CheckpointManager } from './shared';
-import type { DeferredTask, Checkpoint } from './shared';
+import type { DeferredTask } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
 import { findVideoUrls } from './video';

--- a/src/rem/rem-applier.ts
+++ b/src/rem/rem-applier.ts
@@ -1,4 +1,4 @@
-import type { RemLinkCandidate, RemOccurrence } from './types';
+import type { RemLinkCandidate } from './types';
 
 /**
  * Applies accepted wikilink insertions to note content.

--- a/src/shared/file-utils.ts
+++ b/src/shared/file-utils.ts
@@ -1,4 +1,4 @@
-import { App, TFile, TFolder, normalizePath } from 'obsidian';
+import { App, TFile, normalizePath } from 'obsidian';
 
 export async function ensureFolder(app: App, path: string): Promise<void> {
 	const normalized = normalizePath(path);

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -664,8 +664,6 @@ export class SummarizeModule {
 	}
 
 	async scanVault(folderPath?: string, skipConfirmation = false, onlyFile?: TFile): Promise<void> {
-		const settings = this.getSettings().summarize;
-
 		// Phase 1: Scan for files with targets
 		const scopeLabel = folderPath ? `Scanning ${folderPath}` : 'Scanning vault';
 		const scanOp = this.notifications.startOperation(

--- a/src/summarize/templates.ts
+++ b/src/summarize/templates.ts
@@ -109,9 +109,7 @@ const CURRENCY_PATTERN = /(?:\$\d+\.\d{2}|[€£]\d+(?:\.\d{2})?)/;
 const TOTAL_HEADERS = /\b(?:total|subtotal|sub-total|tax|grand\s*total)\b/i;
 const LINE_ITEM_QTY_PRICE = /\d+\s*[x×]\s*\$?\d+/i;
 const LINE_ITEM_DOLLAR = /.+\$\d+\.\d{2}/;
-const PAYMENT_TERMS = /\b(?:cash|credit|debit|visa|mastercard|amex|payment|change\s*due|amount\s*tendered)\b/i;
-const RECEIPT_IDENTIFIERS = /\b(?:store\s*#|register|cashier|receipt|transaction\s*#?|order\s*#?)\b/i;
-const RECEIPT_DATETIME = /\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}\s+\d{1,2}:\d{2}/;
+const RECEIPT_DATETIME = /\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\s+\d{1,2}:\d{2}/;
 
 /**
  * Compute a numeric receipt score for content. Exported for testing.

--- a/src/transcription/time-range-toast.ts
+++ b/src/transcription/time-range-toast.ts
@@ -81,7 +81,7 @@ export function showTimeRangeToast(
 		let selectedStart = 0;
 		let selectedEnd = options.duration;
 
-		const slider = new TimeRangeSlider(sliderContainer, {
+		new TimeRangeSlider(sliderContainer, {
 			duration: options.duration,
 			onChange: (start, end) => {
 				selectedStart = start;

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -9,7 +9,6 @@ import {
 import type { TimeRange } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { AudioExtractor } from './audio-extractor';
-import { findVideoUrls } from './note-scanner';
 import { VideoMetadata, VideoProcessOptions, VideoUrlEmbed } from './types';
 
 export type {


### PR DESCRIPTION
## Summary
Addresses the official Obsidian community-plugin review findings: 11 unused symbols (Recommendations) and 5 unnecessary regex escape characters (Warnings). None affect runtime behavior; they removed lint noise only.

### Dead code removed
- Redundant local `import` of `findAudioEmbeds` / `findImageEmbeds` / `findVideoUrls` in `src/audio/index.ts`, `src/image/index.ts`, `src/video/index.ts`. The separate `export { ... } from './note-scanner'` re-exports (consumed by `src/main.ts`) were preserved.
- Unused named imports: `ensureFolder` (`src/deep-dive/index.ts`), `Checkpoint` (`src/main.ts`, `DeferredTask` kept), `RemOccurrence` (`src/rem/rem-applier.ts`, `RemLinkCandidate` kept), `TFolder` (`src/shared/file-utils.ts`).
- Superseded constants `PAYMENT_TERMS` and `RECEIPT_IDENTIFIERS` in `src/summarize/templates.ts` (receipt detection is implemented in `scoreReceiptContent`). The neighbouring `RECEIPT_DATETIME` is in use and was kept.
- Dead `const settings` local in `scanVault` (`src/summarize/index.ts`); the separate live `settings` in `isExcluded` was left untouched.
- Unused `slider` variable binding in `src/transcription/time-range-toast.ts`; the `new TimeRangeSlider(...)` instantiation (whose constructor renders the slider and wires `onChange`) was kept as a bare statement.

### Unnecessary regex escapes fixed
- `TAG_PATTERN` in `src/enrichment/metadata-classifier.ts`: `[a-zA-Z0-9_/\-]` to `[a-zA-Z0-9_/-]`.
- `RECEIPT_DATETIME` in `src/summarize/templates.ts`: both `[\/\-]` character classes to `[/-]` (covers the four `\/` / `\-` escapes).

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (1256 tests, 98 files)
- [x] `node esbuild.config.mjs production` succeeds
- [x] Each removed symbol verified unused in its file before deletion; re-exports and the `TimeRangeSlider` instantiation preserved

closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)