### PR TITLE
fix(ci): keep package-lock cross-platform-complete (pin @emnapi top-level deps)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "1.0.1",
 			"license": "AGPL-3.0-only",
 			"devDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1",
 				"@types/node": "^22.0.0",
 				"@vitest/coverage-v8": "^4.1.8",
 				"builtin-modules": "^4.0.0",
@@ -100,13 +102,35 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
 			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 	"author": "Dustin Keeton",
 	"license": "AGPL-3.0-only",
 	"devDependencies": {
+		"@emnapi/core": "^1.7.1",
+		"@emnapi/runtime": "^1.7.1",
 		"@types/node": "^22.0.0",
 		"@vitest/coverage-v8": "^4.1.8",
 		"builtin-modules": "^4.0.0",


### PR DESCRIPTION
## Problem

CI's `npm ci` fails on Linux (on `main` and every branch cut from it):

```
npm error code EUSAGE
npm error Missing: @emnapi/core@1.11.1 from lock file
npm error Missing: @emnapi/runtime@1.11.1 from lock file
```

## Root cause — lockfile completeness, not npm version

`@vitest/coverage-v8` → `rolldown` ships an optional `@rolldown/binding-wasm32-wasi` binding whose runtime (`@napi-rs/wasm-runtime`, hoisted to the top level) requires `@emnapi/core` / `@emnapi/runtime` (`^1.7.1`).

A `npm install` on **macOS** prunes those two **top-level** `@emnapi` nodes (the wasm code path isn't installed locally), producing a `package-lock.json` that **Linux `npm ci` rejects**. It is *not* an npm 10 vs 11 problem — npm 11 on Linux fails the same way; npm 10 on macOS reproduces the failure exactly.

This has recurred every time the lockfile is regenerated on macOS — see prior one-off fixes `8a8402b` ("add missing @emnapi top-level entries"), `94e53c9`, `cf8ba53`. The latest `chore: project updates` on `main` regenerated the lockfile and stripped the nodes again.

## Fix (structural, prevents recurrence)

Promote `@emnapi/core` and `@emnapi/runtime` to **direct devDependencies** (`^1.7.1`). As direct deps, npm always records their top-level nodes — on every platform and every npm version — so a macOS regen can no longer prune them. The lockfile is regenerated and now contains the `1.11.1` top-level nodes.

Net diff: **2 lines in `package.json`** + the lockfile.

## Verification

`npx npm@10 ci` reproduces the Linux CI failure on macOS, so it's a faithful local proxy. After the fix:

| check | before | after |
|---|---|---|
| `npx npm@10 ci` (Linux CI proxy) | ❌ EUSAGE | ✅ |
| `npm ci` (npm 11, dev) | ✅ | ✅ |
| `tsc --noEmit` | — | ✅ |
| `check-top-level-requires` | — | ✅ |
| `npm test` | — | ✅ 1256 passed |
| version consistency | — | ✅ |
| `esbuild … production` | — | ✅ |

To check a future lockfile locally before pushing: `npx npm@10 ci`.

Unblocks #309, #310, #311 — they were red only because they inherited the broken lockfile from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)