### PR TITLE
refactor: inject node deps into duration-detector for testability (#271)

### DIFF
--- a/src/transcription/duration-detector.test.ts
+++ b/src/transcription/duration-detector.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest';
-import { formatTimestamp, MIN_SLIDER_DURATION } from './duration-detector';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import { Platform, type TFile } from 'obsidian';
+import {
+	detectLocalFileDuration,
+	detectUrlDuration,
+	formatTimestamp,
+	MIN_SLIDER_DURATION,
+	type NodeDeps,
+} from './duration-detector';
+import { DEFAULT_SETTINGS, type SynapseSettings } from '../settings';
+import { mockFile } from '../__test-utils__/mock-factories';
 
 describe('formatTimestamp', () => {
 	it('formats 0 seconds as 00:00', () => {
@@ -50,5 +61,349 @@ describe('formatTimestamp', () => {
 describe('MIN_SLIDER_DURATION', () => {
 	it('is 10 seconds', () => {
 		expect(MIN_SLIDER_DURATION).toBe(10);
+	});
+});
+
+// --- Injected-dependency tests for the subprocess orchestration ---
+//
+// detectLocalFileDuration / detectUrlDuration require Node builtins
+// (os/path/fs/child_process) at runtime, which vi.mock cannot intercept. The
+// functions accept an optional trailing `deps` parameter so tests can stub
+// execFile/fs and assert on subprocess wiring without spawning a process.
+
+/** execFile stub shared across the DI tests; reset per-test. */
+const execFileMock = vi.fn();
+
+/**
+ * Build a NodeDeps with a stubbed execFile and recording fs.promises so tests
+ * can introspect the temp-file write/cleanup. Uses real os/path.
+ */
+function makeDeps(overrides: Partial<NodeDeps> = {}): {
+	deps: NodeDeps;
+	writeFile: ReturnType<typeof vi.fn>;
+	unlink: ReturnType<typeof vi.fn>;
+} {
+	const writeFile = vi.fn().mockResolvedValue(undefined);
+	const unlink = vi.fn().mockResolvedValue(undefined);
+	const deps: NodeDeps = {
+		os,
+		path,
+		fs: { promises: { writeFile, unlink } } as unknown as NodeDeps['fs'],
+		execFile: execFileMock as unknown as NodeDeps['execFile'],
+		...overrides,
+	};
+	return { deps, writeFile, unlink };
+}
+
+/**
+ * A TFile-like fixture (the mock TFile derives name/basename from the path).
+ * The centralized mock TFile is structurally close but not assignable to the
+ * real obsidian TFile type (e.g. its `vault` is `unknown`), so bridge it with a
+ * single cast at the fixture boundary.
+ */
+function makeFile(filePath = 'notes/clip.mp4'): TFile {
+	return mockFile(filePath) as unknown as TFile;
+}
+
+function settingsWith(overrides: Partial<SynapseSettings['video']> = {}): () => SynapseSettings {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	settings.video = { ...settings.video, ...overrides };
+	return () => settings;
+}
+
+describe('detectLocalFileDuration (injected deps)', () => {
+	beforeEach(() => {
+		execFileMock.mockReset();
+		Platform.isDesktop = true;
+	});
+
+	afterEach(() => {
+		Platform.isDesktop = true;
+		vi.restoreAllMocks();
+	});
+
+	it('derives the ffprobe path from ffmpegPath and probes the temp file', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, '123.45\n')
+		);
+		const { deps, writeFile } = makeDeps();
+
+		const result = await detectLocalFileDuration(
+			makeFile(),
+			async () => new ArrayBuffer(8),
+			settingsWith({ ffmpegPath: '/opt/homebrew/bin/ffmpeg' }),
+			deps
+		);
+
+		expect(result.durationSeconds).toBe(123.45);
+		expect(result.title).toBe('clip');
+
+		// ffprobe path derived by replacing the trailing "ffmpeg" with "ffprobe".
+		const [cmd, args] = execFileMock.mock.calls[0];
+		expect(cmd).toBe('/opt/homebrew/bin/ffprobe');
+		expect(args).toEqual([
+			'-v', 'error',
+			'-show_entries', 'format=duration',
+			'-of', 'csv=p=0',
+			expect.stringContaining('synapse-probe-'),
+		]);
+
+		// The temp file written matches the path passed to ffprobe.
+		const tempPath = writeFile.mock.calls[0][0] as string;
+		expect(tempPath.startsWith(os.tmpdir())).toBe(true);
+		expect(args[args.length - 1]).toBe(tempPath);
+	});
+
+	it('writes the temp file then cleans it up on success', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, '42\n')
+		);
+		const { deps, writeFile, unlink } = makeDeps();
+
+		await detectLocalFileDuration(makeFile(), async () => new ArrayBuffer(4), settingsWith(), deps);
+
+		expect(writeFile).toHaveBeenCalledTimes(1);
+		expect(unlink).toHaveBeenCalledTimes(1);
+		// Cleanup unlinks the same temp file that was written.
+		expect(unlink.mock.calls[0][0]).toBe(writeFile.mock.calls[0][0]);
+	});
+
+	it('still cleans up the temp file when ffprobe fails', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(new Error('ffprobe boom'), '')
+		);
+		const { deps, writeFile, unlink } = makeDeps();
+
+		const result = await detectLocalFileDuration(
+			makeFile(),
+			async () => new ArrayBuffer(4),
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBeUndefined();
+		expect(unlink).toHaveBeenCalledTimes(1);
+		expect(unlink.mock.calls[0][0]).toBe(writeFile.mock.calls[0][0]);
+	});
+
+	it('returns undefined duration when ffprobe errors', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(new Error('not found'), '')
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectLocalFileDuration(
+			makeFile(),
+			async () => new ArrayBuffer(4),
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBeUndefined();
+		expect(result.title).toBe('clip');
+	});
+
+	it('returns undefined duration when ffprobe stdout is non-numeric', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, 'N/A\n')
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectLocalFileDuration(
+			makeFile(),
+			async () => new ArrayBuffer(4),
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBeUndefined();
+	});
+
+	it('augments PATH with common install locations in the exec env', async () => {
+		const original = process.env.PATH;
+		process.env.PATH = '/usr/bin';
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, '10\n')
+		);
+		const { deps } = makeDeps();
+
+		try {
+			await detectLocalFileDuration(makeFile(), async () => new ArrayBuffer(4), settingsWith(), deps);
+		} finally {
+			process.env.PATH = original;
+		}
+
+		const opts = execFileMock.mock.calls[0][2] as { env: NodeJS.ProcessEnv; timeout: number };
+		expect(opts.env.PATH).toContain('/usr/local/bin');
+		expect(opts.env.PATH).toContain('/opt/homebrew/bin');
+		expect(opts.env.PATH).toContain('/usr/bin');
+		expect(opts.timeout).toBe(15_000);
+	});
+
+	it('returns undefined duration without spawning on mobile', async () => {
+		Platform.isDesktop = false;
+		const readBinary = vi.fn();
+		const { deps } = makeDeps();
+
+		const result = await detectLocalFileDuration(
+			makeFile('clip.mp4'),
+			readBinary,
+			settingsWith(),
+			deps
+		);
+
+		expect(result).toEqual({ durationSeconds: undefined, title: 'clip' });
+		expect(execFileMock).not.toHaveBeenCalled();
+		expect(readBinary).not.toHaveBeenCalled();
+	});
+});
+
+describe('detectUrlDuration (injected deps)', () => {
+	beforeEach(() => {
+		execFileMock.mockReset();
+		Platform.isDesktop = true;
+	});
+
+	afterEach(() => {
+		Platform.isDesktop = true;
+	});
+
+	it('parses duration and title from yt-dlp --dump-json output', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) => {
+				expect(args).toContain('--dump-json');
+				expect(args).toContain('--no-download');
+				cb(null, JSON.stringify({ duration: 211.7, title: 'A Clip' }));
+			}
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectUrlDuration(
+			'https://www.youtube.com/watch?v=abc123',
+			settingsWith({ ytDlpPath: '/opt/homebrew/bin/yt-dlp' }),
+			deps
+		);
+
+		expect(result.durationSeconds).toBe(211.7);
+		expect(result.title).toBe('A Clip');
+		expect(execFileMock.mock.calls[0][0]).toBe('/opt/homebrew/bin/yt-dlp');
+	});
+
+	it('falls back to the url as title when yt-dlp omits a title', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, JSON.stringify({ duration: 5 }))
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectUrlDuration(
+			'https://www.youtube.com/watch?v=abc123',
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBe(5);
+		expect(result.title).toBe('https://www.youtube.com/watch?v=abc123');
+	});
+
+	it('returns undefined duration when yt-dlp duration is non-numeric', async () => {
+		// A successfully-parsed payload with a non-numeric duration still yields a
+		// title (only the duration is dropped).
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, JSON.stringify({ duration: 'N/A', title: 'X' }))
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectUrlDuration(
+			'https://www.youtube.com/watch?v=abc123',
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBeUndefined();
+		expect(result.title).toBe('X');
+	});
+
+	it('returns undefined duration when yt-dlp output is not valid JSON', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, 'not json at all')
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectUrlDuration(
+			'https://www.youtube.com/watch?v=abc123',
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBeUndefined();
+		expect(result.title).toBe('https://www.youtube.com/watch?v=abc123');
+	});
+
+	it('returns undefined duration when yt-dlp exec rejects', async () => {
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(new Error('spawn yt-dlp ENOENT'), '')
+		);
+		const { deps } = makeDeps();
+
+		const result = await detectUrlDuration(
+			'https://www.youtube.com/watch?v=abc123',
+			settingsWith(),
+			deps
+		);
+
+		expect(result.durationSeconds).toBeUndefined();
+		expect(result.title).toBe('https://www.youtube.com/watch?v=abc123');
+	});
+
+	it('augments PATH and sets a 30s timeout / 10MB maxBuffer in the exec env', async () => {
+		const original = process.env.PATH;
+		process.env.PATH = '/usr/bin';
+		execFileMock.mockImplementation(
+			(_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, o: string) => void) =>
+				cb(null, JSON.stringify({ duration: 1, title: 'T' }))
+		);
+		const { deps } = makeDeps();
+
+		try {
+			await detectUrlDuration('https://www.youtube.com/watch?v=abc123', settingsWith(), deps);
+		} finally {
+			process.env.PATH = original;
+		}
+
+		const opts = execFileMock.mock.calls[0][2] as {
+			env: NodeJS.ProcessEnv;
+			timeout: number;
+			maxBuffer: number;
+		};
+		expect(opts.env.PATH).toContain('/opt/homebrew/bin');
+		expect(opts.timeout).toBe(30_000);
+		expect(opts.maxBuffer).toBe(10 * 1024 * 1024);
+	});
+
+	it('returns undefined duration without spawning on mobile', async () => {
+		Platform.isDesktop = false;
+		const { deps } = makeDeps();
+
+		const result = await detectUrlDuration(
+			'https://www.youtube.com/watch?v=abc123',
+			settingsWith(),
+			deps
+		);
+
+		expect(result).toEqual({
+			durationSeconds: undefined,
+			title: 'https://www.youtube.com/watch?v=abc123',
+		});
+		expect(execFileMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -12,13 +12,45 @@ export interface DurationResult {
 }
 
 /**
+ * Node builtins used by the subprocess orchestration. Injected so tests can
+ * stub them (a runtime `require` of these inside the function body is not
+ * intercepted by `vi.mock`). Defaults to {@link buildRealNodeDeps}.
+ */
+export interface NodeDeps {
+	os: typeof import('os');
+	path: typeof import('path');
+	fs: typeof import('fs');
+	execFile: typeof import('child_process')['execFile'];
+}
+
+/**
+ * Lazily resolve the real Node builtins via `require`.
+ *
+ * MUST only be called AFTER the `Platform.isDesktop` guard: on mobile these
+ * modules do not exist, so requiring them eagerly (e.g. in a parameter
+ * default) would crash. Keeping the requires here preserves the mobile
+ * early-return as a require-free path.
+ */
+function buildRealNodeDeps(): NodeDeps {
+	/* eslint-disable @typescript-eslint/no-var-requires -- lazy-load Node builtins so the bundle can load on mobile (isDesktopOnly: false) */
+	return {
+		os: require('os'),
+		path: require('path'),
+		fs: require('fs'),
+		execFile: require('child_process').execFile,
+	};
+	/* eslint-enable @typescript-eslint/no-var-requires -- re-enable now that the lazy Node-builtin loads are done */
+}
+
+/**
  * Detect the duration of a local audio file using ffprobe.
  * Returns undefined duration on failure (mobile, missing ffprobe, corrupt file).
  */
 export async function detectLocalFileDuration(
 	file: TFile,
 	readBinary: (file: TFile) => Promise<ArrayBuffer>,
-	getSettings: () => SynapseSettings
+	getSettings: () => SynapseSettings,
+	deps?: NodeDeps
 ): Promise<DurationResult> {
 	const title = file.basename;
 
@@ -27,10 +59,9 @@ export async function detectLocalFileDuration(
 	}
 
 	try {
-		const os = require('os') as typeof import('os');
-		const path = require('path') as typeof import('path');
-		const fs = require('fs') as typeof import('fs');
-		const { execFile } = require('child_process') as typeof import('child_process');
+		// Resolve real Node builtins only AFTER the mobile guard above, so the
+		// mobile early-return never triggers a require().
+		const { os, path, fs, execFile } = deps ?? buildRealNodeDeps();
 
 		const data = await readBinary(file);
 		// Defense-in-depth: file.name is vault-derived; strip any path-unsafe
@@ -81,7 +112,8 @@ export async function detectLocalFileDuration(
  */
 export async function detectUrlDuration(
 	url: string,
-	getSettings: () => SynapseSettings
+	getSettings: () => SynapseSettings,
+	deps?: NodeDeps
 ): Promise<DurationResult> {
 	if (!Platform.isDesktop) {
 		return { durationSeconds: undefined, title: url };
@@ -89,7 +121,9 @@ export async function detectUrlDuration(
 
 	try {
 		const validatedUrl = sanitizeUrl(url);
-		const { execFile } = require('child_process') as typeof import('child_process');
+		// Resolve real Node builtins only AFTER the mobile guard above, so the
+		// mobile early-return never triggers a require().
+		const { execFile } = deps ?? buildRealNodeDeps();
 		const ytDlpPath = sanitizePath(getSettings().video.ytDlpPath);
 
 		const output = await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Summary

`detectLocalFileDuration` and `detectUrlDuration` in `src/transcription/duration-detector.ts` resolved their Node builtins (`os`/`path`/`fs`/`child_process`) via `require()` inside the function bodies, which `vi.mock` cannot intercept — so the subprocess orchestration (ffprobe path derivation, temp-file write/cleanup, timeout/error handling, yt-dlp `--dump-json` parsing) was untested. This PR makes those builtins injectable via an optional trailing `deps?: NodeDeps` parameter that defaults to the real lazy requires, then adds the deferred tests. No behavior change. Caller signatures in `unified-modal.ts` are unchanged.

The real `require()`s now live in a `buildRealNodeDeps()` helper that is resolved only **after** the `Platform.isDesktop` guard (`const node = deps ?? buildRealNodeDeps()`), so the mobile early-return path stays require-free and the bundle still loads on mobile.

closes #271

## Test coverage added

DI-injected tests (stubbed `execFile` + recording `fs.promises`, real `os`/`path`) covering:

- ffprobe path derivation from `ffmpegPath`, and probing the written temp file
- temp-file write + cleanup on success, and cleanup when `execFile` fails
- ffprobe exec error -> `durationSeconds: undefined`
- non-numeric / NaN ffprobe stdout -> `durationSeconds: undefined`
- yt-dlp `--dump-json` happy path (duration + title parsed), and title fallback to URL
- yt-dlp non-numeric duration and invalid-JSON output -> undefined duration
- yt-dlp exec rejection -> undefined duration
- `shellEnv`/PATH augmentation and timeout/maxBuffer options for both functions
- mobile early-return (`Platform.isDesktop = false`) returns undefined duration without spawning or reading the file

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` passes
- [x] `npm test` passes (1270 tests, 98 files)
- [x] `node esbuild.config.mjs production` builds

## Notes

PR 1 of a stacked series (#271 -> #297 phases -> #296 phases); base main. This PR is scoped to the DI refactor + tests only — the raw `reject(error)` in `detectUrlDuration` and the untyped yt-dlp JSON parse are intentionally left for #297 and #296.

Co-Authored-By: Synapse Bot <bot@wafflenet.io>