### PR TITLE
fix: handle unhandled promise rejections in main.ts + add fireAndForget helper (#297)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { CommandRegistrar, auditCommands } from './commands';
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
-import { FolderPickerModal, NotificationManager, CheckpointManager } from './shared';
+import { FolderPickerModal, NotificationManager, CheckpointManager, fireAndForget } from './shared';
 import type { DeferredTask } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
@@ -211,42 +211,42 @@ export default class SynapsePlugin extends Plugin {
 		// Wire enrichment callbacks -- triggers after other processes complete
 		if (this.settings.enrichment.enabled && this.settings.enrichment.autoEnrich) {
 			this.elaboration.onProposalAccepted = (filePath: string) => {
-				this.enrichment.enrich(filePath, 'elaboration');
+				fireAndForget(this.enrichment.enrich(filePath, 'elaboration'), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					this.title.checkTitle(filePath);
+					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			this.audio.onTranscriptionComplete = (filePath: string) => {
-				this.enrichment.enrich(filePath, 'transcription');
+				fireAndForget(this.enrichment.enrich(filePath, 'transcription'), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					this.title.checkTitle(filePath);
+					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			if (this.video) {
 				this.video.onTranscriptionComplete = (filePath: string) => {
-					this.enrichment.enrich(filePath, 'transcription');
+					fireAndForget(this.enrichment.enrich(filePath, 'transcription'), 'Enrich note', { notifications: this.notifications });
 					if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-						this.title.checkTitle(filePath);
+						fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 					}
 				};
 			}
 			this.image.onExtractionComplete = (filePath: string) => {
-				this.enrichment.enrich(filePath, 'transcription');
+				fireAndForget(this.enrichment.enrich(filePath, 'transcription'), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					this.title.checkTitle(filePath);
+					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			this.summarize.onSummaryComplete = (filePath: string) => {
-				this.enrichment.enrich(filePath, 'summarization');
+				fireAndForget(this.enrichment.enrich(filePath, 'summarization'), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					this.title.checkTitle(filePath);
+					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			if (this.settings.deepDive.autoEnrichOnAccept) {
 				this.deepDive.onNoteAccepted = (filePath: string) => {
-					this.enrichment.enrich(filePath, 'deep-dive');
+					fireAndForget(this.enrichment.enrich(filePath, 'deep-dive'), 'Enrich note', { notifications: this.notifications });
 					if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-						this.title.checkTitle(filePath);
+						fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 					}
 				};
 			}
@@ -256,38 +256,38 @@ export default class SynapsePlugin extends Plugin {
 		if (this.settings.title.enabled && this.settings.title.checkAfterOperations &&
 			!(this.settings.enrichment.enabled && this.settings.enrichment.autoEnrich)) {
 			this.elaboration.onProposalAccepted = (filePath: string) => {
-				this.title.checkTitle(filePath);
+				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 			};
 			this.audio.onTranscriptionComplete = (filePath: string) => {
-				this.title.checkTitle(filePath);
+				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 			};
 			if (this.video) {
 				this.video.onTranscriptionComplete = (filePath: string) => {
-					this.title.checkTitle(filePath);
+					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 				};
 			}
 			this.image.onExtractionComplete = (filePath: string) => {
-				this.title.checkTitle(filePath);
+				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 			};
 			this.summarize.onSummaryComplete = (filePath: string) => {
-				this.title.checkTitle(filePath);
+				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 			};
 			this.deepDive.onNoteAccepted = (filePath: string) => {
-				this.title.checkTitle(filePath);
+				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
 			};
 		}
 
 		// Wire deep-dive auto-organize callback
 		if (this.settings.deepDive.autoOrganizeOnAccept && this.settings.organize.enabled) {
 			this.deepDive.onOrganizeRequested = (file) => {
-				this.organize.organizeNote(file);
+				fireAndForget(this.organize.organizeNote(file), 'Organize note', { notifications: this.notifications });
 			};
 		}
 
 		// Wire summarize auto-organize callback (single-note only, never vault-wide)
 		if (this.settings.summarize.autoOrganizeOnSummarize && this.settings.organize.enabled) {
 			this.summarize.onOrganizeRequested = (file) => {
-				this.organize.organizeNote(file);
+				fireAndForget(this.organize.organizeNote(file), 'Organize note', { notifications: this.notifications });
 			};
 		}
 
@@ -295,7 +295,7 @@ export default class SynapsePlugin extends Plugin {
 		// S-Signal mark (registered above) rather than a stock Lucide glyph —
 		// the previous 'sparkles' icon is on the brand's banned inventory.
 		this.addRibbonIcon('synapse', 'Review proposals', () => {
-			this.activateUnifiedView();
+			fireAndForget(this.activateUnifiedView(), 'Open proposal review', { notifications: this.notifications });
 		});
 
 		// Unified transcription ribbon icon (desktop only — mic icon implies video
@@ -319,7 +319,7 @@ export default class SynapsePlugin extends Plugin {
 		});
 
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
-		this.startupTimeout = window.setTimeout(() => this.checkForIncompleteCheckpoints(), 3000);
+		this.startupTimeout = window.setTimeout(() => { void this.checkForIncompleteCheckpoints(); }, 3000);
 
 		// Unified transcription commands (audio on any platform, video on desktop only, image OCR).
 		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
@@ -376,7 +376,13 @@ export default class SynapsePlugin extends Plugin {
 				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
 					this.app,
-					(folder) => synapseRunner.fire(folder.isRoot() ? undefined : folder.path),
+					(folder) => {
+						fireAndForget(
+							synapseRunner.fire(folder.isRoot() ? undefined : folder.path),
+							'Run all features on folder',
+							{ notifications: this.notifications },
+						);
+					},
 					defaultPath,
 				).open();
 			},
@@ -526,7 +532,9 @@ export default class SynapsePlugin extends Plugin {
 			leaf = rightLeaf;
 			await leaf.setViewState({ type: UNIFIED_VIEW_TYPE, active: true });
 		}
-		workspace.revealLeaf(leaf);
+		// Deliberate background work: reveal is best-effort UI and must not block
+		// the refresh below; surface failures to the console only (no toast).
+		fireAndForget(workspace.revealLeaf(leaf), 'Reveal proposal view', { background: true });
 		await this.refreshUnifiedView();
 	}
 
@@ -719,7 +727,9 @@ export default class SynapsePlugin extends Plugin {
 		for (const task of tasks) {
 			switch (task.type) {
 				case 'refresh-sidebar-view':
-					this.refreshUnifiedView();
+					// Deliberate background work: refresh the sidebar without
+					// blocking the caller; log failures to the console only.
+					fireAndForget(this.refreshUnifiedView(), 'Refresh proposal view', { background: true });
 					break;
 				default:
 					console.warn(`[Synapse] Unknown deferred task type: ${task.type}`);

--- a/src/shared/fire-and-forget.test.ts
+++ b/src/shared/fire-and-forget.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Notice } from 'obsidian';
+import { fireAndForget } from './fire-and-forget';
+import type { NotificationManager } from './notifications';
+
+// Wrap the obsidian mock's `Notice` as a spy constructor so we can assert that
+// (and how) a user-facing notice was shown. Everything else falls through to
+// the centralized mock (src/__mocks__/obsidian.ts) via importOriginal.
+vi.mock('obsidian', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('obsidian')>();
+	return {
+		...actual,
+		Notice: vi.fn(function (this: unknown, message?: unknown, duration?: unknown) {
+			// Delegate to the real mock Notice so instance shape stays intact.
+			return new actual.Notice(message as string, duration as number);
+		}),
+	};
+});
+
+/**
+ * `fireAndForget` deliberately does not return the promise it observes, so its
+ * rejection handling runs on the microtask queue. Flushing the queue lets the
+ * `.catch` settle before assertions. Two `await`s cover the extra microtask the
+ * notification-manager path adds.
+ */
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe('fireAndForget', () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.mocked(Notice).mockClear();
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
+	describe('when the promise resolves', () => {
+		it('shows no Notice and logs no error', async () => {
+			fireAndForget(Promise.resolve('ok'), 'Enrich note');
+			await flushMicrotasks();
+
+			expect(Notice).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).not.toHaveBeenCalled();
+		});
+
+		it('returns void (does not return the observed promise)', () => {
+			const result = fireAndForget(Promise.resolve(), 'Enrich note');
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('when the promise rejects (no notification manager)', () => {
+		it('shows a Notice and logs console.error with the label', async () => {
+			const err = new Error('boom');
+			fireAndForget(Promise.reject(err), 'Enrich note');
+			await flushMicrotasks();
+
+			expect(Notice).toHaveBeenCalledTimes(1);
+			expect(String(vi.mocked(Notice).mock.calls[0][0])).toContain('Enrich note');
+
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+			const [message, loggedErr] = consoleErrorSpy.mock.calls[0];
+			expect(message).toContain('Enrich note');
+			expect(message).toContain('[Synapse]');
+			expect(loggedErr).toBe(err);
+		});
+
+		it('does not let the rejection escape as an unhandled rejection', async () => {
+			// If fireAndForget failed to attach a handler, this rejected promise
+			// would surface as an unhandled rejection and fail the test run.
+			expect(() =>
+				fireAndForget(Promise.reject(new Error('swallowed')), 'Check title'),
+			).not.toThrow();
+			await flushMicrotasks();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('when the promise rejects (with notification manager)', () => {
+		it('routes through notifyError with the label and skips the plain Notice', async () => {
+			const err = new Error('boom');
+			const notifyError = vi.fn();
+			const notifications = { notifyError } as unknown as NotificationManager;
+
+			fireAndForget(Promise.reject(err), 'Organize note', { notifications });
+			await flushMicrotasks();
+
+			// The manager owns both the user-facing toast and the console log,
+			// so fireAndForget must not also construct a plain Notice.
+			expect(Notice).not.toHaveBeenCalled();
+			expect(notifyError).toHaveBeenCalledTimes(1);
+			expect(notifyError).toHaveBeenCalledWith('Organize note', err);
+		});
+	});
+
+	describe('background mode', () => {
+		it('logs console.error with the label but shows no Notice', async () => {
+			const err = new Error('boom');
+			const notifyError = vi.fn();
+			const notifications = { notifyError } as unknown as NotificationManager;
+
+			fireAndForget(Promise.reject(err), 'Refresh sidebar', {
+				notifications,
+				background: true,
+			});
+			await flushMicrotasks();
+
+			expect(Notice).not.toHaveBeenCalled();
+			expect(notifyError).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+			expect(consoleErrorSpy.mock.calls[0][0]).toContain('Refresh sidebar');
+		});
+
+		it('does not show a Notice even without a notification manager', async () => {
+			fireAndForget(Promise.reject(new Error('boom')), 'Reveal leaf', {
+				background: true,
+			});
+			await flushMicrotasks();
+
+			expect(Notice).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/src/shared/fire-and-forget.ts
+++ b/src/shared/fire-and-forget.ts
@@ -1,0 +1,67 @@
+import { Notice } from 'obsidian';
+import type { NotificationManager } from './notifications';
+
+/**
+ * Options for {@link fireAndForget}.
+ */
+export interface FireAndForgetOptions {
+	/**
+	 * Notification manager used to surface rejections to the user. When provided,
+	 * a rejection routes through {@link NotificationManager.notifyError} (which
+	 * redacts secrets, shows a styled toast, and logs to the console) so the
+	 * failure is visible and consistent with the rest of the plugin.
+	 *
+	 * When omitted, a plain `Notice` is shown and the error is logged via
+	 * `console.error`.
+	 */
+	notifications?: NotificationManager;
+	/**
+	 * Background mode: suppress the user-facing toast and only log to the console.
+	 * Use for deliberate background work where a visible error would be noise
+	 * (e.g. a sidebar refresh, revealing a leaf). Defaults to `false`.
+	 */
+	background?: boolean;
+}
+
+/**
+ * Attach rejection handling to a promise that is intentionally not awaited.
+ *
+ * Obsidian flagged a class of unhandled promise rejections that silently
+ * swallowed failures. `fireAndForget` is the single convention for handling
+ * those dropped promises across the plugin: it preserves fire-and-forget
+ * semantics (the call stays non-blocking — it never returns the promise) while
+ * guaranteeing a rejection is surfaced rather than lost.
+ *
+ * On rejection it surfaces a user-facing error (via the notification manager
+ * when supplied, otherwise a plain `Notice`) and logs to the console with the
+ * `[Synapse]` prefix and the supplied `label`. In background mode the toast is
+ * suppressed and only the console log is emitted.
+ *
+ * @param promise the promise to observe; its resolved value is ignored.
+ * @param label   a short, human-readable description of the work, used in both
+ *                the user-facing message and the console log (e.g.
+ *                `'Enrich note'`).
+ * @param options optional notification manager and/or background flag.
+ */
+export function fireAndForget(
+	promise: Promise<unknown>,
+	label: string,
+	options: FireAndForgetOptions = {},
+): void {
+	void promise.catch((err: unknown) => {
+		// Background work: log only, never surface a toast.
+		if (options.background) {
+			console.error(`[Synapse] ${label} failed`, err);
+			return;
+		}
+		// Prefer the notification manager — it redacts secrets from the error,
+		// shows a styled toast, AND logs to the console (with `label` as context).
+		if (options.notifications) {
+			options.notifications.notifyError(label, err);
+			return;
+		}
+		// Fallback when no manager is available: plain notice + console log.
+		new Notice(`Synapse: ${label} failed`);
+		console.error(`[Synapse] ${label} failed`, err);
+	});
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -19,6 +19,8 @@ export { arrayBufferToBase64, base64EncodedLength } from './encoding';
 export { redactSecrets } from './redact';
 export { NotificationManager } from './notifications';
 export type { OperationHandle } from './notifications';
+export { fireAndForget } from './fire-and-forget';
+export type { FireAndForgetOptions } from './fire-and-forget';
 export { FolderPickerModal } from './folder-picker-modal';
 export {
 	sanitizeUrl,


### PR DESCRIPTION
## Summary

The Obsidian community-plugin review flagged a class of unhandled promise rejections that silently swallowed failures. This PR is the first implementation phase of #297:

1. Adds a shared `fireAndForget(promise, label, options)` helper — the convention for the **entire #297 series**.
2. Fixes **every** promise-handling site in `src/main.ts` — **25 total** (23 `no-floating-promises` + 2 `no-misused-promises`).

No view or feature-module files are touched here; those are later PRs in the stack.

## Helper API

`src/shared/fire-and-forget.ts`, exported from the `src/shared` barrel:

```ts
fireAndForget(promise: Promise<unknown>, label: string, options?: {
  notifications?: NotificationManager; // route rejection through notifyError (redacted toast + console log)
  background?: boolean;                // console-only, no user-facing toast
}): void
```

- Preserves fire-and-forget semantics — it never returns the promise, so callers stay non-blocking. It only adds rejection handling.
- On rejection (default path): shows a user-facing `Notice` and logs `console.error('[Synapse] <label> failed', err)`.
- With `notifications`: routes through `NotificationManager.notifyError`, which redacts secrets, shows a styled toast, and logs (used by all user-initiated sites so a leaked API key never reaches the toast/log).
- With `background: true`: logs to the console only — for deliberate background work where a toast would be noise.

Co-located vitest spec (`fire-and-forget.test.ts`, 7 cases) covers: resolves -> no Notice/no error; rejects -> Notice shown + `console.error` with the label; manager path -> `notifyError(label, err)` and no plain Notice; background path -> console-only; and that the rejection never escapes as an unhandled rejection.

## Convention applied across the 25 main.ts sites

- **User-initiated fire-and-forget (21 sites)** — the `enrich` / `checkTitle` / `organizeNote` callback wiring clusters and the ribbon `activateUnifiedView()`: `fireAndForget(<promise>, '<label>', { notifications: this.notifications })`.
- **Deliberate background work (2 sites)** — `workspace.revealLeaf(leaf)` and the `refreshUnifiedView()` deferred task: `fireAndForget(<promise>, '<label>', { background: true })`.
- **`no-misused-promises` (2 sites)** — the `window.setTimeout(... checkForIncompleteCheckpoints ...)` startup timer and the `FolderPickerModal` `fire` callback: wrapped in a sync arrow that does `void` / `fireAndForget`.

Worked from the current code (sibling fixes like #298 already merged: `setTimeout` was already `window.setTimeout`; `revealLeaf` already returns `Promise<void>` in the typings). Only the promise-handling concern was addressed; no prior fixes were undone.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — passes
- [x] `npm test` — 1277 passed across 99 files (includes 7 new fire-and-forget tests)
- [x] `node esbuild.config.mjs production` — build succeeds

## Notes

PR 2 of a stacked series; base = `refactor/issue-271-duration-detector-di`. The ESLint enforcement that turns these into CI-checked rules (`no-floating-promises` / `no-misused-promises`) lands in a later PR (#297 prevention). There is no ESLint config in the repo yet, so this PR was verified by reading the code and with `tsc`.

Part of #297