### PR TITLE
fix: handle promise rejections in module index files + duration-detector reject (#297)

### DIFF
--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -3,7 +3,7 @@ import { SynapseSettings, DeepDiveNestingMode } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
 	NotificationManager, readNote, writeNote, wordCount,
-	CheckpointManager, generateId,
+	CheckpointManager, generateId, fireAndForget,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { ContentAnalyzer, DirectoryMatcher } from '../organize';
@@ -650,7 +650,11 @@ export class DeepDiveModule {
 		for (const task of tasks) {
 			switch (task.type) {
 				case 'refresh-sidebar-view':
-					this.onViewRefreshNeeded?.();
+					if (this.onViewRefreshNeeded) {
+						fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', {
+							background: true,
+						});
+					}
 					break;
 				default:
 					console.warn(`[Synapse] Unknown deferred task type: ${task.type}`);

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -4,6 +4,7 @@ import { CommandRegistrar, isInFlow } from '../commands';
 import {
 	buildCallout, CALLOUT_TYPES, FolderPickerModal, getMarkdownFiles,
 	NotificationManager, sanitizeAIResponse, stripCodeFences, CheckpointManager, generateId,
+	fireAndForget,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { PlaceholderDetector } from './detector';
@@ -56,7 +57,13 @@ export class ElaborationModule {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
 					this.plugin.app,
-					(folder) => this.scanVault(folder.isRoot() ? undefined : folder.path),
+					(folder) => {
+						fireAndForget(
+							this.scanVault(folder.isRoot() ? undefined : folder.path),
+							'Scan vault for stub notes',
+							{ notifications: this.notifications },
+						);
+					},
 					defaultPath
 				).open();
 			},
@@ -78,12 +85,20 @@ export class ElaborationModule {
 
 		const settings = this.getSettings().elaboration;
 		if (settings.scanOnStartup && isInFlow('scan-vault', 'startup')) {
-			this.startupTimeout = window.setTimeout(() => this.scanVault(), 5000);
+			this.startupTimeout = window.setTimeout(() => {
+				fireAndForget(this.scanVault(), 'Scan vault for stub notes', {
+					notifications: this.notifications,
+				});
+			}, 5000);
 		}
 
 		if (settings.autoScanInterval > 0 && isInFlow('scan-vault', 'startup')) {
 			this.scanInterval = window.setInterval(
-				() => this.scanVault(),
+				() => {
+					fireAndForget(this.scanVault(), 'Scan vault for stub notes', {
+						notifications: this.notifications,
+					});
+				},
 				settings.autoScanInterval * 60 * 1000
 			);
 		}
@@ -411,7 +426,11 @@ export class ElaborationModule {
 		for (const task of tasks) {
 			switch (task.type) {
 				case 'refresh-sidebar-view':
-					this.onViewRefreshNeeded?.();
+					if (this.onViewRefreshNeeded) {
+						fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', {
+							background: true,
+						});
+					}
 					break;
 				default:
 					console.warn(`[Synapse] Unknown deferred task type: ${task.type}`);

--- a/src/elaboration/proposal-view.ts
+++ b/src/elaboration/proposal-view.ts
@@ -1,4 +1,5 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
+import { fireAndForget } from '../shared';
 import { Proposal } from './types';
 
 export const PROPOSAL_VIEW_TYPE = 'synapse-proposal-review';
@@ -50,6 +51,19 @@ export class ProposalReviewView extends ItemView {
 		this.render();
 	}
 
+	/**
+	 * Register a synchronous click listener that wraps an async callback in
+	 * {@link fireAndForget}, so a failed accept/reject no longer fails silently.
+	 * The listener returns void (never the callback's promise), which satisfies
+	 * `no-misused-promises`. Mirrors the helper added to the unified view in
+	 * PR3 for the same #297 promise-handling pass.
+	 */
+	private onClick(el: HTMLElement, fn: () => Promise<unknown>, label: string): void {
+		el.addEventListener('click', () => {
+			fireAndForget(fn(), label);
+		});
+	}
+
 	private render(): void {
 		const { contentEl } = this;
 		contentEl.empty();
@@ -97,10 +111,10 @@ export class ProposalReviewView extends ItemView {
 				viewBtn.addEventListener('click', () => this.onDetail(proposal.id));
 
 				const acceptBtn = actions.createEl('button', { text: 'Accept' });
-				acceptBtn.addEventListener('click', () => this.onAccept(proposal.id));
+				this.onClick(acceptBtn, () => this.onAccept(proposal.id), 'Accept proposal');
 
 				const rejectBtn = actions.createEl('button', { text: 'Reject' });
-				rejectBtn.addEventListener('click', () => this.onReject(proposal.id));
+				this.onClick(rejectBtn, () => this.onReject(proposal.id), 'Reject proposal');
 			}
 		}
 	}

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -3,7 +3,7 @@ import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, parseFrontmatter,
-	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent,
+	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent, fireAndForget,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { EnrichmentApplier } from './enrichment-applier';
@@ -89,7 +89,13 @@ export class EnrichmentModule {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
 					this.plugin.app,
-					(folder) => this.scanVault(folder.isRoot() ? undefined : folder.path),
+					(folder) => {
+						fireAndForget(
+							this.scanVault(folder.isRoot() ? undefined : folder.path),
+							'Scan vault for enrichment',
+							{ notifications: this.notifications },
+						);
+					},
 					defaultPath
 				).open();
 			},
@@ -644,7 +650,11 @@ export class EnrichmentModule {
 		for (const task of tasks) {
 			switch (task.type) {
 				case 'refresh-sidebar-view':
-					this.onViewRefreshNeeded?.();
+					if (this.onViewRefreshNeeded) {
+						fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', {
+							background: true,
+						});
+					}
 					break;
 				default:
 					console.warn(`[Synapse] Unknown deferred task type: ${task.type}`);

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -3,7 +3,7 @@ import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder,
-	writeNote, generateOrganizeSummary, CheckpointManager, generateId,
+	writeNote, generateOrganizeSummary, CheckpointManager, generateId, fireAndForget,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import type { MoveRecord } from '../shared';
@@ -72,7 +72,13 @@ export class OrganizeModule {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
 					this.plugin.app,
-					(folder) => this.scanDirectory(folder.isRoot() ? undefined : folder.path),
+					(folder) => {
+						fireAndForget(
+							this.scanDirectory(folder.isRoot() ? undefined : folder.path),
+							'Scan directory for organization',
+							{ notifications: this.notifications },
+						);
+					},
 					defaultPath
 				).open();
 			},
@@ -704,7 +710,11 @@ export class OrganizeModule {
 		for (const task of tasks) {
 			switch (task.type) {
 				case 'refresh-sidebar-view':
-					this.onViewRefreshNeeded?.();
+					if (this.onViewRefreshNeeded) {
+						fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', {
+							background: true,
+						});
+					}
 					break;
 				default:
 					console.warn(`[Synapse] Unknown deferred task type: ${task.type}`);

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -4,7 +4,7 @@ import type { CommandRegistrar } from '../commands';
 import type { NotificationManager, CheckpointManager } from '../shared';
 import type { DeferredTask, CheckpointWorkItem } from '../shared';
 import type { RemProposal, RemLinkCandidate } from './types';
-import { generateId, getMarkdownFiles, FolderPickerModal } from '../shared';
+import { generateId, getMarkdownFiles, FolderPickerModal, fireAndForget } from '../shared';
 import { MentionScanner } from './mention-scanner';
 import { SemanticMatcher } from './semantic-matcher';
 import { RemApplier } from './rem-applier';
@@ -69,7 +69,9 @@ export class RemModule {
 					this.plugin.app,
 					(folder) => {
 						const path = folder.isRoot() ? undefined : folder.path;
-						this.remScanDirectory(path);
+						fireAndForget(this.remScanDirectory(path), 'Discover REM links in directory', {
+							notifications: this.notifications,
+						});
 					}
 				).open();
 			},
@@ -485,7 +487,11 @@ export class RemModule {
 		for (const task of tasks) {
 			switch (task.type) {
 				case 'refresh-sidebar-view':
-					this.onViewRefreshNeeded?.();
+					if (this.onViewRefreshNeeded) {
+						fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', {
+							background: true,
+						});
+					}
 					break;
 				default:
 					console.warn(`[Synapse REM] Unknown deferred task type: ${task.type}`);

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -3,7 +3,7 @@ import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout,
-	CALLOUT_TYPES, CheckpointManager, generateId,
+	CALLOUT_TYPES, CheckpointManager, generateId, fireAndForget,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { OperationHandle } from '../shared';
@@ -111,7 +111,13 @@ export class SummarizeModule {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
 					this.plugin.app,
-					(folder) => this.scanVault(folder.isRoot() ? undefined : folder.path),
+					(folder) => {
+						fireAndForget(
+							this.scanVault(folder.isRoot() ? undefined : folder.path),
+							'Scan vault for notes to summarize',
+							{ notifications: this.notifications },
+						);
+					},
 					defaultPath
 				).open();
 			},

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -132,7 +132,7 @@ export async function detectUrlDuration(
 				['--dump-json', '--no-download', validatedUrl],
 				{ env: shellEnv(), maxBuffer: 10 * 1024 * 1024, timeout: 30_000 },
 				(error, stdout) => {
-					if (error) reject(error);
+					if (error) reject(error instanceof Error ? error : new Error(String(error)));
 					else resolve(stdout);
 				}
 			);


### PR DESCRIPTION
## Summary

Third and final fix phase of #297: handle the remaining dropped promises across the feature-module index files, plus harden the yt-dlp `execFile` rejection in `duration-detector`. Reuses the `fireAndForget(promise, label, options?)` convention established in PR2 (`src/shared/fire-and-forget.ts`) and the private `onClick` helper from PR3's unified view.

Two patterns were fixed:
- **FolderPickerModal callbacks** (and the elaboration startup `setTimeout`/`setInterval` scans) invoked async scan methods from a void-returning position — wrapped so the void position gets a sync function, routing the promise through `fireAndForget` with the module's `NotificationManager` (these are user-initiated).
- **`refresh-sidebar-view` deferred task** floated `onViewRefreshNeeded?.()` in `dispatchDeferredTasks` — now `fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', { background: true })`, guarding the optional call (matches how PR2 handled `refreshUnifiedView` in `main.ts`).

## Sites fixed per file

| File | Sites | Detail |
|------|-------|--------|
| `src/elaboration/index.ts` | 4 | FolderPickerModal callback + `setTimeout` scan + `setInterval` scan + `dispatchDeferredTasks` refresh |
| `src/elaboration/proposal-view.ts` | 2 | Accept + Reject `addEventListener` arrows, via new `onClick` helper (View button returns void, untouched) |
| `src/enrichment/index.ts` | 2 | FolderPickerModal callback + `dispatchDeferredTasks` refresh |
| `src/organize/index.ts` | 2 | FolderPickerModal callback + `dispatchDeferredTasks` refresh |
| `src/rem/index.ts` | 2 | FolderPickerModal/`remScanDirectory` callback + `dispatchDeferredTasks` refresh |
| `src/deep-dive/index.ts` | 1 | `dispatchDeferredTasks` refresh (no FolderPickerModal in this module) |
| `src/summarize/index.ts` | 1 | `scanVault` FolderPickerModal callback |
| `src/transcription/duration-detector.ts` | 1 | `detectUrlDuration` execFile wrapper now rejects with a guaranteed `Error` (`error instanceof Error ? error : new Error(String(error))`) |

**Total: 15 promise sites across 8 files.**

## Convention used
- User-initiated scans: `(folder) => { fireAndForget(this.scanX(...), '<label>', { notifications: this.notifications }); }`
- Background sidebar refresh: `fireAndForget(this.onViewRefreshNeeded(), 'Refresh proposal view', { background: true })` (optional call guarded).
- View click handlers (`proposal-view.ts`): private `onClick(el, fn, label)` helper that registers a sync listener wrapping `fireAndForget(fn(), label)` — identical to PR3's unified view; plain-Notice fallback (no `NotificationManager` in that view).

Behavior preserved — handlers stay non-blocking; rejections now surface.

## Scope discipline
- Did **not** touch the frontmatter `Array.isArray(...)` tag ternaries (later #296 PR).
- Did **not** touch the yt-dlp JSON typing (`data.duration`/`data.title` left untyped) — only the `reject()` Error-wrap.
- Only the 8 listed files changed.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — passes
- [x] `npm test` — 99 files / 1277 tests pass
- [x] `node esbuild.config.mjs production` — build succeeds (exit 0)

Part of #297

---

PR 4 of a stacked series (final #297 fix phase); base = `fix/issue-297-proposal-view-promises`. The ESLint promise-rule enforcement that closes #297 lands in the next PR.

Co-Authored-By: Synapse Bot <bot@wafflenet.io>