### PR TITLE
refactor: type yt-dlp/ffprobe + oEmbed + JSON-LD external data (#296)

### DIFF
--- a/src/shared/content-fetcher.ts
+++ b/src/shared/content-fetcher.ts
@@ -1,5 +1,6 @@
 import { requestUrl } from 'obsidian';
 import { sanitizeUrl } from './validation';
+import { isRecord, parseJson } from './json-utils';
 
 /**
  * Fetch a webpage and extract readable text content.
@@ -69,7 +70,7 @@ export function extractJsonLdRecipes(html: string): RecipeJsonLd[] {
 	while ((match = scriptRegex.exec(html)) !== null) {
 		let parsed: unknown;
 		try {
-			parsed = JSON.parse(match[1]);
+			parsed = parseJson(match[1]);
 		} catch {
 			continue;
 		}
@@ -78,19 +79,18 @@ export function extractJsonLdRecipes(html: string): RecipeJsonLd[] {
 
 		if (Array.isArray(parsed)) {
 			candidates.push(...parsed);
-		} else if (parsed && typeof parsed === 'object') {
-			const obj = parsed as Record<string, unknown>;
-			if (Array.isArray(obj['@graph'])) {
-				candidates.push(...obj['@graph']);
+		} else if (isRecord(parsed)) {
+			const graph = parsed['@graph'];
+			if (Array.isArray(graph)) {
+				candidates.push(...graph);
 			} else {
-				candidates.push(obj);
+				candidates.push(parsed);
 			}
 		}
 
 		for (const candidate of candidates) {
-			if (candidate && typeof candidate === 'object') {
-				const c = candidate as Record<string, unknown>;
-				const type = c['@type'];
+			if (isRecord(candidate)) {
+				const type = candidate['@type'];
 				const isRecipe =
 					type === 'Recipe' ||
 					(Array.isArray(type) && type.includes('Recipe'));

--- a/src/shared/tweet-fetcher.ts
+++ b/src/shared/tweet-fetcher.ts
@@ -2,6 +2,7 @@ import { requestUrl } from 'obsidian';
 import { sanitizeUrl } from './validation';
 import { withRetry } from './api-utils';
 import { detectPlatform } from './url-detector';
+import { isRecord, parseJson } from './json-utils';
 
 const FETCH_TIMEOUT_MS = 30_000;
 
@@ -9,6 +10,49 @@ export interface TweetContent {
 	author: string;
 	text: string;
 	url: string;
+}
+
+/**
+ * Twitter / fxtwitter oEmbed response — an HTML blockquote plus author handle.
+ * Both fields are best-effort: a missing `html` yields empty tweet text and a
+ * missing `author_name` falls back to "Unknown" (see {@link fetchViaOEmbed}),
+ * so neither is required.
+ */
+interface OEmbedResponse {
+	html?: string;
+	author_name?: string;
+}
+
+/**
+ * vxtwitter JSON response — structured `{ user_name, text }`. Both are
+ * best-effort: a missing `user_name` falls back to "Unknown" and a missing
+ * `text` to an empty string (see {@link fetchViaVxTwitter}).
+ */
+interface VxTwitterResponse {
+	user_name?: string;
+	text?: string;
+}
+
+/** Narrow unknown oEmbed JSON, coercing each consumed field to a string. */
+function asOEmbedResponse(value: unknown): OEmbedResponse {
+	if (!isRecord(value)) {
+		return {};
+	}
+	return {
+		html: typeof value.html === 'string' ? value.html : undefined,
+		author_name: typeof value.author_name === 'string' ? value.author_name : undefined,
+	};
+}
+
+/** Narrow unknown vxtwitter JSON, coercing each consumed field to a string. */
+function asVxTwitterResponse(value: unknown): VxTwitterResponse {
+	if (!isRecord(value)) {
+		return {};
+	}
+	return {
+		user_name: typeof value.user_name === 'string' ? value.user_name : undefined,
+		text: typeof value.text === 'string' ? value.text : undefined,
+	};
 }
 
 /**
@@ -80,9 +124,11 @@ async function fetchViaOEmbed(url: string, endpoint: string): Promise<TweetConte
 		timeout,
 	]);
 
-	const data = JSON.parse(response.text);
+	const data = asOEmbedResponse(parseJson(response.text));
 
-	const blockquoteMatch = (data.html as string).match(/<blockquote[^>]*><p[^>]*>([\s\S]*?)<\/p>/);
+	// A missing/non-string `html` yields no match → empty tweet text, instead of
+	// throwing on `.match` of undefined (preserves graceful degradation).
+	const blockquoteMatch = data.html?.match(/<blockquote[^>]*><p[^>]*>([\s\S]*?)<\/p>/);
 	const tweetText = blockquoteMatch
 		? blockquoteMatch[1]
 			.replace(/<br\s*\/?>/g, '\n')
@@ -129,7 +175,7 @@ async function fetchViaVxTwitter(url: string): Promise<TweetContent> {
 		timeout,
 	]);
 
-	const data = JSON.parse(response.text);
+	const data = asVxTwitterResponse(parseJson(response.text));
 
 	const author = data.user_name ? `@${data.user_name}` : 'Unknown';
 	const text = data.text ?? '';

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -1,6 +1,27 @@
 import { Platform, TFile } from 'obsidian';
 import type { SynapseSettings } from '../settings';
-import { sanitizePath, sanitizeUrl } from '../shared';
+import { sanitizePath, sanitizeUrl, isRecord, parseJson } from '../shared';
+
+/**
+ * The subset of yt-dlp `--dump-json` output this detector consumes. Both fields
+ * are optional and best-effort: a missing/non-numeric `duration` yields
+ * `undefined` and a missing `title` falls back to the URL — neither is an error.
+ */
+interface YtDlpDurationJson {
+	duration?: number;
+	title?: string;
+}
+
+/** Narrow unknown yt-dlp output to the duration/title subset (non-object → `null`). */
+function asYtDlpDurationJson(value: unknown): YtDlpDurationJson | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+	return {
+		duration: typeof value.duration === 'number' ? value.duration : undefined,
+		title: typeof value.title === 'string' ? value.title : undefined,
+	};
+}
 
 /**
  * Result of a duration detection attempt.
@@ -138,7 +159,12 @@ export async function detectUrlDuration(
 			);
 		});
 
-		const data = JSON.parse(output);
+		// Parse to `unknown` and narrow before reading. Malformed JSON throws and is
+		// caught below into the `{ durationSeconds: undefined, title: url }`
+		// fallback; a non-object payload yields all-fallback fields — both match the
+		// prior untyped behavior. The guard also drops a non-numeric `duration`
+		// (e.g. "N/A") to undefined while preserving any title.
+		const data = asYtDlpDurationJson(parseJson(output)) ?? {};
 		return {
 			durationSeconds: typeof data.duration === 'number' ? data.duration : undefined,
 			title: data.title || url,

--- a/src/video/audio-extractor.ts
+++ b/src/video/audio-extractor.ts
@@ -1,6 +1,45 @@
 import { SynapseSettings } from '../settings';
 import { ExtractionResult, VideoMetadata } from './types';
-import { sanitizePath, sanitizeUrl, describeNetworkError } from '../shared';
+import { sanitizePath, sanitizeUrl, describeNetworkError, isRecord, parseJson } from '../shared';
+
+/**
+ * The subset of yt-dlp's `--dump-json` output that {@link AudioExtractor}
+ * reads. yt-dlp emits a large, format-dependent object; every field below is
+ * optional and best-effort — a missing field falls back (see
+ * {@link AudioExtractor.getMetadata}), it is never a hard error. Validated with
+ * {@link isRecord} + per-field `typeof` checks before access, so a malformed or
+ * partial payload degrades to the URL/`Untitled` fallback instead of throwing.
+ */
+interface YtDlpDumpJson {
+	title?: string;
+	channel?: string;
+	uploader?: string;
+	duration?: number;
+	upload_date?: string;
+	description?: string;
+	extractor_key?: string;
+}
+
+/**
+ * Narrow unknown yt-dlp output to {@link YtDlpDumpJson}, coercing each consumed
+ * field to its expected primitive type (anything else is dropped to the field's
+ * fallback). Returns `null` only when the top level is not an object, so the
+ * caller can fall back wholesale on malformed output.
+ */
+function asYtDlpDumpJson(value: unknown): YtDlpDumpJson | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+	return {
+		title: typeof value.title === 'string' ? value.title : undefined,
+		channel: typeof value.channel === 'string' ? value.channel : undefined,
+		uploader: typeof value.uploader === 'string' ? value.uploader : undefined,
+		duration: typeof value.duration === 'number' ? value.duration : undefined,
+		upload_date: typeof value.upload_date === 'string' ? value.upload_date : undefined,
+		description: typeof value.description === 'string' ? value.description : undefined,
+		extractor_key: typeof value.extractor_key === 'string' ? value.extractor_key : undefined,
+	};
+}
 
 /**
  * Obsidian's Electron process has a minimal PATH that often excludes
@@ -31,13 +70,17 @@ export class AudioExtractor {
 		execFile: typeof import('child_process')['execFile'];
 	} | null = null;
 
-	private get node() {
+	private get node(): NonNullable<AudioExtractor['_node']> {
 		if (!this._node) {
 			/* eslint-disable @typescript-eslint/no-var-requires -- lazy-load Node builtins at first use so the bundle can load on mobile (isDesktopOnly: false) */
+			// `require` is untyped (returns `any`); cast each module to its
+			// `typeof import(...)` form so member access below (e.g. `.execFile`)
+			// is typed rather than unsafe-any. The require() imports themselves are
+			// deliberately left as-is.
 			this._node = {
-				os: require('os'),
-				path: require('path'),
-				execFile: require('child_process').execFile,
+				os: require('os') as typeof import('os'),
+				path: require('path') as typeof import('path'),
+				execFile: (require('child_process') as typeof import('child_process')).execFile,
 			};
 			/* eslint-enable @typescript-eslint/no-var-requires -- re-enable the rule now that the lazy Node-builtin loads are done */
 		}
@@ -169,7 +212,12 @@ export class AudioExtractor {
 			const output = await this.runCommand(sanitizePath(settings.ytDlpPath), [
 				'--dump-json', '--no-download', url,
 			], 'yt-dlp');
-			const data = JSON.parse(output);
+			// Parse to `unknown` and narrow. A non-object payload yields all-fallback
+			// fields (matching the prior untyped `data.x` reads on a non-object,
+			// which were `undefined`); a thrown SyntaxError on malformed JSON is
+			// swallowed by the surrounding catch into the `{ title: 'Untitled' }`
+			// fallback, exactly as before.
+			const data = asYtDlpDumpJson(parseJson(output)) ?? {};
 			return {
 				title: data.title || 'Untitled',
 				channel: data.channel || data.uploader,


### PR DESCRIPTION
## Summary

Types the **subprocess and web JSON** that was previously property-accessed as `any`. Each payload is now parsed to `unknown` via `parseJson` and narrowed with `isRecord` + per-field `typeof` guards (reused from `shared/json-utils`, added in PR6) before any field access. Interfaces are co-located in their source files — no barrel (`shared/index.ts`) change.

### Interfaces defined (all fields optional / best-effort)
- **`src/video/audio-extractor.ts`** — `YtDlpDumpJson` (`title`, `channel`, `uploader`, `duration`, `upload_date`, `description`, `extractor_key`) via `asYtDlpDumpJson()`. The flagged unsafe-any on the lazy node accessor is resolved by casting each `require(...)` **value** to its `typeof import(...)` form (e.g. `require('child_process') as typeof import('child_process')).execFile`) — the `require()` imports themselves are **not** restructured (separate issue).
- **`src/transcription/duration-detector.ts`** — `YtDlpDurationJson` (`duration`, `title` subset) via `asYtDlpDurationJson()`; the `JSON.parse` is switched to `parseJson` + guard. The PR1 DI (`deps ?? buildRealNodeDeps()`) and the PR4 reject (`error instanceof Error ? error : new Error(String(error))`) are **untouched**.
- **`src/shared/tweet-fetcher.ts`** — `OEmbedResponse` (`html`, `author_name`) and `VxTwitterResponse` (`user_name`, `text`) via `asOEmbedResponse()` / `asVxTwitterResponse()`. The oEmbed `html` access is now `data.html?.match(...)` so a missing/non-string `html` yields empty tweet text instead of throwing.
- **`src/shared/content-fetcher.ts`** — JSON-LD parsed via `parseJson` and narrowed with `isRecord` before spreading `@graph` / pushing candidates (replacing the inline `typeof x === 'object'` casts).

### Fallback contracts preserved
These are **best-effort external metadata**, not hard-required data — unlike the AI-response PR. A missing optional field yields the **existing fallback**, never a new error:
- yt-dlp/ffprobe: missing `title` → URL / `Untitled`; missing or non-numeric `duration` → `undefined`; malformed output still swallowed by the existing `try/catch`.
- oEmbed / vxtwitter: missing `author_name`/`user_name` → `Unknown`; missing `html`/`text` → empty string.
- JSON-LD: malformed script blocks still `continue`; non-Recipe types still skipped.

A non-object top-level payload degrades to all-fallback fields (`?? {}`), matching the prior untyped reads (which returned `undefined` per field on a non-object).

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — exit 0
- [x] `npm run lint` — exit 0 (no rules enabled; intentional `no-var-requires` disable directives retained)
- [x] `npm test` — 100 files / 1294 tests pass (the 4 target test files: 96 tests, **unchanged**)
- [x] `node esbuild.config.mjs production` — exit 0

Part of #296

Note: PR 8 of a stacked series; base = `refactor/issue-296-ai-response-types`.

Co-Authored-By: Synapse Bot <bot@wafflenet.io>