### PR TITLE
refactor: clean up assertions/types and enforce type-safety ESLint rules in CI (#296)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,11 +4,17 @@ import tseslint from 'typescript-eslint';
 /**
  * Flat ESLint config for Synapse.
  *
- * Scope: enforce ONLY the three promise-handling rules that the Obsidian
- * review flagged, with type-aware linting so they cannot regress. The broad
- * `recommendedTypeChecked` preset (and the `no-unsafe-*` family in particular)
- * is intentionally NOT enabled here — those violations are addressed by a
- * separate stack (#296). Adding them now would fail CI.
+ * Scope: enforce the promise-handling rules (#297) AND the type-safety rules
+ * the Obsidian review flagged (#296), with type-aware linting so they cannot
+ * regress. We enable an EXPLICIT list rather than the broad
+ * `recommendedTypeChecked` preset: the preset would surface unrelated rules
+ * (with their own, out-of-scope violations) and balloon the green-gate beyond
+ * what #296/#297 actually fixed.
+ *
+ * The `no-unsafe-*` family and `no-unnecessary-type-assertion` are enforced on
+ * shipped code only; test infrastructure (mocks/factories/`*.test.ts`) is
+ * exempted in a later override block because it relies on intentionally loose
+ * `any`-typed mocks — typing those out is tracked separately in #321.
  *
  * Type-aware rules need type information, supplied via `projectService` +
  * `tsconfigRootDir`. The lint glob (`src/**`) is aligned with the tsconfig's
@@ -49,9 +55,37 @@ export default tseslint.config(
 			},
 		},
 		rules: {
+			// Promise-handling rules (#297).
 			'@typescript-eslint/no-floating-promises': 'error',
 			'@typescript-eslint/no-misused-promises': 'error',
 			'@typescript-eslint/prefer-promise-reject-errors': 'error',
+			// Type-safety rules (#296). The on-disk JSON stores, frontmatter, AI
+			// responses, and external tool output are now narrowed via
+			// `src/shared/json-utils.ts` guards; these rules keep `any` from
+			// silently re-entering through those (and other) boundaries.
+			'@typescript-eslint/no-unsafe-assignment': 'error',
+			'@typescript-eslint/no-unsafe-call': 'error',
+			'@typescript-eslint/no-unsafe-member-access': 'error',
+			'@typescript-eslint/no-unsafe-argument': 'error',
+			'@typescript-eslint/no-unsafe-return': 'error',
+			'@typescript-eslint/no-unnecessary-type-assertion': 'error',
+			'@typescript-eslint/no-duplicate-type-constituents': 'error',
+		},
+	},
+	{
+		// Test infra is exempt from no-unsafe-* / unnecessary-assertion — tracked in #321.
+		// Mocks, factories, and test files lean on deliberately loose `any`-typed
+		// stubs (spy objects, `mockResolvedValue`, the Obsidian DOM mock), so the
+		// type-safety family adds churn without protecting shipped code. The
+		// promise rules and `no-duplicate-type-constituents` stay ON here.
+		files: ['**/*.test.ts', 'src/__mocks__/**', 'src/__test-utils__/**'],
+		rules: {
+			'@typescript-eslint/no-unsafe-assignment': 'off',
+			'@typescript-eslint/no-unsafe-call': 'off',
+			'@typescript-eslint/no-unsafe-member-access': 'off',
+			'@typescript-eslint/no-unsafe-argument': 'off',
+			'@typescript-eslint/no-unsafe-return': 'off',
+			'@typescript-eslint/no-unnecessary-type-assertion': 'off',
 		},
 	},
 );

--- a/src/__test-utils__/mock-factories.ts
+++ b/src/__test-utils__/mock-factories.ts
@@ -10,9 +10,22 @@ export function mockFile(path: string): TFile {
 }
 
 /**
- * Create a mock Obsidian App with spy functions on vault, metadataCache, workspace.
+ * Shape returned by {@link createMockApp}. Naming it (rather than leaning on
+ * inference alone) pins the factory's public contract and gives consumers a
+ * stable, non-`any` type to reference. The members are the spy-backed mock
+ * sub-objects; see the factory body for the concrete spy set.
  */
-export function createMockApp() {
+export interface MockApp {
+	vault: MockVault;
+	metadataCache: MockMetadataCache;
+	workspace: MockWorkspace;
+}
+
+type MockVault = ReturnType<typeof buildMockVault>;
+type MockMetadataCache = ReturnType<typeof buildMockMetadataCache>;
+type MockWorkspace = ReturnType<typeof buildMockWorkspace>;
+
+function buildMockVault() {
 	const adapter = {
 		read: vi.fn().mockResolvedValue(''),
 		write: vi.fn().mockResolvedValue(undefined),
@@ -21,14 +34,20 @@ export function createMockApp() {
 		list: vi.fn().mockResolvedValue({ files: [], folders: [] }),
 	};
 
-	const vault = {
-		read: vi.fn().mockResolvedValue(''),
+	// Hoist `read` so `process` can call it WITHOUT referencing the vault object
+	// inside its own initializer. That self-reference made the vault const infer
+	// as implicit `any` (its type depended on itself); reading through the
+	// hoisted spy breaks the cycle so the vault infers a concrete type.
+	const read = vi.fn<(file: TFile) => Promise<string>>().mockResolvedValue('');
+
+	return {
+		read,
 		modify: vi.fn().mockResolvedValue(undefined),
 		// Mimics Obsidian's atomic read -> transform -> write. The callback is
 		// synchronous and receives the file's fresh content; its return value is
 		// the new content. Returns the new content like the real API.
 		process: vi.fn(async (file: TFile, fn: (data: string) => string) => {
-			const data = await vault.read(file);
+			const data = await read(file);
 			return fn(data);
 		}),
 		create: vi.fn().mockResolvedValue(new TFile()),
@@ -39,20 +58,33 @@ export function createMockApp() {
 		readBinary: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
 		adapter,
 	};
+}
 
-	const metadataCache = {
+function buildMockMetadataCache() {
+	return {
 		getFileCache: vi.fn().mockReturnValue(null),
 		getCache: vi.fn().mockReturnValue(null),
 		getFirstLinkpathDest: vi.fn().mockReturnValue(null),
 	};
+}
 
-	const workspace = {
+function buildMockWorkspace() {
+	return {
 		getLeavesOfType: vi.fn().mockReturnValue([]),
 		getRightLeaf: vi.fn().mockReturnValue(null),
 		revealLeaf: vi.fn(),
 	};
+}
 
-	return { vault, metadataCache, workspace };
+/**
+ * Create a mock Obsidian App with spy functions on vault, metadataCache, workspace.
+ */
+export function createMockApp(): MockApp {
+	return {
+		vault: buildMockVault(),
+		metadataCache: buildMockMetadataCache(),
+		workspace: buildMockWorkspace(),
+	};
 }
 
 /**

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -114,7 +114,7 @@ export class AudioModule {
 					tempPath, timeRange.startSeconds, timeRange.endSeconds
 				);
 
-				data = (await fs.promises.readFile(clippedPath)).buffer as ArrayBuffer;
+				data = (await fs.promises.readFile(clippedPath)).buffer;
 
 				// Clean up temp files
 				try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
@@ -173,7 +173,7 @@ export class AudioModule {
 		const checkpointItems: CheckpointWorkItem[] = embeds.map((e, i) => ({
 			id: `audio-${i}-${e.fileName}`,
 			label: e.fileName,
-			payload: { fileName: e.fileName, line: e.line } as Record<string, unknown>,
+			payload: { fileName: e.fileName, line: e.line },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'audio',
@@ -435,7 +435,7 @@ export class AudioModule {
 			const data = buf.buffer.slice(
 				buf.byteOffset,
 				buf.byteOffset + buf.byteLength
-			) as ArrayBuffer;
+			);
 			return { data, sizeBytes: buf.byteLength };
 		} finally {
 			for (const t of tempInputs) {

--- a/src/audio/transcriber.ts
+++ b/src/audio/transcriber.ts
@@ -147,7 +147,7 @@ export function buildMultipartBody(
 
 	return {
 		contentType: `multipart/form-data; boundary=${boundary}`,
-		body: body.buffer as ArrayBuffer,
+		body: body.buffer,
 	};
 }
 

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -320,7 +320,7 @@ export class DeepDiveModule {
 					topic,
 					depth: 0,
 					ancestorTopics: [file.basename],
-				} as Record<string, unknown>,
+				},
 			}));
 
 		const checkpoint = await this.checkpointManager.create({

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -242,7 +242,7 @@ export class ElaborationModule {
 		const checkpointItems: CheckpointWorkItem[] = detected.map((d, i) => ({
 			id: `elab-${i}-${d.notePath}`,
 			label: d.notePath,
-			payload: { notePath: d.notePath } as Record<string, unknown>,
+			payload: { notePath: d.notePath },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'elaboration',

--- a/src/enrichment/enrichment-modal.ts
+++ b/src/enrichment/enrichment-modal.ts
@@ -139,7 +139,7 @@ export class EnrichmentDetailModal extends Modal {
 			const label = config.getLabel(item);
 
 			const row = section.createDiv({ cls: 'synapse-enrichment-item' });
-			const checkbox = row.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+			const checkbox = row.createEl('input', { type: 'checkbox' });
 			checkbox.checked = config.selectedSet.has(id);
 			checkbox.addEventListener('change', () => {
 				if (checkbox.checked) {

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -266,7 +266,7 @@ export class EnrichmentModule {
 		const checkpointItems: CheckpointWorkItem[] = eligible.map((f, i) => ({
 			id: `enrich-${i}-${f.path}`,
 			label: f.path,
-			payload: { filePath: f.path } as Record<string, unknown>,
+			payload: { filePath: f.path },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'enrichment',

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -89,7 +89,7 @@ export class ImageModule {
 		const checkpointItems: CheckpointWorkItem[] = embeds.map((e, i) => ({
 			id: `image-${i}-${e.fileName}`,
 			label: e.fileName,
-			payload: { fileName: e.fileName, line: e.line } as Record<string, unknown>,
+			payload: { fileName: e.fileName, line: e.line },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'image',

--- a/src/main.ts
+++ b/src/main.ts
@@ -418,11 +418,17 @@ export default class SynapsePlugin extends Plugin {
 	}
 
 	async loadSettings(): Promise<void> {
-		const data = await this.loadData();
+		// `loadData()` returns `any`; narrow it to the persisted-settings shape so
+		// the fresh-install check and merge are type-safe. Persisted data is a
+		// (possibly partial / older-schema) settings object, or null on first run.
+		const data = (await this.loadData()) as Partial<SynapseSettings> | null;
 		// No persisted data (null) or an empty object means this is the plugin's
 		// first run in this vault — used to gate the first-run welcome (#89).
 		this.isFreshInstall = !data || Object.keys(data).length === 0;
-		this.settings = this.deepMerge(DEFAULT_SETTINGS, data || {});
+		// A partial settings object satisfies deepMerge's `Record<string, unknown>`
+		// source param directly — no boundary cast needed. deepMerge itself is
+		// left untouched (its prototype-pollution-safe recursion is out of scope).
+		this.settings = this.deepMerge(DEFAULT_SETTINGS, data ?? {});
 	}
 
 	async saveSettings(): Promise<void> {

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -306,7 +306,7 @@ export class OrganizeModule {
 		const checkpointItems: CheckpointWorkItem[] = eligible.map((f, i) => ({
 			id: `org-${i}-${f.path}`,
 			label: f.path,
-			payload: { filePath: f.path } as Record<string, unknown>,
+			payload: { filePath: f.path },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'organize',

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -173,7 +173,7 @@ export class RemModule {
 		const checkpointItems: CheckpointWorkItem[] = eligible.map((f, i) => ({
 			id: `rem-${i}-${f.path}`,
 			label: f.path,
-			payload: { filePath: f.path } as Record<string, unknown>,
+			payload: { filePath: f.path },
 		}));
 
 		const checkpoint = await this.checkpointManager.create({

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -298,7 +298,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		model: 'gpt-4o',
 		maxTokens: 2048,
 		temperature: 0.7,
-	} as AISettings,
+	},
 	elaboration: {
 		enabled: true,
 		proposalFolderPath: '.synapse/proposals',

--- a/src/shared/ai-client.ts
+++ b/src/shared/ai-client.ts
@@ -130,10 +130,10 @@ interface GeminiResponseJson {
 export function extractGeminiResponseText(json: unknown): string {
 	// `requestUrl().json` is `any`; narrow to the known optional shape before
 	// access. A non-object body simply has no candidates and falls through to
-	// the descriptive "returned no text" error below. The cast is sound: every
-	// field is optional and read via optional chaining, so a mismatch surfaces
-	// as a thrown error rather than an unchecked access.
-	const response: GeminiResponseJson = isRecord(json) ? (json as GeminiResponseJson) : {};
+	// the descriptive "returned no text" error below. The narrowing is sound:
+	// every field is optional and read via optional chaining, so a mismatch
+	// surfaces as a thrown error rather than an unchecked access.
+	const response: GeminiResponseJson = isRecord(json) ? json : {};
 	const candidate = response.candidates?.[0];
 	const parts = candidate?.content?.parts;
 	if (!parts || parts.length === 0) {

--- a/src/shared/collapsible-section.ts
+++ b/src/shared/collapsible-section.ts
@@ -127,7 +127,7 @@ export function addCollapsibleSection(
 		toggleSetting.settingEl.addClass('synapse-accordion-toggle-setting');
 		toggleSetting.addToggle((t) => {
 			toggle = t;
-			t.setValue(enabled as boolean);
+			t.setValue(enabled);
 			t.setTooltip(toggleAriaLabel ?? title);
 			t.onChange(async (value) => {
 				// Toggle drives collapse: ON expands, OFF collapses. Do this

--- a/src/shared/content-fetcher.ts
+++ b/src/shared/content-fetcher.ts
@@ -77,12 +77,17 @@ export function extractJsonLdRecipes(html: string): RecipeJsonLd[] {
 
 		const candidates: unknown[] = [];
 
+		// `Array.isArray` narrows `unknown` to `any[]`, so spreading the result
+		// directly would leak `any` into `candidates`. Type the arrays as
+		// `unknown[]` first; each element is structurally guarded below anyway.
 		if (Array.isArray(parsed)) {
-			candidates.push(...parsed);
+			const arr: unknown[] = parsed;
+			candidates.push(...arr);
 		} else if (isRecord(parsed)) {
 			const graph = parsed['@graph'];
 			if (Array.isArray(graph)) {
-				candidates.push(...graph);
+				const arr: unknown[] = graph;
+				candidates.push(...arr);
 			} else {
 				candidates.push(parsed);
 			}
@@ -95,7 +100,7 @@ export function extractJsonLdRecipes(html: string): RecipeJsonLd[] {
 					type === 'Recipe' ||
 					(Array.isArray(type) && type.includes('Recipe'));
 				if (isRecipe) {
-					recipes.push(candidate as RecipeJsonLd);
+					recipes.push(candidate);
 				}
 			}
 		}

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -737,7 +737,7 @@ export class SummarizeModule {
 		const checkpointItems: CheckpointWorkItem[] = filesWithTargets.map((ft, i) => ({
 			id: `sum-${i}-${ft.file.path}`,
 			label: ft.file.path,
-			payload: { filePath: ft.file.path } as Record<string, unknown>,
+			payload: { filePath: ft.file.path },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'summarize',

--- a/src/transcription/duration-detector.ts
+++ b/src/transcription/duration-detector.ts
@@ -54,11 +54,13 @@ export interface NodeDeps {
  */
 function buildRealNodeDeps(): NodeDeps {
 	/* eslint-disable @typescript-eslint/no-var-requires -- lazy-load Node builtins so the bundle can load on mobile (isDesktopOnly: false) */
+	// Cast each require() value to its module type (matching audio-extractor) so
+	// the untyped `require()` result doesn't leak `any` into NodeDeps.
 	return {
-		os: require('os'),
-		path: require('path'),
-		fs: require('fs'),
-		execFile: require('child_process').execFile,
+		os: require('os') as typeof import('os'),
+		path: require('path') as typeof import('path'),
+		fs: require('fs') as typeof import('fs'),
+		execFile: (require('child_process') as typeof import('child_process')).execFile,
 	};
 	/* eslint-enable @typescript-eslint/no-var-requires -- re-enable now that the lazy Node-builtin loads are done */
 }

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -121,7 +121,7 @@ export class VideoModule {
 		let result;
 		try {
 			result = await this.audioModule.transcribe(
-				audioData.buffer as ArrayBuffer,
+				audioData.buffer,
 				extraction.metadata.title + '.mp3',
 				{ sourceName: extraction.metadata.title }
 			);
@@ -211,7 +211,7 @@ export class VideoModule {
 		const checkpointItems: CheckpointWorkItem[] = embeds.map((e, i) => ({
 			id: `video-${i}-${e.url}`,
 			label: e.url,
-			payload: { url: e.url, line: e.line } as Record<string, unknown>,
+			payload: { url: e.url, line: e.line },
 		}));
 		const checkpoint = await this.checkpointManager.create({
 			module: 'video',
@@ -331,7 +331,7 @@ export class VideoModule {
 		const data = videoData.buffer.slice(
 			videoData.byteOffset,
 			videoData.byteOffset + videoData.byteLength
-		) as ArrayBuffer;
+		);
 		const vaultPath = this.findAvailableVaultPath(
 			normalizePath(`${settings.downloadFolder}/${fileName}`)
 		);

--- a/src/views/types.ts
+++ b/src/views/types.ts
@@ -35,11 +35,17 @@ export type UnifiedItem =
 export type ProposalKind = (typeof PROPOSAL_KINDS)[number];
 
 // Compile-time guard: PROPOSAL_KINDS must cover exactly UnifiedItem['kind'].
-// Both assignments must type-check; if the two ever diverge, this errors.
+// Two separate, distinct assertions (not an intersection — that would make the
+// constituents duplicate, since both conditionals resolve to `true`). Each
+// `const ... : true = ...` fails to type-check if its direction diverges: the
+// first if a UnifiedItem kind is missing from PROPOSAL_KINDS, the second if
+// PROPOSAL_KINDS lists a kind not in UnifiedItem.
 type _AssertKindsCoverUnion = UnifiedItem['kind'] extends ProposalKind ? true : never;
 type _AssertUnionCoversKinds = ProposalKind extends UnifiedItem['kind'] ? true : never;
-const _kindsMatchUnion: _AssertKindsCoverUnion & _AssertUnionCoversKinds = true;
-void _kindsMatchUnion;
+const _kindsCoverUnion: _AssertKindsCoverUnion = true;
+const _unionCoversKinds: _AssertUnionCoversKinds = true;
+void _kindsCoverUnion;
+void _unionCoversKinds;
 
 export interface UnifiedViewCallbacks {
 	// Elaboration

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -266,7 +266,7 @@ export class UnifiedProposalView extends ItemView {
 			case 'organize':
 				return `Organize: ${item.data.sourceNotePath}`;
 			case 'deep-dive':
-				return `Deep Dive: ${(item.data as DeepDiveProposal).topic.title}`;
+				return `Deep Dive: ${item.data.topic.title}`;
 			case 'title':
 				return `Title: ${item.data.sourceNotePath}`;
 			case 'rem':
@@ -1131,7 +1131,7 @@ export class UnifiedProposalView extends ItemView {
 
 			// Checkbox row for this candidate
 			const row = section.createEl('label', { cls: 'synapse-checklist-row' });
-			const checkbox = row.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+			const checkbox = row.createEl('input', { type: 'checkbox' });
 			checkbox.checked = this.selectedRemLinks.has(candidate.matchedText);
 			checkbox.addEventListener('change', () => {
 				if (checkbox.checked) {
@@ -1249,7 +1249,7 @@ export class UnifiedProposalView extends ItemView {
 			const label = config.getLabel(item);
 
 			const row = section.createEl('label', { cls: 'synapse-checklist-row' });
-			const checkbox = row.createEl('input', { type: 'checkbox' }) as HTMLInputElement;
+			const checkbox = row.createEl('input', { type: 'checkbox' });
 			checkbox.checked = config.selectedSet.has(id);
 			checkbox.addEventListener('change', () => {
 				if (checkbox.checked) {


### PR DESCRIPTION
PR 9 of 9 — the **final** PR in the #296 stacked series. **Base = `refactor/issue-296-external-data-types`** (PR8). This PR closes the issue.

closes #296

## What this does
PRs 6-8 typed the JSON stores, frontmatter, AI responses, and external tool output using `src/shared/json-utils.ts` guards. This PR does the remaining mechanical cleanups, then **enables the type-safety ESLint rules in CI** so the typing cannot regress, and drives `npm run lint` to exit 0.

## Part A — production cleanups
- **Removed unnecessary type assertions:**
  - `as ArrayBuffer` on `Buffer.buffer` / `.buffer.slice()` — `audio/index.ts`, `video/index.ts`, `audio/transcriber.ts`.
  - The two `as HTMLInputElement` on `createEl('input', ...)` (typed overload makes them redundant) and the switch-narrowed `as DeepDiveProposal` — `views/unified-proposal-view.ts`. **PR3's `onClick`/`fireAndForget` click-handler code is untouched** (only the 3 assertions changed).
  - The enrichment-modal checkbox `as HTMLInputElement`.
  - `enabled as boolean` — `shared/collapsible-section.ts`.
- **`main.ts` `loadData()`** typed as `Partial<SynapseSettings> | null`; fresh-install `Object.keys` check and the `deepMerge` call are now type-safe (no boundary cast needed). **`deepMerge` itself is left untouched** (separate critical sibling issue); **PR2's promise wiring is undisturbed**.
- **`__test-utils__/mock-factories.ts`** — hoisted a typed `read` spy so the `process` mock no longer references the vault object inside its own initializer (the self-reference made the whole const infer as implicit `any`); gave `createMockApp` an explicit `MockApp` return type.
- **`views/types.ts`** — restructured the compile-time exhaustiveness guard from an intersection of two `true`-resolving constituents (which tripped `no-duplicate-type-constituents`) into two distinct `const _x: true` checks. Verified it still fails if `UnifiedItem['kind']` and `PROPOSAL_KINDS` diverge in **either** direction.

## Part B — enforcement
Enabled as **`error`** (explicit list, **not** `recommendedTypeChecked`, to keep the green-gate scoped to exactly what #296/#297 fixed):
- `@typescript-eslint/no-unsafe-assignment`, `no-unsafe-call`, `no-unsafe-member-access`, `no-unsafe-argument`, `no-unsafe-return`
- `@typescript-eslint/no-unnecessary-type-assertion`
- `@typescript-eslint/no-duplicate-type-constituents`

(The review's "unsafe spread of `any`" finding is reported by `no-unsafe-argument` — "Unsafe spread of an `any[]` array type" — so no separate spread rule is needed; the two content-fetcher spread sites are fixed.) The 3 promise rules (#297) remain active everywhere.

### Test-infra override
Enabling the rules across `src/**` surfaced **~1511 violations in test infrastructure** (67 `*.test.ts` files + the Obsidian mock + factories) from intentionally loose `any`-typed mocks — a category the review never enumerated. Per the agreed split, an override turns the `no-unsafe-*` family + `no-unnecessary-type-assertion` **off** for `['**/*.test.ts', 'src/__mocks__/**', 'src/__test-utils__/**']`; the promise rules and `no-duplicate-type-constituents` stay **on** there. Typing the test infra out is tracked in **#321**.

## Stragglers fixed beyond the enumerated cleanups
After the override, **33 shipped-code errors** remained and are all fixed:
- **~23 redundant `as Record<string, unknown>` casts** on checkpoint `payload` objects added by PRs 6-8 across the module index files (`deep-dive`, `elaboration`, `enrichment`, `image`, `organize`, `rem`, `summarize`, `audio`, `video`), plus stray `as AISettings` (`settings.ts`) and `as GeminiResponseJson` (`ai-client.ts`) — removed (auto-fixed via `eslint --fix`, then each diff reviewed; leftover redundant parens/comments cleaned up).
- **5 genuine `no-unsafe-*`** in `transcription/duration-detector.ts` — cast each lazy `require(...)` **value** to its module type (`require('child_process') as typeof import('child_process')`), matching PR8's audio-extractor pattern (types values without restructuring imports).
- **2 unsafe `any[]` spreads** in `shared/content-fetcher.ts` — `Array.isArray` narrows `unknown`→`any[]`; assign to an explicit `unknown[]` before spreading (each element is structurally guarded downstream).
- The `no-duplicate-type-constituents` error is the `views/types.ts` Part A fix.

**No blanket `eslint-disable` added. No scoped `eslint-disable-next-line` needed — zero false positives.** The only pre-existing `eslint-disable` directives (dormant `no-var-requires` in `duration-detector.ts`) were left exactly as prior PRs set them.

## Pre-flight (all green)
- `npx tsc --noEmit --skipLibCheck` → exit 0
- `npm run lint` → exit 0 (with all 9 rules active)
- `npm test` → 100 files / **1294 tests** passing
- `node esbuild.config.mjs production` → exit 0

CI already runs `npm run lint` (wired in PR5) — no workflow change needed.

Co-Authored-By: Synapse Bot <bot@wafflenet.io>