### PR TITLE
fix: adopt Obsidian API & CSS best practices from review

### DIFF
--- a/src/__test-utils__/setup.ts
+++ b/src/__test-utils__/setup.ts
@@ -29,3 +29,11 @@ if (!Object.getOwnPropertyDescriptor(globalThis, 'activeDocument')) {
 		},
 	});
 }
+
+// `createEl` is Obsidian's global element factory; in the renderer it creates
+// elements on the active document. Mirror that here by delegating to
+// `activeDocument.createElement`, so tests that stub `document.createElement`
+// (e.g. the image-preprocess canvas mocks) continue to intercept transparently.
+if (typeof g.createEl === 'undefined') {
+	g.createEl = (tag: string) => (g.document as Document)?.createElement(tag);
+}

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -527,7 +527,9 @@ export class DeepDiveModule {
 			const sPath = syllabusPath(run.rootNotePath, this.getSettings().deepDive.noteOutputFolder);
 			const existingSyllabus = this.plugin.app.vault.getAbstractFileByPath(normalizePath(sPath));
 			if (existingSyllabus instanceof TFile) {
-				await this.plugin.app.vault.delete(existingSyllabus);
+				// trashFile honors the user's "Deleted files" preference so the
+				// syllabus is recoverable rather than permanently deleted.
+				await this.plugin.app.fileManager.trashFile(existingSyllabus);
 			}
 			return;
 		}

--- a/src/image/preprocess.ts
+++ b/src/image/preprocess.ts
@@ -81,9 +81,11 @@ export async function preprocessImage(
 }
 
 function canUseCanvas(): boolean {
+	// `createEl` is Obsidian's global element factory (creates on the active
+	// document). The image decode path additionally needs createImageBitmap or
+	// the Image constructor; in non-DOM test envs lacking both, degrade.
 	return (
-		typeof activeDocument !== 'undefined' &&
-		typeof activeDocument.createElement === 'function' &&
+		typeof createEl === 'function' &&
 		(typeof createImageBitmap === 'function' || typeof Image !== 'undefined')
 	);
 }
@@ -195,7 +197,10 @@ async function rasterizeToBuffer(
 	outputType: string,
 	quality: number
 ): Promise<ArrayBuffer | null> {
-	const canvas = activeDocument.createElement('canvas');
+	// Obsidian's global createEl returns a typed HTMLCanvasElement. The canvas
+	// is offscreen (never appended), so popout/activeDocument handling (#298) is
+	// unaffected.
+	const canvas = createEl('canvas');
 	canvas.width = width;
 	canvas.height = height;
 

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -1,4 +1,5 @@
-import type { Plugin, TFile } from 'obsidian';
+import type { Plugin } from 'obsidian';
+import { TFile } from 'obsidian';
 import type { SynapseSettings } from '../settings';
 import type { CommandRegistrar } from '../commands';
 import type { NotificationManager, CheckpointManager } from '../shared';
@@ -88,12 +89,12 @@ export class RemModule {
 	async remScanNote(filePath: string): Promise<RemProposal | null> {
 		const settings = this.getSettings().rem;
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
-		if (!file || !('extension' in file)) {
+		if (!(file instanceof TFile)) {
 			this.notifications.info('File not found');
 			return null;
 		}
 
-		const tFile = file as TFile;
+		const tFile = file;
 		if (this.isExcluded(tFile)) {
 			this.notifications.info('Note is excluded from REM scanning');
 			return null;
@@ -282,9 +283,9 @@ export class RemModule {
 				op.progress(i + 1, checkpoint.remainingItems.length, 'Resuming');
 
 				const filePath = item.payload.filePath as string;
-				const file = this.plugin.app.vault.getAbstractFileByPath(filePath) as TFile | null;
+				const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 
-				if (!file) {
+				if (!(file instanceof TFile)) {
 					await this.checkpointManager.completeItem(checkpoint.id, item.id);
 					continue;
 				}
@@ -349,12 +350,12 @@ export class RemModule {
 		if (proposal.status !== 'pending') return;
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
-		if (!file) {
+		if (!(file instanceof TFile)) {
 			this.notifications.info('Source note no longer exists');
 			return;
 		}
 
-		const tFile = file as TFile;
+		const tFile = file;
 
 		// Filter candidates to only accepted ones
 		const accepted = proposal.candidates.filter(
@@ -432,12 +433,12 @@ export class RemModule {
 		const originalContent = proposal.originalContent;
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
-		if (!file) {
+		if (!(file instanceof TFile)) {
 			this.notifications.info('Source note no longer exists');
 			return;
 		}
 
-		const tFile = file as TFile;
+		const tFile = file;
 		await this.plugin.app.vault.process(tFile, () => originalContent);
 
 		// Reset proposal to pending

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -141,6 +141,10 @@ export class SynapseSettingTab extends PluginSettingTab {
 		}
 	}
 
+	// NOTE: Migrating this imperative display() to the declarative
+	// getSettingDefinitions() API is deferred until minAppVersion >= 1.13.0.
+	// The project builds against obsidian 1.7.2, where display() is not
+	// deprecated and getSettingDefinitions does not yet exist.
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();

--- a/src/shared/slider-helper.ts
+++ b/src/shared/slider-helper.ts
@@ -39,8 +39,9 @@ export function defaultFormatValue(value: number): string {
  * Adds an enhanced slider to an Obsidian Setting with min/max labels,
  * a live current-value display, and optional tick marks.
  *
- * This wraps Obsidian's native `addSlider` with extra DOM elements since
- * the built-in SliderComponent only supports `setDynamicTooltip()`.
+ * This wraps Obsidian's native `addSlider` with extra DOM elements. The live
+ * value is shown in an always-visible inline badge (rendered below), so the
+ * built-in hover-only `setDynamicTooltip()` is intentionally not used.
  *
  * @param setting - The Obsidian Setting instance to augment.
  * @param options - Configuration for the slider.
@@ -61,7 +62,7 @@ export function addEnhancedSlider(
 	} = options;
 
 	setting.addSlider((slider: SliderComponent) => {
-		slider.setLimits(min, max, step).setValue(value).setDynamicTooltip();
+		slider.setLimits(min, max, step).setValue(value);
 
 		// Build enhanced wrapper inside the Setting's controlEl.
 		// The slider's sliderEl lives inside controlEl; we wrap it

--- a/src/tidy/tidy-module.test.ts
+++ b/src/tidy/tidy-module.test.ts
@@ -60,12 +60,17 @@ describe('TidyModule', () => {
 			create: vi.fn().mockResolvedValue(new TFile()),
 			createFolder: vi.fn().mockResolvedValue(undefined),
 			getAbstractFileByPath: vi.fn().mockReturnValue(null),
-			delete: vi.fn().mockResolvedValue(undefined),
 			adapter: mockAdapter,
 		};
 
+		// Snapshot cleanup goes through FileManager.trashFile (recoverable),
+		// not vault.delete (permanent).
+		const fileManager: any = {
+			trashFile: vi.fn().mockResolvedValue(undefined),
+		};
+
 		mockPlugin = {
-			app: { vault },
+			app: { vault, fileManager },
 			addCommand: vi.fn(),
 			registerEvent: vi.fn(),
 		};
@@ -288,7 +293,7 @@ describe('TidyModule', () => {
 			await module.onload();
 			await (module as any).undoTidy(file);
 
-			expect(mockPlugin.app.vault.delete).toHaveBeenCalled();
+			expect(mockPlugin.app.fileManager.trashFile).toHaveBeenCalled();
 		});
 	});
 });

--- a/src/tidy/tidy-store.test.ts
+++ b/src/tidy/tidy-store.test.ts
@@ -18,6 +18,7 @@ describe('TidyStore', () => {
 	let store: TidyStore;
 	let mockAdapter: any;
 	let mockVault: any;
+	let mockFileManager: any;
 
 	beforeEach(() => {
 		mockAdapter = {
@@ -30,10 +31,15 @@ describe('TidyStore', () => {
 			createFolder: vi.fn().mockResolvedValue(undefined),
 			getAbstractFileByPath: vi.fn().mockReturnValue(null),
 			read: vi.fn().mockResolvedValue(''),
-			delete: vi.fn().mockResolvedValue(undefined),
 		};
 
-		const app = { vault: mockVault } as any;
+		// remove() trashes via FileManager.trashFile (recoverable) rather than
+		// vault.delete (permanent).
+		mockFileManager = {
+			trashFile: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const app = { vault: mockVault, fileManager: mockFileManager } as any;
 		const getSettings = () => ({ ...DEFAULT_SETTINGS });
 		store = new TidyStore(app, getSettings);
 	});
@@ -103,18 +109,18 @@ describe('TidyStore', () => {
 		expect(loaded).toBeNull();
 	});
 
-	it('removes a snapshot when file exists', async () => {
+	it('trashes a snapshot when file exists', async () => {
 		const mockFile = new TFile('snap.json');
 		mockVault.getAbstractFileByPath.mockReturnValue(mockFile);
 
 		await store.remove('notes/test.md');
-		expect(mockVault.delete).toHaveBeenCalledWith(mockFile);
+		expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
 	});
 
 	it('does nothing when removing a nonexistent snapshot', async () => {
 		mockVault.getAbstractFileByPath.mockReturnValue(null);
 		await store.remove('notes/nonexistent.md');
-		expect(mockVault.delete).not.toHaveBeenCalled();
+		expect(mockFileManager.trashFile).not.toHaveBeenCalled();
 	});
 
 	it('sanitizes slashes in file paths for snapshot filename', async () => {

--- a/src/tidy/tidy-store.ts
+++ b/src/tidy/tidy-store.ts
@@ -1,4 +1,4 @@
-import { App } from 'obsidian';
+import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { ensureFolder } from '../shared';
 import { TidySnapshot } from './types';
@@ -28,16 +28,20 @@ export class TidyStore {
 	async load(filePath: string): Promise<TidySnapshot | null> {
 		const path = this.snapshotPath(filePath);
 		const file = this.app.vault.getAbstractFileByPath(path);
-		if (!file) return null;
-		const content = await this.app.vault.read(file as import('obsidian').TFile);
+		// Bail out if the path resolves to a folder or nothing.
+		if (!(file instanceof TFile)) return null;
+		const content = await this.app.vault.read(file);
 		return JSON.parse(content) as TidySnapshot;
 	}
 
 	async remove(filePath: string): Promise<void> {
 		const path = this.snapshotPath(filePath);
 		const file = this.app.vault.getAbstractFileByPath(path);
-		if (file) {
-			await this.app.vault.delete(file);
+		// Only trash actual files; ignore folders / missing paths. trashFile
+		// respects the user's "Deleted files" preference, so snapshots are
+		// recoverable rather than permanently destroyed.
+		if (file instanceof TFile) {
+			await this.app.fileManager.trashFile(file);
 		}
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -326,9 +326,14 @@
  * ToggleComponent. Strip the Setting's default block layout/border/padding so
  * it sits inline in the header next to the title.
  */
-.synapse-accordion-toggle-setting {
-  border-top: none !important;
-  padding: 0 !important;
+/*
+ * Compound `.setting-item.synapse-accordion-toggle-setting` selector wins on
+ * specificity over Obsidian's `.setting-item` defaults without needing
+ * `!important` (both classes co-occur on the Setting's settingEl).
+ */
+.setting-item.synapse-accordion-toggle-setting {
+  border-top: none;
+  padding: 0;
   margin: 0;
 }
 
@@ -390,16 +395,25 @@
 
 /* ── Notification toasts (severity + tracked operations) ── */
 
-.synapse-notice {
+/*
+ * Compound `.notice.synapse-notice` selector beats core `.notice` padding on
+ * specificity without `!important` (both classes co-occur on the toast el).
+ */
+.notice.synapse-notice {
   border-left: 3px solid var(--text-muted);
-  padding-left: 10px !important;
+  padding-left: 10px;
   transition: border-color 0.3s ease;
 }
-.synapse-notice--info     { border-left-color: var(--text-muted); }
-.synapse-notice--progress { border-left-color: var(--interactive-accent); }
-.synapse-notice--success  { border-left-color: var(--color-green); }
-.synapse-notice--warning  { border-left-color: var(--color-yellow); }
-.synapse-notice--error    { border-left-color: var(--color-red); }
+/*
+ * Severity colors. Compounded with `.notice` so they match the base
+ * `.notice.synapse-notice` specificity (0,2,0) and win on source order —
+ * otherwise the base `border-left` shorthand would override the accent color.
+ */
+.notice.synapse-notice--info     { border-left-color: var(--text-muted); }
+.notice.synapse-notice--progress { border-left-color: var(--interactive-accent); }
+.notice.synapse-notice--success  { border-left-color: var(--color-green); }
+.notice.synapse-notice--warning  { border-left-color: var(--color-yellow); }
+.notice.synapse-notice--error    { border-left-color: var(--color-red); }
 
 /* Running operation layout */
 .synapse-notice-op {
@@ -566,15 +580,20 @@
   font-size: 13px;
   color: var(--text-muted);
 }
+/*
+ * No underline at rest; underline + accent color on hover. We transition only
+ * `color` (text-decoration-color animation has partial support on older
+ * Obsidian/Electron, flagged by the community CSS lint). Loses just the
+ * underline fade-in animation.
+ */
 .synapse-note-link {
   cursor: pointer;
-  text-decoration: underline;
-  text-decoration-color: transparent;
-  transition: text-decoration-color 0.15s, color 0.15s;
+  text-decoration: none;
+  transition: color 0.15s;
 }
 .synapse-note-link:hover {
   color: var(--text-accent);
-  text-decoration-color: var(--text-accent);
+  text-decoration: underline;
 }
 .synapse-empty {
   color: var(--text-muted);


### PR DESCRIPTION
## Summary

Addresses the group of non-blocking Obsidian API & CSS best-practice findings from the community-plugin review (issue #300).

- **`vault.delete()` → `FileManager.trashFile()`** — `src/deep-dive/index.ts` (syllabus removal) and `src/tidy/tidy-store.ts` (snapshot removal) now route deletions through `fileManager.trashFile`, honoring the user's "Deleted files" preference so removed files are recoverable.
- **`as TFile` → `instanceof TFile` narrowing** — replaced the casts in `src/rem/index.ts` (all four sites: `remScanNote`, `resumeFromCheckpoint`, `acceptProposal`, `undoProposal`) and `src/tidy/tidy-store.ts` (`load`). Folders / missing paths now bail out via the existing not-found / early-return path instead of being force-cast. `TFile` is imported as a value where needed.
- **`createElement('canvas')` → `createEl('canvas')`** — `src/image/preprocess.ts` now uses Obsidian's global `createEl` (typed `HTMLCanvasElement`). `canUseCanvas()` is simplified (drops the `activeDocument.createElement` probe; keeps the `createImageBitmap`/`Image` guard). The canvas is offscreen, so the #298 popout/`activeDocument` handling is unaffected.
- **Removed `setDynamicTooltip()`** — `src/shared/slider-helper.ts` drops the redundant hover-only tooltip; the always-visible inline `synapse-slider-current-value` badge already shows the value. The stale doc comment is corrected.
- **Removed `!important`** — `styles.css` now uses compound selectors that win on specificity: `.setting-item.synapse-accordion-toggle-setting` (border-top/padding) and `.notice.synapse-notice` (padding-left). Severity modifiers (`--info`/`--progress`/…) were also compounded with `.notice` so the accent colors still win over the base `border-left` shorthand.
- **`text-decoration` partial-support fix** — `.synapse-note-link` no longer animates `text-decoration-color` (transparent→accent). It now shows no underline at rest and `text-decoration: underline` + accent `color` on hover, transitioning `color` only. Loses only the underline fade-in animation. (minAppVersion was NOT bumped.)

### Deferred (intentional, out of scope)

The **`display()` → `getSettingDefinitions()`** migration is DEFERRED until `minAppVersion >= 1.13.0` — the project builds against obsidian 1.7.2, where `display()` is not deprecated and `getSettingDefinitions` does not exist. A code comment at the `display()` override documents this. `minAppVersion`, the `obsidian` devDependency, `versions.json`, and `manifest.json` are all unchanged.

### Test-mock changes

- Added a global `createEl` to `src/__test-utils__/setup.ts` (delegates to `activeDocument.createElement`) so the image-preprocess canvas mocks keep intercepting transparently.
- Added `fileManager.trashFile` spies to the tidy tests (`tidy-store.test.ts`, `tidy-module.test.ts`), which exercise the trash path; updated those assertions from `vault.delete` to `fileManager.trashFile`.

## CI gates (all green)

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` (1294 tests)
- [x] `node scripts/version-bump.mjs --check` (consistent at 1.0.1; no bump)
- [x] `node esbuild.config.mjs production`

Closes #300

Co-Authored-By: Claude <bot@wafflenet.io>