### PR TITLE
feat: centralized per-path exclusion list (#307)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Open **Settings > Synapse** to configure the plugin. All features can be individ
 | Minimum word threshold | Notes with fewer words are considered stubs | 50 |
 | Detect TODO markers | Flag notes containing TODO, TBD, FIXME, PLACEHOLDER | On |
 | Detect empty sections | Flag notes with headings but no content | On |
-| Excluded folders | Comma-separated folders to skip | `templates, .synapse` |
+| Excluded tags | Notes carrying these tags are skipped | `no-elaborate` |
 
 ### Audio Transcription
 
@@ -224,6 +224,23 @@ Open **Settings > Synapse** to configure the plugin. All features can be individ
 | Nesting mode | Nested, flat, or auto-organize | Nested |
 | Auto-enrich on accept | Trigger enrichment when a note is accepted | On |
 | Auto-organize on accept | Trigger organize when a note is accepted | Off |
+
+### Exclusions
+
+A single, cross-cutting list controls which vault paths Synapse may touch. Each rule names a path pattern and the features it blocks, so you can hide a folder from everything or from just a few flows. Path exclusions live here for every feature; tag exclusions (`Excluded tags`) stay per-feature.
+
+By default, `.synapse/**` (the plugin's own data folder) and `templates/**` are excluded from **all** features — including audio/video transcription, OCR, the intake watcher, and title checks, none of which had folder exclusions before. Existing vaults are migrated automatically on upgrade: folders you had excluded from every module broaden to all features, while a folder you scoped to a single feature stays scoped to it.
+
+| Pattern form | Matches | Example |
+|--------------|---------|---------|
+| `folder/**` | The folder and everything beneath it (not the folder note itself) | `Archive/**` |
+| `folder/*` | Direct children only (not nested subfolders) | `Inbox/*` |
+| `path/to/note.md` | One exact note | `Journal/2026-06-14.md` |
+| `name` (typed by hand) | The folder and all descendants (recursive prefix) | `templates` |
+
+Patterns are vault-relative and **case-sensitive**, and metacharacters such as `.` are matched literally (so `.synapse/**` never matches `Xsynapse/...`). Add a folder with the picker (saved in canonical `folder/**` form) or type an exact path / `folder/*` pattern directly. Per rule, toggle **All features** off to reveal a checkbox for each feature and scope the rule precisely.
+
+When a batch or vault-wide scan hits an excluded note it skips silently; an explicitly invoked single-note command refuses with a notice naming the rule that matched.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ By default, `.synapse/**` (the plugin's own data folder) and `templates/**` are 
 | `path/to/note.md` | One exact note | `Journal/2026-06-14.md` |
 | `name` (typed by hand) | The folder and all descendants (recursive prefix) | `templates` |
 
-Patterns are vault-relative and **case-sensitive**, and metacharacters such as `.` are matched literally (so `.synapse/**` never matches `Xsynapse/...`). Add a folder with the picker (saved in canonical `folder/**` form) or type an exact path / `folder/*` pattern directly. Per rule, toggle **All features** off to reveal a checkbox for each feature and scope the rule precisely.
+Patterns are vault-relative and **case-sensitive**, and metacharacters such as `.` are matched literally (so `.synapse/**` never matches `Xsynapse/...`). Add a folder with the picker (saved in canonical `folder/**` form) or type an exact path / `folder/*` pattern directly, choosing the scope up front. Each rule shows the features it blocks as a row of chips: pick **All features**, or add individual flows from the "+ Add feature" dropdown. Remove a chip (`✕`) to narrow the rule; a rule with no chips is inactive and blocks nothing.
 
 When a batch or vault-wide scan hits an excluded note it skips silently; an explicitly invoked single-note command refuses with a notice naming the rule that matched.
 

--- a/docs/decisions/enrichment-system.md
+++ b/docs/decisions/enrichment-system.md
@@ -177,10 +177,11 @@ This enables:
 | `weights.distantFolder` | number | 0.2 | Proximity weight for distant folders |
 | `weights.decayPerLevel` | number | 0.15 | Weight reduction per folder level |
 | `weights.minimumFloor` | number | 0.1 | Minimum weight (never goes below this) |
-| `excludeFolders` | string[] | ['templates', '.synapse'] | Folders to skip during vault analysis |
 | `excludeTags` | string[] | ['no-enrich'] | Notes with these tags are skipped |
 | `relatedNotesHeading` | string | 'Related Notes' | Heading for the internal links section |
 | `referencesHeading` | string | 'References' | Heading for external references |
+
+> **Path exclusion moved (#307):** the former per-module `excludeFolders` field was removed. Path-based exclusion is now centralized in the top-level `exclusions` list (`src/shared/exclusions.ts`), scoped per feature via `FeatureId`. Enrichment's `isExcluded` delegates to `isPathExcluded(path, 'enrichment', settings)`; REM reuses the same list under `'rem'`. Tag exclusion (`excludeTags`) stays module-level.
 
 **Rationale**: The `max*` and `threshold` settings control output volume. The `weights.*` settings control ranking behavior. Most users will only ever change the max counts; the weight parameters are for users who want to fine-tune scoring for their vault structure.
 

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -269,6 +269,29 @@ export class ToggleComponent {
 	}
 }
 
+/**
+ * Minimal stand-in for Obsidian's ButtonComponent / ExtraButtonComponent —
+ * just the chainable builder surface (`setIcon`, `setButtonText`, `setTooltip`,
+ * `onClick`) the settings UI uses. `_click()` is a test helper to fire onClick.
+ */
+export class ButtonComponent {
+	private clickCb: (() => unknown) | undefined;
+	setIcon = vi.fn().mockReturnThis();
+	setButtonText = vi.fn().mockReturnThis();
+	setTooltip = vi.fn().mockReturnThis();
+	setCta = vi.fn().mockReturnThis();
+	setWarning = vi.fn().mockReturnThis();
+	setDisabled = vi.fn().mockReturnThis();
+	onClick = vi.fn((cb: () => unknown) => {
+		this.clickCb = cb;
+		return this;
+	});
+	/** Test helper: simulate a user clicking the button. */
+	_click(): unknown {
+		return this.clickCb?.();
+	}
+}
+
 export class Setting {
 	settingEl: any = createStubEl();
 	/** Child components created via add*, mirroring Obsidian's `components`. */
@@ -287,7 +310,14 @@ export class Setting {
 		return this;
 	});
 	addSlider = vi.fn().mockReturnThis();
-	addButton = vi.fn().mockReturnThis();
+	addButton = vi.fn(function (this: Setting, cb?: (b: ButtonComponent) => void) {
+		if (cb) cb(new ButtonComponent());
+		return this;
+	});
+	addExtraButton = vi.fn(function (this: Setting, cb?: (b: ButtonComponent) => void) {
+		if (cb) cb(new ButtonComponent());
+		return this;
+	});
 	setClass = vi.fn().mockReturnThis();
 	setDisabled = vi.fn().mockReturnThis();
 }

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -3,6 +3,7 @@ import { SynapseSettings } from '../settings';
 import {
 	NotificationManager, buildCallout, CALLOUT_TYPES, sanitizeAIResponse,
 	CheckpointManager, generateId, formatTimeRange, loadNodeModules,
+	isPathExcluded, findMatchingRule,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask, TimeRange } from '../shared';
 import { AudioEmbed } from './types';
@@ -94,6 +95,16 @@ export class AudioModule {
 			return;
 		}
 
+		// Path exclusion (#307): the transcription lands in the ACTIVE note, so
+		// check that note's path. Explicit command → Notice naming the rule.
+		const rule = findMatchingRule(activeFile.path, 'audio', this.getSettings());
+		if (rule) {
+			this.notifications.info(
+				`Skipped — "${activeFile.path}" is excluded by rule "${rule.pattern}"`
+			);
+			return;
+		}
+
 		const op = this.notifications.startOperation(
 			`Transcribing ${file.name}...`,
 			`audio-${file.path}`
@@ -161,6 +172,9 @@ export class AudioModule {
 		noteFile: TFile,
 		embeds: AudioEmbed[]
 	): Promise<void> {
+		// Path exclusion (#307): batch insert into the note → silent skip.
+		if (isPathExcluded(noteFile.path, 'audio', this.getSettings())) return;
+
 		const total = embeds.length;
 		let completed = 0;
 
@@ -271,6 +285,9 @@ export class AudioModule {
 		noteFile: TFile,
 		embeds: AudioEmbed[]
 	): Promise<void> {
+		// Path exclusion (#307): batch insert into the note → silent skip.
+		if (isPathExcluded(noteFile.path, 'audio', this.getSettings())) return;
+
 		// A single file + combine is just a normal single transcription.
 		if (embeds.length < 2) {
 			await this.transcribeAndInsert(noteFile, embeds);

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -3,7 +3,8 @@ import { SynapseSettings, DeepDiveNestingMode } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
 	NotificationManager, readNote, writeNote, wordCount,
-	CheckpointManager, generateId, fireAndForget, normalizeFrontmatterTags,
+	CheckpointManager, generateId, fireAndForget,
+	isPathExcluded, matchesExcludeTag, findMatchingRule,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { ContentAnalyzer, DirectoryMatcher } from '../organize';
@@ -229,7 +230,12 @@ export class DeepDiveModule {
 	 */
 	private async deepDive(file: TFile): Promise<void> {
 		if (this.isExcluded(file)) {
-			this.notifications.info('Note is in an excluded folder or has an excluded tag');
+			const rule = findMatchingRule(file.path, 'deep-dive', this.getSettings());
+			this.notifications.info(
+				rule
+					? `Skipped — "${file.path}" is excluded by rule "${rule.pattern}"`
+					: 'Note is excluded from deep dive (excluded tag)'
+			);
 			return;
 		}
 
@@ -625,24 +631,11 @@ export class DeepDiveModule {
 	}
 
 	private isExcluded(file: TFile): boolean {
-		const settings = this.getSettings().deepDive;
-
-		for (const folder of settings.excludeFolders) {
-			if (file.path.startsWith(folder + '/')) return true;
-		}
-
-		const cache = this.plugin.app.metadataCache.getFileCache(file);
-		if (cache?.frontmatter?.tags) {
-			const fileTags = normalizeFrontmatterTags(cache.frontmatter.tags);
-			for (const excludeTag of settings.excludeTags) {
-				const normalized = excludeTag.startsWith('#')
-					? excludeTag.slice(1)
-					: excludeTag;
-				if (fileTags.includes(normalized)) return true;
-			}
-		}
-
-		return false;
+		const settings = this.getSettings();
+		return (
+			isPathExcluded(file.path, 'deep-dive', settings) ||
+			matchesExcludeTag(file, settings.deepDive.excludeTags, this.plugin.app.metadataCache)
+		);
 	}
 
 	/** Dispatch deferred tasks (I1). */

--- a/src/deep-dive/settings-section.ts
+++ b/src/deep-dive/settings-section.ts
@@ -127,19 +127,6 @@ export function renderDeepDiveSettings(ctx: SettingsSectionContext): void {
 		);
 
 	new Setting(deepDiveBody)
-		.setName('Excluded folders')
-		.setDesc('Comma-separated list of folders to skip for deep dive')
-		.addText((text) =>
-			text
-				.setValue(plugin.settings.deepDive.excludeFolders.join(', '))
-				.onChange(async (value) => {
-					plugin.settings.deepDive.excludeFolders =
-						value.split(',').map((s) => s.trim()).filter(Boolean);
-					await plugin.saveSettings();
-				})
-		);
-
-	new Setting(deepDiveBody)
 		.setName('Excluded tags')
 		.setDesc('Notes with these tags will skip deep dive')
 		.addText((text) =>

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -72,7 +72,7 @@ interface Proposal {
    |
 2. PlaceholderDetector.detect(file)
    |  Checks: word count, TODO markers, empty sections, sparse links
-   |  Filters: excludeFolders, excludeTags
+   |  Filters: centralized isPathExcluded (feature 'elaboration'), excludeTags
    |  Returns: DetectionResult | null
    |
 3. Two-phase confirmation (vault scan only):

--- a/src/elaboration/detector.ts
+++ b/src/elaboration/detector.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { wordCount, normalizeFrontmatterTags } from '../shared';
+import { wordCount, isPathExcluded, matchesExcludeTag } from '../shared';
 import { DetectionReason, DetectionResult } from './types';
 
 export class PlaceholderDetector {
@@ -51,18 +51,11 @@ export class PlaceholderDetector {
 	}
 
 	private isExcluded(file: TFile): boolean {
-		const settings = this.getSettings().elaboration;
-		for (const folder of settings.detection.excludeFolders) {
-			if (file.path.startsWith(folder + '/')) return true;
-		}
-		const cache = this.app.metadataCache.getFileCache(file);
-		if (cache?.frontmatter?.tags) {
-			const tags = normalizeFrontmatterTags(cache.frontmatter.tags);
-			for (const tag of settings.detection.excludeTags) {
-				if (tags.includes(tag)) return true;
-			}
-		}
-		return false;
+		const settings = this.getSettings();
+		return (
+			isPathExcluded(file.path, 'elaboration', settings) ||
+			matchesExcludeTag(file, settings.elaboration.detection.excludeTags, this.app.metadataCache)
+		);
 	}
 
 	private stripFrontmatter(content: string): string {

--- a/src/elaboration/settings-section.ts
+++ b/src/elaboration/settings-section.ts
@@ -54,17 +54,4 @@ export function renderElaborationSettings(ctx: SettingsSectionContext): void {
 					await plugin.saveSettings();
 				})
 		);
-
-	new Setting(elaborationBody)
-		.setName('Excluded folders')
-		.setDesc('Comma-separated list of folders to skip')
-		.addText((text) =>
-			text
-				.setValue(plugin.settings.elaboration.detection.excludeFolders.join(', '))
-				.onChange(async (value) => {
-					plugin.settings.elaboration.detection.excludeFolders =
-						value.split(',').map((s) => s.trim()).filter(Boolean);
-					await plugin.saveSettings();
-				})
-		);
 }

--- a/src/enrichment/AGENTS.md
+++ b/src/enrichment/AGENTS.md
@@ -87,7 +87,7 @@ interface WeightConfig { sameFolder: number; siblingFolder: number; cousinFolder
 ```
 1. enrich(filePath, trigger) -- triggered by callback or command
    |
-2. Exclusion check: excludeFolders, excludeTags
+2. Exclusion check: centralized isPathExcluded (feature 'enrichment') + excludeTags
    |
 3. Parallel enrichment (enrichFile):
    |  MetadataClassifier.classify() -- vocabulary-based tag classification via AI
@@ -205,7 +205,7 @@ All under `settings.enrichment`:
 | `internalLinkThreshold` | Min relevance score for links |
 | `weights.*` | Proximity weight configuration |
 | `enrichmentFolderPath` | Proposal JSON storage |
-| `excludeFolders` | Folders to skip |
+| `exclusions` (top-level, feature `'enrichment'`) | Paths to skip (centralized) |
 | `excludeTags` | Tags that suppress enrichment |
 | `relatedNotesHeading` | Heading for internal links section |
 | `referencesHeading` | Heading for external refs section |

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -4,6 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, parseFrontmatter,
 	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent, fireAndForget,
+	isPathExcluded, matchesExcludeTag, findMatchingRule,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { EnrichmentApplier } from './enrichment-applier';
@@ -375,8 +376,21 @@ export class EnrichmentModule {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
 
-		// Check exclusions
-		if (this.isExcluded(file)) return;
+		// Check exclusions. enrich() is dual-mode: a silent post-op callback
+		// (elaboration/transcription/summarization/deep-dive) and a manual
+		// command. Only the manual path surfaces a Notice naming the rule; all
+		// other triggers skip silently (#307).
+		if (this.isExcluded(file)) {
+			if (trigger === 'manual') {
+				const rule = findMatchingRule(file.path, 'enrichment', this.getSettings());
+				this.notifications.info(
+					rule
+						? `Skipped — "${file.path}" is excluded by rule "${rule.pattern}"`
+						: 'Note is excluded from enrichment (excluded tag)'
+				);
+			}
+			return;
+		}
 
 		const op = this.notifications.startOperation(
 			`Enriching ${file.basename}`,
@@ -605,23 +619,11 @@ export class EnrichmentModule {
 	}
 
 	private isExcluded(file: TFile): boolean {
-		const settings = this.getSettings().enrichment;
-
-		// Check excluded folders
-		for (const folder of settings.excludeFolders) {
-			if (file.path.startsWith(folder + '/')) return true;
-		}
-
-		// Check excluded tags
-		const tags = this.analyzer.getFileTags(file);
-		for (const excludeTag of settings.excludeTags) {
-			const normalized = excludeTag.startsWith('#')
-				? excludeTag.toLowerCase()
-				: `#${excludeTag.toLowerCase()}`;
-			if (tags.includes(normalized)) return true;
-		}
-
-		return false;
+		const settings = this.getSettings();
+		return (
+			isPathExcluded(file.path, 'enrichment', settings) ||
+			matchesExcludeTag(file, settings.enrichment.excludeTags, this.plugin.app.metadataCache)
+		);
 	}
 
 	private async fetchTwitterContext(urls: string[]): Promise<string> {

--- a/src/enrichment/settings-section.ts
+++ b/src/enrichment/settings-section.ts
@@ -174,19 +174,6 @@ export function renderEnrichmentSettings(ctx: SettingsSectionContext): void {
 	}
 
 	new Setting(enrichmentBody)
-		.setName('Excluded folders')
-		.setDesc('Comma-separated list of folders to skip for enrichment')
-		.addText((text) =>
-			text
-				.setValue(plugin.settings.enrichment.excludeFolders.join(', '))
-				.onChange(async (value) => {
-					plugin.settings.enrichment.excludeFolders =
-						value.split(',').map((s) => s.trim()).filter(Boolean);
-					await plugin.saveSettings();
-				})
-		);
-
-	new Setting(enrichmentBody)
 		.setName('Excluded tags')
 		.setDesc('Notes with these tags will skip enrichment')
 		.addText((text) =>

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -2,7 +2,7 @@ import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import {
 	NotificationManager, buildCallout, CALLOUT_TYPES, sanitizeAIResponse,
-	CheckpointManager, generateId,
+	CheckpointManager, generateId, isPathExcluded, findMatchingRule,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { ImageEmbed } from './types';
@@ -34,6 +34,16 @@ export class ImageModule {
 		const activeFile = this.plugin.app.workspace.getActiveFile();
 		if (!activeFile) {
 			this.notifications.info('Open a note first to insert the OCR result');
+			return;
+		}
+
+		// Path exclusion (#307): OCR lands in the ACTIVE note. Explicit command
+		// → Notice naming the rule.
+		const rule = findMatchingRule(activeFile.path, 'image', this.getSettings());
+		if (rule) {
+			this.notifications.info(
+				`Skipped — "${activeFile.path}" is excluded by rule "${rule.pattern}"`
+			);
 			return;
 		}
 
@@ -77,6 +87,10 @@ export class ImageModule {
 		noteFile: TFile,
 		embeds: ImageEmbed[]
 	): Promise<void> {
+		// Path exclusion (#307): batch OCR into the note → silent skip, checked
+		// once for the whole note (not per embed).
+		if (isPathExcluded(noteFile.path, 'image', this.getSettings())) return;
+
 		const total = embeds.length;
 		let completed = 0;
 

--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -5,6 +5,7 @@ import {
 	NotificationManager,
 	ensureFolder,
 	fetchArticleContent,
+	isPathExcluded,
 	parseFrontmatter,
 	serializeFrontmatter,
 	writeNote,
@@ -114,6 +115,13 @@ export class IntakeModule {
 		}
 
 		if (!this.isInIntakeFolder(file.path, settings.intakeFolder)) {
+			return;
+		}
+
+		// Path exclusion (#307): never auto-process a watched note that an
+		// exclusion rule hides from `intake`. Silent — this is an event-driven
+		// gatekeeper, additive to the capture-log guard above.
+		if (isPathExcluded(file.path, 'intake', this.getSettings())) {
 			return;
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,8 @@ import { CommandRegistrar, auditCommands } from './commands';
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
-import { FolderPickerModal, NotificationManager, CheckpointManager, fireAndForget } from './shared';
-import type { DeferredTask } from './shared';
+import { FolderPickerModal, NotificationManager, CheckpointManager, fireAndForget, buildMigratedExclusions } from './shared';
+import type { DeferredTask, LegacyModuleExclusions } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
 import { findVideoUrls } from './video';
@@ -429,6 +429,28 @@ export default class SynapsePlugin extends Plugin {
 		// source param directly — no boundary cast needed. deepMerge itself is
 		// left untouched (its prototype-pollution-safe recursion is out of scope).
 		this.settings = this.deepMerge(DEFAULT_SETTINGS, data ?? {});
+
+		// One-time migration of the legacy per-module `excludeFolders` lists into
+		// the centralized `exclusions` list (#307). Gated on the RAW persisted
+		// data lacking an `exclusions` key (no settings-version system exists —
+		// that's #93), so it runs exactly once and never re-runs even if the user
+		// later empties the list. Fresh installs already get the default
+		// exclusions from DEFAULT_SETTINGS, so they skip migration entirely.
+		if (!this.isFreshInstall && data && data.exclusions === undefined) {
+			try {
+				// Read legacy folders off the raw object via a narrow read type
+				// (the fields no longer exist on SynapseSettings).
+				const migrated = buildMigratedExclusions(data as LegacyModuleExclusions);
+				// Atomic assign of the fully-built list, then persist so the
+				// `exclusions` key is present on the next load.
+				this.settings.exclusions = migrated;
+				await this.saveData(this.settings);
+			} catch (error) {
+				// Swallow-and-warn (mirrors migrateDataFolder): on failure keep the
+				// merged default exclusions rather than breaking load.
+				console.warn('[Synapse] Failed to migrate excludeFolders to exclusions:', error);
+			}
+		}
 	}
 
 	async saveSettings(): Promise<void> {

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder,
 	writeNote, generateOrganizeSummary, CheckpointManager, generateId, fireAndForget,
-	normalizeFrontmatterTags,
+	isPathExcluded, matchesExcludeTag, findMatchingRule,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import type { MoveRecord } from '../shared';
@@ -200,7 +200,12 @@ export class OrganizeModule {
 	 */
 	async organizeNote(file: TFile): Promise<OrganizeResult | null> {
 		if (this.isExcluded(file)) {
-			this.notifications.info('Note is in an excluded folder or has an excluded tag');
+			const rule = findMatchingRule(file.path, 'organize', this.getSettings());
+			this.notifications.info(
+				rule
+					? `Skipped — "${file.path}" is excluded by rule "${rule.pattern}"`
+					: 'Note is excluded from organize (excluded tag)'
+			);
 			return null;
 		}
 
@@ -645,24 +650,11 @@ export class OrganizeModule {
 	}
 
 	private isExcluded(file: TFile): boolean {
-		const settings = this.getSettings().organize;
-
-		for (const folder of settings.excludeFolders) {
-			if (file.path.startsWith(folder + '/')) return true;
-		}
-
-		const cache = this.plugin.app.metadataCache.getFileCache(file);
-		if (cache?.frontmatter?.tags) {
-			const fileTags = normalizeFrontmatterTags(cache.frontmatter.tags);
-			for (const excludeTag of settings.excludeTags) {
-				const normalized = excludeTag.startsWith('#')
-					? excludeTag.slice(1)
-					: excludeTag;
-				if (fileTags.includes(normalized)) return true;
-			}
-		}
-
-		return false;
+		const settings = this.getSettings();
+		return (
+			isPathExcluded(file.path, 'organize', settings) ||
+			matchesExcludeTag(file, settings.organize.excludeTags, this.plugin.app.metadataCache)
+		);
 	}
 
 	private getParentPath(filePath: string): string {

--- a/src/organize/settings-section.ts
+++ b/src/organize/settings-section.ts
@@ -34,19 +34,6 @@ export function renderOrganizeSettings(ctx: SettingsSectionContext): void {
 	);
 
 	new Setting(organizeBody)
-		.setName('Excluded folders')
-		.setDesc('Comma-separated list of folders to skip for organization')
-		.addText((text) =>
-			text
-				.setValue(plugin.settings.organize.excludeFolders.join(', '))
-				.onChange(async (value) => {
-					plugin.settings.organize.excludeFolders =
-						value.split(',').map((s) => s.trim()).filter(Boolean);
-					await plugin.saveSettings();
-				})
-		);
-
-	new Setting(organizeBody)
 		.setName('Excluded tags')
 		.setDesc('Notes with these tags will skip organization')
 		.addText((text) =>

--- a/src/rem/AGENTS.md
+++ b/src/rem/AGENTS.md
@@ -79,7 +79,7 @@ interface RemSettings {
 
 ```
 remScanNote(path) / remScanDirectory(folder?, skip?, onlyFile?)
-  --> isExcluded? (reuses enrichment.excludeFolders / excludeTags)
+  --> isExcluded? (centralized isPathExcluded under 'rem' + reuses enrichment.excludeTags)
   --> MentionScanner.scan(file, content, maxLinksPerNote)            // literal candidates
   --> if semanticMatching: SemanticMatcher.match(...) filtered by confidenceThreshold
   --> RemProposal { candidates, status: 'pending' } --> RemStore.save
@@ -119,6 +119,6 @@ generated proposal is accepted in full as generated. NOTE: REM auto-accept REWRI
 |--------|------|
 | `NotificationManager`, `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask`, `generateId`, `getMarkdownFiles`, `FolderPickerModal` | `../shared` |
 | `CommandRegistrar` | `../commands` |
-| `enrichment.excludeFolders` / `excludeTags` (settings) | reused for exclusion |
+| `isPathExcluded` (centralized, feature `'rem'`) / `enrichment.excludeTags` (settings) | path + tag exclusion |
 
 Exclusion rules reuse the enrichment settings rather than defining REM-specific ones.

--- a/src/rem/index.test.ts
+++ b/src/rem/index.test.ts
@@ -109,13 +109,15 @@ describe('RemModule', () => {
 		});
 
 		it('returns null when the note is in an excluded folder', async () => {
-			settings.enrichment.excludeFolders = ['Archive'];
+			settings.exclusions = [{ pattern: 'Archive/**', features: ['rem'] }];
 			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('Archive/Old.md'));
 			const module = await loadedModule();
 
 			const result = await module.remScanNote('Archive/Old.md');
 			expect(result).toBeNull();
-			expect(notifications.info).toHaveBeenCalledWith('Note is excluded from REM scanning');
+			expect(notifications.info).toHaveBeenCalledWith(
+				'Skipped — "Archive/Old.md" is excluded by rule "Archive/**"'
+			);
 		});
 
 		it('saves a proposal built from literal mention candidates', async () => {
@@ -372,7 +374,9 @@ describe('RemModule', () => {
 
 			const result = await module.remScanNote('notes/Secret.md');
 			expect(result).toBeNull();
-			expect(notifications.info).toHaveBeenCalledWith('Note is excluded from REM scanning');
+			expect(notifications.info).toHaveBeenCalledWith(
+				'Note is excluded from REM scanning (excluded tag)'
+			);
 		});
 	});
 });

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -5,7 +5,7 @@ import type { CommandRegistrar } from '../commands';
 import type { NotificationManager, CheckpointManager } from '../shared';
 import type { DeferredTask, CheckpointWorkItem } from '../shared';
 import type { RemProposal, RemLinkCandidate } from './types';
-import { generateId, getMarkdownFiles, FolderPickerModal, fireAndForget, normalizeFrontmatterTags } from '../shared';
+import { generateId, getMarkdownFiles, FolderPickerModal, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule } from '../shared';
 import { MentionScanner } from './mention-scanner';
 import { SemanticMatcher } from './semantic-matcher';
 import { RemApplier } from './rem-applier';
@@ -96,7 +96,12 @@ export class RemModule {
 
 		const tFile = file;
 		if (this.isExcluded(tFile)) {
-			this.notifications.info('Note is excluded from REM scanning');
+			const rule = findMatchingRule(tFile.path, 'rem', this.getSettings());
+			this.notifications.info(
+				rule
+					? `Skipped — "${tFile.path}" is excluded by rule "${rule.pattern}"`
+					: 'Note is excluded from REM scanning (excluded tag)'
+			);
 			return null;
 		}
 
@@ -290,6 +295,14 @@ export class RemModule {
 					continue;
 				}
 
+				// Re-check exclusions on resume (#307): a path may have been added
+				// to the exclusion list after the checkpoint was created. Silent —
+				// resume is a batch continuation, mirroring organize's resume.
+				if (this.isExcluded(file)) {
+					await this.checkpointManager.completeItem(checkpoint.id, item.id);
+					continue;
+				}
+
 				const content = await this.plugin.app.vault.read(file);
 				const candidates = this.scanner.scan(file, content, settings.maxLinksPerNote);
 
@@ -456,26 +469,16 @@ export class RemModule {
 	}
 
 	/**
-	 * Check if a file is excluded from REM scanning.
-	 * Reuses enrichment exclude-folder and exclude-tag settings.
+	 * Check if a file is excluded from REM scanning. Path exclusion is
+	 * centralized (#307) under the `rem` feature; tag exclusion still reuses
+	 * enrichment's `excludeTags` (REM has no exclude-tag setting of its own).
 	 */
 	private isExcluded(file: TFile): boolean {
-		const enrichmentSettings = this.getSettings().enrichment;
-
-		for (const folder of enrichmentSettings.excludeFolders) {
-			if (file.path.startsWith(folder + '/') || file.path === folder) return true;
-		}
-
-		const cache = this.plugin.app.metadataCache.getFileCache(file);
-		if (cache?.frontmatter?.tags) {
-			const tags = normalizeFrontmatterTags(cache.frontmatter.tags);
-			for (const excludeTag of enrichmentSettings.excludeTags) {
-				const normalized = excludeTag.replace(/^#/, '');
-				if (tags.some(t => t.replace(/^#/, '') === normalized)) return true;
-			}
-		}
-
-		return false;
+		const settings = this.getSettings();
+		return (
+			isPathExcluded(file.path, 'rem', settings) ||
+			matchesExcludeTag(file, settings.enrichment.excludeTags, this.plugin.app.metadataCache)
+		);
 	}
 
 	private async refreshView(): Promise<void> {

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -160,3 +160,92 @@ describe('SynapseSettingTab — About support links (#274)', () => {
 		);
 	});
 });
+
+/** Recursively collect every element in a stub tree. */
+function walkEls(el: any, out: any[] = []): any[] {
+	for (const child of el?.children ?? []) {
+		out.push(child);
+		walkEls(child, out);
+	}
+	return out;
+}
+function elsWithClass(root: any, cls: string): any[] {
+	return walkEls(root).filter((e) => e.classList?.contains(cls));
+}
+function elsWithTag(root: any, tag: string): any[] {
+	return walkEls(root).filter((e) => e.tagName === tag);
+}
+
+describe('SynapseSettingTab — Exclusions chip multi-select (#328)', () => {
+	/**
+	 * The `synapse-exclusion-chips` containers in DOM order: one per rule, then the
+	 * add-folder and add-pattern scope pickers. (The mocked `Setting` rows are not
+	 * appended to the container, so only these chip divs are introspectable.)
+	 */
+	function chipContainers(tab: SynapseSettingTab): any[] {
+		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+		return elsWithClass(containerEl, 'synapse-exclusion-chips');
+	}
+	const chipLabels = (container: any): string[] =>
+		elsWithClass(container, 'synapse-chip-label').map((e) => e.textContent);
+
+	it('renders one removable chip per scoped feature, ordered by FEATURE_ORDER', () => {
+		const { tab } = makeTab((s) => {
+			s.exclusions = [{ pattern: 'Archive/**', features: ['organize', 'summarize'] }];
+		});
+		tab.display();
+
+		const containers = chipContainers(tab);
+		expect(containers).toHaveLength(3); // rule + add-folder + add-pattern
+		expect(chipLabels(containers[0])).toEqual(['Summarize', 'Organize']);
+	});
+
+	it("renders a single 'All features' chip for an all-scoped rule", () => {
+		const { tab } = makeTab((s) => {
+			s.exclusions = [{ pattern: '.synapse/**', features: 'all' }];
+		});
+		tab.display();
+		expect(chipLabels(chipContainers(tab)[0])).toEqual(['All features']);
+	});
+
+	it('adds a feature to a rule via its dropdown and persists', () => {
+		const { tab, plugin } = makeTab((s) => {
+			s.exclusions = [{ pattern: 'Archive/**', features: ['organize'] }];
+		});
+		tab.display();
+
+		const select = elsWithTag(chipContainers(tab)[0], 'SELECT')[0];
+		select.value = 'summarize';
+		select.dispatchEvent({ type: 'change' });
+
+		expect(plugin.settings.exclusions[0].features).toEqual(['summarize', 'organize']);
+		expect(plugin.saveSettings).toHaveBeenCalled();
+	});
+
+	it('removes a feature from a rule via its chip and persists', () => {
+		const { tab, plugin } = makeTab((s) => {
+			s.exclusions = [{ pattern: 'Archive/**', features: ['summarize', 'organize'] }];
+		});
+		tab.display();
+
+		const removeBtn = elsWithClass(chipContainers(tab)[0], 'synapse-chip-remove').find(
+			(b) => b.getAttribute('aria-label') === 'Remove Organize',
+		);
+		removeBtn.dispatchEvent({ type: 'click' });
+
+		expect(plugin.settings.exclusions[0].features).toEqual(['summarize']);
+		expect(plugin.saveSettings).toHaveBeenCalled();
+	});
+
+	it('gives the add rows a scope picker defaulting to "All features"', () => {
+		const { tab } = makeTab((s) => {
+			s.exclusions = [];
+		});
+		tab.display();
+
+		// No rules → the only chip containers are the two add-row pickers.
+		const containers = chipContainers(tab);
+		expect(containers).toHaveLength(2);
+		for (const c of containers) expect(chipLabels(c)).toEqual(['All features']);
+	});
+});

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -7,6 +7,7 @@ import {
 	createSettingsSectionContext,
 	FolderPickerModal,
 	ALL_FEATURE_IDS,
+	renderFeatureChipSelect,
 } from './shared';
 import type { SettingsSectionContext, FeatureId, ExclusionRule } from './shared';
 import { PROPOSAL_KINDS } from './views';
@@ -387,11 +388,13 @@ export class SynapseSettingTab extends PluginSettingTab {
 	/**
 	 * Exclusions — a cross-cutting list of vault paths hidden from some or all
 	 * Synapse flows (#307). Top-level (not per-feature): the single source of
-	 * truth for path-based exclusion. Each rule shows its glob pattern, an "All
-	 * features" toggle that reveals 12 per-feature checkboxes when off, and a
-	 * remove button. New rules are added via a folder picker (canonicalized to
-	 * `<folder>/**`) or a free-text pattern (exact paths, `dir/*`). Layout
-	 * changes re-render the whole tab via `ctx.rerender`.
+	 * truth for path-based exclusion. Each rule shows its glob pattern, a remove
+	 * button, and a chip multi-select for its feature scope (#328 — replaced the
+	 * "All features" toggle + 12 per-feature checkboxes). New rules are added via a
+	 * folder picker (canonicalized to `<folder>/**`) or a free-text pattern (exact
+	 * paths, `dir/*`), with their scope chosen up front. Adding or removing a whole
+	 * rule re-renders the tab via `ctx.rerender`; editing a scope self-redraws only
+	 * its chip row.
 	 */
 	private renderExclusions(ctx: SettingsSectionContext): void {
 		const body = ctx.configSection('exclusions', 'Exclusions');
@@ -418,9 +421,15 @@ export class SynapseSettingTab extends PluginSettingTab {
 		});
 
 		// ── Add controls ──
+		// Each add row carries an up-front scope picker (the chips below it). The
+		// chosen scope is read when the rule is created, so the user no longer has
+		// to add as "all" and narrow afterward. Scope edits update the pending
+		// value and self-redraw their own chip container — they must NOT re-render
+		// the tab (that would wipe the "Add a pattern" text input mid-entry).
+		let pendingFolderScope: 'all' | FeatureId[] = 'all';
 		new Setting(body)
 			.setName('Add a folder')
-			.setDesc('Pick a folder to exclude (saved as "folder/**").')
+			.setDesc('Pick a folder to exclude (saved as "folder/**"). The chips below set which features it is excluded from.')
 			.addButton((btn) =>
 				btn
 					.setButtonText('Choose folder')
@@ -429,17 +438,26 @@ export class SynapseSettingTab extends PluginSettingTab {
 							const pattern = folder.isRoot() ? '/**' : `${folder.path}/**`;
 							// Skip exact duplicates so a re-pick doesn't stack rules.
 							if (!this.plugin.settings.exclusions.some((r) => r.pattern === pattern)) {
-								this.plugin.settings.exclusions.push({ pattern, features: 'all' });
+								this.plugin.settings.exclusions.push({ pattern, features: pendingFolderScope });
 							}
 							void this.plugin.saveSettings().then(() => ctx.rerender());
 						}).open();
 					})
 			);
+		renderFeatureChipSelect(body.createDiv({ cls: 'synapse-exclusion-chips' }), {
+			value: pendingFolderScope,
+			labels: FEATURE_LABELS,
+			order: FEATURE_ORDER,
+			onChange: (next) => {
+				pendingFolderScope = next;
+			},
+		});
 
 		let pendingPattern = '';
+		let pendingPatternScope: 'all' | FeatureId[] = 'all';
 		new Setting(body)
 			.setName('Add a pattern')
-			.setDesc('For exact note paths or direct-children globs (e.g. "Inbox/*").')
+			.setDesc('For exact note paths or direct-children globs (e.g. "Inbox/*"). The chips below set which features it is excluded from.')
 			.addText((text) =>
 				text
 					.setPlaceholder('path/to/note.md or folder/*')
@@ -454,17 +472,27 @@ export class SynapseSettingTab extends PluginSettingTab {
 						const pattern = pendingPattern.trim();
 						if (!pattern) return;
 						if (!this.plugin.settings.exclusions.some((r) => r.pattern === pattern)) {
-							this.plugin.settings.exclusions.push({ pattern, features: 'all' });
+							this.plugin.settings.exclusions.push({ pattern, features: pendingPatternScope });
 						}
 						void this.plugin.saveSettings().then(() => ctx.rerender());
 					})
 			);
+		renderFeatureChipSelect(body.createDiv({ cls: 'synapse-exclusion-chips' }), {
+			value: pendingPatternScope,
+			labels: FEATURE_LABELS,
+			order: FEATURE_ORDER,
+			onChange: (next) => {
+				pendingPatternScope = next;
+			},
+		});
 	}
 
 	/**
-	 * Render a single exclusion rule row plus, when it is feature-scoped, the
-	 * grid of per-feature checkboxes. Toggling "All features" or removing the
-	 * rule mutates settings, persists, and re-renders the tab.
+	 * Render a single exclusion rule row: the pattern name, a remove button, and a
+	 * chip multi-select for the rule's feature scope (#328). The chip control owns
+	 * the `'all' | FeatureId[]` value (incl. the `'all'` shorthand and the empty =
+	 * "rule inactive" case); editing it persists and self-redraws, so only removing
+	 * the rule re-renders the tab.
 	 */
 	private renderExclusionRule(
 		ctx: SettingsSectionContext,
@@ -472,64 +500,27 @@ export class SynapseSettingTab extends PluginSettingTab {
 		rule: ExclusionRule,
 		index: number,
 	): void {
-		const features = rule.features;
-		const isAll = features === 'all';
-		const setting = new Setting(body)
+		new Setting(body)
 			.setName(rule.pattern || '(empty pattern)')
-			.setDesc(
-				features === 'all'
-					? 'Excluded from all features'
-					: `Excluded from: ${this.describeScopedFeatures(features)}`,
-			);
-
-		setting.addToggle((toggle) =>
-			toggle
-				.setTooltip('All features')
-				.setValue(isAll)
-				.onChange((value) => {
-					// Switching to scoped seeds an empty list (user then ticks the
-					// features); switching to all collapses to the literal 'all'.
-					this.plugin.settings.exclusions[index].features = value ? 'all' : [];
-					void this.plugin.saveSettings().then(() => ctx.rerender());
-				}),
-		);
-
-		setting.addExtraButton((btn) =>
-			btn
-				.setIcon('trash')
-				.setTooltip('Remove exclusion')
-				.onClick(() => {
-					this.plugin.settings.exclusions.splice(index, 1);
-					void this.plugin.saveSettings().then(() => ctx.rerender());
-				}),
-		);
-
-		if (isAll) return;
-
-		// Per-feature checkboxes (rendered only for a scoped rule).
-		const scoped = rule.features as FeatureId[];
-		for (const feature of FEATURE_ORDER) {
-			new Setting(body)
-				.setClass('synapse-exclusion-feature-row')
-				.setName(FEATURE_LABELS[feature])
-				.addToggle((toggle) =>
-					toggle.setValue(scoped.includes(feature)).onChange((value) => {
-						const current = this.plugin.settings.exclusions[index].features;
-						if (current === 'all') return; // defensive: shape changed underneath
-						const next = new Set(current);
-						if (value) next.add(feature);
-						else next.delete(feature);
-						this.plugin.settings.exclusions[index].features = [...next];
+			.addExtraButton((btn) =>
+				btn
+					.setIcon('trash')
+					.setTooltip('Remove exclusion')
+					.onClick(() => {
+						this.plugin.settings.exclusions.splice(index, 1);
 						void this.plugin.saveSettings().then(() => ctx.rerender());
 					}),
-				);
-		}
-	}
+			);
 
-	/** Human-readable list of the features a scoped rule blocks. */
-	private describeScopedFeatures(features: FeatureId[]): string {
-		if (features.length === 0) return 'no features (rule inactive)';
-		return features.map((f) => FEATURE_LABELS[f]).join(', ');
+		renderFeatureChipSelect(body.createDiv({ cls: 'synapse-exclusion-chips' }), {
+			value: rule.features,
+			labels: FEATURE_LABELS,
+			order: FEATURE_ORDER,
+			onChange: (next) => {
+				this.plugin.settings.exclusions[index].features = next;
+				void this.plugin.saveSettings();
+			},
+		});
 	}
 
 	/**

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -190,6 +190,12 @@ export class SynapseSettingTab extends PluginSettingTab {
 		// ── AI Configuration (always-needed config — no enable toggle) ──
 		this.renderAIConfiguration(ctx);
 
+		// ── Auto-Accept Proposals (global, non-feature) ──
+		this.renderAutoAccept(ctx);
+
+		// ── Exclusions (global, cross-cutting path exclusion list) ──
+		this.renderExclusions(ctx);
+
 		// ── Per-feature sections, in order (Video gated to desktop) ──
 		for (const render of FEATURE_SECTION_RENDERERS) {
 			render(ctx);
@@ -199,12 +205,6 @@ export class SynapseSettingTab extends PluginSettingTab {
 				renderVideoSettings(ctx);
 			}
 		}
-
-		// ── Auto-Accept Proposals (global, non-feature) ──
-		this.renderAutoAccept(ctx);
-
-		// ── Exclusions (global, cross-cutting path exclusion list) ──
-		this.renderExclusions(ctx);
 
 		// ── About (static support links, always last) ──
 		this.renderAbout(ctx);

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -5,8 +5,10 @@ import type { AIProvider } from './settings';
 import {
 	addEnhancedSlider,
 	createSettingsSectionContext,
+	FolderPickerModal,
+	ALL_FEATURE_IDS,
 } from './shared';
-import type { SettingsSectionContext } from './shared';
+import type { SettingsSectionContext, FeatureId, ExclusionRule } from './shared';
 import { PROPOSAL_KINDS } from './views';
 import type { ProposalKind } from './views';
 import { renderElaborationSettings } from './elaboration';
@@ -53,6 +55,30 @@ const AUTO_ACCEPT_LABELS: Record<ProposalKind, { name: string; desc: string }> =
 		desc: 'Caution: rewrites note body text. Automatically insert all discovered [[wikilinks]] without review.',
 	},
 };
+
+/**
+ * Display labels for every {@link FeatureId}, shown as the per-feature checkbox
+ * labels in the Exclusions section (#307). Keyed by the canonical feature set so
+ * a new {@link FeatureId} forces an entry here. The render order is
+ * {@link FEATURE_ORDER}.
+ */
+const FEATURE_LABELS: Record<FeatureId, string> = {
+	elaboration: 'Elaboration',
+	enrichment: 'Enrichment',
+	summarize: 'Summarize',
+	tidy: 'Tidy',
+	organize: 'Organize',
+	'deep-dive': 'Deep dive',
+	audio: 'Audio transcription',
+	video: 'Video transcription',
+	title: 'Title',
+	image: 'Image OCR',
+	rem: 'REM (link discovery)',
+	intake: 'Intake watcher',
+};
+
+/** Stable display order for the per-feature exclusion checkboxes. */
+const FEATURE_ORDER = Object.keys(ALL_FEATURE_IDS) as FeatureId[];
 
 /**
  * The ordered list of per-feature section renderers (#243). Video is gated
@@ -175,6 +201,9 @@ export class SynapseSettingTab extends PluginSettingTab {
 
 		// ── Auto-Accept Proposals (global, non-feature) ──
 		this.renderAutoAccept(ctx);
+
+		// ── Exclusions (global, cross-cutting path exclusion list) ──
+		this.renderExclusions(ctx);
 
 		// ── About (static support links, always last) ──
 		this.renderAbout(ctx);
@@ -353,6 +382,154 @@ export class SynapseSettingTab extends PluginSettingTab {
 			setting.setDisabled(!this.isFeatureEnabled(kind));
 			this.autoAcceptSettings[kind] = setting;
 		}
+	}
+
+	/**
+	 * Exclusions — a cross-cutting list of vault paths hidden from some or all
+	 * Synapse flows (#307). Top-level (not per-feature): the single source of
+	 * truth for path-based exclusion. Each rule shows its glob pattern, an "All
+	 * features" toggle that reveals 12 per-feature checkboxes when off, and a
+	 * remove button. New rules are added via a folder picker (canonicalized to
+	 * `<folder>/**`) or a free-text pattern (exact paths, `dir/*`). Layout
+	 * changes re-render the whole tab via `ctx.rerender`.
+	 */
+	private renderExclusions(ctx: SettingsSectionContext): void {
+		const body = ctx.configSection('exclusions', 'Exclusions');
+
+		body.createDiv({
+			cls: 'setting-item-description synapse-accordion-empty-note',
+			text:
+				'Paths listed here are skipped by the selected features. Patterns are vault-relative globs: ' +
+				'"folder/**" (folder and everything under it), "folder/*" (direct children only), ' +
+				'or an exact note path. ".synapse" (plugin data) and "templates" are excluded from every feature by default.',
+		});
+
+		const rules = this.plugin.settings.exclusions;
+
+		if (rules.length === 0) {
+			body.createDiv({
+				cls: 'setting-item-description',
+				text: 'No exclusions configured.',
+			});
+		}
+
+		rules.forEach((rule, index) => {
+			this.renderExclusionRule(ctx, body, rule, index);
+		});
+
+		// ── Add controls ──
+		new Setting(body)
+			.setName('Add a folder')
+			.setDesc('Pick a folder to exclude (saved as "folder/**").')
+			.addButton((btn) =>
+				btn
+					.setButtonText('Choose folder')
+					.onClick(() => {
+						new FolderPickerModal(this.app, (folder) => {
+							const pattern = folder.isRoot() ? '/**' : `${folder.path}/**`;
+							// Skip exact duplicates so a re-pick doesn't stack rules.
+							if (!this.plugin.settings.exclusions.some((r) => r.pattern === pattern)) {
+								this.plugin.settings.exclusions.push({ pattern, features: 'all' });
+							}
+							void this.plugin.saveSettings().then(() => ctx.rerender());
+						}).open();
+					})
+			);
+
+		let pendingPattern = '';
+		new Setting(body)
+			.setName('Add a pattern')
+			.setDesc('For exact note paths or direct-children globs (e.g. "Inbox/*").')
+			.addText((text) =>
+				text
+					.setPlaceholder('path/to/note.md or folder/*')
+					.onChange((value) => {
+						pendingPattern = value;
+					})
+			)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Add')
+					.onClick(() => {
+						const pattern = pendingPattern.trim();
+						if (!pattern) return;
+						if (!this.plugin.settings.exclusions.some((r) => r.pattern === pattern)) {
+							this.plugin.settings.exclusions.push({ pattern, features: 'all' });
+						}
+						void this.plugin.saveSettings().then(() => ctx.rerender());
+					})
+			);
+	}
+
+	/**
+	 * Render a single exclusion rule row plus, when it is feature-scoped, the
+	 * grid of per-feature checkboxes. Toggling "All features" or removing the
+	 * rule mutates settings, persists, and re-renders the tab.
+	 */
+	private renderExclusionRule(
+		ctx: SettingsSectionContext,
+		body: HTMLElement,
+		rule: ExclusionRule,
+		index: number,
+	): void {
+		const features = rule.features;
+		const isAll = features === 'all';
+		const setting = new Setting(body)
+			.setName(rule.pattern || '(empty pattern)')
+			.setDesc(
+				features === 'all'
+					? 'Excluded from all features'
+					: `Excluded from: ${this.describeScopedFeatures(features)}`,
+			);
+
+		setting.addToggle((toggle) =>
+			toggle
+				.setTooltip('All features')
+				.setValue(isAll)
+				.onChange((value) => {
+					// Switching to scoped seeds an empty list (user then ticks the
+					// features); switching to all collapses to the literal 'all'.
+					this.plugin.settings.exclusions[index].features = value ? 'all' : [];
+					void this.plugin.saveSettings().then(() => ctx.rerender());
+				}),
+		);
+
+		setting.addExtraButton((btn) =>
+			btn
+				.setIcon('trash')
+				.setTooltip('Remove exclusion')
+				.onClick(() => {
+					this.plugin.settings.exclusions.splice(index, 1);
+					void this.plugin.saveSettings().then(() => ctx.rerender());
+				}),
+		);
+
+		if (isAll) return;
+
+		// Per-feature checkboxes (rendered only for a scoped rule).
+		const scoped = rule.features as FeatureId[];
+		for (const feature of FEATURE_ORDER) {
+			new Setting(body)
+				.setClass('synapse-exclusion-feature-row')
+				.setName(FEATURE_LABELS[feature])
+				.addToggle((toggle) =>
+					toggle.setValue(scoped.includes(feature)).onChange((value) => {
+						const current = this.plugin.settings.exclusions[index].features;
+						if (current === 'all') return; // defensive: shape changed underneath
+						const next = new Set(current);
+						if (value) next.add(feature);
+						else next.delete(feature);
+						this.plugin.settings.exclusions[index].features = [...next];
+						void this.plugin.saveSettings().then(() => ctx.rerender());
+					}),
+				);
+		}
+	}
+
+	/** Human-readable list of the features a scoped rule blocks. */
+	private describeScopedFeatures(features: FeatureId[]): string {
+		if (features.length === 0) return 'no features (rule inactive)';
+		return features.map((f) => FEATURE_LABELS[f]).join(', ');
 	}
 
 	/**

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -56,3 +56,33 @@ describe('onboarding settings (#89)', () => {
 		expect(DEFAULT_SETTINGS.onboarding.hasSeenWelcome).toBe(false);
 	});
 });
+
+describe('exclusions settings (#307)', () => {
+	it('protects .synapse and templates from every feature by default', () => {
+		expect(DEFAULT_SETTINGS.exclusions).toEqual([
+			{ pattern: '.synapse/**', features: 'all' },
+			{ pattern: 'templates/**', features: 'all' },
+		]);
+	});
+
+	it('no longer carries a per-module excludeFolders field', () => {
+		const modules: Array<Record<string, unknown>> = [
+			DEFAULT_SETTINGS.elaboration.detection as unknown as Record<string, unknown>,
+			DEFAULT_SETTINGS.enrichment as unknown as Record<string, unknown>,
+			DEFAULT_SETTINGS.summarize as unknown as Record<string, unknown>,
+			DEFAULT_SETTINGS.organize as unknown as Record<string, unknown>,
+			DEFAULT_SETTINGS.deepDive as unknown as Record<string, unknown>,
+		];
+		for (const m of modules) {
+			expect(m).not.toHaveProperty('excludeFolders');
+		}
+	});
+
+	it('retains per-module excludeTags', () => {
+		expect(DEFAULT_SETTINGS.elaboration.detection.excludeTags).toContain('no-elaborate');
+		expect(DEFAULT_SETTINGS.enrichment.excludeTags).toContain('no-enrich');
+		expect(DEFAULT_SETTINGS.summarize.excludeTags).toContain('no-summarize');
+		expect(DEFAULT_SETTINGS.organize.excludeTags).toContain('no-organize');
+		expect(DEFAULT_SETTINGS.deepDive.excludeTags).toContain('no-deep-dive');
+	});
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,9 @@
 // Type-only import (erased at compile time) so settings.ts stays free of a
 // runtime cycle with views/types.ts → feature modules → settings.ts.
 import type { ProposalKind } from './views/types';
+// Type-only import of the exclusion model (centralized in shared/exclusions.ts).
+// Erased at compile time; the DEFAULT_SETTINGS values below are plain literals.
+import type { ExclusionRule } from './shared/exclusions';
 
 export type AIProvider = 'openai' | 'anthropic' | 'gemini' | 'ollama';
 
@@ -47,7 +50,6 @@ export interface DetectionSettings {
 	detectTodoMarkers: boolean;
 	detectEmptySections: boolean;
 	detectSparseLinks: boolean;
-	excludeFolders: string[];
 	excludeTags: string[];
 }
 
@@ -138,7 +140,6 @@ export interface EnrichmentSettings {
 	internalLinkThreshold: number;
 	weights: EnrichmentWeightSettings;
 	enrichmentFolderPath: string;
-	excludeFolders: string[];
 	excludeTags: string[];
 	relatedNotesHeading: string;
 	referencesHeading: string;
@@ -150,7 +151,6 @@ export interface SummarizeSettings {
 	summaryStyle: 'bullets' | 'paragraph' | 'key-points';
 	customPrompt: string;
 	autoDetectTemplates: boolean;
-	excludeFolders: string[];
 	excludeTags: string[];
 	autoOrganizeOnSummarize: boolean;
 }
@@ -164,7 +164,6 @@ export interface OrganizeSettings {
 	enabled: boolean;
 	proposalFolderPath: string;
 	snapshotFolderPath: string;
-	excludeFolders: string[];
 	excludeTags: string[];
 	/** Minimum topic confidence required to propose a new directory (0-1). */
 	organizeConfidenceThreshold: number;
@@ -182,7 +181,6 @@ export interface DeepDiveSettings {
 	noteOutputFolder: string;
 	/** How child notes are placed: nested under parent, flat in root subfolder, or AI-organized. */
 	nestingMode: DeepDiveNestingMode;
-	excludeFolders: string[];
 	excludeTags: string[];
 	autoEnrichOnAccept: boolean;
 	autoOrganizeOnAccept: boolean;
@@ -288,6 +286,14 @@ export interface SynapseSettings {
 	ui: UISettings;
 	autoAccept: AutoAcceptSettings;
 	onboarding: OnboardingSettings;
+	/**
+	 * Centralized per-path exclusion list (#307). Each rule names a vault-relative
+	 * glob and the features it blocks (or `'all'`). This is the single source of
+	 * truth for path-based exclusion across every flow — the legacy per-module
+	 * `excludeFolders` fields were folded into this on upgrade. Tag-based
+	 * exclusion (`excludeTags`) remains per-module.
+	 */
+	exclusions: ExclusionRule[];
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
@@ -309,7 +315,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 			detectTodoMarkers: true,
 			detectEmptySections: true,
 			detectSparseLinks: true,
-			excludeFolders: ['templates', '.synapse'],
 			excludeTags: ['no-elaborate'],
 		},
 		proposal: {
@@ -378,7 +383,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 			minWeight: 0.1,
 		},
 		enrichmentFolderPath: '.synapse/enrichments',
-		excludeFolders: ['templates', '.synapse'],
 		excludeTags: ['no-enrich'],
 		relatedNotesHeading: 'Related Notes',
 		referencesHeading: 'References',
@@ -389,7 +393,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		summaryStyle: 'bullets',
 		customPrompt: '',
 		autoDetectTemplates: true,
-		excludeFolders: ['templates', '.synapse'],
 		excludeTags: ['no-summarize'],
 		autoOrganizeOnSummarize: false,
 	},
@@ -401,7 +404,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		enabled: true,
 		proposalFolderPath: '.synapse/organize/proposals',
 		snapshotFolderPath: '.synapse/organize/snapshots',
-		excludeFolders: ['templates', '.synapse'],
 		excludeTags: ['no-organize'],
 		organizeConfidenceThreshold: 0.9,
 	},
@@ -413,7 +415,6 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		maxNotesPerRun: 50,
 		noteOutputFolder: 'Deep Dives',
 		nestingMode: 'nested',
-		excludeFolders: ['templates', '.synapse'],
 		excludeTags: ['no-deep-dive'],
 		autoEnrichOnAccept: true,
 		autoOrganizeOnAccept: false,
@@ -453,4 +454,12 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 	onboarding: {
 		hasSeenWelcome: false,
 	},
+	// Centralized path exclusions (#307). `.synapse` (plugin data) and
+	// `templates` are protected from EVERY flow out of the box; users add their
+	// own rules (optionally scoped to specific features) via the Exclusions
+	// settings section. Stored in canonical `/**` form.
+	exclusions: [
+		{ pattern: '.synapse/**', features: 'all' },
+		{ pattern: 'templates/**', features: 'all' },
+	],
 };

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -214,6 +214,8 @@ interface Checkpoint {
 | `checkpoint-manager.ts` | `CheckpointManager` | CRUD and lifecycle management for resumable operation checkpoints |
 | `checkpoint-manager.test.ts` | Tests | CheckpointManager tests |
 | `tweet-fetcher.ts` | `fetchTweetContent`, `isTwitterUrl`, `TweetContent` | Twitter/X.com tweet fetching with oEmbed → fxtwitter → vxtwitter fallback chain |
+| `exclusions.ts` | `FeatureId`, `ExclusionRule`, `findMatchingRule`, `isPathExcluded`, `matchesExcludeTag`, `ALL_FEATURE_IDS`, `buildMigratedExclusions`, `LegacyModuleExclusions` | Centralized per-path exclusion (#307): case-sensitive glob→regex matcher (`/**`, `/*`, exact, bare-token recursive; escapes metacharacters), shared tag-exclusion check, and the legacy `excludeFolders`→`exclusions` migration builder |
+| `exclusions.test.ts` | Tests | Exclusion matcher + migration tests |
 | `tweet-fetcher.test.ts` | Tests | Tweet fetcher tests |
 | `index.ts` | re-exports | Barrel file |
 

--- a/src/shared/exclusions.test.ts
+++ b/src/shared/exclusions.test.ts
@@ -3,8 +3,10 @@ import {
 	findMatchingRule,
 	isPathExcluded,
 	matchesExcludeTag,
+	buildMigratedExclusions,
 	type ExclusionRule,
 	type FeatureId,
+	type LegacyModuleExclusions,
 } from './exclusions';
 import { TFile } from '../__mocks__/obsidian';
 
@@ -217,6 +219,12 @@ describe('findMatchingRule — determinism (first match wins)', () => {
 		expect(findMatchingRule('dir/a.md', 'enrichment', settingsWith([]))).toBeNull();
 		expect(isPathExcluded('dir/a.md', 'enrichment', settingsWith([]))).toBe(false);
 	});
+
+	it('tolerates a missing/undefined exclusions list (partial settings) without throwing', () => {
+		const partial = {} as unknown as { exclusions: ExclusionRule[] };
+		expect(findMatchingRule('dir/a.md', 'enrichment', partial)).toBeNull();
+		expect(isPathExcluded('dir/a.md', 'enrichment', partial)).toBe(false);
+	});
 });
 
 describe('matchesExcludeTag', () => {
@@ -269,5 +277,105 @@ describe('matchesExcludeTag', () => {
 	it('handles a comma-separated frontmatter tags string', () => {
 		const { file, metadataCache } = fileWithTags('keep, no-enrich');
 		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
+	});
+});
+
+describe('buildMigratedExclusions', () => {
+	it('returns [] for empty / missing legacy data (idempotent: already-migrated data has no folders)', () => {
+		expect(buildMigratedExclusions({})).toEqual([]);
+		expect(buildMigratedExclusions({ enrichment: {} })).toEqual([]);
+		expect(buildMigratedExclusions({ enrichment: { excludeFolders: [] } })).toEqual([]);
+	});
+
+	it('collapses to features: "all" when a folder is in EVERY legacy module', () => {
+		const legacy: LegacyModuleExclusions = {
+			elaboration: { detection: { excludeFolders: ['.synapse'] } },
+			enrichment: { excludeFolders: ['.synapse'] },
+			summarize: { excludeFolders: ['.synapse'] },
+			organize: { excludeFolders: ['.synapse'] },
+			deepDive: { excludeFolders: ['.synapse'] },
+		};
+		// enrichment list also feeds rem → all 6 legacy features present.
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: '.synapse/**', features: 'all' },
+		]);
+	});
+
+	it('canonicalizes a bare folder name to "<name>/**"', () => {
+		const legacy: LegacyModuleExclusions = {
+			summarize: { excludeFolders: ['Archive'] },
+		};
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: 'Archive/**', features: ['summarize'] },
+		]);
+	});
+
+	it('strips a trailing slash before appending /**', () => {
+		const legacy: LegacyModuleExclusions = {
+			organize: { excludeFolders: ['Archive/'] },
+		};
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: 'Archive/**', features: ['organize'] },
+		]);
+	});
+
+	it('keeps a custom single-module folder scoped to that feature', () => {
+		const legacy: LegacyModuleExclusions = {
+			organize: { excludeFolders: ['Personal'] },
+		};
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: 'Personal/**', features: ['organize'] },
+		]);
+	});
+
+	it("includes 'rem' wherever enrichment listed a folder (rem mirrors enrichment)", () => {
+		const legacy: LegacyModuleExclusions = {
+			enrichment: { excludeFolders: ['Drafts'] },
+		};
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: 'Drafts/**', features: ['enrichment', 'rem'] },
+		]);
+	});
+
+	it('merges the same folder across a partial set of modules into one scoped rule', () => {
+		const legacy: LegacyModuleExclusions = {
+			summarize: { excludeFolders: ['Notes'] },
+			organize: { excludeFolders: ['Notes'] },
+		};
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: 'Notes/**', features: ['summarize', 'organize'] },
+		]);
+	});
+
+	it('emits one rule per distinct folder, mixing all-scope and feature-scope', () => {
+		const legacy: LegacyModuleExclusions = {
+			elaboration: { detection: { excludeFolders: ['templates'] } },
+			enrichment: { excludeFolders: ['templates'] },
+			summarize: { excludeFolders: ['templates'] },
+			organize: { excludeFolders: ['templates', 'Personal'] },
+			deepDive: { excludeFolders: ['templates'] },
+		};
+		const result = buildMigratedExclusions(legacy);
+		// `templates` is in all → 'all'; `Personal` only in organize → scoped.
+		expect(result).toContainEqual({ pattern: 'templates/**', features: 'all' });
+		expect(result).toContainEqual({ pattern: 'Personal/**', features: ['organize'] });
+		expect(result).toHaveLength(2);
+	});
+
+	it('is deterministic — same input yields equal output across calls', () => {
+		const legacy: LegacyModuleExclusions = {
+			enrichment: { excludeFolders: ['A', 'B'] },
+			organize: { excludeFolders: ['B', 'C'] },
+		};
+		expect(buildMigratedExclusions(legacy)).toEqual(buildMigratedExclusions(legacy));
+	});
+
+	it('ignores non-string / blank legacy folder entries', () => {
+		const legacy = {
+			summarize: { excludeFolders: ['Real', '', '   ', 42, null] },
+		} as unknown as LegacyModuleExclusions;
+		expect(buildMigratedExclusions(legacy)).toEqual([
+			{ pattern: 'Real/**', features: ['summarize'] },
+		]);
 	});
 });

--- a/src/shared/exclusions.test.ts
+++ b/src/shared/exclusions.test.ts
@@ -278,6 +278,37 @@ describe('matchesExcludeTag', () => {
 		const { file, metadataCache } = fileWithTags('keep, no-enrich');
 		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
 	});
+
+	// Build a file whose metadata cache is an arbitrary object, so inline-tag and
+	// combined frontmatter+inline scenarios can be exercised.
+	function fileWithCache(cache: unknown) {
+		const file = new TFile('note.md') as never;
+		const metadataCache = { getFileCache: () => cache };
+		return { file, metadataCache };
+	}
+
+	it('matches an inline body `#tag` (cache.tags), not just frontmatter', () => {
+		const { file, metadataCache } = fileWithCache({ tags: [{ tag: '#no-enrich' }] });
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
+	});
+
+	it('matches case-insensitively when the frontmatter tag differs in case', () => {
+		const { file, metadataCache } = fileWithTags(['No-Enrich']);
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
+	});
+
+	it('matches case-insensitively when the configured tag differs in case', () => {
+		const { file, metadataCache } = fileWithTags(['no-enrich']);
+		expect(matchesExcludeTag(file, ['NO-ENRICH'], metadataCache as never)).toBe(true);
+	});
+
+	it('combines frontmatter and inline tags', () => {
+		const { file, metadataCache } = fileWithCache({
+			frontmatter: { tags: ['keep'] },
+			tags: [{ tag: '#also-inline' }],
+		});
+		expect(matchesExcludeTag(file, ['also-inline'], metadataCache as never)).toBe(true);
+	});
 });
 
 describe('buildMigratedExclusions', () => {

--- a/src/shared/exclusions.test.ts
+++ b/src/shared/exclusions.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import {
+	findMatchingRule,
+	isPathExcluded,
+	matchesExcludeTag,
+	type ExclusionRule,
+	type FeatureId,
+} from './exclusions';
+import { TFile } from '../__mocks__/obsidian';
+
+/**
+ * Build a minimal settings-shaped object carrying only the `exclusions` list.
+ * The matcher reads nothing else off settings, so this stays deliberately thin
+ * (cast through `unknown` to the matcher's narrow `{ exclusions }` contract).
+ */
+function settingsWith(exclusions: ExclusionRule[]): { exclusions: ExclusionRule[] } {
+	return { exclusions };
+}
+
+describe('findMatchingRule / isPathExcluded — glob semantics', () => {
+	describe('folder + descendants (`dir/**`)', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/**', features: 'all' }];
+
+		it('matches a nested descendant', () => {
+			expect(isPathExcluded('dir/note.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('matches a deeply nested descendant', () => {
+			expect(isPathExcluded('dir/sub/deep/note.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('does NOT match the folder itself', () => {
+			expect(isPathExcluded('dir', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('does NOT match a sibling file sharing the prefix (`dir.md`)', () => {
+			expect(isPathExcluded('dir.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('does NOT match a sibling folder sharing the prefix (`dirX/...`)', () => {
+			expect(isPathExcluded('dirX/note.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('direct children only (`dir/*`)', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/*', features: 'all' }];
+
+		it('matches a direct child', () => {
+			expect(isPathExcluded('dir/note.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('does NOT match a grandchild', () => {
+			expect(isPathExcluded('dir/sub/note.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('does NOT match the folder itself', () => {
+			expect(isPathExcluded('dir', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('exact file path (has slash, no wildcard)', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/note.md', features: 'all' }];
+
+		it('matches itself exactly', () => {
+			expect(isPathExcluded('dir/note.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('does NOT match a different file in the same folder', () => {
+			expect(isPathExcluded('dir/other.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('does NOT match a descendant path that extends it', () => {
+			expect(isPathExcluded('dir/note.md/child.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('bare token (no slash, no wildcard) — recursive prefix parity', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'templates', features: 'all' }];
+
+		it('matches a nested descendant (legacy startsWith parity)', () => {
+			expect(isPathExcluded('templates/daily.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('matches the bare folder itself', () => {
+			expect(isPathExcluded('templates', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('does NOT match a sibling sharing the prefix (`templatesX/...`)', () => {
+			expect(isPathExcluded('templatesX/a.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('does NOT match a file sharing the prefix (`templates.md`)', () => {
+			expect(isPathExcluded('templates.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('regex metacharacter escaping (`.synapse/**`)', () => {
+		const rules: ExclusionRule[] = [{ pattern: '.synapse/**', features: 'all' }];
+
+		it('matches a real `.synapse` descendant', () => {
+			expect(isPathExcluded('.synapse/proposals/a.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('does NOT over-match when `.` is treated literally (`Xsynapse/a.md`)', () => {
+			expect(isPathExcluded('Xsynapse/a.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('does NOT over-match `asynapse/a.md` either', () => {
+			expect(isPathExcluded('asynapse/a.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('trailing-slash normalization', () => {
+		it('treats `dir/` (one trailing slash) as the `dir` folder, matching descendants', () => {
+			const rules: ExclusionRule[] = [{ pattern: 'dir/', features: 'all' }];
+			expect(isPathExcluded('dir/note.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('treats `dir/**/` as `dir/**`', () => {
+			const rules: ExclusionRule[] = [{ pattern: 'dir/**/', features: 'all' }];
+			expect(isPathExcluded('dir/sub/note.md', 'enrichment', settingsWith(rules))).toBe(true);
+			expect(isPathExcluded('dir', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('empty / whitespace patterns match nothing', () => {
+		it('an empty pattern never matches', () => {
+			const rules: ExclusionRule[] = [{ pattern: '', features: 'all' }];
+			expect(isPathExcluded('anything/at/all.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('a whitespace-only pattern never matches', () => {
+			const rules: ExclusionRule[] = [{ pattern: '   ', features: 'all' }];
+			expect(isPathExcluded('anything.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+
+		it('a lone slash never matches everything', () => {
+			const rules: ExclusionRule[] = [{ pattern: '/', features: 'all' }];
+			expect(isPathExcluded('anything.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+
+	describe('case sensitivity', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'Templates/**', features: 'all' }];
+
+		it('matches the exact case', () => {
+			expect(isPathExcluded('Templates/a.md', 'enrichment', settingsWith(rules))).toBe(true);
+		});
+
+		it('does NOT match a different case', () => {
+			expect(isPathExcluded('templates/a.md', 'enrichment', settingsWith(rules))).toBe(false);
+		});
+	});
+});
+
+describe('findMatchingRule / isPathExcluded — feature scoping', () => {
+	it('a feature-scoped rule does NOT match a different feature', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/**', features: ['organize'] }];
+		expect(isPathExcluded('dir/a.md', 'enrichment', settingsWith(rules))).toBe(false);
+	});
+
+	it('a feature-scoped rule matches its own feature', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/**', features: ['organize'] }];
+		expect(isPathExcluded('dir/a.md', 'organize', settingsWith(rules))).toBe(true);
+	});
+
+	it("`features: 'all'` matches every feature", () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/**', features: 'all' }];
+		const everyFeature: FeatureId[] = [
+			'elaboration', 'enrichment', 'summarize', 'tidy', 'organize',
+			'deep-dive', 'audio', 'video', 'title', 'image', 'rem', 'intake',
+		];
+		for (const feature of everyFeature) {
+			expect(isPathExcluded('dir/a.md', feature, settingsWith(rules))).toBe(true);
+		}
+	});
+
+	it('`features: []` matches nothing', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/**', features: [] }];
+		expect(isPathExcluded('dir/a.md', 'enrichment', settingsWith(rules))).toBe(false);
+	});
+
+	it('a multi-feature list matches any listed feature', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'dir/**', features: ['enrichment', 'summarize'] }];
+		expect(isPathExcluded('dir/a.md', 'enrichment', settingsWith(rules))).toBe(true);
+		expect(isPathExcluded('dir/a.md', 'summarize', settingsWith(rules))).toBe(true);
+		expect(isPathExcluded('dir/a.md', 'organize', settingsWith(rules))).toBe(false);
+	});
+});
+
+describe('findMatchingRule — determinism (first match wins)', () => {
+	it('returns the FIRST matching rule in array order', () => {
+		const rules: ExclusionRule[] = [
+			{ pattern: 'dir/**', features: 'all' },
+			{ pattern: 'dir/note.md', features: 'all' },
+		];
+		const rule = findMatchingRule('dir/note.md', 'enrichment', settingsWith(rules));
+		expect(rule).not.toBeNull();
+		expect(rule?.pattern).toBe('dir/**');
+	});
+
+	it('skips a non-applicable (feature-scoped) earlier rule and returns the next match', () => {
+		const rules: ExclusionRule[] = [
+			{ pattern: 'dir/**', features: ['organize'] },
+			{ pattern: 'dir/**', features: ['enrichment'] },
+		];
+		const rule = findMatchingRule('dir/a.md', 'enrichment', settingsWith(rules));
+		expect(rule?.features).toEqual(['enrichment']);
+	});
+
+	it('returns null when no rule applies', () => {
+		const rules: ExclusionRule[] = [{ pattern: 'other/**', features: 'all' }];
+		expect(findMatchingRule('dir/a.md', 'enrichment', settingsWith(rules))).toBeNull();
+	});
+
+	it('returns null for an empty exclusions list', () => {
+		expect(findMatchingRule('dir/a.md', 'enrichment', settingsWith([]))).toBeNull();
+		expect(isPathExcluded('dir/a.md', 'enrichment', settingsWith([]))).toBe(false);
+	});
+});
+
+describe('matchesExcludeTag', () => {
+	function fileWithTags(tags: unknown) {
+		// Cast through `never`: the centralized mock's TFile is structurally a
+		// stand-in for obsidian's, and matchesExcludeTag only forwards it to
+		// metadataCache.getFileCache (also a stub here).
+		const file = new TFile('note.md') as never;
+		const metadataCache = {
+			getFileCache: () => (tags === undefined ? null : { frontmatter: { tags } }),
+		};
+		return { file, metadataCache };
+	}
+
+	it('matches a frontmatter tag (no `#` on either side)', () => {
+		const { file, metadataCache } = fileWithTags(['no-enrich']);
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
+	});
+
+	it('strips a leading `#` from the configured exclude tag before comparing', () => {
+		const { file, metadataCache } = fileWithTags(['no-enrich']);
+		expect(matchesExcludeTag(file, ['#no-enrich'], metadataCache as never)).toBe(true);
+	});
+
+	it('strips a leading `#` from the frontmatter tag before comparing', () => {
+		const { file, metadataCache } = fileWithTags(['#no-enrich']);
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
+	});
+
+	it('matches when both sides carry `#`', () => {
+		const { file, metadataCache } = fileWithTags(['#no-enrich']);
+		expect(matchesExcludeTag(file, ['#no-enrich'], metadataCache as never)).toBe(true);
+	});
+
+	it('returns false when no tag matches', () => {
+		const { file, metadataCache } = fileWithTags(['keep']);
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(false);
+	});
+
+	it('returns false when the note has no frontmatter cache', () => {
+		const { file, metadataCache } = fileWithTags(undefined);
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(false);
+	});
+
+	it('returns false for an empty exclude-tag list', () => {
+		const { file, metadataCache } = fileWithTags(['no-enrich']);
+		expect(matchesExcludeTag(file, [], metadataCache as never)).toBe(false);
+	});
+
+	it('handles a comma-separated frontmatter tags string', () => {
+		const { file, metadataCache } = fileWithTags('keep, no-enrich');
+		expect(matchesExcludeTag(file, ['no-enrich'], metadataCache as never)).toBe(true);
+	});
+});

--- a/src/shared/exclusions.ts
+++ b/src/shared/exclusions.ts
@@ -152,7 +152,11 @@ export function findMatchingRule(
 	feature: FeatureId,
 	settings: ExclusionSettings,
 ): ExclusionRule | null {
-	for (const rule of settings.exclusions) {
+	// Defensive: tolerate a missing/undefined list (partial settings) as "no
+	// rules" rather than throwing. Real settings always carry it via defaults.
+	const rules = settings?.exclusions;
+	if (!Array.isArray(rules)) return null;
+	for (const rule of rules) {
 		if (!ruleAppliesToFeature(rule, feature)) continue;
 		const regex = patternToRegExp(rule.pattern);
 		if (regex && regex.test(path)) return rule;
@@ -199,4 +203,101 @@ export function matchesExcludeTag(
 /** Strip a single leading `#` so tag comparisons are hash-insensitive. */
 function stripHash(tag: string): string {
 	return tag.startsWith('#') ? tag.slice(1) : tag;
+}
+
+/**
+ * Read-only shape of the legacy persisted settings the #307 migration inspects.
+ * Only the per-module `excludeFolders` lists matter; everything else is ignored.
+ * Deliberately a narrow read type (not `any`) so the migration stays type-safe.
+ * Every field is optional — older/partial data may omit any of these.
+ */
+export interface LegacyModuleExclusions {
+	elaboration?: { detection?: { excludeFolders?: unknown } };
+	enrichment?: { excludeFolders?: unknown };
+	summarize?: { excludeFolders?: unknown };
+	organize?: { excludeFolders?: unknown };
+	deepDive?: { excludeFolders?: unknown };
+}
+
+/**
+ * The features that carried a legacy per-module `excludeFolders` list. `rem`
+ * mirrored `enrichment`'s list at runtime, so it joins the set. When a single
+ * folder appeared in EVERY one of these, the migrated rule collapses to
+ * `features: 'all'` (this is how the shared `templates`/`.synapse` folders
+ * broaden to all flows on upgrade); otherwise it stays scoped to exactly the
+ * features that listed it.
+ */
+const LEGACY_FOLDER_FEATURES: FeatureId[] = [
+	'elaboration',
+	'enrichment',
+	'summarize',
+	'organize',
+	'deep-dive',
+	'rem',
+];
+
+/** Coerce an unknown legacy `excludeFolders` value to a clean `string[]`. */
+function readLegacyFolders(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+}
+
+/**
+ * Canonicalize a legacy folder name into the stored `<folder>/**` form (strip a
+ * trailing slash first). The legacy matcher was `startsWith(folder + '/')` — a
+ * recursive descendant match — which `<folder>/**` reproduces exactly.
+ */
+function canonicalizeLegacyFolder(folder: string): string {
+	const trimmed = folder.trim().replace(/\/+$/, '');
+	return `${trimmed}/**`;
+}
+
+/**
+ * Build the migrated {@link ExclusionRule}[] from legacy per-module
+ * `excludeFolders` data (#307). For each module's folders (with `rem` mirroring
+ * `enrichment`), record which features listed each folder; canonicalize the
+ * folder to `<name>/**`; then emit one rule per distinct pattern —
+ * `features: 'all'` when the pattern was listed by ALL
+ * {@link LEGACY_FOLDER_FEATURES}, otherwise the specific sorted feature list.
+ * Pattern order is first-seen across the module scan, which is deterministic.
+ */
+export function buildMigratedExclusions(data: LegacyModuleExclusions): ExclusionRule[] {
+	// Preserve first-seen pattern order with a Map; track the feature set per
+	// canonical pattern.
+	const byPattern = new Map<string, Set<FeatureId>>();
+
+	const record = (folders: string[], feature: FeatureId): void => {
+		for (const folder of folders) {
+			const pattern = canonicalizeLegacyFolder(folder);
+			let set = byPattern.get(pattern);
+			if (!set) {
+				set = new Set<FeatureId>();
+				byPattern.set(pattern, set);
+			}
+			set.add(feature);
+		}
+	};
+
+	const enrichmentFolders = readLegacyFolders(data.enrichment?.excludeFolders);
+
+	record(readLegacyFolders(data.elaboration?.detection?.excludeFolders), 'elaboration');
+	record(enrichmentFolders, 'enrichment');
+	record(readLegacyFolders(data.summarize?.excludeFolders), 'summarize');
+	record(readLegacyFolders(data.organize?.excludeFolders), 'organize');
+	record(readLegacyFolders(data.deepDive?.excludeFolders), 'deep-dive');
+	// rem reused enrichment's folder list at runtime (no list of its own).
+	record(enrichmentFolders, 'rem');
+
+	const totalLegacyFeatures = LEGACY_FOLDER_FEATURES.length;
+	const rules: ExclusionRule[] = [];
+	for (const [pattern, features] of byPattern) {
+		if (features.size === totalLegacyFeatures) {
+			rules.push({ pattern, features: 'all' });
+		} else {
+			// Emit in canonical feature order for stable, comparable output.
+			const ordered = LEGACY_FOLDER_FEATURES.filter((f) => features.has(f));
+			rules.push({ pattern, features: ordered });
+		}
+	}
+	return rules;
 }

--- a/src/shared/exclusions.ts
+++ b/src/shared/exclusions.ts
@@ -192,19 +192,27 @@ export function matchesExcludeTag(
 ): boolean {
 	if (excludeTags.length === 0) return false;
 	const cache = metadataCache.getFileCache(file);
-	// frontmatter is loosely typed (index signature → `any`); treat the tags
-	// field as `unknown` and let normalizeFrontmatterTags coerce it safely.
-	const raw: unknown = cache?.frontmatter?.tags;
-	if (raw === undefined || raw === null) return false;
+	if (!cache) return false;
 
-	const fileTags = normalizeFrontmatterTags(raw).map(stripHash);
-	const wanted = excludeTags.map(stripHash);
+	// Collect tags from BOTH sources, matching the most inclusive legacy behavior
+	// (enrichment read Obsidian's getAllTags): frontmatter `tags` (array or
+	// comma/space-separated string, coerced by normalizeFrontmatterTags) AND inline
+	// body `#tags` (cache.tags). Compare with a leading `#` stripped and case
+	// folded — Obsidian treats tags case-insensitively.
+	const frontmatterTags = normalizeFrontmatterTags(cache.frontmatter?.tags);
+	const inlineTags = cache.tags?.map((t) => t.tag) ?? [];
+	const fileTags = [...frontmatterTags, ...inlineTags].map(foldTag);
+	const wanted = excludeTags.map(foldTag);
 	return wanted.some((tag) => fileTags.includes(tag));
 }
 
-/** Strip a single leading `#` so tag comparisons are hash-insensitive. */
-function stripHash(tag: string): string {
-	return tag.startsWith('#') ? tag.slice(1) : tag;
+/**
+ * Normalize a tag for comparison: strip a single leading `#` and case-fold, so
+ * `no-enrich`, `#no-enrich`, and `#No-Enrich` all compare equal.
+ */
+function foldTag(tag: string): string {
+	const stripped = tag.startsWith('#') ? tag.slice(1) : tag;
+	return stripped.toLowerCase();
 }
 
 /**

--- a/src/shared/exclusions.ts
+++ b/src/shared/exclusions.ts
@@ -1,0 +1,202 @@
+import type { MetadataCache, TFile } from 'obsidian';
+import { normalizePath } from 'obsidian';
+import { normalizeFrontmatterTags } from './frontmatter-utils';
+
+/**
+ * Every user-facing Synapse flow that can touch a note, as a closed union. This
+ * is the vocabulary an {@link ExclusionRule} uses to scope which features a path
+ * is hidden from.
+ *
+ * Deliberately a FRESH 12-member union — NOT reused from `commands/types.ts`'s
+ * `FeatureKey` (which is the "modules that own palette commands" set and omits
+ * audio/image/intake/title). Exclusion participation is a different axis: it
+ * covers every flow that reads/writes a target note, including the post-op and
+ * event-driven ones that have no command.
+ */
+export type FeatureId =
+	| 'elaboration'
+	| 'enrichment'
+	| 'summarize'
+	| 'tidy'
+	| 'organize'
+	| 'deep-dive'
+	| 'audio'
+	| 'video'
+	| 'title'
+	| 'image'
+	| 'rem'
+	| 'intake';
+
+/**
+ * Compile-time exhaustiveness guard. Every {@link FeatureId} must appear as a
+ * key here; adding a member to the union without listing it is a type error,
+ * which forces a future flow to make an explicit decision about whether it
+ * participates in path exclusion. Exported so a test (or a future module) can
+ * iterate the canonical feature set.
+ */
+export const ALL_FEATURE_IDS: Record<FeatureId, true> = {
+	elaboration: true,
+	enrichment: true,
+	summarize: true,
+	tidy: true,
+	organize: true,
+	'deep-dive': true,
+	audio: true,
+	video: true,
+	title: true,
+	image: true,
+	rem: true,
+	intake: true,
+};
+
+/**
+ * A single exclusion rule. `pattern` is a vault-relative glob (see
+ * {@link findMatchingRule} for the supported forms); `features` is either the
+ * literal `'all'` (block every flow) or an explicit list of {@link FeatureId}s
+ * to block (an empty list blocks nothing).
+ */
+export interface ExclusionRule {
+	pattern: string;
+	features: 'all' | FeatureId[];
+}
+
+/**
+ * The slice of {@link SynapseSettings} the matcher reads. Narrowed to just
+ * `exclusions` so the matcher stays decoupled from the full settings shape (and
+ * so tests can pass a thin object).
+ */
+interface ExclusionSettings {
+	exclusions: ExclusionRule[];
+}
+
+/**
+ * Escape every regex metacharacter in a literal path segment so it matches
+ * literally. Critically this escapes `.` so a pattern like `.synapse/**` cannot
+ * over-match `Xsynapse/...`.
+ */
+function escapeRegex(literal: string): string {
+	return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Compile a glob `pattern` into an anchored, case-sensitive {@link RegExp}, or
+ * return `null` for a pattern that should match nothing (empty after
+ * normalization). Supported forms (normalized first via {@link normalizePath},
+ * trimmed, with one trailing slash stripped):
+ *
+ * - `dir/**` → folder and all descendants, NOT the folder itself.
+ * - `dir/*`  → direct children only.
+ * - `dir/file.md` (has `/`, no wildcard) → that exact path only.
+ * - `templates` (bare token, no `/`, no wildcard) → recursive prefix: the token
+ *   itself and every descendant (parity with the legacy
+ *   `startsWith(folder + '/')` behavior, and lets a hand-typed folder name "just
+ *   work").
+ *
+ * Mid-segment wildcards (e.g. `dir/*.md`) are intentionally out of scope for v1
+ * and fall through to the exact-path branch.
+ */
+function patternToRegExp(pattern: string): RegExp | null {
+	// Normalize separators, trim surrounding whitespace, and drop exactly one
+	// trailing slash (so `dir/` behaves like `dir`). Never let an empty pattern
+	// compile — that would match everything.
+	let normalized = normalizePath(pattern.trim()).trim();
+	if (normalized.endsWith('/')) {
+		normalized = normalized.slice(0, -1);
+	}
+	if (normalized === '' || normalized === '/') {
+		return null;
+	}
+
+	if (normalized.endsWith('/**')) {
+		const base = normalized.slice(0, -3);
+		if (base === '') return null;
+		return new RegExp(`^${escapeRegex(base)}/.*$`);
+	}
+
+	if (normalized.endsWith('/*')) {
+		const base = normalized.slice(0, -2);
+		if (base === '') return null;
+		return new RegExp(`^${escapeRegex(base)}/[^/]+$`);
+	}
+
+	if (!normalized.includes('/')) {
+		// Bare token → recursive prefix (the token itself or any descendant).
+		return new RegExp(`^${escapeRegex(normalized)}(/.*)?$`);
+	}
+
+	// Has a slash, no recognized wildcard → exact file path.
+	return new RegExp(`^${escapeRegex(normalized)}$`);
+}
+
+/**
+ * Whether a rule applies to the given feature. `'all'` applies to every
+ * feature; an explicit list applies only when it includes `feature` (so `[]`
+ * applies to nothing).
+ */
+function ruleAppliesToFeature(rule: ExclusionRule, feature: FeatureId): boolean {
+	return rule.features === 'all' || rule.features.includes(feature);
+}
+
+/**
+ * The exclusion primitive. Iterate `settings.exclusions` in array order and
+ * return the FIRST rule that (a) applies to `feature` and (b) whose pattern
+ * matches `path`, or `null` if none do. First-match-wins is deterministic, so a
+ * Notice can name a stable rule.
+ *
+ * @param path vault-relative path of the note being considered
+ * @param feature the flow asking whether it may touch `path`
+ * @param settings settings carrying the `exclusions` list
+ */
+export function findMatchingRule(
+	path: string,
+	feature: FeatureId,
+	settings: ExclusionSettings,
+): ExclusionRule | null {
+	for (const rule of settings.exclusions) {
+		if (!ruleAppliesToFeature(rule, feature)) continue;
+		const regex = patternToRegExp(rule.pattern);
+		if (regex && regex.test(path)) return rule;
+	}
+	return null;
+}
+
+/**
+ * Convenience boolean wrapper over {@link findMatchingRule}: `true` when some
+ * rule excludes `path` for `feature`.
+ */
+export function isPathExcluded(
+	path: string,
+	feature: FeatureId,
+	settings: ExclusionSettings,
+): boolean {
+	return findMatchingRule(path, feature, settings) !== null;
+}
+
+/**
+ * Shared tag-exclusion check, extracted from the six modules that each
+ * hand-rolled it. Reads the note's frontmatter `tags` from the metadata cache
+ * and returns `true` when any configured `excludeTags` entry matches one of
+ * them, comparing with a leading `#` stripped from BOTH sides (so `no-enrich`,
+ * `#no-enrich`, and a frontmatter `#no-enrich` all compare equal). Path
+ * exclusion is centralized in {@link isPathExcluded}; tag exclusion stays
+ * per-module (each passes its own `excludeTags`).
+ */
+export function matchesExcludeTag(
+	file: TFile,
+	excludeTags: string[],
+	metadataCache: MetadataCache,
+): boolean {
+	if (excludeTags.length === 0) return false;
+	const cache = metadataCache.getFileCache(file);
+	const raw = cache?.frontmatter?.tags;
+	if (raw === undefined || raw === null) return false;
+
+	const fileTags = normalizeFrontmatterTags(raw).map(stripHash);
+	const wanted = excludeTags.map(stripHash);
+	return wanted.some((tag) => fileTags.includes(tag));
+}
+
+/** Strip a single leading `#` so tag comparisons are hash-insensitive. */
+function stripHash(tag: string): string {
+	return tag.startsWith('#') ? tag.slice(1) : tag;
+}

--- a/src/shared/exclusions.ts
+++ b/src/shared/exclusions.ts
@@ -192,7 +192,9 @@ export function matchesExcludeTag(
 ): boolean {
 	if (excludeTags.length === 0) return false;
 	const cache = metadataCache.getFileCache(file);
-	const raw = cache?.frontmatter?.tags;
+	// frontmatter is loosely typed (index signature → `any`); treat the tags
+	// field as `unknown` and let normalizeFrontmatterTags coerce it safely.
+	const raw: unknown = cache?.frontmatter?.tags;
 	if (raw === undefined || raw === null) return false;
 
 	const fileTags = normalizeFrontmatterTags(raw).map(stripHash);

--- a/src/shared/feature-chip-select.test.ts
+++ b/src/shared/feature-chip-select.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEl } from '../__mocks__/obsidian';
+import { renderFeatureChipSelect } from './feature-chip-select';
+import { ALL_FEATURE_IDS } from './exclusions';
+import type { FeatureId } from './exclusions';
+
+// Mirror of FEATURE_LABELS in settings-tab.ts; ORDER is the canonical feature set
+// so these tests track any future change to the union.
+const LABELS: Record<FeatureId, string> = {
+	elaboration: 'Elaboration',
+	enrichment: 'Enrichment',
+	summarize: 'Summarize',
+	tidy: 'Tidy',
+	organize: 'Organize',
+	'deep-dive': 'Deep dive',
+	audio: 'Audio transcription',
+	video: 'Video transcription',
+	title: 'Title',
+	image: 'Image OCR',
+	rem: 'REM (link discovery)',
+	intake: 'Intake watcher',
+};
+const ORDER = Object.keys(ALL_FEATURE_IDS) as FeatureId[];
+
+// ── Stub-tree introspection helpers ──
+function walk(el: any, out: any[] = []): any[] {
+	for (const c of el?.children ?? []) {
+		out.push(c);
+		walk(c, out);
+	}
+	return out;
+}
+function byClass(root: any, cls: string): any[] {
+	return walk(root).filter((e) => e.classList?.contains(cls));
+}
+function byTag(root: any, tag: string): any[] {
+	return walk(root).filter((e) => e.tagName === tag);
+}
+function chipLabels(root: any): string[] {
+	return byClass(root, 'synapse-chip-label').map((e) => e.textContent);
+}
+function selectEl(root: any): any {
+	return byTag(root, 'SELECT')[0];
+}
+function optionValues(root: any): string[] {
+	return byTag(root, 'OPTION').map((e) => e.value);
+}
+function optionTexts(root: any): string[] {
+	return byTag(root, 'OPTION').map((e) => e.textContent);
+}
+function removeButton(root: any, ariaLabel: string): any {
+	return byClass(root, 'synapse-chip-remove').find(
+		(b) => b.getAttribute('aria-label') === ariaLabel,
+	);
+}
+
+function render(value: 'all' | FeatureId[]) {
+	const container = createEl();
+	const onChange = vi.fn();
+	renderFeatureChipSelect(container, { value, labels: LABELS, order: ORDER, onChange });
+	return { container, onChange };
+}
+
+describe('renderFeatureChipSelect — chip rendering', () => {
+	it("shows a single 'All features' chip for 'all'", () => {
+		const { container } = render('all');
+		expect(chipLabels(container)).toEqual(['All features']);
+		expect(byClass(container, 'synapse-exclusion-chips-empty')).toHaveLength(0);
+	});
+
+	it('shows one chip per feature, ordered by FEATURE_ORDER (not input order)', () => {
+		const { container } = render(['organize', 'summarize']);
+		expect(chipLabels(container)).toEqual(['Summarize', 'Organize']);
+	});
+
+	it('shows the inactive hint (and no chips) for an empty list', () => {
+		const { container } = render([]);
+		expect(chipLabels(container)).toEqual([]);
+		const hint = byClass(container, 'synapse-exclusion-chips-empty');
+		expect(hint).toHaveLength(1);
+		expect(hint[0].textContent).toBe('No features — rule inactive');
+	});
+
+	it('does not call onChange on the initial render', () => {
+		const { onChange } = render(['summarize']);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});
+
+describe('renderFeatureChipSelect — add dropdown options', () => {
+	it("offers 'All features' + every unselected feature when scoped", () => {
+		const { container } = render(['summarize']);
+		const values = optionValues(container);
+		expect(values[0]).toBe(''); // placeholder
+		expect(values).toContain('__all__');
+		expect(values).not.toContain('summarize'); // already selected
+		expect(values).toContain('organize');
+		// placeholder + All + (12 - 1 selected) = 13
+		expect(values).toHaveLength(1 + 1 + (ORDER.length - 1));
+	});
+
+	it("offers every feature (to narrow) and no 'All features' when value is 'all'", () => {
+		const { container } = render('all');
+		const values = optionValues(container);
+		expect(values).not.toContain('__all__');
+		for (const f of ORDER) expect(values).toContain(f);
+		expect(values).toHaveLength(1 + ORDER.length); // placeholder + 12
+	});
+
+	it('renders a disabled placeholder as the first option', () => {
+		const { container } = render([]);
+		const placeholder = byTag(container, 'OPTION')[0];
+		expect(placeholder.textContent).toBe('+ Add feature…');
+		expect(placeholder.value).toBe('');
+		expect(placeholder.disabled).toBe(true);
+		// An empty list still exposes the dropdown so the user can recover.
+		expect(selectEl(container)).toBeDefined();
+		expect(optionTexts(container)).toContain('All features');
+	});
+});
+
+describe('renderFeatureChipSelect — adding via the dropdown', () => {
+	function pick(container: any, value: string): void {
+		const select = selectEl(container);
+		select.value = value;
+		select.dispatchEvent({ type: 'change' });
+	}
+
+	it('appends a feature and re-emits the list in FEATURE_ORDER', () => {
+		const { container, onChange } = render(['organize']);
+		pick(container, 'summarize');
+		expect(onChange).toHaveBeenCalledWith(['summarize', 'organize']);
+		expect(chipLabels(container)).toEqual(['Summarize', 'Organize']);
+	});
+
+	it("maps the 'All features' option to the 'all' shorthand", () => {
+		const { container, onChange } = render(['summarize']);
+		pick(container, '__all__');
+		expect(onChange).toHaveBeenCalledWith('all');
+		expect(chipLabels(container)).toEqual(['All features']);
+	});
+
+	it("narrows from 'all' to a single-feature list", () => {
+		const { container, onChange } = render('all');
+		pick(container, 'tidy');
+		expect(onChange).toHaveBeenCalledWith(['tidy']);
+		expect(chipLabels(container)).toEqual(['Tidy']);
+	});
+
+	it('ignores a change back to the placeholder', () => {
+		const { container, onChange } = render(['summarize']);
+		pick(container, '');
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});
+
+describe('renderFeatureChipSelect — removing via chips', () => {
+	function clickRemove(container: any, ariaLabel: string): void {
+		removeButton(container, ariaLabel).dispatchEvent({ type: 'click' });
+	}
+
+	it("removing the 'All features' chip drops to the inactive empty list", () => {
+		const { container, onChange } = render('all');
+		clickRemove(container, 'Remove All features');
+		expect(onChange).toHaveBeenCalledWith([]);
+		expect(chipLabels(container)).toEqual([]);
+		expect(byClass(container, 'synapse-exclusion-chips-empty')).toHaveLength(1);
+	});
+
+	it('removing one feature keeps the rest', () => {
+		const { container, onChange } = render(['summarize', 'organize', 'tidy']);
+		clickRemove(container, 'Remove Tidy');
+		expect(onChange).toHaveBeenCalledWith(['summarize', 'organize']);
+		expect(chipLabels(container)).toEqual(['Summarize', 'Organize']);
+	});
+
+	it('removing the last feature drops to the inactive empty list', () => {
+		const { container, onChange } = render(['summarize']);
+		clickRemove(container, 'Remove Summarize');
+		expect(onChange).toHaveBeenCalledWith([]);
+		expect(byClass(container, 'synapse-exclusion-chips-empty')).toHaveLength(1);
+	});
+});
+
+describe('renderFeatureChipSelect — accessibility', () => {
+	it('labels each remove button and the add dropdown', () => {
+		const { container } = render(['summarize']);
+		expect(removeButton(container, 'Remove Summarize')).toBeDefined();
+		expect(selectEl(container).getAttribute('aria-label')).toBe(
+			'Add feature to exclusion scope',
+		);
+	});
+
+	it('marks the chip remove glyph aria-hidden', () => {
+		const { container } = render(['summarize']);
+		const glyphs = walk(container).filter((e) => e.textContent === '✕');
+		expect(glyphs.length).toBeGreaterThan(0);
+		expect(glyphs[0].getAttribute('aria-hidden')).toBe('true');
+	});
+});

--- a/src/shared/feature-chip-select.ts
+++ b/src/shared/feature-chip-select.ts
@@ -1,0 +1,146 @@
+import type { FeatureId } from './exclusions';
+
+/**
+ * Option value used by the add-dropdown to mean "block every feature" — maps to
+ * the {@link FeatureChipSelectOptions.value} `'all'` shorthand. Underscores keep
+ * it disjoint from every {@link FeatureId} (which are kebab-case words).
+ */
+const ALL_SENTINEL = '__all__';
+
+/** Configuration for {@link renderFeatureChipSelect}. */
+export interface FeatureChipSelectOptions {
+	/**
+	 * Current scope: the literal `'all'` (block every feature), or an explicit
+	 * list of {@link FeatureId}s. An empty list is legal and renders as the
+	 * "rule inactive" hint (it blocks nothing — see `src/shared/exclusions.ts`).
+	 */
+	value: 'all' | FeatureId[];
+	/** Display label per feature (the caller's `FEATURE_LABELS`). */
+	labels: Record<FeatureId, string>;
+	/** Stable render order for chips and dropdown options (`FEATURE_ORDER`). */
+	order: FeatureId[];
+	/**
+	 * Invoked with the new scope after every edit (add/remove). The caller
+	 * persists it; the component has already redrawn `container`, so no caller
+	 * re-render is needed.
+	 */
+	onChange: (next: 'all' | FeatureId[]) => void;
+}
+
+/**
+ * Render a compact chip multi-select for an exclusion rule's feature scope into
+ * `container` (#328). Selected features show as removable chips; an inline
+ * `<select class="dropdown">` adds more. The control fully owns the
+ * `'all' | FeatureId[]` value, including the `'all'` shorthand and the empty-list
+ * = "rule inactive" case — the data model is unchanged.
+ *
+ * It keeps its own `current` value and **self-redraws `container`** on every edit
+ * (it calls `container.empty()` first), so the caller's `onChange` only needs to
+ * persist — it must NOT also trigger a full settings re-render (that would wipe a
+ * sibling text input mid-edit; see the "Add a pattern" row in `settings-tab.ts`).
+ *
+ * Mirrors the DOM-wrapper style of {@link addCollapsibleSection} /
+ * {@link addEnhancedSlider}: it builds its own `synapse-*` structure inside the
+ * container the caller provides.
+ *
+ * @param container - Element to render into (emptied and rebuilt on each edit).
+ * @param options - {@link FeatureChipSelectOptions}.
+ */
+export function renderFeatureChipSelect(
+	container: HTMLElement,
+	options: FeatureChipSelectOptions,
+): void {
+	const { labels, order, onChange } = options;
+	let current: 'all' | FeatureId[] = options.value;
+
+	/** Commit a new scope: update state, notify the caller, redraw. */
+	function apply(next: 'all' | FeatureId[]): void {
+		current = next;
+		onChange(next);
+		render();
+	}
+
+	function renderChip(parent: HTMLElement, label: string, onRemove: () => void): void {
+		const chip = parent.createSpan({ cls: 'synapse-chip' });
+		chip.createSpan({ cls: 'synapse-chip-label', text: label });
+		const remove = chip.createEl('button', {
+			cls: 'synapse-chip-remove',
+			attr: { type: 'button', 'aria-label': `Remove ${label}` },
+		});
+		// Glyph is decorative; the accessible name comes from the button's aria-label.
+		remove.createSpan({ text: '✕' }).setAttribute('aria-hidden', 'true');
+		remove.addEventListener('click', () => onRemove());
+	}
+
+	function renderAddDropdown(parent: HTMLElement): void {
+		const select = parent.createEl('select', {
+			cls: ['dropdown', 'synapse-chip-add'],
+			attr: { 'aria-label': 'Add feature to exclusion scope' },
+		});
+
+		const placeholder = select.createEl('option', { text: '+ Add feature…' });
+		placeholder.value = '';
+		placeholder.disabled = true;
+		placeholder.selected = true;
+
+		if (current === 'all') {
+			// Already blocking everything — offer each feature to NARROW to it.
+			for (const feature of order) {
+				select.createEl('option', { text: labels[feature] }).value = feature;
+			}
+		} else {
+			// Offer "All features" plus every not-yet-selected feature.
+			select.createEl('option', { text: 'All features' }).value = ALL_SENTINEL;
+			for (const feature of order) {
+				if (!current.includes(feature)) {
+					select.createEl('option', { text: labels[feature] }).value = feature;
+				}
+			}
+		}
+
+		select.value = '';
+		select.addEventListener('change', () => {
+			const picked = select.value;
+			if (!picked) return; // placeholder
+			if (picked === ALL_SENTINEL) {
+				apply('all');
+				return;
+			}
+			const feature = picked as FeatureId;
+			if (current === 'all') {
+				// Narrowing from "all" starts a fresh list with just this feature.
+				apply([feature]);
+				return;
+			}
+			const next = new Set(current);
+			next.add(feature);
+			apply(order.filter((f) => next.has(f))); // re-emit in stable order
+		});
+	}
+
+	function render(): void {
+		container.empty();
+
+		if (current === 'all') {
+			renderChip(container, 'All features', () => apply([]));
+		} else if (current.length === 0) {
+			container.createSpan({
+				cls: 'synapse-exclusion-chips-empty',
+				text: 'No features — rule inactive',
+			});
+		} else {
+			const scoped = current;
+			for (const feature of order) {
+				if (scoped.includes(feature)) {
+					renderChip(container, labels[feature], () =>
+						apply(scoped.filter((f) => f !== feature)),
+					);
+				}
+			}
+		}
+
+		renderAddDropdown(container);
+	}
+
+	render();
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -72,6 +72,8 @@ export type {
 	CollapsibleSection,
 	CollapsibleSectionOptions,
 } from './collapsible-section';
+export { renderFeatureChipSelect } from './feature-chip-select';
+export type { FeatureChipSelectOptions } from './feature-chip-select';
 export {
 	createSettingsSectionContext,
 	isSectionCollapsed,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -81,6 +81,13 @@ export type {
 	SettingsSectionContext,
 	SettingsSectionContextOptions,
 } from './settings-section';
+export {
+	findMatchingRule,
+	isPathExcluded,
+	matchesExcludeTag,
+	ALL_FEATURE_IDS,
+} from './exclusions';
+export type { FeatureId, ExclusionRule } from './exclusions';
 export { generateId, isValidCheckpointId } from './id-utils';
 export {
 	loadNodeModules,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -86,8 +86,9 @@ export {
 	isPathExcluded,
 	matchesExcludeTag,
 	ALL_FEATURE_IDS,
+	buildMigratedExclusions,
 } from './exclusions';
-export type { FeatureId, ExclusionRule } from './exclusions';
+export type { FeatureId, ExclusionRule, LegacyModuleExclusions } from './exclusions';
 export { generateId, isValidCheckpointId } from './id-utils';
 export {
 	loadNodeModules,

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -3,7 +3,8 @@ import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout,
-	CALLOUT_TYPES, CheckpointManager, generateId, fireAndForget, normalizeFrontmatterTags,
+	CALLOUT_TYPES, CheckpointManager, generateId, fireAndForget,
+	isPathExcluded, matchesExcludeTag,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { OperationHandle } from '../shared';
@@ -795,24 +796,11 @@ export class SummarizeModule {
 	}
 
 	private isExcluded(file: TFile): boolean {
-		const settings = this.getSettings().summarize;
-
-		for (const folder of settings.excludeFolders) {
-			if (file.path.startsWith(folder + '/')) return true;
-		}
-
-		const cache = this.plugin.app.metadataCache.getFileCache(file);
-		if (cache?.frontmatter?.tags) {
-			const fileTags = normalizeFrontmatterTags(cache.frontmatter.tags);
-			for (const excludeTag of settings.excludeTags) {
-				const normalized = excludeTag.startsWith('#')
-					? excludeTag.slice(1)
-					: excludeTag;
-				if (fileTags.includes(normalized)) return true;
-			}
-		}
-
-		return false;
+		const settings = this.getSettings();
+		return (
+			isPathExcluded(file.path, 'summarize', settings) ||
+			matchesExcludeTag(file, settings.summarize.excludeTags, this.plugin.app.metadataCache)
+		);
 	}
 
 	/** Dispatch deferred tasks (I1). */

--- a/src/summarize/settings-section.ts
+++ b/src/summarize/settings-section.ts
@@ -75,19 +75,6 @@ export function renderSummarizeSettings(ctx: SettingsSectionContext): void {
 		);
 
 	new Setting(summarizeBody)
-		.setName('Excluded folders')
-		.setDesc('Comma-separated list of folders to skip for summarization')
-		.addText((text) =>
-			text
-				.setValue(plugin.settings.summarize.excludeFolders.join(', '))
-				.onChange(async (value) => {
-					plugin.settings.summarize.excludeFolders =
-						value.split(',').map((s) => s.trim()).filter(Boolean);
-					await plugin.saveSettings();
-				})
-		);
-
-	new Setting(summarizeBody)
 		.setName('Excluded tags')
 		.setDesc('Notes with these tags will skip summarization')
 		.addText((text) =>

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -1,7 +1,7 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
-import { AIClient, NotificationManager, getMarkdownFiles, parseFrontmatter, sanitizeAIResponse, stripCodeFences, serializeFrontmatter, withRetry, generateId } from '../shared';
+import { AIClient, NotificationManager, getMarkdownFiles, parseFrontmatter, sanitizeAIResponse, stripCodeFences, serializeFrontmatter, withRetry, generateId, isPathExcluded, findMatchingRule } from '../shared';
 import { TidyStore } from './tidy-store';
 import { TidySnapshot } from './types';
 
@@ -49,9 +49,17 @@ export class TidyModule {
 		this.registrar.register('tidy-current-note', this.getSettings().tidy.enabled, {
 			name: 'Tidy current note',
 			editorCallback: async (_editor, ctx) => {
-				if (ctx.file) {
-					await this.tidy(ctx.file);
+				if (!ctx.file) return;
+				// Path exclusion (#307): explicit single-note command → Notice
+				// naming the rule. The batch loop in scanVault skips silently.
+				const rule = findMatchingRule(ctx.file.path, 'tidy', this.getSettings());
+				if (rule) {
+					this.notifications.info(
+						`Skipped — "${ctx.file.path}" is excluded by rule "${rule.pattern}"`
+					);
+					return;
 				}
+				await this.tidy(ctx.file);
 			},
 		});
 
@@ -96,6 +104,9 @@ export class TidyModule {
 		for (let i = 0; i < allFiles.length; i++) {
 			if (op.cancelled) break;
 			op.progress(i + 1, allFiles.length, 'Tidying notes');
+
+			// Path exclusion (#307): batch scan → silently skip excluded notes.
+			if (isPathExcluded(allFiles[i].path, 'tidy', this.getSettings())) continue;
 
 			try {
 				await this.tidy(allFiles[i]);

--- a/src/title/index.ts
+++ b/src/title/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, NotificationManager, generateId, readNote } from '../shared';
+import { AIClient, NotificationManager, generateId, readNote, isPathExcluded } from '../shared';
 import { TitleProposalStore } from './title-store';
 import { TitleSuggester } from './title-suggester';
 import { isUntitled } from './title-detector';
@@ -151,6 +151,10 @@ export class TitleModule {
 	async checkTitle(filePath: string): Promise<void> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
+
+		// Path exclusion (#307). checkTitle is a silent post-op callback (no user
+		// command), so skip quietly when the note is excluded from `title`.
+		if (isPathExcluded(file.path, 'title', this.getSettings())) return;
 
 		if (isUntitled(file.basename)) {
 			await this.checkUntitled(filePath);

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -5,6 +5,7 @@ import { AudioModule, TranscriptionResult } from '../audio';
 import {
 	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, CALLOUT_TYPES,
 	CheckpointManager, generateId, formatTimeRange, detectPlatform, loadNodeModules,
+	isPathExcluded, findMatchingRule,
 } from '../shared';
 import type { TimeRange } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
@@ -149,6 +150,16 @@ export class VideoModule {
 			return;
 		}
 
+		// Path exclusion (#307): transcription lands in the ACTIVE note. Explicit
+		// command → Notice naming the rule.
+		const rule = findMatchingRule(activeFile.path, 'video', this.getSettings());
+		if (rule) {
+			this.notifications.info(
+				`Skipped — "${activeFile.path}" is excluded by rule "${rule.pattern}"`
+			);
+			return;
+		}
+
 		const op = this.notifications.startOperation(
 			'Processing video URL...',
 			`video-url-${Date.now()}`
@@ -202,6 +213,9 @@ export class VideoModule {
 		noteFile: TFile,
 		embeds: VideoUrlEmbed[]
 	): Promise<void> {
+		// Path exclusion (#307): batch insert into the note → silent skip.
+		if (isPathExcluded(noteFile.path, 'video', this.getSettings())) return;
+
 		const total = embeds.length;
 		let completed = 0;
 

--- a/styles.css
+++ b/styles.css
@@ -1020,17 +1020,58 @@
   font-weight: var(--font-semibold);
 }
 
-/* ── Exclusions: per-feature checkbox rows (#307) ──
- * Indents and de-emphasizes the 12 per-feature toggles revealed under a
- * feature-scoped exclusion rule, so they read as children of the rule above
- * rather than as top-level settings. */
-.setting-item.synapse-exclusion-feature-row {
-  padding-left: 24px;
-  border-top: none;
-  padding-top: 4px;
-  padding-bottom: 4px;
+/* ── Exclusions: feature scope chips (#328) ──
+ * A compact, wrapping row of removable chips (the rule's blocked features) plus
+ * an inline "add" dropdown, replacing the per-feature toggle grid. Rendered just
+ * below each exclusion rule and each add-folder/add-pattern row. */
+.synapse-exclusion-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 8px 24px;
 }
-.synapse-exclusion-feature-row .setting-item-name {
+.synapse-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 2px 10px;
+  border-radius: 12px;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  font-size: var(--font-ui-small);
+  line-height: 1.4;
+}
+.synapse-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  font-size: var(--font-ui-smaller);
+  cursor: pointer;
+  opacity: 0.75;
+  box-shadow: none;
+}
+.synapse-chip-remove:hover {
+  opacity: 1;
+  background: var(--background-modifier-hover);
+}
+.synapse-chip-remove:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+  opacity: 1;
+}
+.synapse-chip-add {
+  font-size: var(--font-ui-small);
+}
+.synapse-exclusion-chips-empty {
   font-size: var(--font-ui-small);
   color: var(--text-muted);
+  font-style: italic;
 }

--- a/styles.css
+++ b/styles.css
@@ -1019,3 +1019,18 @@
 .synapse-setting-required .setting-item-name {
   font-weight: var(--font-semibold);
 }
+
+/* ── Exclusions: per-feature checkbox rows (#307) ──
+ * Indents and de-emphasizes the 12 per-feature toggles revealed under a
+ * feature-scoped exclusion rule, so they read as children of the rule above
+ * rather than as top-level settings. */
+.setting-item.synapse-exclusion-feature-row {
+  padding-left: 24px;
+  border-top: none;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.synapse-exclusion-feature-row .setting-item-name {
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary

Replaces Synapse's fragmented, per-module folder-exclusion settings with a single, cross-cutting `exclusions` list and one shared matcher, and wires path-exclusion enforcement into **every** user-facing flow. One place to say "never let feature X (or any feature) touch this path," with consistent glob semantics.

closes #307
closes #328

## Behavior change

`.synapse/**` and `templates/**` are now excluded from **all** flows — including audio/video transcription, image OCR, the intake watcher, title checks, and tidy, none of which had folder exclusion before. This applies to existing vaults too: a one-time migration (gated on the persisted data lacking an `exclusions` key) folds the legacy per-module `excludeFolders` lists into the new list — folders excluded from every module broaden to `features: 'all'`, while a folder scoped to a single module stays scoped to that feature.

Batch/vault scans skip excluded notes silently; an explicitly invoked single-note command refuses with a notice naming the matching rule's pattern.

## Per-phase changes

- **Phase 1 — `src/settings.ts`:** add top-level `exclusions: ExclusionRule[]` (defaults `.synapse/**` + `templates/**`, both `features:'all'`); remove the `excludeFolders` field + default from the 5 feature interfaces (`excludeTags` retained).
- **Phase 2 — `src/shared/exclusions.ts` (new):** `FeatureId` (fresh 12-member union), `ExclusionRule`, `findMatchingRule` (first-match-wins primitive), `isPathExcluded`, a case-sensitive glob→regex converter (`/**`, `/*`, exact, bare-token recursive; escapes metacharacters incl. `.`), an `ALL_FEATURE_IDS` exhaustiveness guard, and a shared `matchesExcludeTag` extracted from the duplicated per-module tag checks. Exported from the `shared` barrel.
- **Phase 3 — `src/main.ts` + `buildMigratedExclusions`:** legacy→centralized migration in `loadSettings` (atomic assign + `saveData`, try/catch swallow-and-warn, idempotent). `rem` mirrors `enrichment` in the migration.
- **Phase 4 — existing flows:** `isExcluded` rewritten to `isPathExcluded(...) || matchesExcludeTag(...)` in `elaboration/detector`, `enrichment`, `summarize`, `organize`, `deep-dive`, `rem`. Single-file notices name the matching rule; enrichment is dual-mode (notice only when `trigger==='manual'`).
- **Phase 5 — new enforcement + gaps:** added enforcement to `title` (silent), `intake` (silent), `audio` (notice on active note / silent batch, incl. combined), `image` (notice / silent), `video` (notice / silent), and `tidy` (silent batch / notice on the single-note command). Fixed the `rem` `resumeFromCheckpoint` gap with a silent re-check. All notices route through `NotificationManager`.
- **Phase 6 — `src/settings-tab.ts`:** new cross-cutting "Exclusions" section — per-rule pattern, an "All features" toggle that reveals 12 per-feature checkboxes when off, a remove button, "Add a folder" via `FolderPickerModal` (canonicalized to `/**`), and an "Add a pattern" input. Removed the per-module "Excluded folders" UI from the 5 feature sections (kept "Excluded tags"). Added styles + an `addExtraButton`/`ButtonComponent` stub to the obsidian mock.
- **Phase 7 — docs/test infra:** README "Exclusions" section + glob-syntax table; updated enrichment decision doc and the rem/enrichment/elaboration/shared `AGENTS.md` exclusion notes; settings-defaults tests.

## Tests

- New `src/shared/exclusions.test.ts` — **57 cases**: glob semantics (`/**` not matching the folder/`dir.md`/`dirX`, `/*` direct-child-only, exact-path, bare-token recursive parity), `.`-escaping (`Xsynapse/a.md` negative), trailing-slash normalization, empty-pattern-matches-nothing, case sensitivity, feature scoping (`'all'` / `[]` / specific / multi), first-match determinism, a defensive missing-list guard, `matchesExcludeTag` (frontmatter + inline `#tags`, case-insensitive), and 10 migration cases (all-modules→`'all'`, canonicalization, `rem` mirroring, partial-scope merge, determinism, junk filtering).
- `src/settings.test.ts` — exclusions defaults shape, no-`excludeFolders` regression, `excludeTags` retained.
- Updated `src/rem/index.test.ts` for the new rule-naming / `(excluded tag)` notices.

## Test plan / CI parity (all green)

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` — 1391 passing (103 files)
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

## Notes / minor deviations

- **Chip multi-select for exclusion scoping (#328, folded in):** the per-rule "All features" toggle + 12-checkbox grid is replaced by a compact removable-chip control with an inline "+ Add feature" dropdown, and folder/pattern adds choose their scope up front. UI-only — the `ExclusionRule` model (the `'all'` shorthand and empty-list = inactive) is unchanged. New reusable `src/shared/feature-chip-select.ts` with unit + settings-tab tests.
- **Tag-exclusion source (resolved in `3de52f2`):** the shared `matchesExcludeTag` now reads **both** frontmatter `tags` (array or comma/space-separated string) **and** inline body `#tags`, comparing case-insensitively — preserving enrichment's prior `getAllTags`-based opt-out behavior and applying it uniformly to every flow. (An earlier revision read frontmatter-only/case-sensitively, which would have regressed enrichment's inline-tag exclusion; REM was already frontmatter-only so it was unaffected.)
- `audio.transcribeAndInsertCombined` also got the silent batch guard (the plan named `transcribeAndInsert`; combined is the sibling batch insert path).
- Summarize has no standalone single-file command (only `scanVault` + the pipeline `onlyFile` path), so its exclusion is the silent loop `continue`; the scan's "Found 0 items" already gives feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

