### PR TITLE
refactor: promote content-type auto-formatting registry to src/shared (#233)

### DIFF
--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -217,6 +217,8 @@ interface Checkpoint {
 | `exclusions.ts` | `FeatureId`, `ExclusionRule`, `findMatchingRule`, `isPathExcluded`, `matchesExcludeTag`, `ALL_FEATURE_IDS`, `buildMigratedExclusions`, `LegacyModuleExclusions` | Centralized per-path exclusion (#307): case-sensitive glob→regex matcher (`/**`, `/*`, exact, bare-token recursive; escapes metacharacters), shared tag-exclusion check, and the legacy `excludeFolders`→`exclusions` migration builder |
 | `exclusions.test.ts` | Tests | Exclusion matcher + migration tests |
 | `tweet-fetcher.test.ts` | Tests | Tweet fetcher tests |
+| `content-schemas.ts` | `ContentSchema`, `PipelineStage`, `SchemaMode`, `CONTENT_SCHEMAS`, `detectSchemaFor`, `isRecipeContent`, `scoreRecipeContent`, `isReceiptContent`, `scoreReceiptContent` | Content-aware formatting registry (#233): recipe/receipt detection heuristics + prompts, stage-gated via `appliesTo` (`'transcription' \| 'summary'`) and `mode` (`'reformat' \| 'summarize'`). Promoted out of `summarize/` so both summarize and transcription stages can consult it via `detectSchemaFor(stage, content)` |
+| `content-schemas.test.ts` | Tests | Schema detection + scoring + stage-gate lock tests |
 | `index.ts` | re-exports | Barrel file |
 
 ## AIClient Provider Routing

--- a/src/shared/content-schemas.test.ts
+++ b/src/shared/content-schemas.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
-	detectContentTemplate,
+	detectSchemaFor,
 	isRecipeContent,
 	scoreRecipeContent,
 	isReceiptContent,
 	scoreReceiptContent,
-	CONTENT_TEMPLATES,
-} from './templates';
+	CONTENT_SCHEMAS,
+} from './content-schemas';
+import type { PipelineStage, SchemaMode } from './content-schemas';
 
 // ── Recipe Detection ──────────────────────────────────────────────────
 
@@ -179,10 +180,10 @@ describe('scoreRecipeContent', () => {
 	});
 });
 
-// ── detectContentTemplate ─────────────────────────────────────────────
+// ── detectSchemaFor (recipe) ──────────────────────────────────────────
 
-describe('detectContentTemplate', () => {
-	it('returns the recipe template for recipe content', () => {
+describe('detectSchemaFor', () => {
+	it('returns the recipe schema for recipe content', () => {
 		const content = [
 			'# Pancakes',
 			'',
@@ -197,10 +198,10 @@ describe('detectContentTemplate', () => {
 			'3. Cook on a griddle for 2 minutes per side.',
 		].join('\n');
 
-		const template = detectContentTemplate(content);
-		expect(template).not.toBeNull();
-		expect(template!.id).toBe('recipe');
-		expect(template!.name).toBe('Recipe');
+		const schema = detectSchemaFor('summary', content);
+		expect(schema).not.toBeNull();
+		expect(schema!.id).toBe('recipe');
+		expect(schema!.name).toBe('Recipe');
 	});
 
 	it('returns null for non-recipe content', () => {
@@ -211,27 +212,99 @@ describe('detectContentTemplate', () => {
 			'We have completed 80% of the planned features.',
 		].join('\n');
 
-		expect(detectContentTemplate(content)).toBeNull();
+		expect(detectSchemaFor('summary', content)).toBeNull();
 	});
 });
 
-// ── Template Shape Validation ─────────────────────────────────────────
+// ── Stage Gate Lock ───────────────────────────────────────────────────
+// Locks the appliesTo stage gate so the transcription stage cannot
+// accidentally fire summary-only schemas (recipe/receipt).
 
-describe('CONTENT_TEMPLATES', () => {
-	it('each template has a valid id, name, detect function, and prompt', () => {
-		for (const template of CONTENT_TEMPLATES) {
-			expect(typeof template.id).toBe('string');
-			expect(template.id.length).toBeGreaterThan(0);
-			expect(typeof template.name).toBe('string');
-			expect(template.name.length).toBeGreaterThan(0);
-			expect(typeof template.detect).toBe('function');
-			expect(typeof template.prompt).toBe('string');
-			expect(template.prompt.length).toBeGreaterThan(0);
+describe('detectSchemaFor stage gating', () => {
+	const recipe = [
+		'# Pancakes',
+		'',
+		'## Ingredients',
+		'- 1 cup flour',
+		'- 2 tbsp sugar',
+		'- 1 tsp baking powder',
+		'',
+		'## Instructions',
+		'1. Whisk dry ingredients.',
+		'2. Stir in milk and eggs.',
+		'3. Cook on a griddle for 2 minutes per side.',
+	].join('\n');
+
+	const receipt = [
+		'TARGET',
+		'Store #1234',
+		'Cashier: Mike',
+		'01/20/2026 10:15',
+		'',
+		'PAPER TOWELS          $8.99',
+		'DISH SOAP             $3.49',
+		'',
+		'Subtotal              $12.48',
+		'Tax                   $1.00',
+		'Total                 $13.48',
+		'',
+		'Debit **** 9876',
+		'Payment               $13.48',
+	].join('\n');
+
+	it('fires recipe at the summary stage', () => {
+		expect(detectSchemaFor('summary', recipe)?.id).toBe('recipe');
+	});
+
+	it('fires receipt at the summary stage', () => {
+		expect(detectSchemaFor('summary', receipt)?.id).toBe('receipt');
+	});
+
+	it('does NOT fire recipe at the transcription stage', () => {
+		expect(detectSchemaFor('transcription', recipe)).toBeNull();
+	});
+
+	it('does NOT fire receipt at the transcription stage', () => {
+		expect(detectSchemaFor('transcription', receipt)).toBeNull();
+	});
+});
+
+// ── Schema Shape Validation ───────────────────────────────────────────
+
+describe('CONTENT_SCHEMAS', () => {
+	const VALID_STAGES: PipelineStage[] = ['transcription', 'summary'];
+	const VALID_MODES: SchemaMode[] = ['reformat', 'summarize'];
+
+	it('each schema has a valid id, name, detect function, and prompt', () => {
+		for (const schema of CONTENT_SCHEMAS) {
+			expect(typeof schema.id).toBe('string');
+			expect(schema.id.length).toBeGreaterThan(0);
+			expect(typeof schema.name).toBe('string');
+			expect(schema.name.length).toBeGreaterThan(0);
+			expect(typeof schema.detect).toBe('function');
+			expect(typeof schema.prompt).toBe('string');
+			expect(schema.prompt.length).toBeGreaterThan(0);
 		}
 	});
 
-	it('recipe template prompt includes structured output instructions', () => {
-		const recipe = CONTENT_TEMPLATES.find(t => t.id === 'recipe');
+	it('each schema declares a non-empty appliesTo with valid stages', () => {
+		for (const schema of CONTENT_SCHEMAS) {
+			expect(Array.isArray(schema.appliesTo)).toBe(true);
+			expect(schema.appliesTo.length).toBeGreaterThan(0);
+			for (const stage of schema.appliesTo) {
+				expect(VALID_STAGES).toContain(stage);
+			}
+		}
+	});
+
+	it('each schema declares a valid mode', () => {
+		for (const schema of CONTENT_SCHEMAS) {
+			expect(VALID_MODES).toContain(schema.mode);
+		}
+	});
+
+	it('recipe schema prompt includes structured output instructions', () => {
+		const recipe = CONTENT_SCHEMAS.find(s => s.id === 'recipe');
 		expect(recipe).toBeDefined();
 		expect(recipe!.prompt).toContain('Ingredients');
 		expect(recipe!.prompt).toContain('Instructions');
@@ -242,7 +315,7 @@ describe('CONTENT_TEMPLATES', () => {
 // ── RECIPE_PROMPT Content ────────────────────────────────────────────
 
 describe('RECIPE_PROMPT content', () => {
-	const recipe = CONTENT_TEMPLATES.find(t => t.id === 'recipe');
+	const recipe = CONTENT_SCHEMAS.find(s => s.id === 'recipe');
 
 	it('requires exact ingredient amounts', () => {
 		expect(recipe!.prompt).toContain('exact amount');
@@ -434,9 +507,9 @@ describe('receipt content detection', () => {
 		});
 	});
 
-	describe('receipt template shape', () => {
-		it('receipt template has valid id, name, detect function, and prompt', () => {
-			const receipt = CONTENT_TEMPLATES.find(t => t.id === 'receipt');
+	describe('receipt schema shape', () => {
+		it('receipt schema has valid id, name, detect function, and prompt', () => {
+			const receipt = CONTENT_SCHEMAS.find(s => s.id === 'receipt');
 			expect(receipt).toBeDefined();
 			expect(receipt!.id).toBe('receipt');
 			expect(receipt!.name).toBe('Receipt');
@@ -445,8 +518,8 @@ describe('receipt content detection', () => {
 			expect(receipt!.prompt.length).toBeGreaterThan(0);
 		});
 
-		it('receipt template prompt includes structured output sections', () => {
-			const receipt = CONTENT_TEMPLATES.find(t => t.id === 'receipt');
+		it('receipt schema prompt includes structured output sections', () => {
+			const receipt = CONTENT_SCHEMAS.find(s => s.id === 'receipt');
 			expect(receipt).toBeDefined();
 			expect(receipt!.prompt).toContain('Items');
 			expect(receipt!.prompt).toContain('Totals');
@@ -455,8 +528,8 @@ describe('receipt content detection', () => {
 		});
 	});
 
-	describe('detectContentTemplate for receipts', () => {
-		it('returns the receipt template for receipt content', () => {
+	describe('detectSchemaFor for receipts', () => {
+		it('returns the receipt schema for receipt content', () => {
 			const content = [
 				'TARGET',
 				'Store #1234',
@@ -474,10 +547,10 @@ describe('receipt content detection', () => {
 				'Payment               $13.48',
 			].join('\n');
 
-			const template = detectContentTemplate(content);
-			expect(template).not.toBeNull();
-			expect(template!.id).toBe('receipt');
-			expect(template!.name).toBe('Receipt');
+			const schema = detectSchemaFor('summary', content);
+			expect(schema).not.toBeNull();
+			expect(schema!.id).toBe('receipt');
+			expect(schema!.name).toBe('Receipt');
 		});
 	});
 });

--- a/src/shared/content-schemas.ts
+++ b/src/shared/content-schemas.ts
@@ -1,14 +1,24 @@
 /**
- * Content-aware summary templates.
+ * Content-aware formatting schemas.
  *
- * Each template defines a detection heuristic and a specialized prompt.
- * When auto-detection is enabled and no custom prompt is set, the first
- * matching template's prompt is used instead of the default style prompt.
+ * Each schema defines a detection heuristic and a specialized prompt, plus
+ * metadata describing which pipeline stage(s) it applies to and whether it
+ * reformats or summarizes. When auto-detection is enabled and no custom
+ * prompt is set, the first matching schema's prompt is used instead of the
+ * default style prompt.
+ *
+ * This registry is shared so both the summarize and transcription stages can
+ * consult it via `detectSchemaFor(stage, content)`.
  */
 
-export interface ContentTemplate {
+export type PipelineStage = 'transcription' | 'summary';
+export type SchemaMode = 'reformat' | 'summarize';
+
+export interface ContentSchema {
 	id: string;
 	name: string;
+	appliesTo: PipelineStage[];
+	mode: SchemaMode;
 	detect: (content: string) => boolean;
 	prompt: string;
 }
@@ -198,30 +208,36 @@ const RECEIPT_PROMPT =
 	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +
 	'Do not invent information that is not in the original text.';
 
-// ── Template Registry ─────────────────────────────────────────────────
+// ── Schema Registry ───────────────────────────────────────────────────
 
-export const CONTENT_TEMPLATES: ContentTemplate[] = [
+export const CONTENT_SCHEMAS: ContentSchema[] = [
 	{
 		id: 'recipe',
 		name: 'Recipe',
+		appliesTo: ['summary'],
+		mode: 'summarize',
 		detect: isRecipeContent,
 		prompt: RECIPE_PROMPT,
 	},
 	{
 		id: 'receipt',
 		name: 'Receipt',
+		appliesTo: ['summary'],
+		mode: 'summarize',
 		detect: isReceiptContent,
 		prompt: RECEIPT_PROMPT,
 	},
 ];
 
 /**
- * Iterate registered templates and return the first match, or null.
+ * Iterate registered schemas applicable to the given pipeline stage and
+ * return the first match, or null. Order matters: recipe is checked before
+ * receipt.
  */
-export function detectContentTemplate(content: string): ContentTemplate | null {
-	for (const template of CONTENT_TEMPLATES) {
-		if (template.detect(content)) {
-			return template;
+export function detectSchemaFor(stage: PipelineStage, content: string): ContentSchema | null {
+	for (const schema of CONTENT_SCHEMAS) {
+		if (schema.appliesTo.includes(stage) && schema.detect(content)) {
+			return schema;
 		}
 	}
 	return null;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -91,6 +91,15 @@ export {
 	buildMigratedExclusions,
 } from './exclusions';
 export type { FeatureId, ExclusionRule, LegacyModuleExclusions } from './exclusions';
+export {
+	CONTENT_SCHEMAS,
+	detectSchemaFor,
+	isRecipeContent,
+	scoreRecipeContent,
+	isReceiptContent,
+	scoreReceiptContent,
+} from './content-schemas';
+export type { ContentSchema, PipelineStage, SchemaMode } from './content-schemas';
 export { generateId, isValidCheckpointId } from './id-utils';
 export {
 	loadNodeModules,

--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -48,9 +48,9 @@ Exported types: `SummarizeTarget`, `SummarizeSettings`, `TranscribeUrlFn`, `Tran
 | `summarize-modal.ts` | `SummarizeSelectionModal` | Selection modal when multiple targets found |
 | `summarize-module.test.ts` | Tests | SummarizeModule integration tests |
 | `audio-summarize.test.ts` | Tests | Audio-embed summarization tests |
-| `templates.ts` | `detectContentTemplate`, `isRecipeContent`, `scoreRecipeContent`, `CONTENT_TEMPLATES` | Content-aware template detection (recipe format, extensible) |
-| `templates.test.ts` | Tests | Template detection unit tests |
 | `types.ts` | -- | `SummarizeTarget` |
+
+> Content-aware formatting schemas (recipe/receipt detection + prompts) live in the shared `content-schemas.ts` registry (`shared/content-schemas.ts`), consumed here via `detectSchemaFor('summary', content)`. See [Content-Aware Schemas](#content-aware-schemas).
 
 ## Data Flow
 
@@ -76,7 +76,7 @@ processFileTargets(file, targets, op, content)
     else (inline target):
       --> fetchContentForUrl(url) or use transcription content
       --> determine effectivePrompt:
-            customPrompt > detectContentTemplate(content) > style default
+            customPrompt > detectSchemaFor('summary', content) > style default
       --> Summarizer.summarize(content, url, style, effectivePrompt)
       --> insert callout after target line
   --> vault.modify(sourceFile)
@@ -149,36 +149,42 @@ this.summarize = new SummarizeModule(
 
 ## Dependencies
 
-- `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, OperationHandle, buildCallout, CALLOUT_TYPES, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask, fetchPageContent, fetchTweetContent, isSupportedUrl, detectPlatform)
+- `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, OperationHandle, buildCallout, CALLOUT_TYPES, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask, fetchPageContent, fetchTweetContent, isSupportedUrl, detectPlatform, detectSchemaFor)
 - `audio/` (findAudioEmbeds -- used in collectTargets)
 - `settings.ts` (SynapseSettings, SummarizeSettings)
 - NO static `video/` import. URL-platform helpers (`isSupportedUrl`/`detectPlatform`) and content fetchers (`fetchPageContent`/`fetchTweetContent`) resolve from `shared`. Video transcription happens only through the injected `transcribeUrl` callback (`TranscribeUrlFn`).
 
-## Content-Aware Templates
+## Content-Aware Schemas
 
-When `autoDetectTemplates` is enabled (default: true) and no `customPrompt` is set, the module runs `detectContentTemplate(content)` on inline-target content before summarization. If a template matches, its specialized prompt replaces the style-based default.
+The content-aware formatting registry lives in the **shared** module (`shared/content-schemas.ts`) so both the summarize and transcription stages can consult it. Each `ContentSchema` declares which `appliesTo` pipeline stage(s) it targets (`'transcription' | 'summary'`) and a `mode` (`'reformat' | 'summarize'`). The summarize module only ever asks for the `'summary'` stage.
 
-Priority chain: `customPrompt` > template match > style default.
+When `autoDetectTemplates` is enabled (default: true) and no `customPrompt` is set, the module runs `detectSchemaFor('summary', content)` on inline-target content before summarization. If a schema matches, its specialized prompt replaces the style-based default.
 
-Enrichment targets (standalone notes) always use `COMPREHENSIVE_SUMMARY_PROMPT` and are not affected by template detection.
+Priority chain: `customPrompt` > schema match > style default.
 
-### Templates
+Enrichment targets (standalone notes) always use `COMPREHENSIVE_SUMMARY_PROMPT` and are not affected by schema detection.
+
+### Summary-stage schemas
 
 | ID | Name | Detection | Prompt Format |
 |----|------|-----------|---------------|
 | `recipe` | Recipe | Keyword scoring (structural headers, cooking verbs, measurements); threshold >= 5 | Structured recipe: title, times, servings, ingredients with exact amounts, numbered instructions with step images, notes |
+| `receipt` | Receipt | Keyword scoring (currency/total headers, line items, payment terms, identifiers, date/time); threshold >= 5 | Structured receipt: store, date, item table, totals, payment method, notes |
 
-### Adding New Templates
+### Adding new schemas
 
-1. Create a detection function in `templates.ts` (pure function, no side effects).
+Schemas are defined centrally in `shared/content-schemas.ts`:
+
+1. Create a detection function (pure function, no side effects).
 2. Define the specialized prompt string.
-3. Add a `ContentTemplate` entry to the `CONTENT_TEMPLATES` array.
-4. Add tests in `templates.test.ts` for both positive and negative detection.
+3. Add a `ContentSchema` entry to the `CONTENT_SCHEMAS` array with `appliesTo` + `mode` set, and export anything needed from `shared/index.ts`.
+4. Add tests in `shared/content-schemas.test.ts` for both positive and negative detection (and the stage gate).
 
 ## Tests
 
 - `summarizer.test.ts`
 - `note-scanner.test.ts`
 - `summarize-module.test.ts`
-- `templates.test.ts`
 - `audio-summarize.test.ts`
+
+> Content-schema detection tests live in `shared/content-schemas.test.ts`.

--- a/src/summarize/audio-summarize.test.ts
+++ b/src/summarize/audio-summarize.test.ts
@@ -35,7 +35,10 @@ vi.mock('../audio', () => ({
 
 // Mock the shared module. Content fetchers are stubbed here (they moved from
 // ./content-fetcher into ../shared) to avoid real network calls.
-vi.mock('../shared', () => ({
+vi.mock('../shared', async () => ({
+	// Use the REAL content-schema registry so auto-format detection runs as in
+	// production rather than throwing on an undefined mock.
+	...(await vi.importActual<typeof import('../shared/content-schemas')>('../shared/content-schemas')),
 	FolderPickerModal: vi.fn(),
 	getMarkdownFiles: vi.fn().mockReturnValue([]),
 	NotificationManager: vi.fn(),

--- a/src/summarize/combine-summarize.test.ts
+++ b/src/summarize/combine-summarize.test.ts
@@ -26,7 +26,10 @@ vi.mock('../audio', () => ({
 	findAudioEmbeds: (...args: any[]) => mockFindAudioEmbeds(...args),
 }));
 
-vi.mock('../shared', () => ({
+vi.mock('../shared', async () => ({
+	// Use the REAL content-schema registry so auto-format detection runs as in
+	// production (this path consults detectSchemaFor on the combined transcript).
+	...(await vi.importActual<typeof import('../shared/content-schemas')>('../shared/content-schemas')),
 	FolderPickerModal: vi.fn(),
 	getMarkdownFiles: vi.fn().mockReturnValue([]),
 	NotificationManager: vi.fn(),

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout,
 	CALLOUT_TYPES, CheckpointManager, generateId, fireAndForget,
-	isPathExcluded, matchesExcludeTag,
+	isPathExcluded, matchesExcludeTag, detectSchemaFor,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { OperationHandle } from '../shared';
@@ -15,7 +15,6 @@ import { findSummarizeTargets } from './note-scanner';
 import { hasSummaryBelow } from './note-scanner';
 import { SummarizeSelectionModal } from './summarize-modal';
 import { Summarizer } from './summarizer';
-import { detectContentTemplate } from './templates';
 import { SummarizeTarget } from './types';
 
 export type { SummarizeTarget } from './types';
@@ -288,8 +287,8 @@ export class SummarizeModule {
 
 					let effectivePrompt = settings.customPrompt || undefined;
 					if (!effectivePrompt && settings.autoDetectTemplates) {
-						const template = detectContentTemplate(transcript);
-						if (template) effectivePrompt = template.prompt;
+						const schema = detectSchemaFor('summary', transcript);
+						if (schema) effectivePrompt = schema.prompt;
 					}
 
 					const summary = await this.summarizer.summarize(
@@ -551,12 +550,12 @@ export class SummarizeModule {
 
 					op.update(`Summarizing ${target.source}`);
 
-					// Priority chain: customPrompt > template match > style default
+					// Priority chain: customPrompt > schema match > style default
 					let effectivePrompt = settings.customPrompt || undefined;
 					if (!effectivePrompt && settings.autoDetectTemplates) {
-						const template = detectContentTemplate(textToSummarize);
-						if (template) {
-							effectivePrompt = template.prompt;
+						const schema = detectSchemaFor('summary', textToSummarize);
+						if (schema) {
+							effectivePrompt = schema.prompt;
 						}
 					}
 

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -35,7 +35,10 @@ vi.mock('../video', () => ({
 // Mock the shared module to avoid folder picker / getMarkdownFiles issues.
 // Content fetchers are stubbed here (they moved from ./content-fetcher into
 // ../shared) to avoid real network calls.
-vi.mock('../shared', () => ({
+vi.mock('../shared', async () => ({
+	// Use the REAL content-schema registry (recipe/receipt detection + prompts)
+	// so auto-format behavior is exercised faithfully through the shared barrel.
+	...(await vi.importActual<typeof import('../shared/content-schemas')>('../shared/content-schemas')),
 	FolderPickerModal: vi.fn(),
 	getMarkdownFiles: vi.fn().mockReturnValue([]),
 	NotificationManager: vi.fn(),


### PR DESCRIPTION
## Summary

Behavior-preserving refactor (first of two stacked PRs). Promotes the content-type auto-formatting registry **out of** `src/summarize/` into a new **shared** module so both the summarize and (upcoming) transcription stages can consult it. **Recipe/receipt behavior is 100% unchanged.**

## What moved

- **New `src/shared/content-schemas.ts`** — the registry, moved (not rewritten):
  - `interface ContentSchema { id, name, appliesTo: PipelineStage[], mode: SchemaMode, detect, prompt }`
  - `type PipelineStage = 'transcription' | 'summary'`, `type SchemaMode = 'reformat' | 'summarize'`
  - `CONTENT_SCHEMAS` = `[recipe, receipt]` (recipe still checked **before** receipt)
  - `detectSchemaFor(stage, content)` — stage-gated lookup (replaces `detectContentTemplate`)
  - All detection heuristics carried over verbatim: `isRecipeContent`/`scoreRecipeContent` (threshold ≥5, +10 structured-recipe boost), `isReceiptContent`/`scoreReceiptContent` (≥5), and the `RECIPE_PROMPT`/`RECEIPT_PROMPT` strings (verified **byte-for-byte** identical — 43/43 literal lines).
- **`src/shared/index.ts`** — barrel re-exports the registry + types.
- **`src/summarize/index.ts`** — imports `detectSchemaFor` from `../shared` (no deep import); both call sites swap `detectContentTemplate(x)` → `detectSchemaFor('summary', x)`. The `customPrompt > schema.prompt > style` priority and `autoDetectTemplates` gate are untouched.
- **Deleted** `src/summarize/templates.ts` + `templates.test.ts` (no remaining references).
- Updated `src/summarize/AGENTS.md` + `src/shared/AGENTS.md` registries to reflect the move.

## New API

`detectSchemaFor(stage: PipelineStage, content: string): ContentSchema | null` — iterates `CONTENT_SCHEMAS`, returning the first schema whose `appliesTo` includes `stage` **and** whose `detect(content)` matches. Today both schemas are `appliesTo: ['summary']`, so transcription-stage calls return `null`.

## Tests

- Ported every case from `templates.test.ts` into `src/shared/content-schemas.test.ts` (retargeted to `detectSchemaFor('summary', …)`).
- **Added stage-gate lock tests**: recipe/receipt fire at `'summary'`, and `detectSchemaFor('transcription', <recipe|receipt>) === null` — this locks the gate so the #234 follow-up can't accidentally fire summary schemas at transcription.
- Schema-shape assertions extended to cover non-empty `appliesTo` + valid `mode`.
- The summarize integration tests mock the `../shared` barrel, so they now spread the **real** `content-schemas` exports to keep auto-format detection faithful.

Full CI set green locally: `tsc --noEmit`, **Test Files 103 passed / Tests 1397 passed**, production build, `check-top-level-requires.mjs`, `version-bump --check`, `eslint`.

## Stacking

PR **#234** (lyrics schema, applied at the transcription stage) stacks on this branch — it will add a `lyrics` schema with `appliesTo: ['transcription']` and wire `detectSchemaFor('transcription', …)` into the transcription pipeline.

closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)