### PR TITLE
feat: auto-format song transcripts as structured lyrics (#234)

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -1,7 +1,8 @@
 import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import {
-	NotificationManager, buildCallout, CALLOUT_TYPES, sanitizeAIResponse,
+	NotificationManager, buildCallout, CALLOUT_TYPES, calloutForTranscriptionResult,
+	sanitizeAIResponse, AIClient, detectSchemaFor,
 	CheckpointManager, generateId, formatTimeRange, loadNodeModules,
 	isPathExcluded, findMatchingRule,
 } from '../shared';
@@ -21,6 +22,7 @@ export class AudioModule {
 
 	private transcriber: Transcriber;
 	private postProcessor: PostProcessor;
+	private aiClient: AIClient;
 
 	/**
 	 * Delay (ms) between sequential per-file transcriptions in the no-ffmpeg
@@ -40,6 +42,7 @@ export class AudioModule {
 	) {
 		this.transcriber = new Transcriber(getSettings);
 		this.postProcessor = new PostProcessor(getSettings);
+		this.aiClient = new AIClient(getSettings);
 	}
 
 	async onload(): Promise<void> {
@@ -81,11 +84,43 @@ export class AudioModule {
 			result.processed = await this.postProcessor.process(result.raw);
 		}
 
+		await this.maybeReformatBySchema(result);
+
 		if (options?.sourceName) {
 			result.sourceName = options.sourceName;
 		}
 
 		return result;
+	}
+
+	/**
+	 * Content-schema reformat (#234): if a transcription-stage schema (e.g.
+	 * lyrics) matches and auto-formatting is enabled, reformat the transcript in
+	 * place — preserving it rather than condensing it. The reformatted text is
+	 * written to `result.processed` (every consumer reads `processed || raw`) and
+	 * tagged via `schemaId`/`reformatted` so the write sites emit a distinct
+	 * callout type. Detection is local (no AI cost); the AI call fires only on a
+	 * match. Any failure falls back to the unmodified transcript.
+	 */
+	private async maybeReformatBySchema(result: TranscriptionResult): Promise<void> {
+		if (!this.getSettings().audio.autoFormatLyrics) return;
+
+		const base = result.processed ?? result.raw;
+		const schema = detectSchemaFor('transcription', base);
+		if (!schema || schema.mode !== 'reformat') return;
+
+		try {
+			const reformatted = sanitizeAIResponse(await this.aiClient.complete(base, schema.prompt));
+			if (reformatted.trim()) {
+				result.processed = reformatted;
+				result.reformatted = true;
+				result.schemaId = schema.id;
+			}
+		} catch (error) {
+			// Graceful fallback (#234): keep the raw/cleaned transcript on any
+			// failure (e.g. the provider refuses or truncates a long song).
+			console.warn('[Synapse] Schema reformat failed; keeping transcript', error);
+		}
 	}
 
 	async transcribeFileToActiveNote(file: TFile, timeRange?: TimeRange): Promise<void> {
@@ -137,11 +172,12 @@ export class AudioModule {
 			const result = await this.transcribe(data, file.name);
 			const text = result.processed || result.raw;
 
+			const { type, verb } = calloutForTranscriptionResult(result);
 			const title = timeRange && this.extractor
-				? `Transcription of ${file.name} ${formatTimeRange(timeRange)}`
-				: `Transcription of ${file.name}`;
+				? `${verb} ${file.name} ${formatTimeRange(timeRange)}`
+				: `${verb} ${file.name}`;
 			const transcriptionBlock = buildCallout(
-				CALLOUT_TYPES.transcription,
+				type,
 				title,
 				text,
 				true
@@ -222,9 +258,10 @@ export class AudioModule {
 				const result = await this.transcribe(data, embed.fileName);
 				const text = result.processed || result.raw;
 
+				const { type, verb } = calloutForTranscriptionResult(result);
 				const transcriptionBlock = buildCallout(
-					CALLOUT_TYPES.transcription,
-					`Transcription of ${embed.fileName}`,
+					type,
+					`${verb} ${embed.fileName}`,
 					text,
 					true
 				);

--- a/src/audio/lyrics-reformat.test.ts
+++ b/src/audio/lyrics-reformat.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted so the transcriber mock factory (lifted above imports) can use it.
+const fixtures = vi.hoisted(() => ({
+	LYRICS: [
+		'[Verse 1]',
+		'City lights are calling out my name',
+		'Walking down these empty streets again',
+		'But I keep moving on',
+		'',
+		'[Chorus]',
+		'We were running through the night',
+		'Holding on to something that felt right',
+		'We were running through the night',
+		'Chasing every star in sight',
+		'',
+		'[Chorus]',
+		'We were running through the night',
+		'Holding on to something that felt right',
+		'We were running through the night',
+		'Chasing every star in sight',
+	].join('\n'),
+}));
+
+// Transcriber returns a song; post-processor passes the text through unchanged
+// so the reformat step sees the lyrics as its input. No network/API calls.
+vi.mock('./transcriber', () => ({
+	Transcriber: class {
+		transcribe = vi.fn(async () => ({ raw: fixtures.LYRICS, sourceName: 'song' }));
+	},
+	GEMINI_MAX_INLINE_AUDIO_BYTES: 15 * 1024 * 1024,
+}));
+vi.mock('./post-processor', () => ({
+	PostProcessor: class {
+		process = vi.fn(async (t: string) => t);
+	},
+}));
+
+import { AudioModule } from './index';
+import { AIClient } from '../shared';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+const REFORMATTED =
+	'## Untitled\n**Artist:** Not specified\n\n> [!verse] Verse 1\n> City lights are calling out my name';
+
+function makeModule(autoFormatLyrics: boolean): AudioModule {
+	return new AudioModule(
+		{} as never,
+		() => ({ audio: { autoFormatLyrics, transcriptionProvider: 'whisper-api' } }) as never,
+		{ info: vi.fn() } as never,
+		createMockCheckpointManager() as never,
+		undefined
+	);
+}
+
+describe('AudioModule.transcribe lyrics reformatting (#234)', () => {
+	let completeSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		completeSpy = vi.spyOn(AIClient.prototype, 'complete').mockResolvedValue(REFORMATTED);
+	});
+	afterEach(() => { vi.restoreAllMocks(); });
+
+	it('reformats a detected song and tags the result as lyrics when enabled', async () => {
+		const module = makeModule(true);
+
+		const result = await module.transcribe(new ArrayBuffer(8), 'song.mp3');
+
+		// The reformat fired exactly once, driven by the lyrics prompt (system arg).
+		expect(completeSpy).toHaveBeenCalledTimes(1);
+		expect(completeSpy.mock.calls[0][1]).toContain('[!verse]');
+		// processed now holds the reformatted lyrics, tagged for the lyrics callout.
+		expect(result.processed).toContain('> [!verse] Verse 1');
+		expect(result.reformatted).toBe(true);
+		expect(result.schemaId).toBe('lyrics');
+	});
+
+	it('does not reformat when autoFormatLyrics is disabled', async () => {
+		const module = makeModule(false);
+
+		const result = await module.transcribe(new ArrayBuffer(8), 'song.mp3');
+
+		expect(completeSpy).not.toHaveBeenCalled();
+		expect(result.reformatted).toBeUndefined();
+		expect(result.schemaId).toBeUndefined();
+		// Falls back to the (post-processed) transcript unchanged.
+		expect(result.processed).toBe(fixtures.LYRICS);
+	});
+});

--- a/src/audio/note-scanner.test.ts
+++ b/src/audio/note-scanner.test.ts
@@ -132,6 +132,16 @@ describe('hasTranscriptionBelow', () => {
 		expect(hasTranscriptionBelow(lines, 0, 'recording.mp3')).toBe(true);
 	});
 
+	it('returns true for a lyrics callout (#234 reformatted song)', () => {
+		const lines = [
+			'![[recording.mp3]]',
+			'',
+			'> [!synapse-lyrics]- Lyrics of recording.mp3',
+			'> ## Untitled',
+		];
+		expect(hasTranscriptionBelow(lines, 0, 'recording.mp3')).toBe(true);
+	});
+
 	it('returns false when no transcription exists', () => {
 		const lines = [
 			'![[recording.mp3]]',

--- a/src/audio/note-scanner.ts
+++ b/src/audio/note-scanner.ts
@@ -45,6 +45,11 @@ export function hasTranscriptionBelow(lines: string[], embedLine: number, fileNa
 		if (lines[j].includes(`[!${CALLOUT_TYPES.transcription}]`) && lines[j].includes(`Transcription of ${fileName}`)) {
 			return true;
 		}
+		// Lyrics callout format (#234): a reformatted song transcript counts as
+		// already transcribed, so re-scans don't re-offer transcription.
+		if (lines[j].includes(`[!${CALLOUT_TYPES.lyrics}]`) && lines[j].includes(`Lyrics of ${fileName}`)) {
+			return true;
+		}
 		// Stop looking if we hit another embed or non-empty non-blank line that isn't a blockquote
 		if (lines[j].trim().length > 0 && !lines[j].startsWith('>') && lines[j].trim() !== '') {
 			break;

--- a/src/audio/settings-section.test.ts
+++ b/src/audio/settings-section.test.ts
@@ -57,4 +57,23 @@ describe('renderAudioSettings', () => {
 		const openaiAI = makeCtx((s) => { s.audio.transcriptionProvider = 'gemini'; s.ai.provider = 'openai'; });
 		expect(() => renderAudioSettings(openaiAI.ctx)).not.toThrow();
 	});
+
+	it('renders the auto-format lyrics toggle reflecting the setting and saves changes', async () => {
+		// Make autoFormatLyrics the only OFF toggle so it is uniquely identifiable
+		// (header enabled + post-processing toggles are all ON).
+		const { ctx, plugin, saveSettings } = makeCtx((s) => {
+			s.audio.enabled = true;
+			s.audio.autoFormatLyrics = false;
+			s.audio.postProcessing.enabled = true;
+			s.audio.postProcessing.removeFiller = true;
+		});
+		renderAudioSettings(ctx);
+
+		const lyricsToggle = ToggleComponent.instances.find((t) => t.getValue() === false);
+		expect(lyricsToggle).toBeDefined();
+
+		await lyricsToggle!._trigger(true);
+		expect(plugin.settings.audio.autoFormatLyrics).toBe(true);
+		expect(saveSettings).toHaveBeenCalled();
+	});
 });

--- a/src/audio/settings-section.ts
+++ b/src/audio/settings-section.ts
@@ -152,6 +152,22 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 		);
 
 	new Setting(audioBody)
+		.setName('Auto-format song lyrics')
+		.setDesc(
+			'Detect transcripts that are song lyrics and format them into verse/chorus ' +
+			'sections (preserving every line) instead of leaving them as prose. Makes one ' +
+			'extra AI call when a song is detected.'
+		)
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.audio.autoFormatLyrics)
+				.onChange(async (value) => {
+					plugin.settings.audio.autoFormatLyrics = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(audioBody)
 		.setName('Post-processing')
 		.setDesc('Clean up and structure transcriptions with AI')
 		.addToggle((toggle) =>

--- a/src/audio/types.ts
+++ b/src/audio/types.ts
@@ -8,6 +8,10 @@ export interface TranscriptionResult {
 	duration?: number;
 	sourceName: string;
 	timestamps?: TimestampEntry[];
+	/** True when a content schema (#234, e.g. lyrics) reformatted the transcript. */
+	reformatted?: boolean;
+	/** Id of the content schema that reformatted the transcript, if any (e.g. 'lyrics'). */
+	schemaId?: string;
 }
 
 export interface TimestampEntry {

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -49,6 +49,10 @@ describe('Gemini provider settings (#251)', () => {
 	it('defaults the dedicated Gemini transcription key to empty', () => {
 		expect(DEFAULT_SETTINGS.audio.geminiApiKey).toBe('');
 	});
+
+	it('enables lyric auto-formatting by default (#234)', () => {
+		expect(DEFAULT_SETTINGS.audio.autoFormatLyrics).toBe(true);
+	});
 });
 
 describe('onboarding settings (#89)', () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -85,6 +85,8 @@ export interface AudioSettings {
 	whisperModel: string;
 	localWhisperPath: string;
 	language: string;
+	/** Auto-detect song transcripts and format them as structured lyrics (#234). */
+	autoFormatLyrics: boolean;
 	postProcessing: PostProcessingSettings;
 }
 
@@ -332,6 +334,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		whisperModel: 'whisper-1',
 		localWhisperPath: '',
 		language: '',
+		autoFormatLyrics: true,
 		postProcessing: {
 			enabled: true,
 			removeFiller: true,

--- a/src/shared/callouts.test.ts
+++ b/src/shared/callouts.test.ts
@@ -1,14 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import { buildCallout, CALLOUT_TYPES } from './callouts';
+import { buildCallout, CALLOUT_TYPES, calloutForTranscriptionResult } from './callouts';
 
 describe('CALLOUT_TYPES', () => {
 	it('has all expected types', () => {
 		expect(CALLOUT_TYPES.summary).toBe('synapse-summary');
 		expect(CALLOUT_TYPES.transcription).toBe('synapse-transcription');
+		expect(CALLOUT_TYPES.lyrics).toBe('synapse-lyrics');
+		expect(CALLOUT_TYPES.verse).toBe('synapse-verse');
+		expect(CALLOUT_TYPES.chorus).toBe('synapse-chorus');
 		expect(CALLOUT_TYPES.enrichment).toBe('synapse-enrichment');
 		expect(CALLOUT_TYPES.elaboration).toBe('synapse-elaboration');
 		expect(CALLOUT_TYPES.deepDive).toBe('synapse-deep-dive');
 		expect(CALLOUT_TYPES.nav).toBe('synapse-nav');
+	});
+});
+
+describe('calloutForTranscriptionResult', () => {
+	it('uses the lyrics callout and verb when a lyrics schema reformatted the transcript', () => {
+		const result = calloutForTranscriptionResult({ reformatted: true, schemaId: 'lyrics' });
+		expect(result.type).toBe(CALLOUT_TYPES.lyrics);
+		expect(result.verb).toBe('Lyrics of');
+	});
+
+	it('uses the transcription callout and verb for an unreformatted transcript', () => {
+		const result = calloutForTranscriptionResult({});
+		expect(result.type).toBe(CALLOUT_TYPES.transcription);
+		expect(result.verb).toBe('Transcription of');
+	});
+
+	it('falls back to transcription for an unknown schema id', () => {
+		const result = calloutForTranscriptionResult({ reformatted: true, schemaId: 'recipe' });
+		expect(result.type).toBe(CALLOUT_TYPES.transcription);
+		expect(result.verb).toBe('Transcription of');
 	});
 });
 

--- a/src/shared/callouts.ts
+++ b/src/shared/callouts.ts
@@ -9,6 +9,9 @@
 export const CALLOUT_TYPES = {
 	summary: 'synapse-summary',
 	transcription: 'synapse-transcription',
+	lyrics: 'synapse-lyrics',
+	verse: 'synapse-verse',
+	chorus: 'synapse-chorus',
 	enrichment: 'synapse-enrichment',
 	elaboration: 'synapse-elaboration',
 	deepDive: 'synapse-deep-dive',
@@ -17,6 +20,21 @@ export const CALLOUT_TYPES = {
 } as const;
 
 export type CalloutType = (typeof CALLOUT_TYPES)[keyof typeof CALLOUT_TYPES];
+
+/**
+ * Choose the callout type and header verb for a finished transcription based on
+ * whether a content schema reformatted it. Lyric reformatting (#234) writes a
+ * distinct `synapse-lyrics` callout — which the summarize note-scanner does not
+ * match — so reformatted song lyrics are never re-condensed into a summary.
+ */
+export function calloutForTranscriptionResult(
+	result: { reformatted?: boolean; schemaId?: string }
+): { type: CalloutType; verb: string } {
+	if (result.schemaId === 'lyrics') {
+		return { type: CALLOUT_TYPES.lyrics, verb: 'Lyrics of' };
+	}
+	return { type: CALLOUT_TYPES.transcription, verb: 'Transcription of' };
+}
 
 /**
  * Legacy comment-based enrichment section markers.

--- a/src/shared/content-schemas.test.ts
+++ b/src/shared/content-schemas.test.ts
@@ -5,6 +5,8 @@ import {
 	scoreRecipeContent,
 	isReceiptContent,
 	scoreReceiptContent,
+	isLyricsContent,
+	scoreLyricsContent,
 	CONTENT_SCHEMAS,
 } from './content-schemas';
 import type { PipelineStage, SchemaMode } from './content-schemas';
@@ -551,6 +553,157 @@ describe('receipt content detection', () => {
 			expect(schema).not.toBeNull();
 			expect(schema!.id).toBe('receipt');
 			expect(schema!.name).toBe('Receipt');
+		});
+	});
+});
+
+// ── Lyrics Detection ─────────────────────────────────────────────────
+
+describe('lyrics content detection', () => {
+	// Structured lyrics with explicit section markers and a repeated chorus.
+	const BRACKETED_LYRICS = [
+		'[Verse 1]',
+		'City lights are calling out my name',
+		'Walking down these empty streets again',
+		'Every shadow tells me you are the same',
+		'But I keep moving on',
+		'',
+		'[Chorus]',
+		'We were running, running through the night',
+		'Holding on to something that felt right',
+		'We were running, running through the night',
+		'Chasing every star in sight',
+		'',
+		'[Verse 2]',
+		'Morning comes and washes you away',
+		'All the words I never got to say',
+		'Faded like a photograph in rain',
+		'But I keep moving on',
+		'',
+		'[Chorus]',
+		'We were running, running through the night',
+		'Holding on to something that felt right',
+		'We were running, running through the night',
+		'Chasing every star in sight',
+	].join('\n');
+
+	// Real Whisper output: one run-on paragraph, no markers. Detection has to
+	// rely on repetition + short-phrase statistics, not section headers.
+	const RUNON_LYRICS =
+		'I see the fire in your eyes, I see the fire in your eyes, dancing like the summer skies, ' +
+		'we don\'t have to say goodbye, I see the fire in your eyes, I see the fire in your eyes, ' +
+		'take my hand and hold it tight, we will be running through the night, ' +
+		'I see the fire in your eyes, I see the fire in your eyes, na na na na, na na na na';
+
+	describe('isLyricsContent — positives', () => {
+		it('detects lyrics with [Verse]/[Chorus] markers', () => {
+			expect(isLyricsContent(BRACKETED_LYRICS)).toBe(true);
+		});
+
+		it('detects run-on single-paragraph lyrics via repetition (no markers)', () => {
+			expect(isLyricsContent(RUNON_LYRICS)).toBe(true);
+			// The run-on case must NOT lean on section markers.
+			expect(RUNON_LYRICS).not.toMatch(/\[(verse|chorus)/i);
+		});
+	});
+
+	describe('isLyricsContent — false-positive guards', () => {
+		const poem = [
+			'The Road Not Taken',
+			'',
+			'Two roads diverged in a yellow wood,',
+			'And sorry I could not travel both',
+			'And be one traveler, long I stood',
+			'And looked down one as far as I could',
+			'To where it bent in the undergrowth;',
+			'',
+			'Then took the other, as just as fair,',
+			'And having perhaps the better claim,',
+			'Because it was grassy and wanted wear;',
+			'Though as for that the passing there',
+			'Had worn them really about the same,',
+		].join('\n');
+
+		const prose =
+			'The quarterly report shows that revenue increased by twelve percent compared to the ' +
+			'previous period. This growth was driven primarily by strong performance in the enterprise ' +
+			'segment, which saw new customer acquisition rise significantly. Management expects this ' +
+			'trend to continue into the next fiscal year, although some uncertainty remains.';
+
+		const meetingNotes = [
+			'# Team Sync — March 12',
+			'',
+			'Attendees: Alice, Bob, Carol.',
+			'',
+			'- Alice gave an update on the API migration; on track for Q2.',
+			'- Bob raised concerns about the test coverage in the auth module.',
+			'- Carol will follow up with design on the new onboarding flow.',
+			'- Next meeting scheduled for March 19 at 10am.',
+		].join('\n');
+
+		const listHeavy = [
+			'Shopping list',
+			'',
+			'- Milk',
+			'- Eggs',
+			'- Bread',
+			'- Coffee beans',
+			'- Olive oil',
+			'- Spinach',
+			'- Chicken thighs',
+			'- Greek yogurt',
+		].join('\n');
+
+		const recipe = [
+			'## Banana Bread',
+			'',
+			'Ingredients:',
+			'- 3 ripe bananas',
+			'- 2 cups flour',
+			'- 1 cup sugar',
+			'',
+			'Instructions:',
+			'1. Preheat oven to 350 degrees.',
+			'2. Mash the bananas in a large bowl.',
+			'3. Bake for 60 minutes.',
+		].join('\n');
+
+		it.each([
+			['a poem', poem],
+			['a prose paragraph', prose],
+			['meeting notes', meetingNotes],
+			['a list-heavy note', listHeavy],
+			['a recipe', recipe],
+		])('does not flag %s as lyrics', (_label, content) => {
+			expect(scoreLyricsContent(content)).toBeLessThan(5);
+			expect(isLyricsContent(content)).toBe(false);
+		});
+	});
+
+	describe('detectSchemaFor — lyrics stage gating', () => {
+		it('fires lyrics at the transcription stage', () => {
+			expect(detectSchemaFor('transcription', BRACKETED_LYRICS)?.id).toBe('lyrics');
+		});
+
+		it('does NOT fire lyrics at the summary stage', () => {
+			expect(detectSchemaFor('summary', BRACKETED_LYRICS)).toBeNull();
+		});
+	});
+
+	describe('lyrics schema shape', () => {
+		const lyrics = CONTENT_SCHEMAS.find(s => s.id === 'lyrics');
+
+		it('is registered with transcription applicability and reformat mode', () => {
+			expect(lyrics).toBeDefined();
+			expect(lyrics!.appliesTo).toEqual(['transcription']);
+			expect(lyrics!.mode).toBe('reformat');
+		});
+
+		it('prompt preserves every line, segments verse/chorus, and reuses the guardrail', () => {
+			expect(lyrics!.prompt).toContain('[!verse]');
+			expect(lyrics!.prompt).toContain('[!chorus]');
+			expect(lyrics!.prompt).toMatch(/do not (summarize|paraphrase|condense)|omit/i);
+			expect(lyrics!.prompt).toContain('Not specified');
 		});
 	});
 });

--- a/src/shared/content-schemas.ts
+++ b/src/shared/content-schemas.ts
@@ -208,6 +208,140 @@ const RECEIPT_PROMPT =
 	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +
 	'Do not invent information that is not in the original text.';
 
+// ── Lyrics Detection ──────────────────────────────────────────────────
+
+// Explicit section markers — the strongest signal a transcript is song lyrics.
+const LYRICS_SECTION_MARKER =
+	/(\[\s*(?:verse|chorus|pre[-\s]?chorus|bridge|intro|outro|hook|refrain)\s*\d*\s*\]|\(\s*(?:bridge|chorus|hook|refrain|pre[-\s]?chorus)\s*\))/i;
+
+// Annotations and vocable runs common to lyrics ("[x2]", "(repeat)", "la la").
+const LYRICS_ANNOTATION =
+	/(\[\s*x\s*\d+\s*\]|\(\s*(?:x\s*\d+|\d+\s*x|repeat)\s*\)|\b(?:la(?:\s+la)+|na(?:\s+na)+|oh(?:\s+oh)+|whoa(?:\s+whoa)+|yeah(?:\s+yeah)+)\b)/i;
+
+/** Normalize a chunk for repetition comparison: lowercase, strip punctuation, collapse whitespace. */
+function normalizeChunk(chunk: string): string {
+	return chunk.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Fraction of chunks that are verbatim repeats of an earlier chunk. Choruses
+ * repeat word-for-word, which is the single most distinctive statistical signal
+ * for lyrics. Returns 0 below a minimum chunk count to avoid trivial-input noise.
+ */
+function repetitionRatio(chunks: string[]): number {
+	const normalized = chunks.map(normalizeChunk).filter(c => c.length > 0);
+	if (normalized.length < 6) return 0;
+	const counts = new Map<string, number>();
+	for (const c of normalized) counts.set(c, (counts.get(c) ?? 0) + 1);
+	let repeated = 0;
+	for (const n of counts.values()) if (n > 1) repeated += n - 1;
+	return repeated / normalized.length;
+}
+
+/**
+ * Split content into comparable segments. Prefers real line breaks; for the
+ * run-on single-paragraph output Whisper typically produces, falls back to
+ * splitting on sentence/clause punctuation so the statistical signals still work.
+ */
+function lyricSegments(text: string): string[] {
+	const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+	if (lines.length >= 4) return lines;
+	return text.split(/[,.;!?\n]+/).map(s => s.trim()).filter(Boolean);
+}
+
+/**
+ * Score content for song-lyric characteristics. Exported for testing.
+ *
+ * Repetition is weighted highest because choruses repeat verbatim — a signal
+ * prose, lists, notes, and recipes lack — which keeps false positives down.
+ *
+ * Scoring (threshold 5):
+ *   - Section markers ([Verse]/[Chorus]/(Bridge)) — 2 pts
+ *   - Repetition ratio — 2 pts (>= 0.15), or 3 pts (>= 0.35)
+ *   - Short-segment profile — 1 pt (>= 0.6 short & unterminated), or 2 pts (>= 0.85)
+ *   - Stanza structure (multiple short blank-line-delimited blocks) — 1 pt
+ *   - Lyric annotations / vocable runs — 1 pt
+ */
+export function scoreLyricsContent(content: string): number {
+	const text = content.trim();
+	if (!text) return 0;
+	let score = 0;
+
+	if (LYRICS_SECTION_MARKER.test(text)) {
+		score += 2;
+	}
+
+	// Repetition — the max of line- and phrase-level ratios so it fires on both
+	// stanza'd lyrics and run-on paragraphs.
+	const lines = text.split('\n');
+	const phrases = text.split(/[\n.,;!?]+/);
+	const repetition = Math.max(repetitionRatio(lines), repetitionRatio(phrases));
+	if (repetition >= 0.35) {
+		score += 3;
+	} else if (repetition >= 0.15) {
+		score += 2;
+	}
+
+	// Short-segment profile — lyric lines are short and rarely end in . ? !
+	const segments = lyricSegments(text);
+	if (segments.length >= 4) {
+		const short = segments.filter(s => s.length <= 50).length / segments.length;
+		const unterminated = segments.filter(s => !/[.?!]$/.test(s)).length / segments.length;
+		if (short >= 0.85 && unterminated >= 0.85) {
+			score += 2;
+		} else if (short >= 0.6 && unterminated >= 0.6) {
+			score += 1;
+		}
+	}
+
+	// Stanza structure — multiple blank-line-delimited blocks of short lines.
+	const blocks = text.split(/\n\s*\n/).map(b => b.trim()).filter(Boolean);
+	const shortBlocks = blocks.filter(b => {
+		const ls = b.split('\n').map(l => l.trim()).filter(Boolean);
+		return ls.length >= 2 && ls.every(l => l.length <= 60);
+	});
+	if (shortBlocks.length >= 2) {
+		score += 1;
+	}
+
+	if (LYRICS_ANNOTATION.test(text)) {
+		score += 1;
+	}
+
+	return score;
+}
+
+/**
+ * Score content for song-lyric characteristics.
+ * Returns true if the score meets or exceeds the threshold (5).
+ */
+export function isLyricsContent(content: string): boolean {
+	return scoreLyricsContent(content) >= 5;
+}
+
+const LYRICS_PROMPT =
+	'You are formatting a song transcript as structured lyrics. The transcript IS the lyrics — ' +
+	'preserve EVERY line exactly. Do NOT summarize, paraphrase, condense, translate, or omit any line. ' +
+	'Reproduce repeated sections (such as a repeated chorus) IN FULL each time they occur — never collapse ' +
+	'a repeat to "Chorus (repeat)" or similar.\n\n' +
+	'Produce the lyrics using the following format:\n\n' +
+	'## [Song Title or "Untitled"]\n' +
+	'**Artist:** [artist or "Not specified"]\n\n' +
+	'Then output each section as a callout. Use `> [!verse] Verse N` for verses and `> [!chorus] Chorus` ' +
+	'for choruses (use `> [!verse] Bridge`, `> [!verse] Intro`, `> [!verse] Outro` for other sections), ' +
+	'with one lyric line per line inside the callout, for example:\n\n' +
+	'> [!verse] Verse 1\n' +
+	'> first line\n' +
+	'> second line\n\n' +
+	'> [!chorus] Chorus\n' +
+	'> first line\n' +
+	'> second line\n\n' +
+	'If the transcript already contains [Verse]/[Chorus] markers, honor them; otherwise infer the ' +
+	'verse/chorus structure from repetition and phrasing. If the transcript is one run-on paragraph, ' +
+	'split it into natural lyric lines.\n\n' +
+	'Extract all information from the provided content. If a field is not present in the source, write "Not specified". ' +
+	'Do not invent information that is not in the original text.';
+
 // ── Schema Registry ───────────────────────────────────────────────────
 
 export const CONTENT_SCHEMAS: ContentSchema[] = [
@@ -226,6 +360,14 @@ export const CONTENT_SCHEMAS: ContentSchema[] = [
 		mode: 'summarize',
 		detect: isReceiptContent,
 		prompt: RECEIPT_PROMPT,
+	},
+	{
+		id: 'lyrics',
+		name: 'Lyrics',
+		appliesTo: ['transcription'],
+		mode: 'reformat',
+		detect: isLyricsContent,
+		prompt: LYRICS_PROMPT,
 	},
 ];
 

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -34,7 +34,7 @@ export {
 	formatTimeRange,
 } from './validation';
 export type { TimeRange } from './validation';
-export { CALLOUT_TYPES, buildCallout, ENRICHMENT_START, ENRICHMENT_END } from './callouts';
+export { CALLOUT_TYPES, buildCallout, calloutForTranscriptionResult, ENRICHMENT_START, ENRICHMENT_END } from './callouts';
 export type { CalloutType } from './callouts';
 export {
 	parseFrontmatter,
@@ -98,6 +98,8 @@ export {
 	scoreRecipeContent,
 	isReceiptContent,
 	scoreReceiptContent,
+	isLyricsContent,
+	scoreLyricsContent,
 } from './content-schemas';
 export type { ContentSchema, PipelineStage, SchemaMode } from './content-schemas';
 export { generateId, isValidCheckpointId } from './id-utils';

--- a/src/summarize/note-scanner.ts
+++ b/src/summarize/note-scanner.ts
@@ -11,6 +11,7 @@ const CALLOUT_TRANSCRIPTION_HEADER = new RegExp(
 );
 const CALLOUT_SUMMARY_PREFIX = `[!${CALLOUT_TYPES.summary}]`;
 const CALLOUT_TRANSCRIPTION_PREFIX = `[!${CALLOUT_TYPES.transcription}]`;
+const CALLOUT_LYRICS_PREFIX = `[!${CALLOUT_TYPES.lyrics}]`;
 const CALLOUT_ENRICHMENT_PREFIX = `[!${CALLOUT_TYPES.enrichment}]`;
 
 /**
@@ -181,6 +182,11 @@ function hasTranscriptionBelow(lines: string[], urlLine: number, url: string): b
 		}
 		// Callout format: > [!synapse-transcription] Transcription of <url>
 		if (line.includes(CALLOUT_TRANSCRIPTION_PREFIX) && (line.includes(`Transcription of ${url}`) || line.includes(`Transcription of ${normalized}`))) {
+			return true;
+		}
+		// Lyrics callout (#234): a reformatted song transcript also counts, so a
+		// transcribed song URL isn't re-fetched and summarized.
+		if (line.includes(CALLOUT_LYRICS_PREFIX) && (line.includes(`Lyrics of ${url}`) || line.includes(`Lyrics of ${normalized}`))) {
 			return true;
 		}
 		// Stop at non-empty, non-blockquote content

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -3,7 +3,7 @@ import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import { AudioModule, TranscriptionResult } from '../audio';
 import {
-	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, CALLOUT_TYPES,
+	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, calloutForTranscriptionResult,
 	CheckpointManager, generateId, formatTimeRange, detectPlatform, loadNodeModules,
 	isPathExcluded, findMatchingRule,
 } from '../shared';
@@ -176,11 +176,12 @@ export class VideoModule {
 				blockLines.push('');
 			}
 
+			const { type, verb } = calloutForTranscriptionResult(result);
 			const title = timeRange
-				? `Transcription of ${url} ${formatTimeRange(timeRange)}`
-				: `Transcription of ${url}`;
+				? `${verb} ${url} ${formatTimeRange(timeRange)}`
+				: `${verb} ${url}`;
 			const callout = buildCallout(
-				CALLOUT_TYPES.transcription,
+				type,
 				title,
 				text,
 				true
@@ -270,9 +271,10 @@ export class VideoModule {
 					blockLines.push('');
 				}
 
+				const { type, verb } = calloutForTranscriptionResult(result);
 				const callout = buildCallout(
-					CALLOUT_TYPES.transcription,
-					`Transcription of ${embed.url}`,
+					type,
+					`${verb} ${embed.url}`,
 					text,
 					true
 				);


### PR DESCRIPTION
## Summary

Adds a **`lyrics`** content schema that detects song transcripts and reformats them into structured verse/chorus — preserving every line instead of condensing them. Applied at the **transcription stage**, built on the shared content-schema registry from #233.

> **Stacked on #233** — base branch is `refactor/issue-233-content-schemas` (PR #329). Review/merge that first; this PR's diff is only the lyrics feature. After #329 merges to `main`, this base will be retargeted to `main`.

## What it does

- **Detection** (`scoreLyricsContent`/`isLyricsContent`, threshold ≥5) in `src/shared/content-schemas.ts`, registered as `appliesTo: ['transcription'], mode: 'reformat'`. Tuned for real Whisper output (often one run-on paragraph with no markers): **repetition + short-segment statistics** carry detection when `[Verse]`/`[Chorus]` markers are absent. Repetition is weighted highest because only choruses repeat verbatim — which keeps poems, prose, notes, lists, and recipes under the threshold (all covered by false-positive guard tests).
- **`LYRICS_PROMPT`** preserves every line (explicitly forbids summarizing/omitting), **expands repeated choruses verbatim**, segments verse/chorus, fills Title/Artist or "Not specified", reuses the shared guardrail line, and emits inner `> [!verse]` / `> [!chorus]` callouts.
- **Application:** `AudioModule.transcribe()` reformats in place after post-processing when `audio.autoFormatLyrics` is on (default **true**), writing `result.processed` + `reformatted`/`schemaId`. Detection is local (no AI cost); the AI call fires only on a match, with a graceful fallback to the raw transcript on any failure. Both audio and video write sites pick the callout via the shared `calloutForTranscriptionResult` helper.
- **Suppress-summary (structural):** reformatted lyrics live under a distinct `[!synapse-lyrics]` callout, which the summarize note-scanner never matches — so a detected song is **never re-condensed** by the summarize phase. No body marker (which would have leaked into the summary).
- **Idempotency:** a lyrics block below an embed/URL counts as already transcribed, so re-scans don't re-offer transcription (`audio/note-scanner.ts` + `summarize/note-scanner.ts`).
- **Settings:** new `audio.autoFormatLyrics` toggle (default on).

## Tests
+19 tests: lyrics detection (bracketed **and** run-on-repetition positives, 5 false-positive guards, stage gating), `calloutForTranscriptionResult` mapping + new callout types, the `transcribe()` reformat orchestration (mocked transcriber/post-processor/AIClient, toggle on/off), note-scanner suppression, the settings toggle, and the default.

## Pre-flight — all green
`tsc --noEmit` · `npm test` (**104 files, 1416 tests**) · `esbuild production` · `check-top-level-requires` · `version-bump --check` · `eslint src`

## Out of scope (follow-ups)
- Fully automatic *bare song URL → transcription → lyrics* depends on #112 (the intake media-URL transcription stub). The schema already works on the existing manual audio/video transcription paths.

closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)