### PR TITLE
feat: apply folder exclusions to vault-enumeration sites

### DIFF
--- a/src/deep-dive/topic-analyzer.test.ts
+++ b/src/deep-dive/topic-analyzer.test.ts
@@ -16,6 +16,9 @@ vi.mock('../shared', async () => {
 		sanitizeAIResponse: (text: string) => text,
 		parseJson,
 		isRecord,
+		// Passthrough: exclusion filtering is covered in file-utils.test.ts; these
+		// tests only need the same files getMarkdownFiles would have returned.
+		getIncludedMarkdownFiles: (app: import('obsidian').App) => app.vault.getMarkdownFiles(),
 	};
 });
 

--- a/src/deep-dive/topic-analyzer.ts
+++ b/src/deep-dive/topic-analyzer.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, isRecord, parseJson, sanitizeAIResponse } from '../shared';
+import { AIClient, isRecord, parseJson, sanitizeAIResponse, getIncludedMarkdownFiles } from '../shared';
 import { ExtractedTopic } from './types';
 
 /**
@@ -85,7 +85,7 @@ ${content.slice(0, 4000)}`;
 	}
 
 	private matchVaultNotes(topics: ExtractedTopic[]): ExtractedTopic[] {
-		const allFiles = this.app.vault.getMarkdownFiles();
+		const allFiles = getIncludedMarkdownFiles(this.app, 'deep-dive', this.getSettings());
 		const titleMap = new Map<string, TFile>();
 		for (const file of allFiles) {
 			titleMap.set(file.basename.toLowerCase(), file);

--- a/src/elaboration/detector.ts
+++ b/src/elaboration/detector.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { wordCount, isPathExcluded, matchesExcludeTag } from '../shared';
+import { wordCount, isPathExcluded, matchesExcludeTag, getIncludedMarkdownFiles } from '../shared';
 import { DetectionReason, DetectionResult } from './types';
 
 export class PlaceholderDetector {
@@ -101,7 +101,7 @@ export class PlaceholderDetector {
 
 	private findInboundLinks(file: TFile): string[] {
 		const links: string[] = [];
-		const allFiles = this.app.vault.getMarkdownFiles();
+		const allFiles = getIncludedMarkdownFiles(this.app, 'elaboration', this.getSettings());
 		for (const other of allFiles) {
 			if (other.path === file.path) continue;
 			const cache = this.app.metadataCache.getFileCache(other);

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -56,7 +56,7 @@ export class EnrichmentModule {
 		shouldAutoAccept?: () => boolean
 	) {
 		if (shouldAutoAccept) this.shouldAutoAccept = shouldAutoAccept;
-		this.analyzer = new VaultAnalyzer(plugin.app);
+		this.analyzer = new VaultAnalyzer(plugin.app, getSettings);
 		this.classifier = new MetadataClassifier(getSettings);
 		this.topicExtractor = new TopicExtractor(plugin.app, this.analyzer, getSettings);
 		this.linkResolver = new LinkResolver(plugin.app, this.analyzer, getSettings);

--- a/src/enrichment/link-resolver.ts
+++ b/src/enrichment/link-resolver.ts
@@ -1,5 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
+import { getIncludedMarkdownFiles } from '../shared';
 import { InternalLinkCandidate, WeightConfig } from './types';
 import { VaultAnalyzer } from './vault-analyzer';
 import { computeProximityWeight } from './weight-calculator';
@@ -191,7 +192,7 @@ export class LinkResolver {
 	): void {
 		// Files in the same folder or sibling folders
 		const fileFolder = file.path.substring(0, file.path.lastIndexOf('/'));
-		const allFiles = this.app.vault.getMarkdownFiles();
+		const allFiles = getIncludedMarkdownFiles(this.app, 'enrichment', this.getSettings());
 
 		for (const other of allFiles) {
 			if (other.path === file.path) continue;

--- a/src/enrichment/topic-extractor.test.ts
+++ b/src/enrichment/topic-extractor.test.ts
@@ -16,6 +16,9 @@ vi.mock('../shared', async () => {
 		},
 		sanitizeAIResponse: (text: string) => text,
 		parseJson,
+		// Passthrough: exclusion filtering is covered in file-utils.test.ts; these
+		// tests only need the same files getMarkdownFiles would have returned.
+		getIncludedMarkdownFiles: (app: import('obsidian').App) => app.vault.getMarkdownFiles(),
 	};
 });
 

--- a/src/enrichment/topic-extractor.ts
+++ b/src/enrichment/topic-extractor.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, parseJson, sanitizeAIResponse } from '../shared';
+import { AIClient, parseJson, sanitizeAIResponse, getIncludedMarkdownFiles } from '../shared';
 import { InternalLinkCandidate } from './types';
 import { VaultAnalyzer } from './vault-analyzer';
 import { computeProximityWeight } from './weight-calculator';
@@ -146,7 +146,7 @@ export class TopicExtractor {
 
 	private buildTitleMap(): Map<string, string> {
 		const map = new Map<string, string>();
-		const files = this.app.vault.getMarkdownFiles();
+		const files = getIncludedMarkdownFiles(this.app, 'enrichment', this.getSettings());
 		for (const file of files) {
 			map.set(file.basename.toLowerCase(), file.path);
 		}

--- a/src/enrichment/vault-analyzer.test.ts
+++ b/src/enrichment/vault-analyzer.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VaultAnalyzer } from './vault-analyzer';
 import { TFile } from '../__mocks__/obsidian';
 
+const noExclusions = () => ({ exclusions: [] }) as any;
+const settingsWith = (exclusions: unknown[]) => () => ({ exclusions }) as any;
+
 function createMockApp(files: TFile[], caches: Map<string, any>, resolvedLinks: Record<string, Record<string, number>> = {}) {
 	return {
 		vault: {
@@ -29,7 +32,7 @@ describe('VaultAnalyzer', () => {
 			});
 
 			const app = createMockApp([file1, file2], caches);
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 			const index = analyzer.buildTagIndex();
 
 			expect(index.tags.get('#python')).toEqual({
@@ -46,13 +49,31 @@ describe('VaultAnalyzer', () => {
 			});
 		});
 
+		it('omits files in folders excluded for enrichment (#323)', () => {
+			const included = new TFile('notes/a.md');
+			const excluded = new TFile('Templates/t.md');
+			const caches = new Map();
+			caches.set('notes/a.md', { tags: [{ tag: '#python' }] });
+			caches.set('Templates/t.md', { tags: [{ tag: '#tpl' }] });
+
+			const app = createMockApp([included, excluded], caches);
+			const analyzer = new VaultAnalyzer(
+				app,
+				settingsWith([{ pattern: 'Templates/**', features: ['enrichment'] }])
+			);
+			const index = analyzer.buildTagIndex();
+
+			expect(index.tags.get('#python')).toEqual({ count: 1, files: ['notes/a.md'] });
+			expect(index.tags.has('#tpl')).toBe(false);
+		});
+
 		it('returns empty index for vault with no tags', () => {
 			const file = new TFile('empty.md');
 			const caches = new Map();
 			caches.set('empty.md', {});
 
 			const app = createMockApp([file], caches);
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 			const index = analyzer.buildTagIndex();
 
 			expect(index.tags.size).toBe(0);
@@ -64,7 +85,7 @@ describe('VaultAnalyzer', () => {
 			caches.set('note.md', { tags: [{ tag: '#test' }] });
 
 			const app = createMockApp([file], caches);
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			const index1 = analyzer.buildTagIndex();
 			const index2 = analyzer.buildTagIndex();
@@ -84,7 +105,7 @@ describe('VaultAnalyzer', () => {
 			};
 
 			const app = createMockApp([], new Map(), resolvedLinks);
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 			const graph = analyzer.buildLinkGraph();
 
 			// Outgoing
@@ -98,7 +119,7 @@ describe('VaultAnalyzer', () => {
 
 		it('handles empty resolved links', () => {
 			const app = createMockApp([], new Map(), {});
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 			const graph = analyzer.buildLinkGraph();
 
 			expect(graph.outgoing.size).toBe(0);
@@ -115,7 +136,7 @@ describe('VaultAnalyzer', () => {
 			});
 
 			const app = createMockApp([file], caches);
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			expect(analyzer.getFileTags(file as any)).toEqual(['#python', '#ml']);
 		});
@@ -123,7 +144,7 @@ describe('VaultAnalyzer', () => {
 		it('returns empty array for file with no cache', () => {
 			const file = new TFile('uncached.md');
 			const app = createMockApp([file], new Map());
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			expect(analyzer.getFileTags(file as any)).toEqual([]);
 		});
@@ -137,7 +158,7 @@ describe('VaultAnalyzer', () => {
 			};
 
 			const app = createMockApp([], new Map(), resolvedLinks);
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			expect(analyzer.getOutgoingLinks('a.md')).toEqual(['b.md']);
 			expect(analyzer.getIncomingLinks('a.md')).toEqual(['b.md']);
@@ -146,7 +167,7 @@ describe('VaultAnalyzer', () => {
 
 		it('returns empty for unknown files', () => {
 			const app = createMockApp([], new Map(), {});
-			const analyzer = new VaultAnalyzer(app);
+			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			expect(analyzer.getOutgoingLinks('unknown.md')).toEqual([]);
 			expect(analyzer.getIncomingLinks('unknown.md')).toEqual([]);

--- a/src/enrichment/vault-analyzer.ts
+++ b/src/enrichment/vault-analyzer.ts
@@ -1,4 +1,6 @@
 import { App, getAllTags, TFile } from 'obsidian';
+import type { SynapseSettings } from '../settings';
+import { getIncludedMarkdownFiles } from '../shared';
 import { TagIndex, LinkGraph } from './types';
 
 /**
@@ -10,7 +12,10 @@ export class VaultAnalyzer {
 	private tagIndexCache: TagIndex | null = null;
 	private linkGraphCache: LinkGraph | null = null;
 
-	constructor(private app: App) {}
+	constructor(
+		private app: App,
+		private getSettings: () => SynapseSettings
+	) {}
 
 	/** Invalidate all caches — call from metadataCache 'resolved' event. */
 	invalidate(): void {
@@ -26,7 +31,7 @@ export class VaultAnalyzer {
 		if (this.tagIndexCache) return this.tagIndexCache;
 
 		const tags = new Map<string, { count: number; files: string[] }>();
-		const files = this.app.vault.getMarkdownFiles();
+		const files = getIncludedMarkdownFiles(this.app, 'enrichment', this.getSettings());
 
 		for (const file of files) {
 			const cache = this.app.metadataCache.getFileCache(file);

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -46,7 +46,7 @@ export class RemModule {
 
 	async onload(): Promise<void> {
 		this.store = new RemStore(this.plugin.app, this.getSettings);
-		this.scanner = new MentionScanner(this.plugin.app);
+		this.scanner = new MentionScanner(this.plugin.app, this.getSettings);
 		this.semanticMatcher = new SemanticMatcher(this.plugin.app, this.getSettings);
 		this.applier = new RemApplier();
 

--- a/src/rem/mention-scanner.test.ts
+++ b/src/rem/mention-scanner.test.ts
@@ -24,6 +24,9 @@ function makeApp(files: TFile[], cacheMap: Map<string, Partial<CachedMetadata>> 
 	} as any;
 }
 
+const noExclusions = () => ({ exclusions: [] }) as any;
+const settingsWith = (exclusions: unknown[]) => () => ({ exclusions }) as any;
+
 // ── Tests ────────────────────────────────────────────────────
 
 describe('MentionScanner', () => {
@@ -36,7 +39,7 @@ describe('MentionScanner', () => {
 				makeFile('Machine Learning.md', 'Machine Learning'),
 				makeFile('Data Science.md', 'Data Science'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 		});
 
 		it('should find exact title mentions', () => {
@@ -74,6 +77,20 @@ describe('MentionScanner', () => {
 		});
 	});
 
+	describe('folder exclusion (#323)', () => {
+		it('does not match notes in folders excluded for rem', () => {
+			const files = [
+				makeFile('source.md', 'source'),
+				makeFile('Templates/Machine Learning.md', 'Machine Learning'),
+			];
+			const getSettings = settingsWith([{ pattern: 'Templates/**', features: ['rem'] }]);
+			const excludingScanner = new MentionScanner(makeApp(files), getSettings);
+			const source = makeFile('source.md', 'source');
+			const results = excludingScanner.scan(source, 'I am studying machine learning today.', 20);
+			expect(results).toHaveLength(0);
+		});
+	});
+
 	describe('alias match', () => {
 		beforeEach(() => {
 			const files = [
@@ -87,7 +104,7 @@ describe('MentionScanner', () => {
 					position: { start: { line: 0, col: 0, offset: 0 }, end: { line: 0, col: 0, offset: 0 } },
 				},
 			});
-			scanner = new MentionScanner(makeApp(files, cache));
+			scanner = new MentionScanner(makeApp(files, cache), noExclusions);
 		});
 
 		it('should match aliases', () => {
@@ -117,7 +134,7 @@ describe('MentionScanner', () => {
 				makeFile('source.md', 'source'),
 				makeFile('Machine Learning.md', 'Machine Learning'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 		});
 
 		it('should match regardless of case', () => {
@@ -137,7 +154,7 @@ describe('MentionScanner', () => {
 				makeFile('Data.md', 'Data'),
 				makeFile('Art.md', 'Art'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 		});
 
 		it('should not match partial words', () => {
@@ -177,7 +194,7 @@ describe('MentionScanner', () => {
 				makeFile('source.md', 'source'),
 				makeFile('Machine Learning.md', 'Machine Learning'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 		});
 
 		it('should skip frontmatter', () => {
@@ -237,7 +254,7 @@ describe('MentionScanner', () => {
 				makeFile('Machine.md', 'Machine'),
 				makeFile('Machine Learning.md', 'Machine Learning'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 		});
 
 		it('should prefer longest match when candidates overlap', () => {
@@ -268,7 +285,7 @@ describe('MentionScanner', () => {
 			const files = [
 				makeFile('Machine Learning.md', 'Machine Learning'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 
 			const source = makeFile('Machine Learning.md', 'Machine Learning');
 			const content = 'This note is about machine learning.';
@@ -287,7 +304,7 @@ describe('MentionScanner', () => {
 				makeFile('Gamma.md', 'Gamma'),
 				makeFile('Delta.md', 'Delta'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 
 			const source = makeFile('source.md', 'source');
 			const content = 'alpha beta gamma delta';
@@ -303,7 +320,7 @@ describe('MentionScanner', () => {
 				makeFile('source.md', 'source'),
 				makeFile('Résumé.md', 'Résumé'),
 			];
-			scanner = new MentionScanner(makeApp(files));
+			scanner = new MentionScanner(makeApp(files), noExclusions);
 
 			const source = makeFile('source.md', 'source');
 			const content = 'Update your résumé today.';

--- a/src/rem/mention-scanner.ts
+++ b/src/rem/mention-scanner.ts
@@ -1,5 +1,6 @@
 import type { App, CachedMetadata, TFile } from 'obsidian';
-import { normalizeFrontmatterTags } from '../shared';
+import type { SynapseSettings } from '../settings';
+import { normalizeFrontmatterTags, getIncludedMarkdownFiles } from '../shared';
 import type { RemLinkCandidate, RemOccurrence } from './types';
 
 /** Entry in the lookup table: a term and the note it maps to. */
@@ -27,7 +28,10 @@ interface SkipRegion {
  * Returns link candidates with precise occurrence positions.
  */
 export class MentionScanner {
-	constructor(private app: App) {}
+	constructor(
+		private app: App,
+		private getSettings: () => SynapseSettings
+	) {}
 
 	/**
 	 * Scan a note's content for mentions of other vault notes.
@@ -87,7 +91,7 @@ export class MentionScanner {
 	 */
 	private buildLookupTable(sourceFilePath: string): LookupEntry[] {
 		const entries: LookupEntry[] = [];
-		const files = this.app.vault.getMarkdownFiles();
+		const files = getIncludedMarkdownFiles(this.app, 'rem', this.getSettings());
 
 		for (const file of files) {
 			// Skip self-references

--- a/src/rem/semantic-matcher.ts
+++ b/src/rem/semantic-matcher.ts
@@ -1,7 +1,7 @@
 import type { App, TFile } from 'obsidian';
 import type { SynapseSettings } from '../settings';
 import type { RemLinkCandidate, RemOccurrence } from './types';
-import { AIClient, isRecord, parseJson } from '../shared';
+import { AIClient, isRecord, parseJson, getIncludedMarkdownFiles } from '../shared';
 
 /** One conceptual match the AI is expected to return, after validation. */
 interface SemanticMatch {
@@ -57,7 +57,7 @@ export class SemanticMatcher {
 
 		// Gather vault note titles (excluding self and already-matched)
 		const noteTitles: { path: string; title: string }[] = [];
-		for (const file of this.app.vault.getMarkdownFiles()) {
+		for (const file of getIncludedMarkdownFiles(this.app, 'rem', this.getSettings())) {
 			if (file.path === sourceFile.path) continue;
 			if (existingMatches.has(file.path)) continue;
 			noteTitles.push({ path: file.path, title: file.basename });

--- a/src/shared/exclusions.ts
+++ b/src/shared/exclusions.ts
@@ -65,7 +65,7 @@ export interface ExclusionRule {
  * `exclusions` so the matcher stays decoupled from the full settings shape (and
  * so tests can pass a thin object).
  */
-interface ExclusionSettings {
+export interface ExclusionSettings {
 	exclusions: ExclusionRule[];
 }
 

--- a/src/shared/file-utils.test.ts
+++ b/src/shared/file-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getIncludedMarkdownFiles } from './file-utils';
+import { TFile } from '../__mocks__/obsidian';
+import type { ExclusionRule } from './exclusions';
+
+function settingsWith(exclusions: ExclusionRule[]) {
+	return { exclusions };
+}
+
+function appWith(files: TFile[]) {
+	return {
+		vault: {
+			getMarkdownFiles: vi.fn().mockReturnValue(files),
+		},
+	} as any;
+}
+
+describe('getIncludedMarkdownFiles', () => {
+	it('returns all files when no exclusion rules apply', () => {
+		const a = new TFile('notes/a.md');
+		const b = new TFile('notes/b.md');
+		const result = getIncludedMarkdownFiles(appWith([a, b]), 'enrichment', settingsWith([]));
+		expect(result).toEqual([a, b]);
+	});
+
+	it('drops a folder and all its descendants for the asked feature (`dir/**`)', () => {
+		const kept = new TFile('notes/a.md');
+		const child = new TFile('Archive/b.md');
+		const deep = new TFile('Archive/sub/c.md');
+		const result = getIncludedMarkdownFiles(
+			appWith([kept, child, deep]),
+			'enrichment',
+			settingsWith([{ pattern: 'Archive/**', features: ['enrichment'] }])
+		);
+		expect(result).toEqual([kept]);
+	});
+
+	it('does not drop files when the rule is scoped to a different feature', () => {
+		const file = new TFile('Personal/note.md');
+		const result = getIncludedMarkdownFiles(
+			appWith([file]),
+			'enrichment',
+			settingsWith([{ pattern: 'Personal/**', features: ['organize'] }])
+		);
+		expect(result).toEqual([file]);
+	});
+
+	it('applies `features: "all"` rules to every feature', () => {
+		const file = new TFile('.synapse/state.md');
+		const result = getIncludedMarkdownFiles(
+			appWith([file]),
+			'rem',
+			settingsWith([{ pattern: '.synapse/**', features: 'all' }])
+		);
+		expect(result).toEqual([]);
+	});
+
+	it('still scopes to a folder prefix when one is given', () => {
+		const inFolder = new TFile('Notes/a.md');
+		const outOfFolder = new TFile('Other/b.md');
+		const result = getIncludedMarkdownFiles(
+			appWith([inFolder, outOfFolder]),
+			'enrichment',
+			settingsWith([]),
+			'Notes'
+		);
+		expect(result).toEqual([inFolder]);
+	});
+});

--- a/src/shared/file-utils.ts
+++ b/src/shared/file-utils.ts
@@ -1,4 +1,6 @@
 import { App, TFile, normalizePath } from 'obsidian';
+import { isPathExcluded } from './exclusions';
+import type { FeatureId, ExclusionSettings } from './exclusions';
 
 export async function ensureFolder(app: App, path: string): Promise<void> {
 	const normalized = normalizePath(path);
@@ -47,6 +49,25 @@ export function getMarkdownFiles(app: App, folder?: string): TFile[] {
 	if (!folder) return files;
 	const normalized = normalizePath(folder);
 	return files.filter(f => f.path.startsWith(normalized + '/'));
+}
+
+/**
+ * Like {@link getMarkdownFiles}, but additionally drops any file excluded for
+ * `feature` by the centralized exclusion rules (#323). Use this for the
+ * candidate/index enumerations — tag indexes, title maps, link/mention/semantic
+ * candidate lists — so notes in an excluded folder are never offered as a link,
+ * tag, or match target, mirroring how each flow already skips them as a
+ * processing source.
+ */
+export function getIncludedMarkdownFiles(
+	app: App,
+	feature: FeatureId,
+	settings: ExclusionSettings,
+	folder?: string
+): TFile[] {
+	return getMarkdownFiles(app, folder).filter(
+		f => !isPathExcluded(f.path, feature, settings)
+	);
 }
 
 export function wordCount(text: string): number {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -13,6 +13,7 @@ export {
 	readNote,
 	writeNote,
 	getMarkdownFiles,
+	getIncludedMarkdownFiles,
 	wordCount,
 } from './file-utils';
 export { arrayBufferToBase64, base64EncodedLength } from './encoding';
@@ -90,7 +91,7 @@ export {
 	ALL_FEATURE_IDS,
 	buildMigratedExclusions,
 } from './exclusions';
-export type { FeatureId, ExclusionRule, LegacyModuleExclusions } from './exclusions';
+export type { FeatureId, ExclusionRule, LegacyModuleExclusions, ExclusionSettings } from './exclusions';
 export {
 	CONTENT_SCHEMAS,
 	detectSchemaFor,

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -2,7 +2,7 @@ import { App, Modal, Notice, Platform, Setting, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { AUDIO_EXTENSIONS } from '../audio';
 import { detectPlatform } from '../video';
-import { validateTimeRange } from '../shared';
+import { validateTimeRange, isPathExcluded } from '../shared';
 import type { TimeRange } from '../shared';
 import {
 	detectLocalFileDuration,
@@ -35,9 +35,16 @@ export class UnifiedTranscriptionModal extends Modal {
 
 		// Local File section
 		if (this.enabledModules.audio || this.enabledModules.video) {
+			const settings = this.getSettings();
+			// Honor folder exclusions scoped to audio: a folder the user excluded
+			// from audio transcription is also hidden from this manual picker (#323).
 			const audioFiles = this.app.vault
 				.getFiles()
-				.filter((f) => AUDIO_EXTENSIONS.test(f.name));
+				.filter(
+					(f) =>
+						AUDIO_EXTENSIONS.test(f.name) &&
+						!isPathExcluded(f.path, 'audio', settings)
+				);
 
 			new Setting(contentEl)
 				.setName('Local file')
@@ -55,8 +62,7 @@ export class UnifiedTranscriptionModal extends Modal {
 				});
 
 			// Post-processing info
-			const settings = this.getSettings().audio.postProcessing;
-			const ppStatus = settings.enabled
+			const ppStatus = settings.audio.postProcessing.enabled
 				? 'Enabled (configure in settings)'
 				: 'Disabled';
 			new Setting(contentEl)


### PR DESCRIPTION
## Summary

Routes the plugin's *index/candidate* vault enumerations through a new exclusion-aware helper so notes in a user-excluded folder are no longer offered as link, tag, or match targets. Source-note processing was already filtered per-flow; this closes the target-side gap raised in the official Obsidian community-plugin review (`docs/reviews/obsidian-review-20260612.md`) and deferred from #299.

## What changed

New shared helper `getIncludedMarkdownFiles(app, feature, settings)` in `src/shared/file-utils.ts` — composes the existing `getMarkdownFiles` + `isPathExcluded`, no new matching logic.

Wired into the previously-unfiltered enumerations with the right `FeatureId`:

| Site | Feature |
|---|---|
| `enrichment/vault-analyzer.ts` (tag index) | enrichment |
| `enrichment/topic-extractor.ts` (title map) | enrichment |
| `enrichment/link-resolver.ts` (proximity candidates) | enrichment |
| `deep-dive/topic-analyzer.ts` (title match) | deep-dive |
| `rem/semantic-matcher.ts` (AI candidates) | rem |
| `rem/mention-scanner.ts` (lookup table) | rem |
| `elaboration/detector.ts` (inbound links) | elaboration |
| `transcription/unified-modal.ts` (audio picker) | audio |

- Threaded `getSettings` into `VaultAnalyzer` and `MentionScanner` (the two leaves that lacked it).
- `vault-analyzer.ts` `buildLinkGraph()` reads `resolvedLinks` (existing-link topology, not candidate generation) and is intentionally left as full enumeration.

## Behavior change

Users with existing exclusion rules will see fewer suggestions after upgrade: an excluded folder is now skipped as a *target* (link/tag/match candidate), not just as a processing source. This is the intended fix and the reason it was split from #299 for independent review.

## Testing

- New `src/shared/file-utils.test.ts` unit-tests the helper (passthrough, `dir/**`, feature-scoping, `features: 'all'`, folder prefix).
- Updated `vault-analyzer.test.ts` / `mention-scanner.test.ts` for the new ctor arg + an exclusion assertion each.
- Full suite green: 1423 passed. tsc, eslint, `check-top-level-requires`, `version-bump --check`, and the production build all pass.

closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)