### PR TITLE
feat: hoist transcription provider & API key to AI Configuration

### DIFF
--- a/src/audio/settings-section.test.ts
+++ b/src/audio/settings-section.test.ts
@@ -44,20 +44,6 @@ describe('renderAudioSettings', () => {
 		expect(saveSettings).toHaveBeenCalled();
 	});
 
-	it('renders without throwing for either AI provider (Whisper key visibility branch)', () => {
-		const openai = makeCtx((s) => { s.audio.transcriptionProvider = 'whisper-api'; s.ai.provider = 'openai'; });
-		expect(() => renderAudioSettings(openai.ctx)).not.toThrow();
-		const anthropic = makeCtx((s) => { s.audio.transcriptionProvider = 'whisper-api'; s.ai.provider = 'anthropic'; });
-		expect(() => renderAudioSettings(anthropic.ctx)).not.toThrow();
-	});
-
-	it('renders without throwing for the Gemini provider (key visibility branch)', () => {
-		const geminiAI = makeCtx((s) => { s.audio.transcriptionProvider = 'gemini'; s.ai.provider = 'gemini'; });
-		expect(() => renderAudioSettings(geminiAI.ctx)).not.toThrow();
-		const openaiAI = makeCtx((s) => { s.audio.transcriptionProvider = 'gemini'; s.ai.provider = 'openai'; });
-		expect(() => renderAudioSettings(openaiAI.ctx)).not.toThrow();
-	});
-
 	it('renders the auto-format lyrics toggle reflecting the setting and saves changes', async () => {
 		// Make autoFormatLyrics the only OFF toggle so it is uniquely identifiable
 		// (header enabled + post-processing toggles are all ON).

--- a/src/audio/settings-section.ts
+++ b/src/audio/settings-section.ts
@@ -1,13 +1,13 @@
 import { Setting } from 'obsidian';
 import type { SettingsSectionContext } from '../shared';
-import { GEMINI_MAX_INLINE_AUDIO_BYTES } from './transcriber';
 
 /**
  * Render the Audio Transcription settings accordion (#243).
  *
- * The transcription provider dropdown and AI provider together decide which
- * API-key fields are shown, so changing the provider triggers a full re-render
- * via {@link SettingsSectionContext.rerender}.
+ * The transcription provider dropdown and its provider-specific API-key fields
+ * live in the AI Configuration section (#332, see
+ * {@link renderTranscriptionCredentials}); this section owns the remaining
+ * audio settings (language, lyrics formatting, post-processing).
  */
 export function renderAudioSettings(ctx: SettingsSectionContext): void {
 	const { plugin } = ctx;
@@ -19,106 +19,6 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 		(v) => { plugin.settings.audio.enabled = v; },
 		'Enable audio transcription',
 	);
-
-	const providerOptions: Record<string, string> = {
-		'whisper-api': 'OpenAI Whisper API',
-		deepgram: 'Deepgram',
-		gemini: 'Google Gemini',
-	};
-	// 'local-whisper' is intentionally hidden from the dropdown until implemented
-	// (see src/audio/transcriber.ts). The type is kept for forward compatibility.
-
-	const providerSetting = new Setting(audioBody)
-		.setName('Transcription provider')
-		.addDropdown((dd) =>
-			dd
-				.addOptions(providerOptions)
-				.setValue(plugin.settings.audio.transcriptionProvider)
-				.onChange(async (value) => {
-					plugin.settings.audio.transcriptionProvider =
-						value as 'whisper-api' | 'deepgram' | 'gemini' | 'local-whisper';
-					await plugin.saveSettings();
-					ctx.rerender(); // Re-render to show/hide provider-specific fields
-				})
-		);
-	if (plugin.settings.audio.transcriptionProvider === 'gemini') {
-		const limitMb = GEMINI_MAX_INLINE_AUDIO_BYTES / (1024 * 1024);
-		providerSetting.setDesc(
-			`Gemini sends audio inline with the request, so files are limited to ${limitMb} MB ` +
-			'(the API caps requests at 20 MB). Use Whisper or Deepgram for larger files. ' +
-			'Note: Gemini transcribes with an LLM, so spoken instructions inside untrusted ' +
-			'audio could still influence the transcript — review output before trusting it.'
-		);
-	}
-
-	// Show Whisper API key field when provider is whisper-api and AI provider isn't OpenAI
-	// (if AI provider is OpenAI, the shared API key is already an OpenAI key)
-	if (
-		plugin.settings.audio.transcriptionProvider === 'whisper-api' &&
-		plugin.settings.ai.provider !== 'openai'
-	) {
-		new Setting(audioBody)
-			.setName('OpenAI API key (Whisper)')
-			.setDesc(
-				'Whisper uses the OpenAI API. Provide your OpenAI key here since your AI provider is set to ' +
-				plugin.settings.ai.provider.charAt(0).toUpperCase() +
-				plugin.settings.ai.provider.slice(1) + '.'
-			)
-			.addText((text) => {
-				text
-					.setPlaceholder('sk-...')
-					.setValue(plugin.settings.audio.whisperApiKey)
-					.onChange(async (value) => {
-						plugin.settings.audio.whisperApiKey = value;
-						await plugin.saveSettings();
-					});
-				text.inputEl.type = 'password';
-				text.inputEl.autocomplete = 'off';
-			});
-	}
-
-	// Show Gemini API key field when provider is gemini and AI provider isn't Gemini
-	// (if AI provider is Gemini, the shared API key is already a Google key)
-	if (
-		plugin.settings.audio.transcriptionProvider === 'gemini' &&
-		plugin.settings.ai.provider !== 'gemini'
-	) {
-		new Setting(audioBody)
-			.setName('Google Gemini API key')
-			.setDesc(
-				'Gemini transcription uses the Google AI API. Provide your Gemini key here since your AI provider is set to ' +
-				plugin.settings.ai.provider.charAt(0).toUpperCase() +
-				plugin.settings.ai.provider.slice(1) + '.'
-			)
-			.addText((text) => {
-				text
-					.setPlaceholder('AIza...')
-					.setValue(plugin.settings.audio.geminiApiKey)
-					.onChange(async (value) => {
-						plugin.settings.audio.geminiApiKey = value;
-						await plugin.saveSettings();
-					});
-				text.inputEl.type = 'password';
-				text.inputEl.autocomplete = 'off';
-			});
-	}
-
-	if (plugin.settings.audio.transcriptionProvider === 'deepgram') {
-		new Setting(audioBody)
-			.setName('Deepgram API key')
-			.setDesc('Required for Deepgram transcription provider')
-			.addText((text) => {
-				text
-					.setPlaceholder('dg-...')
-					.setValue(plugin.settings.audio.deepgramApiKey)
-					.onChange(async (value) => {
-						plugin.settings.audio.deepgramApiKey = value;
-						await plugin.saveSettings();
-					});
-				text.inputEl.type = 'password';
-				text.inputEl.autocomplete = 'off';
-			});
-	}
 
 	new Setting(audioBody)
 		.setName('Language')

--- a/src/audio/transcription-credentials.test.ts
+++ b/src/audio/transcription-credentials.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { vi } from 'vitest';
+import { createEl } from '../__mocks__/obsidian';
+import { renderTranscriptionCredentials } from './transcription-credentials';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+import type { SettingsSectionContext } from '../shared';
+
+/**
+ * Build a `body` element + a spy {@link SettingsSectionContext} for rendering
+ * {@link renderTranscriptionCredentials} in isolation.
+ *
+ * The Obsidian mock no-ops `Setting.addDropdown`/`addText` (their callbacks
+ * never run), so these tests can only assert that every conditional branch
+ * renders without throwing — they cannot inspect dropdown/input DOM or fire
+ * `onChange`. The combos below exercise each provider branch and the
+ * AI-provider coupling (whisper-api+openai hides the Whisper key; gemini+gemini
+ * hides the Gemini key).
+ */
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const rerender = vi.fn();
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const body = createEl();
+	const ctx = {
+		containerEl: body,
+		plugin: plugin as never,
+		featureSection: vi.fn(() => createEl()),
+		configSection: vi.fn(() => createEl()),
+		rerender,
+	} as unknown as SettingsSectionContext;
+	return { ctx, body, plugin, saveSettings, rerender };
+}
+
+describe('renderTranscriptionCredentials', () => {
+	it('renders the whisper-api provider without throwing (AI provider OpenAI hides the Whisper key)', () => {
+		const { ctx, body } = makeCtx((s) => {
+			s.audio.transcriptionProvider = 'whisper-api';
+			s.ai.provider = 'openai';
+		});
+		expect(() => renderTranscriptionCredentials(body, ctx)).not.toThrow();
+	});
+
+	it('renders the whisper-api provider without throwing (non-OpenAI AI provider shows the Whisper key)', () => {
+		const { ctx, body } = makeCtx((s) => {
+			s.audio.transcriptionProvider = 'whisper-api';
+			s.ai.provider = 'anthropic';
+		});
+		expect(() => renderTranscriptionCredentials(body, ctx)).not.toThrow();
+	});
+
+	it('renders the gemini provider without throwing (AI provider Gemini hides the Gemini key)', () => {
+		const { ctx, body } = makeCtx((s) => {
+			s.audio.transcriptionProvider = 'gemini';
+			s.ai.provider = 'gemini';
+		});
+		expect(() => renderTranscriptionCredentials(body, ctx)).not.toThrow();
+	});
+
+	it('renders the gemini provider without throwing (non-Gemini AI provider shows the Gemini key)', () => {
+		const { ctx, body } = makeCtx((s) => {
+			s.audio.transcriptionProvider = 'gemini';
+			s.ai.provider = 'openai';
+		});
+		expect(() => renderTranscriptionCredentials(body, ctx)).not.toThrow();
+	});
+
+	it('renders the deepgram provider without throwing (always shows the Deepgram key)', () => {
+		const { ctx, body } = makeCtx((s) => {
+			s.audio.transcriptionProvider = 'deepgram';
+		});
+		expect(() => renderTranscriptionCredentials(body, ctx)).not.toThrow();
+	});
+});

--- a/src/audio/transcription-credentials.ts
+++ b/src/audio/transcription-credentials.ts
@@ -1,0 +1,123 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared/settings-section';
+import { GEMINI_MAX_INLINE_AUDIO_BYTES } from './transcriber';
+
+/**
+ * Transcription provider options shown in the dropdown.
+ *
+ * 'local-whisper' is intentionally hidden from the dropdown until implemented
+ * (see src/audio/transcriber.ts). The type is kept for forward compatibility.
+ */
+const providerOptions: Record<string, string> = {
+	'whisper-api': 'OpenAI Whisper API',
+	deepgram: 'Deepgram',
+	gemini: 'Google Gemini',
+};
+
+/**
+ * Render the transcription provider dropdown and its provider-specific API-key
+ * fields (#332). These controls live in the AI Configuration section but write
+ * to `settings.audio.*`, since they configure the audio transcription backend.
+ *
+ * The transcription provider dropdown and AI provider together decide which
+ * API-key fields are shown, so changing either provider triggers a full
+ * re-render via {@link SettingsSectionContext.rerender}. (The AI provider
+ * dropdown re-renders the whole tab, and `rerender` is that same `display()`.)
+ *
+ * Rendered into the passed `body` element, not `ctx.containerEl`.
+ */
+export function renderTranscriptionCredentials(body: HTMLElement, ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const providerSetting = new Setting(body)
+		.setName('Transcription provider')
+		.addDropdown((dd) =>
+			dd
+				.addOptions(providerOptions)
+				.setValue(plugin.settings.audio.transcriptionProvider)
+				.onChange(async (value) => {
+					plugin.settings.audio.transcriptionProvider =
+						value as 'whisper-api' | 'deepgram' | 'gemini' | 'local-whisper';
+					await plugin.saveSettings();
+					ctx.rerender(); // Re-render to show/hide provider-specific fields
+				})
+		);
+	if (plugin.settings.audio.transcriptionProvider === 'gemini') {
+		const limitMb = GEMINI_MAX_INLINE_AUDIO_BYTES / (1024 * 1024);
+		providerSetting.setDesc(
+			`Gemini sends audio inline with the request, so files are limited to ${limitMb} MB ` +
+			'(the API caps requests at 20 MB). Use Whisper or Deepgram for larger files. ' +
+			'Note: Gemini transcribes with an LLM, so spoken instructions inside untrusted ' +
+			'audio could still influence the transcript — review output before trusting it.'
+		);
+	}
+
+	// Show Whisper API key field when provider is whisper-api and AI provider isn't OpenAI
+	// (if AI provider is OpenAI, the shared API key is already an OpenAI key)
+	if (
+		plugin.settings.audio.transcriptionProvider === 'whisper-api' &&
+		plugin.settings.ai.provider !== 'openai'
+	) {
+		new Setting(body)
+			.setName('OpenAI API key (Whisper)')
+			.setDesc(
+				'Whisper uses the OpenAI API. Provide your OpenAI key here since your AI provider is set to ' +
+				plugin.settings.ai.provider.charAt(0).toUpperCase() +
+				plugin.settings.ai.provider.slice(1) + '.'
+			)
+			.addText((text) => {
+				text
+					.setPlaceholder('sk-...')
+					.setValue(plugin.settings.audio.whisperApiKey)
+					.onChange(async (value) => {
+						plugin.settings.audio.whisperApiKey = value;
+						await plugin.saveSettings();
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.autocomplete = 'off';
+			});
+	}
+
+	// Show Gemini API key field when provider is gemini and AI provider isn't Gemini
+	// (if AI provider is Gemini, the shared API key is already a Google key)
+	if (
+		plugin.settings.audio.transcriptionProvider === 'gemini' &&
+		plugin.settings.ai.provider !== 'gemini'
+	) {
+		new Setting(body)
+			.setName('Google Gemini API key')
+			.setDesc(
+				'Gemini transcription uses the Google AI API. Provide your Gemini key here since your AI provider is set to ' +
+				plugin.settings.ai.provider.charAt(0).toUpperCase() +
+				plugin.settings.ai.provider.slice(1) + '.'
+			)
+			.addText((text) => {
+				text
+					.setPlaceholder('AIza...')
+					.setValue(plugin.settings.audio.geminiApiKey)
+					.onChange(async (value) => {
+						plugin.settings.audio.geminiApiKey = value;
+						await plugin.saveSettings();
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.autocomplete = 'off';
+			});
+	}
+
+	if (plugin.settings.audio.transcriptionProvider === 'deepgram') {
+		new Setting(body)
+			.setName('Deepgram API key')
+			.setDesc('Required for Deepgram transcription provider')
+			.addText((text) => {
+				text
+					.setPlaceholder('dg-...')
+					.setValue(plugin.settings.audio.deepgramApiKey)
+					.onChange(async (value) => {
+						plugin.settings.audio.deepgramApiKey = value;
+						await plugin.saveSettings();
+					});
+				text.inputEl.type = 'password';
+				text.inputEl.autocomplete = 'off';
+			});
+	}
+}

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -142,6 +142,26 @@ describe('SynapseSettingTab — Auto-Accept disabled state', () => {
 	});
 });
 
+describe('SynapseSettingTab — transcription credentials in AI Configuration (#332)', () => {
+	beforeEach(() => {
+		ToggleComponent.instances.length = 0;
+	});
+
+	// The transcription provider dropdown + its API-key fields now render inside
+	// the AI Configuration section. A full display() across a couple of provider
+	// values confirms the relocated controls render in their new home without
+	// throwing (the Obsidian mock no-ops dropdown/text, so this is a smoke test).
+	it.each(['whisper-api', 'gemini', 'deepgram'] as const)(
+		'renders the settings tab without throwing for transcription provider %s',
+		(provider) => {
+			const { tab } = makeTab((s) => {
+				s.audio.transcriptionProvider = provider;
+			});
+			expect(() => tab.display()).not.toThrow();
+		},
+	);
+});
+
 describe('SynapseSettingTab — About support links (#274)', () => {
 	it('renders static GitHub Sponsors and Buy Me a Coffee links', () => {
 		const { tab } = makeTab();

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -16,6 +16,7 @@ import { renderElaborationSettings } from './elaboration';
 import { renderIntakeSettings } from './intake';
 import { renderImageSettings } from './image';
 import { renderAudioSettings } from './audio';
+import { renderTranscriptionCredentials } from './audio/transcription-credentials';
 import { renderVideoSettings } from './video';
 import { renderEnrichmentSettings } from './enrichment';
 import { renderSummarizeSettings } from './summarize';
@@ -292,6 +293,13 @@ export class SynapseSettingTab extends PluginSettingTab {
 						})
 				);
 		}
+
+		// Transcription provider + its provider-specific API-key fields (#332).
+		// They configure audio transcription but live here because the choice of
+		// transcription provider is coupled to the AI provider above (e.g. when
+		// the AI provider already supplies the needed key). Changing either
+		// provider re-renders the tab, resolving the coupling.
+		renderTranscriptionCredentials(aiBody, ctx);
 
 		const currentProvider = this.plugin.settings.ai.provider;
 		const models = MODEL_OPTIONS[currentProvider];


### PR DESCRIPTION
## Summary
Relocates the **Transcription provider** dropdown and its provider-specific API-key fields (Whisper / Gemini / Deepgram) out of the **Audio Transcription** settings section and into the **AI Configuration** section (#332).

The choice of transcription provider is coupled to the AI provider — e.g. when the AI provider is OpenAI/Gemini the shared key already covers Whisper/Gemini, so the provider-specific key field is hidden. Placing these controls next to the AI provider makes that relationship clear.

closes #332

## What changed
- **New `src/audio/transcription-credentials.ts`** — `renderTranscriptionCredentials(body, ctx)` renders the provider dropdown + the three conditional key fields (lifted verbatim, including password inputs, placeholders, and the AI-provider-aware descriptions). The `providerOptions` map moved here too.
- **`src/settings-tab.ts`** — `renderAIConfiguration` now calls `renderTranscriptionCredentials(aiBody, ctx)` after the AI API-key / Ollama-endpoint block and before the Model dropdown.
- **`src/audio/settings-section.ts`** — removed the dropdown + three key-field blocks (and the now-unused `providerOptions` const and `GEMINI_MAX_INLINE_AUDIO_BYTES` import); the section now opens with the Language setting. Language, Auto-format song lyrics, Post-processing, and Remove filler words are unchanged.

**UI-only relocation.** Data still lives under `settings.audio.*` — no data-model change, no migration. `transcriber.ts`, `audio/index.ts`, `video/index.ts`, and summarize logic are untouched.

## Tests
- New `src/audio/transcription-credentials.test.ts` — renders every provider branch (whisper-api×{openai,anthropic}, gemini×{gemini,openai}, deepgram) and asserts no throw (the Obsidian mock no-ops dropdown/text callbacks, so behavior is verified at the render level).
- `src/audio/settings-section.test.ts` — removed the two relocated branch tests; kept the feature-header and `autoFormatLyrics` toggle tests.
- `src/settings-tab.test.ts` — added a smoke test calling `display()` across a few `audio.transcriptionProvider` values to confirm the controls render in their new home.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` — 106 files / 1429 tests passing
- [x] `node scripts/version-bump.mjs --check` — consistent at 1.0.2 (not bumped)
- [x] `node esbuild.config.mjs production`

Co-Authored-By: Synapse Bot <bot@wafflenet.io>