### PR TITLE
feat: registry-driven Synapse actions sidebar for mobile access (#289)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Output: `main.js` (single bundle, Obsidian loads this)
 | main | `src/main.ts` | Plugin entry, module orchestration, command/view registration, checkpoint dispatch | `SynapsePlugin` (default) |
 | settings | `src/settings.ts` | Settings interfaces, defaults, model options | `SynapseSettings`, `DEFAULT_SETTINGS`, `AIProvider`, `MODEL_OPTIONS` |
 | settings-tab | `src/settings-tab.ts` | Obsidian settings UI | `SynapseSettingTab` |
-| commands | `src/commands/` | Command registry: developer source of truth + master control (status/flow gating), central registrar, drift audit | `CommandRegistrar`, `COMMAND_REGISTRY`, `isInFlow`, `isPipelineKeyInFlow`, `auditCommands` |
+| commands | `src/commands/` | Command registry: developer source of truth + master control (status/flow/context gating), central registrar, drift audit, palette-action derivation | `CommandRegistrar`, `COMMAND_REGISTRY`, `isInFlow`, `isPipelineKeyInFlow`, `listPaletteActions`, `auditCommands` |
 | pipeline | `src/pipeline/` | Fire Synapse orchestration: ordered multi-phase run over a folder or single note | `SynapseRunner`, `SYNAPSE_PIPELINE`, `PipelineModuleKey`, `PipelineModuleMap`, `PipelineScanFn` |
 | intake | `src/intake/` | Watches intake folder, auto-routes + pipeline-processes new notes (#111) | `IntakeModule`, `IntakeDispatcher`, `IntakeDeps`, `IntakeRoute` |
 | rem | `src/rem/` | REM: discover linkable references, propose in-place `[[wikilink]]` insertions | `RemModule`, types |
@@ -42,7 +42,7 @@ Output: `main.js` (single bundle, Obsidian loads this)
 | deep-dive | `src/deep-dive/` | Recursive topic extraction and child note generation | `DeepDiveModule`, types |
 | title | `src/title/` | AI title suggestions for untitled/mismatched notes | `TitleModule`, types |
 | shared | `src/shared/` | AI client (multi-modal), file utils, validation, notifications, callouts, frontmatter, checkpoints | `AIClient`, `NotificationManager`, `CheckpointManager`, file/validation utils, callout registry, id-utils |
-| views | `src/views/` | Unified sidebar for all proposal types and checkpoint management | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE`, `UnifiedItem` |
+| views | `src/views/` | Unified proposal/checkpoint sidebar + registry-driven Synapse actions sidebar | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE`, `UnifiedItem`, `SynapseActionsView`, `SYNAPSE_ACTIONS_VIEW_TYPE` |
 
 ## Dependency Graph
 
@@ -88,7 +88,7 @@ Key constraints:
 
 ## Command Registry
 
-Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries + 1 synthetic pipeline-only entry. Only `status: active` entries register/run; 6 ship `disabled` as a developer master switch (gated out of registration). Flows: `p`=palette, `f`=fire-synapse, `s`=startup. `pipelineKey` links an entry to a Fire Synapse phase.
+Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries + 1 synthetic pipeline-only entry. Only `status: active` entries register/run; 6 ship `disabled` as a developer master switch (gated out of registration). Flows: `p`=palette, `f`=fire-synapse, `s`=startup. `pipelineKey` links an entry to a Fire Synapse phase. Each entry also carries a `context` (`note` | `vault` | `global`); the Synapse actions sidebar (`listPaletteActions`) uses it to disable per-note (`note`) buttons when no note is active.
 
 | ID | Name | Type | Module | Flows | Status | pipelineKey |
 |----|------|------|--------|-------|--------|-------------|
@@ -123,14 +123,16 @@ Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries
 
 | Icon | Label | Action |
 |------|-------|--------|
-| `sparkles` | Review proposals | Opens unified proposal sidebar |
+| `synapse` | Review proposals | Opens unified proposal sidebar |
 | `mic` | Transcribe media | Opens unified transcription modal (desktop only) |
+| `layout-grid` | Synapse actions | Opens registry-driven actions sidebar |
 
 ## View Types
 
 | View Type ID | Class | Location |
 |--------------|-------|----------|
 | `synapse-proposals` | `UnifiedProposalView` | `src/views/unified-proposal-view.ts` |
+| `synapse-actions` | `SynapseActionsView` | `src/views/synapse-actions-view.ts` |
 
 Legacy views (`ProposalReviewView`, `EnrichmentReviewView`) exist in source but are not registered.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,6 +219,7 @@ src/
 │
 └── views/                  # UI components
     ├── unified-proposal-view.ts  # Single sidebar for all proposal types + checkpoints
+    ├── synapse-actions-view.ts   # Registry-driven action buttons sidebar (mobile-friendly)
     └── types.ts                  # UnifiedItem, UnifiedViewCallbacks
 ```
 

--- a/src/commands/actions.test.ts
+++ b/src/commands/actions.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { listPaletteActions } from './actions';
+
+describe('listPaletteActions', () => {
+	it('returns the registered entries in registry order (not set-insertion order)', () => {
+		// Set built in a deliberately scrambled order; output must follow COMMAND_REGISTRY.
+		const registered = new Set(['deep-dive', 'fire', 'review-proposals']);
+		const result = listPaletteActions(registered);
+		expect(result.map((c) => c.id)).toEqual(['review-proposals', 'fire', 'deep-dive']);
+	});
+
+	it('ignores ids that are not registry members', () => {
+		const result = listPaletteActions(new Set(['enrich-current-note', 'not-a-real-command']));
+		expect(result.map((c) => c.id)).toEqual(['enrich-current-note']);
+	});
+
+	it('returns an empty list when nothing is registered', () => {
+		expect(listPaletteActions(new Set())).toEqual([]);
+	});
+
+	it('returns full command metadata (name, feature, context) for the sidebar to render', () => {
+		const [entry] = listPaletteActions(new Set(['enrich-current-note']));
+		expect(entry).toMatchObject({
+			id: 'enrich-current-note',
+			name: 'Enrich current note',
+			feature: 'enrichment',
+			context: 'note',
+		});
+	});
+});

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -1,0 +1,24 @@
+/**
+ * Registry-driven derivation of the palette actions a user can actually invoke.
+ *
+ * The Synapse actions sidebar (`src/views/synapse-actions-view.ts`) renders one
+ * button per entry returned here. We don't re-declare any command behavior — the
+ * button invokes the already-registered Obsidian command by id. This keeps the
+ * sidebar in lockstep with the command registry (no hand-maintained list).
+ */
+
+import { COMMAND_REGISTRY } from './registry';
+import type { CommandDefinition } from './types';
+
+/**
+ * The active palette commands the user actually has enabled, in registry order.
+ *
+ * `registered` is `CommandRegistrar.getRegistered()` — the ids that passed the
+ * full gate (`status === 'active'` AND `flows.includes('palette')` AND the
+ * feature's user-level `enabled` flag). Filtering by membership therefore
+ * naturally excludes disabled-status commands, the pipeline-only `tidy-vault`
+ * (never registered), and any feature the user has turned off.
+ */
+export function listPaletteActions(registered: ReadonlySet<string>): CommandDefinition[] {
+	return COMMAND_REGISTRY.filter((c) => registered.has(c.id));
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@
 export type {
 	CommandStatus,
 	CommandFlow,
+	CommandContext,
 	FeatureKey,
 	CommandDefinition,
 } from './types';
@@ -26,5 +27,6 @@ export {
 	isPipelineKeyInFlow,
 } from './registry';
 
+export { listPaletteActions } from './actions';
 export { CommandRegistrar } from './registrar';
 export { auditCommands } from './audit';

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -81,6 +81,32 @@ describe('COMMAND_REGISTRY', () => {
 			expect(entry.name.length).toBeGreaterThan(0);
 		}
 	});
+
+	it('gives every entry a valid context', () => {
+		const validContexts = ['note', 'vault', 'global'];
+		for (const entry of COMMAND_REGISTRY) {
+			expect(validContexts, `bad context on ${entry.id}`).toContain(entry.context);
+		}
+	});
+
+	it('marks exactly the per-note commands as note-context', () => {
+		const noteContext = COMMAND_REGISTRY.filter(c => c.context === 'note')
+			.map(c => c.id)
+			.sort();
+		expect(noteContext).toEqual([
+			'deep-dive',
+			'enrich-current-note',
+			'organize-current-note',
+			'rem-current-note',
+			'scan-current-note',
+			'summarize-current-note',
+			'tidy-current-note',
+			'transcribe-note-media',
+			'undo-enrichment',
+			'undo-organize',
+			'undo-tidy',
+		]);
+	});
 });
 
 describe('pipeline mapping', () => {
@@ -101,8 +127,8 @@ describe('pipeline mapping', () => {
 
 	it('throws when two entries share a pipelineKey', () => {
 		const dupes: CommandDefinition[] = [
-			{ id: 'a', name: 'A', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy' },
-			{ id: 'b', name: 'B', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy' },
+			{ id: 'a', name: 'A', feature: 'tidy', status: 'active', flows: ['fire-synapse'], context: 'vault', pipelineKey: 'tidy' },
+			{ id: 'b', name: 'B', feature: 'tidy', status: 'active', flows: ['fire-synapse'], context: 'vault', pipelineKey: 'tidy' },
 		];
 		expect(() => buildPipelineKeyMap(dupes)).toThrow(/Duplicate pipelineKey/);
 	});

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -14,45 +14,45 @@ import { CommandDefinition, CommandFlow } from './types';
 
 export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	// --- main (src/main.ts) ---
-	{ id: 'review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'transcribe-media', name: 'Transcribe media', feature: 'main', status: 'disabled', flows: ['palette'] },
-	{ id: 'transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'] },
-	{ id: 'fire', name: 'Run all features on a directory', feature: 'main', status: 'active', flows: ['palette'] },
+	{ id: 'review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'], context: 'global' },
+	{ id: 'manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'], context: 'global' },
+	{ id: 'transcribe-media', name: 'Transcribe media', feature: 'main', status: 'disabled', flows: ['palette'], context: 'global' },
+	{ id: 'transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'fire', name: 'Run all features on a directory', feature: 'main', status: 'active', flows: ['palette'], context: 'vault' },
 
 	// --- elaboration (src/elaboration/index.ts) ---
-	{ id: 'scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], pipelineKey: 'elaboration' },
-	{ id: 'scan-current-note', name: 'Scan current note for elaboration', feature: 'elaboration', status: 'active', flows: ['palette'] },
-	{ id: 'clear-proposals', name: 'Clear all pending proposals', feature: 'elaboration', status: 'disabled', flows: ['palette'] },
+	{ id: 'scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], context: 'vault', pipelineKey: 'elaboration' },
+	{ id: 'scan-current-note', name: 'Scan current note for elaboration', feature: 'elaboration', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'clear-proposals', name: 'Clear all pending proposals', feature: 'elaboration', status: 'disabled', flows: ['palette'], context: 'global' },
 
 	// --- enrichment (src/enrichment/index.ts) ---
-	{ id: 'enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'] },
-	{ id: 'scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'enrichment' },
-	{ id: 'undo-enrichment', name: 'Undo last enrichment on current note', feature: 'enrichment', status: 'disabled', flows: ['palette'] },
+	{ id: 'enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'enrichment' },
+	{ id: 'undo-enrichment', name: 'Undo last enrichment on current note', feature: 'enrichment', status: 'disabled', flows: ['palette'], context: 'note' },
 
 	// --- organize (src/organize/index.ts) ---
-	{ id: 'organize-current-note', name: 'Organize current note', feature: 'organize', status: 'active', flows: ['palette'] },
-	{ id: 'scan-directory-organize', name: 'Scan directory for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'organize' },
-	{ id: 'undo-organize', name: 'Undo last organize on current note', feature: 'organize', status: 'disabled', flows: ['palette'] },
+	{ id: 'organize-current-note', name: 'Organize current note', feature: 'organize', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'scan-directory-organize', name: 'Scan directory for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'organize' },
+	{ id: 'undo-organize', name: 'Undo last organize on current note', feature: 'organize', status: 'disabled', flows: ['palette'], context: 'note' },
 
 	// --- deep-dive (src/deep-dive/index.ts) ---
-	{ id: 'deep-dive', name: 'Deep dive into current note', feature: 'deep-dive', status: 'active', flows: ['palette'] },
-	{ id: 'clear-deep-dive', name: 'Clear deep dive proposals', feature: 'deep-dive', status: 'disabled', flows: ['palette'] },
+	{ id: 'deep-dive', name: 'Deep dive into current note', feature: 'deep-dive', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'clear-deep-dive', name: 'Clear deep dive proposals', feature: 'deep-dive', status: 'disabled', flows: ['palette'], context: 'global' },
 
 	// --- summarize (src/summarize/index.ts) ---
-	{ id: 'summarize-current-note', name: 'Summarize current note', feature: 'summarize', status: 'active', flows: ['palette'] },
-	{ id: 'scan-vault-summarize', name: 'Scan vault for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'summarize' },
+	{ id: 'summarize-current-note', name: 'Summarize current note', feature: 'summarize', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'scan-vault-summarize', name: 'Scan vault for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'summarize' },
 
 	// --- tidy (src/tidy/index.ts) ---
-	{ id: 'tidy-current-note', name: 'Tidy current note', feature: 'tidy', status: 'active', flows: ['palette'] },
-	{ id: 'undo-tidy', name: 'Undo last tidy on current note', feature: 'tidy', status: 'disabled', flows: ['palette'] },
+	{ id: 'tidy-current-note', name: 'Tidy current note', feature: 'tidy', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'undo-tidy', name: 'Undo last tidy on current note', feature: 'tidy', status: 'disabled', flows: ['palette'], context: 'note' },
 
 	// --- rem (src/rem/index.ts) ---
-	{ id: 'rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'] },
-	{ id: 'rem-directory', name: 'REM: Discover links in directory', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], pipelineKey: 'rem' },
+	{ id: 'rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'rem-directory', name: 'REM: Discover links in directory', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'rem' },
 
 	// --- video (src/video/index.ts) ---
-	{ id: 'check-dependencies', name: 'Check external tool availability', feature: 'video', status: 'active', flows: ['palette'] },
+	{ id: 'check-dependencies', name: 'Check external tool availability', feature: 'video', status: 'active', flows: ['palette'], context: 'global' },
 
 	// --- synthetic, pipeline-only ---
 	// Tidy is the only Fire Synapse phase with no matching palette command: the
@@ -60,7 +60,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	// palette command runs `tidy()` on a single note — a different operation. This
 	// entry carries `pipelineKey: 'tidy'` so the tidy pipeline phase is controlled
 	// independently of the palette command. It is never passed to registrar.register().
-	{ id: 'tidy-vault', name: 'Tidy vault', feature: 'tidy', status: 'active', flows: ['fire-synapse'], pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
+	{ id: 'tidy-vault', name: 'Tidy vault', feature: 'tidy', status: 'active', flows: ['fire-synapse'], context: 'vault', pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
 ];
 
 /** Lookup by command id. */

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -13,6 +13,17 @@ export type CommandStatus = 'active' | 'deprecated' | 'disabled';
 /** The flows a command can participate in. */
 export type CommandFlow = 'palette' | 'fire-synapse' | 'startup';
 
+/**
+ * The runtime environment a command needs to act on.
+ * - `note`   — operates on the active note (Obsidian `editorCallback`); unavailable when no markdown note is active.
+ * - `vault`  — operates over the vault or a chosen folder (vault scan / folder picker); always available.
+ * - `global` — app-level action independent of any note (open a view, manage checkpoints); always available.
+ *
+ * Consumed by the Synapse actions sidebar (`src/views/synapse-actions-view.ts`) to disable
+ * `note` buttons when no note is active. Mirrors each command's handler kind in its module.
+ */
+export type CommandContext = 'note' | 'vault' | 'global';
+
 /** The feature module a command belongs to (modules without commands are omitted). */
 export type FeatureKey =
 	| 'main'
@@ -41,6 +52,8 @@ export interface CommandDefinition {
 	status: CommandStatus;
 	/** Flows this command participates in. All palette commands include `'palette'`. */
 	flows: readonly CommandFlow[];
+	/** Runtime environment the command needs (drives per-note gating in the actions sidebar). */
+	context: CommandContext;
 	/**
 	 * Links a command to a Fire Synapse pipeline phase (matches a `PipelineModuleKey`).
 	 * Typed as `string` deliberately so `src/commands/` never imports from `src/pipeline/`

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Platform, Plugin, addIcon } from 'obsidian';
+import { MarkdownView, Notice, Platform, Plugin, addIcon } from 'obsidian';
 import { SynapseSettings, DEFAULT_SETTINGS } from './settings';
 import { SynapseSettingTab } from './settings-tab';
 import { ElaborationModule } from './elaboration';
@@ -13,7 +13,7 @@ import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
 import { RemModule } from './rem';
 import { IntakeModule } from './intake';
-import { CommandRegistrar, auditCommands } from './commands';
+import { CommandRegistrar, auditCommands, listPaletteActions } from './commands';
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
@@ -26,6 +26,8 @@ import { findImageEmbeds } from './image';
 import {
 	UNIFIED_VIEW_TYPE,
 	UnifiedProposalView,
+	SYNAPSE_ACTIONS_VIEW_TYPE,
+	SynapseActionsView,
 } from './views';
 import type { UnifiedItem } from './views';
 
@@ -163,6 +165,24 @@ export default class SynapsePlugin extends Plugin {
 				onCheckpointResume: (id) => this.resumeCheckpoint(id),
 			});
 		});
+
+		// Registry-driven "Synapse actions" sidebar (#289): touch-friendly buttons
+		// for every enabled palette command, so mobile users reach key functions in
+		// <=2 taps without the command palette. Buttons run the already-registered
+		// command via executeCommandById (see runCommand) — no behavior re-declared.
+		// The factory closes over the local `registrar`; it runs at view-open time
+		// (post-onload), so getRegistered() is fully populated.
+		this.registerView(SYNAPSE_ACTIONS_VIEW_TYPE, (leaf) => new SynapseActionsView(leaf, {
+			getActions: () => listPaletteActions(registrar.getRegistered()),
+			runAction: (id) => this.runCommand(id),
+			isNoteActive: () => this.app.workspace.getActiveViewOfType(MarkdownView) !== null,
+		}));
+
+		// Keep per-note buttons in sync with the active note (enable/disable live).
+		this.registerEvent(this.app.workspace.on('active-leaf-change', () => {
+			const view = this.app.workspace.getLeavesOfType(SYNAPSE_ACTIONS_VIEW_TYPE)[0]?.view;
+			if (view instanceof SynapseActionsView) view.refresh();
+		}));
 
 		// Wire refresh callback -- both modules call this to update the shared view
 		const refreshView = () => this.refreshUnifiedView();
@@ -307,6 +327,13 @@ export default class SynapsePlugin extends Plugin {
 				this.openUnifiedModal();
 			});
 		}
+
+		// Opener for the Synapse actions sidebar (#289). Unconditional so it appears
+		// on mobile, where the command palette is hardest to reach. 'layout-grid' is
+		// a functional Lucide glyph (only the sparkle family is on the banned list).
+		this.addRibbonIcon('layout-grid', 'Synapse actions', () => {
+			fireAndForget(this.activateSynapseActionsView(), 'Open Synapse actions', { notifications: this.notifications });
+		});
 
 		registrar.register('review-proposals', true, {
 			name: 'Open proposal review sidebar',
@@ -564,6 +591,29 @@ export default class SynapsePlugin extends Plugin {
 		// the refresh below; surface failures to the console only (no toast).
 		fireAndForget(workspace.revealLeaf(leaf), 'Reveal proposal view', { background: true });
 		await this.refreshUnifiedView();
+	}
+
+	private async activateSynapseActionsView(): Promise<void> {
+		const { workspace } = this.app;
+		let leaf = workspace.getLeavesOfType(SYNAPSE_ACTIONS_VIEW_TYPE)[0];
+		if (!leaf) {
+			const rightLeaf = workspace.getRightLeaf(false);
+			if (!rightLeaf) return;
+			leaf = rightLeaf;
+			await leaf.setViewState({ type: SYNAPSE_ACTIONS_VIEW_TYPE, active: true });
+		}
+		fireAndForget(workspace.revealLeaf(leaf), 'Reveal Synapse actions', { background: true });
+	}
+
+	/**
+	 * Run a registered command by its registry id (without the `synapse:` prefix).
+	 * Goes through Obsidian's own command dispatch — the same gated path the palette
+	 * uses, so editor/check gating is honored. `app.commands` isn't in the public
+	 * typings, hence the localized cast (the repo has no global App augmentation).
+	 */
+	private runCommand(id: string): void {
+		(this.app as unknown as { commands: { executeCommandById(id: string): boolean } })
+			.commands.executeCommandById(`${this.manifest.id}:${id}`);
 	}
 
 	private async discardCheckpoint(id: string): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Notice, Platform, Plugin, addIcon } from 'obsidian';
+import { MarkdownView, Notice, Platform, Plugin, TFile, addIcon } from 'obsidian';
 import { SynapseSettings, DEFAULT_SETTINGS } from './settings';
 import { SynapseSettingTab } from './settings-tab';
 import { ElaborationModule } from './elaboration';
@@ -13,7 +13,7 @@ import { DeepDiveModule } from './deep-dive';
 import { TitleModule } from './title';
 import { RemModule } from './rem';
 import { IntakeModule } from './intake';
-import { CommandRegistrar, auditCommands, listPaletteActions } from './commands';
+import { CommandRegistrar, auditCommands, listPaletteActions, REGISTRY_BY_ID } from './commands';
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
@@ -175,7 +175,7 @@ export default class SynapsePlugin extends Plugin {
 		this.registerView(SYNAPSE_ACTIONS_VIEW_TYPE, (leaf) => new SynapseActionsView(leaf, {
 			getActions: () => listPaletteActions(registrar.getRegistered()),
 			runAction: (id) => this.runCommand(id),
-			isNoteActive: () => this.app.workspace.getActiveViewOfType(MarkdownView) !== null,
+			isNoteActive: () => this.activeMarkdownFile() !== null,
 		}));
 
 		// Keep per-note buttons in sync with the active note (enable/disable live).
@@ -606,14 +606,47 @@ export default class SynapsePlugin extends Plugin {
 	}
 
 	/**
-	 * Run a registered command by its registry id (without the `synapse:` prefix).
-	 * Goes through Obsidian's own command dispatch — the same gated path the palette
-	 * uses, so editor/check gating is honored. `app.commands` isn't in the public
-	 * typings, hence the localized cast (the repo has no global App augmentation).
+	 * The active markdown note, or null. Uses `getActiveFile()` (which returns the
+	 * most recently active file) rather than `getActiveViewOfType(MarkdownView)`,
+	 * so it survives the actions sidebar — especially the mobile drawer — stealing
+	 * focus from the editor. That focus theft is exactly why the per-note buttons
+	 * used to grey out once the panel was open (#289 follow-up).
+	 */
+	private activeMarkdownFile(): TFile | null {
+		const file = this.app.workspace.getActiveFile();
+		return file && file.extension === 'md' ? file : null;
+	}
+
+	/**
+	 * Run a registered command by its registry id (without the `synapse:` prefix),
+	 * via Obsidian's own command dispatch — the same gated path the palette uses,
+	 * so editor/check gating is honored. `app.commands` isn't in the public typings,
+	 * hence the localized cast (the repo has no global App augmentation).
+	 *
+	 * For `context: 'note'` commands (registered as `editorCallback`s) the active
+	 * editor is required, but opening the actions sidebar makes the note's editor
+	 * inactive (`workspace.activeEditor` goes null) — so the command would silently
+	 * no-op. We re-activate the note's markdown leaf first, restoring the editor
+	 * context so the command runs against the note the user was viewing.
 	 */
 	private runCommand(id: string): void {
-		(this.app as unknown as { commands: { executeCommandById(id: string): boolean } })
-			.commands.executeCommandById(`${this.manifest.id}:${id}`);
+		const commands = (this.app as unknown as {
+			commands: { executeCommandById(id: string): boolean };
+		}).commands;
+
+		if (REGISTRY_BY_ID.get(id)?.context === 'note') {
+			const file = this.activeMarkdownFile();
+			if (!file) {
+				new Notice('Synapse: open a note first to use this action.');
+				return;
+			}
+			const mdLeaf = this.app.workspace
+				.getLeavesOfType('markdown')
+				.find((leaf) => leaf.view instanceof MarkdownView && leaf.view.file === file);
+			if (mdLeaf) this.app.workspace.setActiveLeaf(mdLeaf, { focus: true });
+		}
+
+		commands.executeCommandById(`${this.manifest.id}:${id}`);
 	}
 
 	private async discardCheckpoint(id: string): Promise<void> {

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -2,6 +2,11 @@ export {
 	UNIFIED_VIEW_TYPE,
 	UnifiedProposalView,
 } from './unified-proposal-view';
+export {
+	SYNAPSE_ACTIONS_VIEW_TYPE,
+	SynapseActionsView,
+} from './synapse-actions-view';
+export type { SynapseActionsCallbacks } from './synapse-actions-view';
 export { PROPOSAL_KINDS } from './types';
 export type {
 	UnifiedItem,

--- a/src/views/synapse-actions-view.test.ts
+++ b/src/views/synapse-actions-view.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createEl } from '../__mocks__/obsidian';
+import { SynapseActionsView, SynapseActionsCallbacks } from './synapse-actions-view';
+import type { CommandDefinition } from '../commands';
+
+// --- Helpers ----------------------------------------------------------------
+
+/** Stub WorkspaceLeaf that satisfies the ItemView constructor. */
+function mockLeaf(): any {
+	return { view: {} };
+}
+
+/** A small, representative action set spanning two features and all contexts. */
+function sampleActions(): CommandDefinition[] {
+	return [
+		{ id: 'review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'], context: 'global' },
+		{ id: 'enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'], context: 'note' },
+		{ id: 'scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault' },
+	];
+}
+
+function makeView(overrides: Partial<SynapseActionsCallbacks> = {}) {
+	const callbacks: SynapseActionsCallbacks = {
+		getActions: () => sampleActions(),
+		runAction: vi.fn(),
+		isNoteActive: () => true,
+		...overrides,
+	};
+	const view = new SynapseActionsView(mockLeaf(), callbacks);
+	// Mock ItemView.contentEl is a bare no-op stub; swap in the tracking stub el.
+	const contentEl = createEl();
+	(view as unknown as { contentEl: any }).contentEl = contentEl;
+	return { view, callbacks, contentEl };
+}
+
+/** Recursively collect all <button> descendants of a stub element. */
+function buttons(el: any): any[] {
+	const out: any[] = [];
+	const walk = (node: any) => {
+		for (const child of node.children ?? []) {
+			if (child.tagName === 'BUTTON') out.push(child);
+			walk(child);
+		}
+	};
+	walk(el);
+	return out;
+}
+
+/** Recursively collect text of all descendants carrying `cls`. */
+function textsByClass(el: any, cls: string): string[] {
+	const out: string[] = [];
+	const walk = (node: any) => {
+		for (const child of node.children ?? []) {
+			if (child.classList?.contains?.(cls)) out.push(child.textContent);
+			walk(child);
+		}
+	};
+	walk(el);
+	return out;
+}
+
+// --- Tests ------------------------------------------------------------------
+
+describe('SynapseActionsView', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders one button per action with its registry name', async () => {
+		const { view, contentEl } = makeView();
+		await view.onOpen();
+		const labels = buttons(contentEl).map((b) => b.textContent);
+		expect(labels).toEqual([
+			'Open proposal review sidebar',
+			'Enrich current note',
+			'Scan vault for enrichment',
+		]);
+	});
+
+	it('groups actions under sentence-case feature headings in registry order', async () => {
+		const { view, contentEl } = makeView();
+		await view.onOpen();
+		expect(textsByClass(contentEl, 'synapse-actions-group-heading')).toEqual([
+			'General',
+			'Enrichment',
+		]);
+	});
+
+	it('disables note-context buttons when no note is active and never wires their click', async () => {
+		const runAction = vi.fn();
+		const { view, contentEl } = makeView({ isNoteActive: () => false, runAction });
+		await view.onOpen();
+
+		const noteButton = buttons(contentEl).find((b) => b.textContent === 'Enrich current note');
+		expect(noteButton.disabled).toBe(true);
+		// A disabled button has no handler, so dispatching a click is a no-op.
+		noteButton.dispatchEvent({ type: 'click' });
+		expect(runAction).not.toHaveBeenCalled();
+	});
+
+	it('keeps vault/global buttons enabled even when no note is active', async () => {
+		const runAction = vi.fn();
+		const { view, contentEl } = makeView({ isNoteActive: () => false, runAction });
+		await view.onOpen();
+
+		const vaultButton = buttons(contentEl).find((b) => b.textContent === 'Scan vault for enrichment');
+		expect(vaultButton.disabled).toBeFalsy();
+		vaultButton.dispatchEvent({ type: 'click' });
+		expect(runAction).toHaveBeenCalledWith('scan-vault-enrichment');
+	});
+
+	it('invokes runAction with the command id when an enabled button is clicked', async () => {
+		const runAction = vi.fn();
+		const { view, contentEl } = makeView({ isNoteActive: () => true, runAction });
+		await view.onOpen();
+
+		buttons(contentEl).find((b) => b.textContent === 'Enrich current note').dispatchEvent({ type: 'click' });
+		expect(runAction).toHaveBeenCalledWith('enrich-current-note');
+	});
+
+	it('refresh() re-renders so per-note buttons enable when a note becomes active', async () => {
+		let noteActive = false;
+		const { view, contentEl } = makeView({ isNoteActive: () => noteActive });
+		await view.onOpen();
+		expect(buttons(contentEl).find((b) => b.textContent === 'Enrich current note').disabled).toBe(true);
+
+		noteActive = true;
+		view.refresh();
+		expect(buttons(contentEl).find((b) => b.textContent === 'Enrich current note').disabled).toBeFalsy();
+	});
+
+	it('shows an empty-state message and no buttons when nothing is registered', async () => {
+		const { view, contentEl } = makeView({ getActions: () => [] });
+		await view.onOpen();
+		expect(buttons(contentEl)).toHaveLength(0);
+		expect(textsByClass(contentEl, 'synapse-actions-empty')).toEqual([
+			'No actions available — enable features in settings.',
+		]);
+	});
+});

--- a/src/views/synapse-actions-view.ts
+++ b/src/views/synapse-actions-view.ts
@@ -1,0 +1,137 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import type { CommandDefinition, FeatureKey } from '../commands';
+
+export const SYNAPSE_ACTIONS_VIEW_TYPE = 'synapse-actions';
+
+/**
+ * Sentence-case section headings per feature (brand: sentence case; REM is an
+ * initialism so it stays uppercase). `main` is surfaced as "General".
+ */
+const FEATURE_LABELS: Record<FeatureKey, string> = {
+	main: 'General',
+	elaboration: 'Elaboration',
+	enrichment: 'Enrichment',
+	organize: 'Organize',
+	'deep-dive': 'Deep dive',
+	summarize: 'Summarize',
+	tidy: 'Tidy',
+	rem: 'REM',
+	video: 'Video',
+};
+
+/**
+ * Host-provided behavior. The view never touches `app`/workspace directly (keeps
+ * it a pure renderer, like UnifiedProposalView) — main.ts wires these in.
+ */
+export interface SynapseActionsCallbacks {
+	/** The palette commands to show, in registry order (from `listPaletteActions`). */
+	getActions: () => CommandDefinition[];
+	/** Invoke a command by its registry id (main.ts runs it via `executeCommandById`). */
+	runAction: (id: string) => void;
+	/** Whether a markdown note is currently active (gates `context: 'note'` buttons). */
+	isNoteActive: () => boolean;
+}
+
+/**
+ * "Synapse actions" sidebar: a touch-friendly panel of buttons for the active
+ * palette commands, grouped by feature and derived entirely from the command
+ * registry (no hand-maintained list). Gives mobile users every key function in
+ * ≤2 taps (ribbon → button) without the command palette.
+ *
+ * Per-note actions (`context: 'note'`) are disabled when no note is active;
+ * main.ts calls `refresh()` on `active-leaf-change` so they enable/disable live.
+ */
+export class SynapseActionsView extends ItemView {
+	private callbacks: SynapseActionsCallbacks;
+
+	constructor(leaf: WorkspaceLeaf, callbacks: SynapseActionsCallbacks) {
+		super(leaf);
+		this.callbacks = callbacks;
+	}
+
+	getViewType(): string {
+		return SYNAPSE_ACTIONS_VIEW_TYPE;
+	}
+
+	getDisplayText(): string {
+		return 'Synapse actions';
+	}
+
+	getIcon(): string {
+		// Non-sparkle Lucide glyph (the sparkle family is on the brand's banned
+		// inventory). Distinct from the 'synapse' mark used by the proposal view.
+		return 'layout-grid';
+	}
+
+	async onOpen(): Promise<void> {
+		this.render();
+	}
+
+	async onClose(): Promise<void> {
+		this.contentEl.empty();
+	}
+
+	/** Re-render — called by main.ts when the active note changes. */
+	refresh(): void {
+		this.render();
+	}
+
+	private render(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('synapse-actions-view-root');
+
+		const actions = this.callbacks.getActions();
+		if (actions.length === 0) {
+			contentEl.createEl('p', {
+				text: 'No actions available — enable features in settings.',
+				cls: 'synapse-actions-empty',
+			});
+			return;
+		}
+
+		const noteActive = this.callbacks.isNoteActive();
+
+		for (const { feature, actions: groupActions } of groupByFeature(actions)) {
+			const group = contentEl.createDiv({ cls: 'synapse-actions-group' });
+			group.createEl('div', {
+				text: FEATURE_LABELS[feature],
+				cls: 'synapse-actions-group-heading',
+			});
+
+			for (const action of groupActions) {
+				const disabled = action.context === 'note' && !noteActive;
+				const button = group.createEl('button', {
+					text: action.name,
+					cls: 'synapse-actions-button',
+				});
+				if (disabled) {
+					// Real <button disabled> can't be clicked and matches `:disabled`
+					// styling; we also skip wiring the handler so it can never fire.
+					button.disabled = true;
+					button.setAttribute('aria-disabled', 'true');
+				} else {
+					button.addEventListener('click', () => this.callbacks.runAction(action.id));
+				}
+			}
+		}
+	}
+}
+
+/** Group actions by feature, preserving first-seen (registry) order. */
+function groupByFeature(
+	actions: CommandDefinition[],
+): { feature: FeatureKey; actions: CommandDefinition[] }[] {
+	const order: { feature: FeatureKey; actions: CommandDefinition[] }[] = [];
+	const index = new Map<FeatureKey, CommandDefinition[]>();
+	for (const action of actions) {
+		let bucket = index.get(action.feature);
+		if (!bucket) {
+			bucket = [];
+			index.set(action.feature, bucket);
+			order.push({ feature: action.feature, actions: bucket });
+		}
+		bucket.push(action);
+	}
+	return order;
+}

--- a/styles.css
+++ b/styles.css
@@ -1075,3 +1075,42 @@
   color: var(--text-muted);
   font-style: italic;
 }
+
+/* ══════════════════════════════════════════════════════════════
+ * Synapse actions sidebar (#289)
+ * Registry-driven action buttons, grouped by feature. Buttons are
+ * sized for touch so mobile users reach key functions in <=2 taps.
+ * ══════════════════════════════════════════════════════════════ */
+.synapse-actions-view-root {
+  padding: 0 8px;
+}
+.synapse-actions-group {
+  margin-bottom: 12px;
+}
+.synapse-actions-group-heading {
+  font-size: var(--font-ui-smaller);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: 8px 0 4px;
+}
+.synapse-actions-button {
+  display: block;
+  width: 100%;
+  min-height: 44px; /* comfortable touch target (iOS/Material guidance) */
+  margin: 4px 0;
+  padding: 8px 12px;
+  text-align: left;
+  white-space: normal;
+  cursor: pointer;
+}
+.synapse-actions-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.synapse-actions-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 8px;
+}


### PR DESCRIPTION
## Summary

Adds a touch-friendly **Synapse actions** sidebar (`ItemView`) opened by a single ribbon icon. Every enabled palette command becomes a button, grouped by feature, so key functions are reachable in **≤2 taps on mobile** (ribbon → button) without the command palette.

The button list is derived entirely from the command registry — there is no hand-maintained duplicate, and it stays in sync as commands are added/disabled.

closes #289

## Reassessment (issue carried the `reassess` label)

The issue asked that buttons "invoke commands through the central registrar." The registrar only *registers* commands — it doesn't store callbacks or invoke them. The faithful, zero-duplication implementation:

- **Derive** the list from `COMMAND_REGISTRY` filtered by `CommandRegistrar.getRegistered()` (which already encodes `status === 'active'` AND `palette` flow AND the feature's user-level `enabled`), via the new `listPaletteActions`.
- **Invoke** via `app.commands.executeCommandById('synapse:'+id)` — the exact same gated path the palette uses, so `editorCallback`/`checkCallback` gating is honored. No command behavior is re-declared.

## Scope (confirmed with maintainer during planning)

- ✅ Sidebar view + **one** opener ribbon icon. No extra per-action ribbon icons / no new settings toggle.
- ✅ Per-note buttons **visibly disable when no note is active**, re-rendering live on `active-leaf-change`. Implemented via a new required `context` field on every registry entry (`note` | `vault` | `global`).

## Changes

- **`src/commands/`** — `CommandContext` type + required `context` on all 24 entries (mapped from each command's handler kind: `editorCallback` ⇒ `note`, folder-picker/vault scans ⇒ `vault`, app-level ⇒ `global`); new `listPaletteActions(registered)`.
- **`src/views/synapse-actions-view.ts`** — new `ItemView`, a pure DI renderer (no `app`/workspace access) following the `UnifiedProposalView` pattern. Groups by feature with sentence-case headings; disabled `note` buttons get no click handler; empty state when nothing is enabled.
- **`src/main.ts`** — `registerView`, the `layout-grid` ribbon icon (unconditional so it shows on mobile), `activateSynapseActionsView()`, `runCommand()` (localized typed shim for `app.commands`), and the `active-leaf-change` refresh wiring.
- **`styles.css`** — 44px touch targets + grouped layout.
- **Docs** — AGENTS.md (views/commands rows, registry note, ribbon + view-type tables; also corrected a stale `sparkles`→`synapse` ribbon entry) and ARCHITECTURE.md.

## Test plan

- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (1442 tests; new: `src/commands/actions.test.ts`, `src/views/synapse-actions-view.test.ts`, plus `context` invariants in `registry.test.ts`)
- `node esbuild.config.mjs production` ✅
- `npm run lint` ✅
- `node scripts/check-top-level-requires.mjs` ✅ · `node scripts/version-bump.mjs --check` ✅

The view test asserts registry-driven button generation, feature grouping, per-note disable gating (and that disabled buttons can't fire), and click → `runAction(id)`.

**Manual mobile check (not automatable here):** load in Obsidian mobile, confirm the `layout-grid` ribbon icon appears in the drawer, the panel opens, per-note buttons enable/disable as you switch notes, and buttons meet the touch target. (This is the issue's "Mobile verification" sub-task.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)