### PR TITLE
feat: add Review action to proposal toasts

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -177,12 +177,17 @@ export function createEl(tag = 'div'): any {
 }
 
 export class Notice {
+	/** Test helper: every Notice ever constructed (clear between tests). */
+	static instances: Notice[] = [];
 	noticeEl: any;
+	duration?: number;
 	constructor(_message: string | DocumentFragment, _duration?: number) {
 		this.noticeEl = createStubEl();
+		this.duration = _duration;
 		if (typeof _message === 'string') {
 			this.noticeEl.textContent = _message;
 		}
+		Notice.instances.push(this);
 	}
 	setMessage = vi.fn((msg: string) => {
 		if (this.noticeEl) this.noticeEl.textContent = msg;

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -53,6 +53,9 @@ export class DeepDiveModule {
 	onNoteAccepted: ((filePath: string) => void) | null = null;
 	onOrganizeRequested: ((file: TFile) => void) | null = null;
 
+	/** Optional callback to open the unified proposal view. Wired by main.ts (#340). */
+	onOpenProposalView: (() => void) | null = null;
+
 	private analyzer: TopicAnalyzer;
 	private generator: NoteGenerator;
 	private store: DeepDiveStore;
@@ -489,8 +492,14 @@ export class DeepDiveModule {
 				const depthSummary = Object.entries(run.stats.byDepth)
 					.map(([d, c]) => `depth ${d}: ${c}`)
 					.join(', ');
+				// Review action only when proposals remain pending — auto-accept
+				// (applied right after) creates every note, leaving nothing to
+				// review (#340).
 				genOp.finish(
-					`Generated ${run.stats.totalProposals} proposals (${depthSummary})`
+					`Generated ${run.stats.totalProposals} proposals (${depthSummary})`,
+					run.stats.totalProposals > 0 && !this.shouldAutoAccept()
+						? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+						: undefined
 				);
 
 				// Auto-accept the whole generated tree if enabled (#228), in

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -27,6 +27,9 @@ export class ElaborationModule {
 	/** Optional callback to refresh the unified proposal view. Wired by main.ts. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/** Optional callback to open the unified proposal view. Wired by main.ts (#340). */
+	onOpenProposalView: (() => void) | null = null;
+
 	/**
 	 * Live accessor for the elaboration auto-accept flag (#228). Wired by
 	 * main.ts to `() => this.settings.autoAccept.elaboration` so a settings
@@ -172,7 +175,12 @@ export class ElaborationModule {
 
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
-		genOp.finish(`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
+		genOp.finish(
+			`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
+			proposalCount - autoAcceptedCount > 0
+				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				: undefined
+		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
 				`Auto-accepted ${autoAcceptedCount} elaboration proposal${autoAcceptedCount === 1 ? '' : 's'}`
@@ -295,7 +303,14 @@ export class ElaborationModule {
 		// Mark checkpoint completed and dispatch deferred tasks (I1)
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
-		genOp.finish(`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
+		// Review action only when at least one proposal remains pending after
+		// any batch auto-accept (#340).
+		genOp.finish(
+			`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
+			proposalCount - autoAcceptedCount > 0
+				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				: undefined
+		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
 				`Auto-accepted ${autoAcceptedCount} elaboration proposal${autoAcceptedCount === 1 ? '' : 's'}`
@@ -325,7 +340,12 @@ export class ElaborationModule {
 				op.update(`Generating proposal for ${file.basename}`);
 				const proposal = await this.proposer.generate(result);
 				await this.store.save(proposal);
-				op.finish('Proposal generated');
+				// Review action only when the proposal stays pending — auto-accept
+				// (applied right after) leaves nothing to review (#340).
+				op.finish(
+					'Proposal generated',
+					this.shouldAutoAccept() ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				);
 				await this.maybeAutoAccept(proposal);
 				await this.refreshView();
 			} else {

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -40,6 +40,9 @@ export class EnrichmentModule {
 	/** Optional callback to refresh the unified proposal view. Wired by main.ts. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/** Optional callback to open the unified proposal view. Wired by main.ts (#340). */
+	onOpenProposalView: (() => void) | null = null;
+
 	/**
 	 * Live accessor for the enrichment auto-accept flag (#228). Wired by
 	 * main.ts to `() => this.settings.autoAccept.enrichment`. Defaults to
@@ -182,7 +185,12 @@ export class EnrichmentModule {
 
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
-		genOp.finish(`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
+		genOp.finish(
+			`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
+			proposalCount - autoAcceptedCount > 0
+				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				: undefined
+		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
 				`Auto-accepted ${autoAcceptedCount} enrichment proposal${autoAcceptedCount === 1 ? '' : 's'}`
@@ -355,8 +363,13 @@ export class EnrichmentModule {
 		// Mark checkpoint completed and dispatch deferred tasks (I1)
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
+		// Review action only when at least one proposal remains pending after
+		// any batch auto-accept (#340).
 		genOp.finish(
-			`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`
+			`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
+			proposalCount - autoAcceptedCount > 0
+				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				: undefined
 		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
@@ -403,7 +416,12 @@ export class EnrichmentModule {
 			// so discard any accumulated unmatched topics
 			this.topicExtractor.clearPending();
 			if (id) {
-				op.finish('Enrichment proposal created');
+				// Review action only when the proposal stays pending — auto-accept
+				// (applied right after) leaves nothing to review (#340).
+				op.finish(
+					'Enrichment proposal created',
+					this.shouldAutoAccept() ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				);
 				// Single-note path is final here (no Phase 4 merge), so the
 				// stored proposal is fully formed — safe to auto-accept (#228).
 				await this.maybeAutoAccept(id);

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,6 +193,18 @@ export default class SynapsePlugin extends Plugin {
 		this.title.onViewRefreshNeeded = refreshView;
 		this.rem.onViewRefreshNeeded = refreshView;
 
+		// Wire the "Review" toast action (#340): proposal-generation toasts carry a
+		// Review button that opens the unified proposal view. Shared opener across
+		// all six proposal-producing modules.
+		const openProposalView = () =>
+			fireAndForget(this.activateUnifiedView(), 'Open proposal review', { notifications: this.notifications });
+		this.elaboration.onOpenProposalView = openProposalView;
+		this.enrichment.onOpenProposalView = openProposalView;
+		this.organize.onOpenProposalView = openProposalView;
+		this.deepDive.onOpenProposalView = openProposalView;
+		this.title.onOpenProposalView = openProposalView;
+		this.rem.onOpenProposalView = openProposalView;
+
 		// Load enabled modules
 		if (this.settings.elaboration.enabled) {
 			await this.elaboration.onload();

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -30,6 +30,9 @@ export { DirectoryMatcher } from './directory-matcher';
 export class OrganizeModule {
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/** Optional callback to open the unified proposal view. Wired by main.ts (#340). */
+	onOpenProposalView: (() => void) | null = null;
+
 	private analyzer: ContentAnalyzer;
 	private matcher: DirectoryMatcher;
 	private store: OrganizeStore;
@@ -174,7 +177,14 @@ export class OrganizeModule {
 		if (movedCount > 0) parts.push(`${movedCount} moved`);
 		if (proposalCount > 0) parts.push(`${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
 		if (errorCount > 0) parts.push(`${errorCount} failed`);
-		genOp.finish(`Resumed -- ${parts.length > 0 ? parts.join(', ') : 'no changes needed'}`);
+		// Review action only when at least one new-directory proposal remains
+		// pending after any auto-accept (#340).
+		genOp.finish(
+			`Resumed -- ${parts.length > 0 ? parts.join(', ') : 'no changes needed'}`,
+			proposalCount - autoAcceptedCount > 0
+				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				: undefined
+		);
 
 		if (moveRecords.length > 0) {
 			const summaryPath = await this.writeOrganizeSummary(moveRecords);
@@ -225,7 +235,12 @@ export class OrganizeModule {
 			if (result.movedDirectly) {
 				op.finish(`Moved to ${result.action.type === 'move' ? result.action.targetDirectory : ''}`);
 			} else if (result.proposalCreated) {
-				op.finish('Proposal created for new directory');
+				// Review action only when the proposal stays pending — organize
+				// auto-accept moves the note, leaving nothing to review (#340).
+				op.finish(
+					'Proposal created for new directory',
+					result.autoAccepted ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				);
 			} else {
 				op.finish('Note is already well-placed');
 			}

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -388,7 +388,14 @@ export class OrganizeModule {
 		if (movedCount > 0) parts.push(`${movedCount} moved`);
 		if (proposalCount > 0) parts.push(`${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
 		if (errorCount > 0) parts.push(`${errorCount} failed`);
-		genOp.finish(parts.length > 0 ? parts.join(', ') : 'No changes needed');
+		// Review action only when at least one new-directory proposal remains
+		// pending after any auto-accept (#340).
+		genOp.finish(
+			parts.length > 0 ? parts.join(', ') : 'No changes needed',
+			proposalCount - autoAcceptedCount > 0
+				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+				: undefined
+		);
 
 		// Generate organize summary with move diagram
 		if (moveRecords.length > 0) {

--- a/src/organize/review-toast.test.ts
+++ b/src/organize/review-toast.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OrganizeModule } from './index';
+import { OrganizeStore } from './organize-store';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+import type { OrganizeProposal } from './types';
+
+// Analyzer finds a topic; matcher proposes a NEW directory — the only path that
+// creates an organize proposal (a reviewable item).
+vi.mock('./content-analyzer', () => ({
+	ContentAnalyzer: class MockContentAnalyzer {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		analyze = vi.fn().mockResolvedValue({
+			notePath: 'inbox/note.md',
+			topics: [{ label: 'machine learning', confidence: 0.95 }],
+			tags: [],
+			links: [],
+		});
+	},
+}));
+
+vi.mock('./directory-matcher', () => ({
+	DirectoryMatcher: class MockDirectoryMatcher {
+		constructor(_app: unknown) {}
+		scoreDirectories = vi.fn().mockReturnValue([]);
+		determineAction = vi.fn().mockReturnValue({
+			type: 'propose-new-directory',
+			targetDirectory: 'Machine Learning',
+			reasoning: 'Note is about machine learning',
+		});
+	},
+}));
+
+function makeOp(cancelled = false) {
+	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+}
+
+describe('OrganizeModule Review toast action (#340)', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let notifications: {
+		info: ReturnType<typeof vi.fn>;
+		success: ReturnType<typeof vi.fn>;
+		notifyError: ReturnType<typeof vi.fn>;
+		startOperation: ReturnType<typeof vi.fn>;
+	};
+	let settings: SynapseSettings;
+	let scanOp: ReturnType<typeof makeOp>;
+	let genOp: ReturnType<typeof makeOp>;
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		app = createMockApp();
+		sourceFile = new TFile('inbox/note.md');
+		app.vault.getMarkdownFiles.mockReturnValue([sourceFile]);
+		// Source note resolves; every other path (new folder, move destination)
+		// is absent, so the new-directory proposal path runs and the move is free.
+		app.vault.getAbstractFileByPath.mockImplementation((p: string) =>
+			p === 'inbox/note.md' ? sourceFile : null
+		);
+		(app.vault as unknown as { rename: ReturnType<typeof vi.fn> }).rename = vi
+			.fn()
+			.mockResolvedValue(undefined);
+		plugin = { app } as unknown as Plugin;
+		settings = structuredClone(DEFAULT_SETTINGS);
+
+		// Distinct ops per phase so we can assert on the generation toast only.
+		scanOp = makeOp();
+		genOp = makeOp();
+		notifications = {
+			info: vi.fn(),
+			success: vi.fn(),
+			notifyError: vi.fn(),
+			startOperation: vi.fn((_label: string, id?: string) =>
+				id === 'organize-generate' ? genOp : scanOp
+			),
+		};
+
+		vi.spyOn(OrganizeStore.prototype, 'init').mockResolvedValue(undefined);
+		vi.spyOn(OrganizeStore.prototype, 'saveProposal').mockResolvedValue(undefined);
+		vi.spyOn(OrganizeStore.prototype, 'saveSnapshot').mockResolvedValue(undefined);
+		vi.spyOn(OrganizeStore.prototype, 'updateProposalStatus').mockResolvedValue(undefined);
+		vi.spyOn(OrganizeStore.prototype, 'loadPendingProposals').mockResolvedValue([]);
+		// acceptProposal (the auto-accept path) re-loads the proposal; return a
+		// still-pending one so the accept (note move) succeeds.
+		vi.spyOn(OrganizeStore.prototype, 'loadProposal').mockImplementation(
+			async (id: string) =>
+				({
+					id,
+					sourceNotePath: 'inbox/note.md',
+					proposedDirectory: 'Machine Learning',
+					reasoning: 'Note is about machine learning',
+					createdAt: '2026-06-11T00:00:00.000Z',
+					status: 'pending',
+				}) as OrganizeProposal
+		);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	function build(shouldAutoAccept: () => boolean): OrganizeModule {
+		const registrar = { register: vi.fn() };
+		return new OrganizeModule(
+			plugin,
+			() => settings,
+			notifications as never,
+			createMockCheckpointManager() as never,
+			registrar as never,
+			shouldAutoAccept
+		);
+	}
+
+	it('forwards a Review action to the directory-scan completion toast when proposals remain', async () => {
+		settings.autoAccept.organize = false;
+		const mod = build(() => settings.autoAccept.organize);
+		await mod.onload();
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.scanDirectory(undefined, true); // skipConfirmation
+
+		expect(genOp.finish).toHaveBeenCalledWith(
+			expect.stringContaining('proposal'),
+			expect.objectContaining({ label: 'Review' })
+		);
+		// The action opens the unified proposal view.
+		genOp.finish.mock.calls.at(-1)![1].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the Review action when everything was auto-accepted (nothing left to review)', async () => {
+		settings.autoAccept.organize = true;
+		const mod = build(() => settings.autoAccept.organize);
+		await mod.onload();
+
+		await mod.scanDirectory(undefined, true);
+
+		// proposalCount === autoAcceptedCount, so the guard yields no action.
+		expect(genOp.finish).toHaveBeenCalledWith(
+			expect.stringContaining('proposal'),
+			undefined
+		);
+		// And the note was actually moved by auto-accept.
+		expect((app.vault as unknown as { rename: ReturnType<typeof vi.fn> }).rename).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/rem/index.test.ts
+++ b/src/rem/index.test.ts
@@ -131,7 +131,11 @@ describe('RemModule', () => {
 			expect(result!.candidates).toHaveLength(2);
 			expect(result!.status).toBe('pending');
 			expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({ sourceNotePath: 'notes/A.md' }));
-			expect(notifications.success).toHaveBeenCalledWith(expect.stringContaining('2 linkable mentions'));
+			expect(notifications.success).toHaveBeenCalledWith(
+				expect.stringContaining('2 linkable mentions'),
+				undefined,
+				expect.objectContaining({ label: 'Review' })
+			);
 		});
 
 		it('returns null when no linkable mentions are found', async () => {
@@ -255,6 +259,71 @@ describe('RemModule', () => {
 				'accepted',
 				['Foo'],
 				expect.any(String)
+			);
+		});
+	});
+
+	describe('Review toast action (#340)', () => {
+		it('forwards a Review action that opens the proposal view to the success toast', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('mentions Foo');
+			scanSpy.mockReturnValue([candidate('Foo')]);
+			const module = await loadedModule(); // auto-accept off
+			const openSpy = vi.fn();
+			module.onOpenProposalView = openSpy;
+
+			await module.remScanNote('notes/A.md');
+
+			expect(notifications.success).toHaveBeenCalledWith(
+				expect.stringContaining('linkable mention'),
+				undefined,
+				expect.objectContaining({ label: 'Review' })
+			);
+			// The action opens the unified proposal view.
+			const action = notifications.success.mock.calls[0][2];
+			action.onClick();
+			expect(openSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('forwards a Review action to the directory-scan completion toast', async () => {
+			const op = makeOp();
+			notifications.startOperation.mockReturnValue(op);
+			app.vault.getMarkdownFiles.mockReturnValue([mockFile('notes/A.md')]);
+			app.vault.read.mockResolvedValue('Foo content');
+			scanSpy.mockReturnValue([candidate('Foo')]);
+			const module = await loadedModule(); // auto-accept off
+			const openSpy = vi.fn();
+			module.onOpenProposalView = openSpy;
+
+			await module.remScanDirectory();
+
+			expect(op.finish).toHaveBeenCalledWith(
+				expect.stringContaining('REM scan complete'),
+				expect.objectContaining({ label: 'Review' })
+			);
+			op.finish.mock.calls.at(-1)![1].onClick();
+			expect(openSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('omits the Review action when auto-accept is on (nothing left to review)', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('mentions Foo');
+			scanSpy.mockReturnValue([candidate('Foo')]);
+			loadSpy.mockImplementation(async () => ({
+				id: 'x',
+				sourceNotePath: 'notes/A.md',
+				createdAt: '2026-06-11T00:00:00.000Z',
+				candidates: [candidate('Foo')],
+				status: 'pending',
+			}));
+			const module = await loadedModule(() => true);
+
+			await module.remScanNote('notes/A.md');
+
+			expect(notifications.success).toHaveBeenCalledWith(
+				expect.stringContaining('linkable mention'),
+				undefined,
+				undefined
 			);
 		});
 	});

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -26,6 +26,9 @@ export class RemModule {
 	/** Optional callback to refresh the unified proposal view. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/** Optional callback to open the unified proposal view. Wired by main.ts (#340). */
+	onOpenProposalView: (() => void) | null = null;
+
 	/**
 	 * Live accessor for the REM auto-accept flag (#228). Wired by main.ts to
 	 * `() => this.settings.autoAccept.rem`. Defaults to "never auto-accept".
@@ -142,8 +145,12 @@ export class RemModule {
 		};
 
 		await this.store.save(proposal);
+		// Review action only when the proposal stays pending — auto-accept
+		// (applied right after) inserts the links, leaving nothing to review (#340).
 		this.notifications.success(
-			`Found ${allCandidates.length} linkable mention${allCandidates.length === 1 ? '' : 's'}`
+			`Found ${allCandidates.length} linkable mention${allCandidates.length === 1 ? '' : 's'}`,
+			undefined,
+			this.shouldAutoAccept() ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
 		);
 
 		// Single-note path: auto-accept the whole proposal if enabled (#228).
@@ -256,7 +263,14 @@ export class RemModule {
 		} else {
 			const tasks = await this.checkpointManager.complete(checkpoint.id);
 			this.dispatchDeferredTasks(tasks);
-			op.finish(`REM scan complete -- ${created} note${created === 1 ? '' : 's'} with linkable mentions`);
+			// Review action only when at least one proposal remains pending after
+			// any batch auto-accept (#340).
+			op.finish(
+				`REM scan complete -- ${created} note${created === 1 ? '' : 's'} with linkable mentions`,
+				created - autoAcceptedCount > 0
+					? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+					: undefined
+			);
 			if (autoAcceptedCount > 0) {
 				this.notifications.info(
 					`Auto-accepted REM links in ${autoAcceptedCount} note${autoAcceptedCount === 1 ? '' : 's'}`
@@ -334,7 +348,12 @@ export class RemModule {
 		} else {
 			const tasks = await this.checkpointManager.complete(checkpoint.id);
 			this.dispatchDeferredTasks(tasks);
-			op.finish(`Resumed -- generated ${createdProposalIds.length} proposals`);
+			op.finish(
+				`Resumed -- generated ${createdProposalIds.length} proposals`,
+				createdProposalIds.length - autoAcceptedCount > 0
+					? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+					: undefined
+			);
 			if (autoAcceptedCount > 0) {
 				this.notifications.info(
 					`Auto-accepted REM links in ${autoAcceptedCount} note${autoAcceptedCount === 1 ? '' : 's'}`

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -25,7 +25,7 @@ export type { ValidationResult, ValidationStatus, ValidateOptions } from './cred
 export { decorateCredentialField } from './credential-field';
 export type { CredentialFieldOptions, CredentialFieldHandle } from './credential-field';
 export { NotificationManager } from './notifications';
-export type { OperationHandle } from './notifications';
+export type { OperationHandle, NoticeAction } from './notifications';
 export { fireAndForget } from './fire-and-forget';
 export type { FireAndForgetOptions } from './fire-and-forget';
 export { FolderPickerModal } from './folder-picker-modal';

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Notice } from 'obsidian';
 import { NotificationManager } from './notifications';
+
+/** Recursively locate the first <button> element in a stub-element tree. */
+function findButton(el: any): any | null {
+	for (const child of el.children ?? []) {
+		if (child.tagName === 'BUTTON') return child;
+		const nested = findButton(child);
+		if (nested) return nested;
+	}
+	return null;
+}
+
+/** The most recently constructed Notice (the visible completion/success toast). */
+function lastNotice(): any {
+	return (Notice as unknown as { instances: any[] }).instances.at(-1);
+}
 
 describe('NotificationManager', () => {
 	let manager: NotificationManager;
 
 	beforeEach(() => {
 		manager = new NotificationManager();
+		(Notice as unknown as { instances: any[] }).instances.length = 0;
 	});
 
 	afterEach(() => {
@@ -112,6 +129,49 @@ describe('NotificationManager', () => {
 			const handle = manager.startOperation('Work', 'sb-done');
 			handle.finish();
 			expect((mockEl as any).setText).toHaveBeenLastCalledWith('Synapse');
+		});
+	});
+
+	describe('action button (#340)', () => {
+		it('success renders a button labelled by the action and wires its click', () => {
+			const onClick = vi.fn();
+			manager.success('Title proposal ready', undefined, { label: 'Review', onClick });
+
+			const notice = lastNotice();
+			const button = findButton(notice.noticeEl);
+			expect(button).not.toBeNull();
+			expect(button.textContent).toBe('Review');
+			expect(button.classList.contains('mod-cta')).toBe(true);
+
+			// Clicking invokes the handler exactly once, then hides the toast.
+			button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+			expect(onClick).toHaveBeenCalledTimes(1);
+			expect(notice.hide).toHaveBeenCalledTimes(1);
+		});
+
+		it('success without an action renders no button (regression guard)', () => {
+			manager.success('Done!');
+			expect(findButton(lastNotice().noticeEl)).toBeNull();
+		});
+
+		it('finish renders an action button when an action is supplied', () => {
+			const onClick = vi.fn();
+			const handle = manager.startOperation('Generating', 'op-action');
+			handle.finish('Generated 3 proposals', { label: 'Review', onClick });
+
+			const notice = lastNotice();
+			const button = findButton(notice.noticeEl);
+			expect(button?.textContent).toBe('Review');
+
+			button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+			expect(onClick).toHaveBeenCalledTimes(1);
+			expect(notice.hide).toHaveBeenCalledTimes(1);
+		});
+
+		it('finish without an action renders no button (regression guard)', () => {
+			const handle = manager.startOperation('Working', 'op-plain');
+			handle.finish('Done');
+			expect(findButton(lastNotice().noticeEl)).toBeNull();
 		});
 	});
 

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -2,13 +2,26 @@ import { Notice } from 'obsidian';
 
 export type NoticeLevel = 'info' | 'progress' | 'success' | 'warning' | 'error';
 
+/**
+ * A single action button rendered on an actionable success/completion toast
+ * (e.g. "Review"). `onClick` runs when the user presses the button; the toast
+ * then hides itself.
+ */
+export interface NoticeAction {
+	label: string;
+	onClick: () => void;
+}
+
 export interface OperationHandle {
 	/** Update the operation's status message */
 	update(message: string): void;
 	/** Update with progress counter (e.g., 3/5) */
 	progress(current: number, total: number, label?: string): void;
-	/** Mark operation as successfully finished */
-	finish(message?: string): void;
+	/**
+	 * Mark operation as successfully finished. When `action` is supplied the
+	 * completion toast renders an action button (e.g. "Review").
+	 */
+	finish(message?: string, action?: NoticeAction): void;
 	/** Mark operation as failed */
 	error(message: string): void;
 	/** Whether the operation has been cancelled */
@@ -36,6 +49,13 @@ interface TrackedOperation {
  * automatically with the plugin.
  */
 const CLS = 'synapse-notice';
+
+/**
+ * Auto-dismiss (ms) for actionable success/completion toasts. Longer than the
+ * plain 4s default so the user has time to click the action button before the
+ * toast disappears.
+ */
+const ACTION_NOTICE_DURATION = 8000;
 
 /** Get the underlying DOM element from a Notice */
 function getNoticeEl(notice: Notice): HTMLElement {
@@ -202,9 +222,16 @@ export class NotificationManager {
 				this.updateStatusBar();
 			},
 
-			finish: (message?: string) => {
+			finish: (message?: string, action?: NoticeAction) => {
 				if (op.state !== 'running') return;
-				this.completeOperation(opId, 'done', message || `${op.label} complete`, 'success', 4000);
+				this.completeOperation(
+					opId,
+					'done',
+					message || `${op.label} complete`,
+					'success',
+					action ? ACTION_NOTICE_DURATION : 4000,
+					action
+				);
 			},
 
 			error: (message: string) => {
@@ -270,16 +297,64 @@ export class NotificationManager {
 		this.completeOperation(id, 'cancelled', 'Operation cancelled', 'warning', 4000);
 	}
 
-	/** Show a one-shot informational notice (not tracked, dismissible) */
-	info(message: string, duration = 4000): void {
+	/**
+	 * Show a one-shot informational notice (not tracked, dismissible).
+	 * When `action` is supplied the toast renders an action button (e.g. "Review").
+	 */
+	info(message: string, duration = 4000, action?: NoticeAction): void {
+		if (action) {
+			this.showActionNotice(message, 'info', Math.max(duration, ACTION_NOTICE_DURATION), action);
+			return;
+		}
 		const notice = new Notice(`Synapse: ${message}`, duration);
 		styleNotice(notice, 'info');
 	}
 
-	/** Show a one-shot success notice (dismissible) */
-	success(message: string, duration = 4000): void {
+	/**
+	 * Show a one-shot success notice (dismissible). When `action` is supplied the
+	 * toast renders an action button (e.g. "Review") and stays up longer.
+	 */
+	success(message: string, duration = 4000, action?: NoticeAction): void {
+		if (action) {
+			this.showActionNotice(message, 'success', Math.max(duration, ACTION_NOTICE_DURATION), action);
+			return;
+		}
 		const notice = new Notice(`Synapse: ${message}`, duration);
 		styleNotice(notice, 'success');
+	}
+
+	/**
+	 * Build an interactive one-shot notice carrying a single action button.
+	 * Mirrors the confirm() snackbar markup: a message div plus an actions
+	 * container holding one `.mod-cta` button. The notice blocks background
+	 * click-to-dismiss, but the button click passes through (preventDismiss
+	 * lets button targets through), runs the action, and hides the toast.
+	 */
+	private showActionNotice(
+		message: string,
+		level: NoticeLevel,
+		duration: number,
+		action: NoticeAction
+	): void {
+		const notice = new Notice('', duration);
+		styleNotice(notice, level);
+		preventDismiss(notice);
+
+		const el = getNoticeEl(notice);
+		el.empty();
+
+		el.createEl('div', { text: `Synapse: ${message}` });
+
+		const actions = el.createDiv({ cls: `${CLS}-actions` });
+		const button = actions.createEl('button', {
+			text: action.label,
+			cls: 'mod-cta',
+		});
+		button.addEventListener('click', (e) => {
+			e.stopPropagation();
+			action.onClick();
+			notice.hide();
+		});
 	}
 
 	/** Show a one-shot error notice (dismissible, stays longer) */
@@ -299,16 +374,23 @@ export class NotificationManager {
 		newState: TrackedOperation['state'],
 		message: string,
 		level: NoticeLevel,
-		duration: number
+		duration: number,
+		action?: NoticeAction
 	): void {
 		const op = this.operations.get(id);
 		if (!op) return;
 		op.state = newState;
 		stopEllipsis(op.ellipsisInterval);
 		op.notice.hide();
-		// Completion/error/cancel notices are normal dismissible toasts
-		const notice = new Notice(`Synapse: ${message}`, duration);
-		styleNotice(notice, level);
+		// Completion/error/cancel notices are normal dismissible toasts. When an
+		// action is supplied, build an interactive notice with a single button;
+		// otherwise keep the plain (unchanged) path.
+		if (action) {
+			this.showActionNotice(message, level, duration, action);
+		} else {
+			const notice = new Notice(`Synapse: ${message}`, duration);
+			styleNotice(notice, level);
+		}
 		this.operations.delete(id);
 		this.updateStatusBar();
 	}

--- a/src/title/index.ts
+++ b/src/title/index.ts
@@ -16,6 +16,9 @@ export class TitleModule {
 	/** Optional callback to refresh the unified proposal view. Wired by main.ts. */
 	onViewRefreshNeeded: (() => Promise<void>) | null = null;
 
+	/** Optional callback to open the unified proposal view. Wired by main.ts (#340). */
+	onOpenProposalView: (() => void) | null = null;
+
 	/**
 	 * Live accessor for the title auto-accept flag (#228). Wired by main.ts to
 	 * `() => this.settings.autoAccept.title`. Defaults to "never auto-accept".
@@ -39,13 +42,17 @@ export class TitleModule {
 	 * Auto-accept a freshly generated title proposal (#228), if the title
 	 * auto-accept flag is on. This RENAMES the file. A single Notice fires
 	 * (title proposals are generated one-at-a-time, never in a tight batch).
+	 *
+	 * Returns `true` when auto-accept was applied, so callers can suppress the
+	 * "Title proposal ready" Review toast for proposals that were consumed (#340).
 	 */
-	private async maybeAutoAccept(proposal: TitleProposal): Promise<void> {
-		if (!this.shouldAutoAccept()) return;
+	private async maybeAutoAccept(proposal: TitleProposal): Promise<boolean> {
+		if (!this.shouldAutoAccept()) return false;
 		await this.acceptProposal(proposal.id, { silent: true });
 		this.notifications.info(
 			`Auto-accepted title "${proposal.proposedTitle}"`
 		);
+		return true;
 	}
 
 	async onload(): Promise<void> {
@@ -94,7 +101,16 @@ export class TitleModule {
 			};
 
 			await this.store.save(proposal);
-			await this.maybeAutoAccept(proposal);
+			const autoAccepted = await this.maybeAutoAccept(proposal);
+			// Title's check is silent until a proposal is actually pending: surface
+			// a Review toast so the otherwise-silent title flow is reachable, but
+			// never for an auto-accepted (already-applied) proposal (#340).
+			if (!autoAccepted) {
+				this.notifications.success('Title proposal ready', undefined, {
+					label: 'Review',
+					onClick: () => this.onOpenProposalView?.(),
+				});
+			}
 			await this.refreshView();
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
@@ -136,7 +152,15 @@ export class TitleModule {
 			};
 
 			await this.store.save(proposal);
-			await this.maybeAutoAccept(proposal);
+			const autoAccepted = await this.maybeAutoAccept(proposal);
+			// As in checkUntitled: a Review toast unless the proposal was already
+			// applied via auto-accept (#340).
+			if (!autoAccepted) {
+				this.notifications.success('Title proposal ready', undefined, {
+					label: 'Review',
+					onClick: () => this.onOpenProposalView?.(),
+				});
+			}
 			await this.refreshView();
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);

--- a/src/title/review-toast.test.ts
+++ b/src/title/review-toast.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TitleModule } from './index';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile, TFolder } from '../__mocks__/obsidian';
+
+// Stub the title suggester so checkUntitled produces a deterministic proposal
+// without any AI/network call.
+vi.mock('./title-suggester', () => ({
+	TitleSuggester: class MockTitleSuggester {
+		constructor(_client: unknown) {}
+		suggestTitle = vi.fn().mockResolvedValue({
+			title: 'Neural Networks',
+			reasoning: 'Content is about neural networks',
+		});
+		checkTitleMismatch = vi.fn().mockResolvedValue({ isMismatch: false });
+	},
+}));
+
+/** In-memory adapter so TitleProposalStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+function makeUntitledFile(): TFile {
+	const file = new TFile('Inbox/Untitled.md');
+	file.parent = new TFolder('Inbox');
+	return file;
+}
+
+describe('TitleModule Review toast action (#340)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: { app: { vault: Record<string, unknown>; metadataCache: Record<string, unknown> } };
+	let settings: SynapseSettings;
+	let notifications: { info: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn>; notifyError: ReturnType<typeof vi.fn> };
+	let untitledFile: TFile;
+
+	beforeEach(() => {
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		notifications = { info: vi.fn(), success: vi.fn(), notifyError: vi.fn() };
+		untitledFile = makeUntitledFile();
+
+		mockPlugin = {
+			app: {
+				vault: {
+					read: vi.fn().mockResolvedValue('# Notes\n\nDetailed content about neural networks.'),
+					rename: vi.fn().mockResolvedValue(undefined),
+					createFolder: vi.fn().mockResolvedValue(undefined),
+					getAbstractFileByPath: vi.fn((path: string) =>
+						path === 'Inbox/Untitled.md' ? untitledFile : null
+					),
+					adapter,
+				},
+				metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+			},
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(shouldAutoAccept: () => boolean): TitleModule {
+		return new TitleModule(
+			mockPlugin as never,
+			() => settings,
+			notifications as never,
+			shouldAutoAccept
+		);
+	}
+
+	it('emits a "Title proposal ready" Review toast when auto-accept is off', async () => {
+		settings.autoAccept.title = false;
+		const mod = build(() => settings.autoAccept.title);
+		await mod.onload();
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.checkUntitled('Inbox/Untitled.md');
+
+		expect(notifications.success).toHaveBeenCalledWith(
+			'Title proposal ready',
+			undefined,
+			expect.objectContaining({ label: 'Review' })
+		);
+		// The action opens the unified proposal view.
+		notifications.success.mock.calls[0][2].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+
+		// Nothing was renamed (proposal left pending for review).
+		expect(mockPlugin.app.vault.rename).not.toHaveBeenCalled();
+	});
+
+	it('does NOT emit the Review toast when auto-accept is on', async () => {
+		settings.autoAccept.title = true;
+		const mod = build(() => settings.autoAccept.title);
+		await mod.onload();
+
+		await mod.checkUntitled('Inbox/Untitled.md');
+
+		// No Review toast — the proposal was auto-applied, nothing to review.
+		expect(notifications.success).not.toHaveBeenCalled();
+		// Auto-accept renames the file and surfaces its own info toast.
+		expect(mockPlugin.app.vault.rename).toHaveBeenCalledTimes(1);
+		expect(notifications.info).toHaveBeenCalledWith(expect.stringContaining('Auto-accepted title'));
+	});
+});

--- a/styles.css
+++ b/styles.css
@@ -472,6 +472,16 @@
   background: transparent;
   color: var(--text-muted);
 }
+/*
+ * Actionable success/info toasts carry a single button (e.g. "Review");
+ * right-align it so it reads as a trailing call-to-action rather than a
+ * left-aligned form control. Scoped to single-action toasts so the
+ * confirmation snackbar's Proceed/Cancel pair is unaffected.
+ */
+.notice.synapse-notice--success .synapse-notice-actions,
+.notice.synapse-notice--info .synapse-notice-actions {
+  justify-content: flex-end;
+}
 
 /* ══════════════════════════════════════════════════════════════
  * Unified Proposal View (sidebar)


### PR DESCRIPTION
## Summary

Proposal-generation toasts previously announced a result but were dead ends. This adds a generic, optional **Review** action button to those toasts that opens the `UnifiedProposalView`, covering **all six proposal types** (elaboration, enrichment, organize, deep-dive, rem, title — including title, which was silent before and now gets a new toast).

closes #340

## How it works

- **`src/shared/notifications.ts`** — new exported `NoticeAction { label; onClick }`. Threaded an optional `action?` through `OperationHandle.finish`, `completeOperation`, `success()` and `info()`. When an action is present the toast builds an interactive notice (same markup as `confirm()`: message div + `.synapse-notice-actions` + one `.mod-cta` button), auto-dismisses slower (~8s), and `preventDismiss` lets the button click through while blocking background dismissal. **When no action is supplied the toast is byte-for-byte the original plain `new Notice` path** — existing toasts are unchanged.
- **`src/main.ts`** — a single shared `onOpenProposalView` opener (`fireAndForget(this.activateUnifiedView(), …)`) wired to all six proposal modules, mirroring the existing `onViewRefreshNeeded` pattern.
- **`styles.css`** — small scoped tweak to right-align the single-button success/info toast action (reuses the existing `.synapse-notice-actions` rules; confirmation snackbar unaffected). No action-type color rules touched (left for stacked #342).

## Toast sites wired

The Review button is shown **only when a reviewable proposal actually remains** (skipped when auto-accept already consumed everything):

| Module | Sites |
|---|---|
| elaboration | `scanNote` single, `scanVault` batch, resume |
| enrichment | `enrich` single, `scanVault` batch, resume |
| organize | `organizeNote` ("Proposal created for new directory"), `scanDirectory` batch, resume |
| deep-dive | generation finish ("Generated N proposals…") |
| rem | `remScanNote` (success), `remScanDirectory` finish, resume |
| title | **new** "Title proposal ready" toast in `checkUntitled` / `checkMismatch`, emitted only when the proposal was **not** auto-accepted |

Guards: batch paths compare `proposalCount - autoAcceptedCount > 0`; single-note paths emit a toast before auto-accept runs so they guard on `shouldAutoAccept()` / `result.autoAccepted`; title guards on `maybeAutoAccept()`'s new boolean return.

## Tests

- `notifications.test.ts` — `success()`/`finish()` render a button whose text == `action.label`, a click calls `onClick` once and hides the notice; **regression guards** assert no button when no action is supplied.
- `rem/index.test.ts` — module forwards the action through `success()` and `op.finish()`, opens the view on click, and omits the action when auto-accept is on.
- `organize/review-toast.test.ts` — directory-scan forwards the action when proposals remain (opens the view on click) and omits it when everything was auto-accepted.
- `title/review-toast.test.ts` — emits the Review toast when auto-accept is off; does **not** emit when auto-accept is on.

## Preflight (all green)

`tsc --noEmit --skipLibCheck` · `npm test` (1501 passed) · `esbuild production` · `check-top-level-requires.mjs` · `version-bump.mjs --check` (consistent at 1.0.3, no bump needed) · `eslint src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)