### PR TITLE
feat: unify action-type colors into semantic theme tokens

### DIFF
--- a/src/elaboration/proposal-modal.ts
+++ b/src/elaboration/proposal-modal.ts
@@ -21,6 +21,9 @@ export class ProposalDetailModal extends Modal {
 	onOpen(): void {
 		const { contentEl } = this;
 		contentEl.empty();
+		// Type-accent hook: styles the title underline with the elaboration token
+		// (single source of truth in styles.css), matching the sidebar card/badge.
+		contentEl.addClass('synapse-elaboration-detail');
 
 		contentEl.createEl('h2', { text: `Proposal for: ${this.proposal.sourceNotePath}` });
 

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -13,3 +13,11 @@ export type {
 	UnifiedViewCallbacks,
 	ProposalKind,
 } from './types';
+export {
+	SYNAPSE_COLOR_TOKENS,
+	FEATURE_COLOR_TOKENS,
+	cardClass,
+	badgeClass,
+	reviewPaneLabelClass,
+	actionsGroupClass,
+} from './proposal-styles';

--- a/src/views/proposal-styles.test.ts
+++ b/src/views/proposal-styles.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PROPOSAL_KINDS } from './types';
+import {
+	SYNAPSE_COLOR_TOKENS,
+	FEATURE_COLOR_TOKENS,
+	cardClass,
+	badgeClass,
+	reviewPaneLabelClass,
+	actionsGroupClass,
+} from './proposal-styles';
+
+/** styles.css lives at the repo root (two levels up from src/views/). */
+const stylesCss = fs.readFileSync(path.resolve(__dirname, '../../styles.css'), 'utf8');
+
+describe('semantic color tokens (#342)', () => {
+	it('maps every proposal kind to its --synapse-color-* token', () => {
+		for (const kind of PROPOSAL_KINDS) {
+			expect(SYNAPSE_COLOR_TOKENS[kind]).toBe(`--synapse-color-${kind}`);
+		}
+	});
+
+	it('has exactly one token entry per proposal kind (no extras, no gaps)', () => {
+		expect(Object.keys(SYNAPSE_COLOR_TOKENS).sort()).toEqual([...PROPOSAL_KINDS].sort());
+	});
+
+	it('declares every proposal-kind token in styles.css', () => {
+		for (const token of Object.values(SYNAPSE_COLOR_TOKENS)) {
+			expect(stylesCss).toContain(`${token}:`);
+		}
+	});
+
+	it('declares every feature token in styles.css (sidebar coverage)', () => {
+		for (const token of Object.values(FEATURE_COLOR_TOKENS)) {
+			expect(stylesCss).toContain(`${token}:`);
+		}
+	});
+
+	it('feature tokens are a superset of proposal-kind tokens', () => {
+		// Every proposal kind that is also a feature must point at the same token.
+		for (const kind of PROPOSAL_KINDS) {
+			if (kind in FEATURE_COLOR_TOKENS) {
+				expect(FEATURE_COLOR_TOKENS[kind as keyof typeof FEATURE_COLOR_TOKENS]).toBe(
+					SYNAPSE_COLOR_TOKENS[kind]
+				);
+			}
+		}
+	});
+});
+
+describe('class-name helpers (#342)', () => {
+	it('cardClass returns the kind modifier', () => {
+		expect(cardClass('elaboration')).toBe('synapse-card--elaboration');
+		expect(cardClass('deep-dive')).toBe('synapse-card--deep-dive');
+	});
+
+	it('badgeClass returns the kind modifier', () => {
+		expect(badgeClass('rem')).toBe('synapse-badge--rem');
+		expect(badgeClass('title')).toBe('synapse-badge--title');
+	});
+
+	it('reviewPaneLabelClass returns the kind modifier', () => {
+		expect(reviewPaneLabelClass('organize')).toBe('synapse-review-pane-label--organize');
+		expect(reviewPaneLabelClass('enrichment')).toBe('synapse-review-pane-label--enrichment');
+	});
+
+	it('actionsGroupClass returns the feature modifier', () => {
+		expect(actionsGroupClass('video')).toBe('synapse-actions-group--video');
+		expect(actionsGroupClass('main')).toBe('synapse-actions-group--main');
+	});
+
+	it('produces card/badge/label classes for every kind, and styles.css defines each', () => {
+		for (const kind of PROPOSAL_KINDS) {
+			expect(stylesCss).toContain(`.${cardClass(kind)}`);
+			expect(stylesCss).toContain(`.${badgeClass(kind)}`);
+			expect(stylesCss).toContain(`.${reviewPaneLabelClass(kind)}`);
+		}
+	});
+});

--- a/src/views/proposal-styles.ts
+++ b/src/views/proposal-styles.ts
@@ -1,0 +1,64 @@
+import type { ProposalKind } from './types';
+import type { FeatureKey } from '../commands';
+
+/**
+ * Semantic color tokens — the TypeScript half of the single source of truth
+ * for action-type colors (#342).
+ *
+ * The CSS custom properties themselves are declared once in `styles.css` (the
+ * `.theme-light, .theme-dark` block). CSS tokens are invisible to the
+ * compiler, so THIS map is where the exhaustiveness guard lives: typing it as
+ * `Record<ProposalKind, string>` makes the build FAIL if a proposal kind ever
+ * loses its `--synapse-color-*` token — mirroring the union guard in
+ * {@link ./types}. Keep the values in lockstep with styles.css.
+ */
+export const SYNAPSE_COLOR_TOKENS: Record<ProposalKind, string> = {
+	elaboration: '--synapse-color-elaboration',
+	enrichment: '--synapse-color-enrichment',
+	organize: '--synapse-color-organize',
+	'deep-dive': '--synapse-color-deep-dive',
+	title: '--synapse-color-title',
+	rem: '--synapse-color-rem',
+};
+
+/**
+ * Feature-level color tokens — a superset of {@link SYNAPSE_COLOR_TOKENS}.
+ *
+ * The actions sidebar groups by {@link FeatureKey} (not proposal kind), so it
+ * needs tokens for the feature-only types (`main`, `summarize`, `tidy`,
+ * `video`) and omits the proposal-only `title`. `Record<FeatureKey, string>`
+ * guards sidebar coverage the same way the proposal map guards card/badge
+ * coverage. Shared values (e.g. `tidy` reusing organize's hue) are intentional
+ * and stay independently editable in styles.css.
+ */
+export const FEATURE_COLOR_TOKENS: Record<FeatureKey, string> = {
+	main: '--synapse-color-main',
+	elaboration: '--synapse-color-elaboration',
+	enrichment: '--synapse-color-enrichment',
+	organize: '--synapse-color-organize',
+	'deep-dive': '--synapse-color-deep-dive',
+	summarize: '--synapse-color-summarize',
+	tidy: '--synapse-color-tidy',
+	rem: '--synapse-color-rem',
+	video: '--synapse-color-video',
+};
+
+/** BEM-style modifier class for a proposal card of the given kind. */
+export function cardClass(kind: ProposalKind): string {
+	return `synapse-card--${kind}`;
+}
+
+/** BEM-style modifier class for a proposal badge of the given kind. */
+export function badgeClass(kind: ProposalKind): string {
+	return `synapse-badge--${kind}`;
+}
+
+/** BEM-style modifier class for a review-pane label of the given kind. */
+export function reviewPaneLabelClass(kind: ProposalKind): string {
+	return `synapse-review-pane-label--${kind}`;
+}
+
+/** BEM-style modifier class for an actions-sidebar group of the given feature. */
+export function actionsGroupClass(feature: FeatureKey): string {
+	return `synapse-actions-group--${feature}`;
+}

--- a/src/views/synapse-actions-view.ts
+++ b/src/views/synapse-actions-view.ts
@@ -1,5 +1,6 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import type { CommandDefinition, FeatureKey } from '../commands';
+import { actionsGroupClass } from './proposal-styles';
 
 export const SYNAPSE_ACTIONS_VIEW_TYPE = 'synapse-actions';
 
@@ -93,7 +94,9 @@ export class SynapseActionsView extends ItemView {
 		const noteActive = this.callbacks.isNoteActive();
 
 		for (const { feature, actions: groupActions } of groupByFeature(actions)) {
-			const group = contentEl.createDiv({ cls: 'synapse-actions-group' });
+			const group = contentEl.createDiv({
+				cls: `synapse-actions-group ${actionsGroupClass(feature)}`,
+			});
 			group.createEl('div', {
 				text: FEATURE_LABELS[feature],
 				cls: 'synapse-actions-group-heading',

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -8,6 +8,7 @@ import type { RemProposal } from '../rem';
 import type { Checkpoint } from '../shared';
 import { fireAndForget } from '../shared';
 import type { UnifiedItem, UnifiedViewCallbacks } from './types';
+import { badgeClass, cardClass, reviewPaneLabelClass } from './proposal-styles';
 
 export { type UnifiedItem, type UnifiedViewCallbacks } from './types';
 
@@ -454,9 +455,14 @@ export class UnifiedProposalView extends ItemView {
 	}
 
 	private renderElaborationCard(container: HTMLElement, proposal: Proposal): void {
-		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--elaboration' });
+		const card = container.createDiv({
+			cls: `synapse-proposal-card ${cardClass('elaboration')}`,
+		});
 
-		card.createEl('span', { text: 'Elaboration', cls: 'synapse-badge synapse-badge--elaboration' });
+		card.createEl('span', {
+			text: 'Elaboration',
+			cls: `synapse-badge ${badgeClass('elaboration')}`,
+		});
 
 		const reasons = proposal.detectionReasons.map(r => r.type).join(', ');
 		card.createEl('small', { text: reasons, cls: 'synapse-reasons' });
@@ -487,9 +493,14 @@ export class UnifiedProposalView extends ItemView {
 	}
 
 	private renderEnrichmentCard(container: HTMLElement, proposal: EnrichmentProposal): void {
-		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--enrichment' });
+		const card = container.createDiv({
+			cls: `synapse-proposal-card ${cardClass('enrichment')}`,
+		});
 
-		card.createEl('span', { text: 'Enrichment', cls: 'synapse-badge synapse-badge--enrichment' });
+		card.createEl('span', {
+			text: 'Enrichment',
+			cls: `synapse-badge ${badgeClass('enrichment')}`,
+		});
 
 		const { result } = proposal;
 		const parts: string[] = [];
@@ -547,9 +558,14 @@ export class UnifiedProposalView extends ItemView {
 	}
 
 	private renderOrganizeCard(container: HTMLElement, proposal: OrganizeProposal): void {
-		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--organize' });
+		const card = container.createDiv({
+			cls: `synapse-proposal-card ${cardClass('organize')}`,
+		});
 
-		card.createEl('span', { text: 'Organize', cls: 'synapse-badge synapse-badge--organize' });
+		card.createEl('span', {
+			text: 'Organize',
+			cls: `synapse-badge ${badgeClass('organize')}`,
+		});
 
 		card.createEl('small', {
 			text: `Move to ${proposal.proposedDirectory}`,
@@ -610,9 +626,11 @@ export class UnifiedProposalView extends ItemView {
 		const editorPane = contentEl.createDiv({ cls: 'synapse-review-pane' });
 		editorPane.createEl('div', {
 			text: 'Proposed additions',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--elaboration',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('elaboration')}`,
 		});
-		const textarea = editorPane.createEl('textarea', { cls: 'synapse-review-editor' });
+		const textarea = editorPane.createEl('textarea', {
+			cls: 'synapse-review-editor synapse-review-editor--elaboration',
+		});
 		textarea.value = proposal.proposedAdditions;
 
 		const actionBar = contentEl.createDiv({ cls: 'synapse-review-actions' });
@@ -770,22 +788,22 @@ export class UnifiedProposalView extends ItemView {
 		const dirPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		dirPane.createEl('div', {
 			text: 'Proposed directory',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--organize',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('organize')}`,
 		});
 		dirPane.createEl('p', {
 			text: proposal.proposedDirectory,
-			cls: 'synapse-organize-directory',
+			cls: 'synapse-organize-directory synapse-review-box--organize',
 		});
 
 		// Reasoning
 		const reasonPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		reasonPane.createEl('div', {
 			text: 'Reasoning',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--organize',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('organize')}`,
 		});
 		reasonPane.createEl('p', {
 			text: proposal.reasoning,
-			cls: 'synapse-organize-reasoning',
+			cls: 'synapse-organize-reasoning synapse-review-box--organize',
 		});
 
 		// Action bar
@@ -805,10 +823,15 @@ export class UnifiedProposalView extends ItemView {
 	// ── Deep Dive Card ────────────────────────────────────────
 
 	private renderDeepDiveCard(container: HTMLElement, proposal: DeepDiveProposal): void {
-		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--deep-dive' });
+		const card = container.createDiv({
+			cls: `synapse-proposal-card ${cardClass('deep-dive')}`,
+		});
 
 		const badgeRow = card.createDiv({ cls: 'synapse-badge-row' });
-		badgeRow.createEl('span', { text: 'Deep dive', cls: 'synapse-badge synapse-badge--deep-dive' });
+		badgeRow.createEl('span', {
+			text: 'Deep dive',
+			cls: `synapse-badge ${badgeClass('deep-dive')}`,
+		});
 		badgeRow.createEl('span', {
 			text: `D${proposal.depth}`,
 			cls: 'synapse-depth-badge',
@@ -884,18 +907,18 @@ export class UnifiedProposalView extends ItemView {
 		const pathPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		pathPane.createEl('div', {
 			text: 'Proposed path',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--deep-dive',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('deep-dive')}`,
 		});
 		pathPane.createEl('p', {
 			text: proposal.proposedPath,
-			cls: 'synapse-organize-directory',
+			cls: 'synapse-organize-directory synapse-review-box--deep-dive',
 		});
 
 		// Content preview
 		const editorPane = contentEl.createDiv({ cls: 'synapse-review-pane' });
 		editorPane.createEl('div', {
 			text: 'Proposed content',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--deep-dive',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('deep-dive')}`,
 		});
 		const textarea = editorPane.createEl('textarea', { cls: 'synapse-review-editor synapse-review-editor--deep-dive' });
 		textarea.value = proposal.proposedContent;
@@ -926,9 +949,14 @@ export class UnifiedProposalView extends ItemView {
 	// ── Title Card ───────────────────────────────────────────
 
 	private renderTitleCard(container: HTMLElement, proposal: TitleProposal): void {
-		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--title' });
+		const card = container.createDiv({
+			cls: `synapse-proposal-card ${cardClass('title')}`,
+		});
 
-		card.createEl('span', { text: 'Title', cls: 'synapse-badge synapse-badge--title' });
+		card.createEl('span', {
+			text: 'Title',
+			cls: `synapse-badge ${badgeClass('title')}`,
+		});
 
 		const triggerLabel = proposal.trigger === 'untitled' ? 'Untitled note' : 'Content mismatch';
 		card.createEl('small', {
@@ -983,33 +1011,33 @@ export class UnifiedProposalView extends ItemView {
 		const currentPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		currentPane.createEl('div', {
 			text: 'Current title',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--title',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('title')}`,
 		});
 		currentPane.createEl('p', {
 			text: proposal.currentTitle,
-			cls: 'synapse-organize-directory',
+			cls: 'synapse-organize-directory synapse-review-box--title',
 		});
 
 		// Proposed title
 		const proposedPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		proposedPane.createEl('div', {
 			text: 'Proposed title',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--title',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('title')}`,
 		});
 		proposedPane.createEl('p', {
 			text: proposal.proposedTitle,
-			cls: 'synapse-organize-directory',
+			cls: 'synapse-organize-directory synapse-review-box--title',
 		});
 
 		// Reasoning
 		const reasonPane = contentEl.createDiv({ cls: 'synapse-organize-detail' });
 		reasonPane.createEl('div', {
 			text: 'Reasoning',
-			cls: 'synapse-review-pane-label synapse-review-pane-label--title',
+			cls: `synapse-review-pane-label ${reviewPaneLabelClass('title')}`,
 		});
 		reasonPane.createEl('p', {
 			text: proposal.reasoning,
-			cls: 'synapse-organize-reasoning',
+			cls: 'synapse-organize-reasoning synapse-review-box--title',
 		});
 
 		// Action bar
@@ -1029,9 +1057,14 @@ export class UnifiedProposalView extends ItemView {
 	// ── REM Card ─────────────────────────────────────────────
 
 	private renderRemCard(container: HTMLElement, proposal: RemProposal): void {
-		const card = container.createDiv({ cls: 'synapse-proposal-card synapse-card--rem' });
+		const card = container.createDiv({
+			cls: `synapse-proposal-card ${cardClass('rem')}`,
+		});
 
-		card.createEl('span', { text: 'REM', cls: 'synapse-badge synapse-badge--rem' });
+		card.createEl('span', {
+			text: 'REM',
+			cls: `synapse-badge ${badgeClass('rem')}`,
+		});
 
 		const { candidates } = proposal;
 		const parts: string[] = [];

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,52 @@
 /* Synapse plugin styles */
 
+/* ══════════════════════════════════════════════════════════════
+ * Action-type color tokens — SINGLE SOURCE OF TRUTH (#342)
+ *
+ * One semantic token per Synapse action type. EVERY action-type surface
+ * (cards, badges, review labels, checklist headings, callouts, actions-sidebar
+ * groups, modal accents) consumes these — no action-type hue is hardcoded
+ * anywhere else. Re-theming a type is a one-line edit here.
+ *
+ * Base tokens map to Obsidian's `--color-*` vars so they adapt to the active
+ * theme (and light/dark) automatically. The TypeScript guard in
+ * `src/views/proposal-styles.ts` (`Record<ProposalKind, string>`) fails the
+ * build if a proposal kind ever loses its token.
+ *
+ * Notes:
+ * - `elaboration` uses `--color-blue` (moved OFF `--interactive-accent` so it
+ *   no longer collides with the user's accent or the generic CTA buttons).
+ * - `tidy` intentionally shares organize's hue (sibling structural-cleanup
+ *   ops) but keeps its own token, so it can diverge with a one-line change.
+ * - `main` ("General") is neutral.
+ * ══════════════════════════════════════════════════════════════ */
+.theme-light,
+.theme-dark {
+  --synapse-color-elaboration: var(--color-blue);
+  --synapse-color-enrichment: var(--color-green);
+  --synapse-color-organize: var(--color-orange);
+  --synapse-color-deep-dive: var(--color-purple);
+  --synapse-color-title: var(--color-cyan);
+  --synapse-color-rem: var(--color-pink);
+  --synapse-color-summarize: var(--color-red);
+  --synapse-color-tidy: var(--color-orange);
+  --synapse-color-video: var(--color-yellow);
+  --synapse-color-main: var(--text-muted);
+
+  /*
+   * Callout tints take comma-separated RGB CHANNELS (not a color value), so
+   * these companion tokens carry literal channels aligned to each hue above.
+   * Only the types that render as callouts need an `-rgb` companion. Channels
+   * are fixed (theme vars are not channel-decomposable), matching how the
+   * callouts already worked; the low-opacity tint reads fine in light + dark.
+   */
+  --synapse-color-elaboration-rgb: 100, 160, 255;
+  --synapse-color-enrichment-rgb: 80, 180, 120;
+  --synapse-color-deep-dive-rgb: 160, 120, 220;
+  --synapse-color-summarize-rgb: 230, 110, 110;
+  --synapse-color-video-rgb: 220, 180, 70;
+}
+
 /*
  * Cap the height of embedded videos so portrait-oriented content
  * (TikTok, Instagram Reels, phone recordings) does not dominate the note.
@@ -66,28 +113,30 @@
   opacity: 0.95;
 }
 
+/* synapse-summary ↔ summarize feature */
 .callout[data-callout="synapse-summary"] {
-  --callout-color: 100, 160, 255;
+  --callout-color: var(--synapse-color-summarize-rgb);
   --callout-icon: lucide-file-text;
 }
 
+/* synapse-transcription ↔ video feature */
 .callout[data-callout="synapse-transcription"] {
-  --callout-color: 160, 120, 220;
+  --callout-color: var(--synapse-color-video-rgb);
   --callout-icon: lucide-mic;
 }
 
 .callout[data-callout="synapse-enrichment"] {
-  --callout-color: 80, 180, 120;
+  --callout-color: var(--synapse-color-enrichment-rgb);
   --callout-icon: lucide-link;
 }
 
 .callout[data-callout="synapse-elaboration"] {
-  --callout-color: 220, 160, 60;
+  --callout-color: var(--synapse-color-elaboration-rgb);
   --callout-icon: lucide-pen-tool;
 }
 
 .callout[data-callout="synapse-deep-dive"] {
-  --callout-color: 60, 180, 200;
+  --callout-color: var(--synapse-color-deep-dive-rgb);
   --callout-icon: lucide-layers;
 }
 
@@ -98,6 +147,18 @@
   gap: 8px;
   justify-content: flex-end;
   margin-top: 16px;
+}
+
+/* ── Modal type accents (#342) ──
+ * A type-colored underline beneath the modal title ties each detail modal to
+ * its action type, matching the sidebar card/badge for that type. */
+.synapse-elaboration-detail h2 {
+  border-bottom: 2px solid var(--synapse-color-elaboration);
+  padding-bottom: 6px;
+}
+.synapse-enrichment-detail h2 {
+  border-bottom: 2px solid var(--synapse-color-enrichment);
+  padding-bottom: 6px;
 }
 
 /* ── Proposal editor textarea ── */
@@ -526,13 +587,13 @@
   margin-top: auto;
 }
 .synapse-card--elaboration {
-  border-left-color: var(--interactive-accent);
+  border-left-color: var(--synapse-color-elaboration);
 }
 .synapse-card--enrichment {
-  border-left-color: var(--color-green);
+  border-left-color: var(--synapse-color-enrichment);
 }
 .synapse-card--organize {
-  border-left-color: var(--color-orange);
+  border-left-color: var(--synapse-color-organize);
 }
 .synapse-badge {
   display: inline-block;
@@ -547,15 +608,15 @@
   white-space: nowrap;
 }
 .synapse-badge--elaboration {
-  background: var(--interactive-accent);
+  background: var(--synapse-color-elaboration);
   color: var(--text-on-accent);
 }
 .synapse-badge--enrichment {
-  background: var(--color-green);
+  background: var(--synapse-color-enrichment);
   color: var(--text-on-accent);
 }
 .synapse-badge--organize {
-  background: var(--color-orange);
+  background: var(--synapse-color-organize);
   color: var(--text-on-accent);
 }
 .synapse-reasons {
@@ -689,9 +750,23 @@
   border-radius: 4px 4px 0 0;
 }
 .synapse-review-pane-label--elaboration {
-  background: var(--interactive-accent);
+  background: var(--synapse-color-elaboration);
   color: var(--text-on-accent);
 }
+.synapse-review-pane-label--enrichment {
+  background: var(--synapse-color-enrichment);
+  color: var(--text-on-accent);
+}
+.synapse-review-pane-label--rem {
+  background: var(--synapse-color-rem);
+  color: var(--text-on-accent);
+}
+/*
+ * Shared editor base — neutral structural border. The action-type hue is
+ * applied per editor via a `.synapse-review-editor--<type>` modifier so the
+ * editor matches its label/card (elaboration was previously hardcoded to
+ * `--interactive-accent`, colliding with the user's accent).
+ */
 .synapse-review-editor {
   flex: 1;
   padding: 8px;
@@ -699,16 +774,19 @@
   font-family: var(--font-monospace);
   line-height: 1.5;
   background: var(--background-primary);
-  border: 1px solid var(--interactive-accent);
+  border: 1px solid var(--background-modifier-border);
   border-top: none;
   border-radius: 0 0 4px 4px;
   resize: none;
   color: var(--text-normal);
   min-height: 120px;
 }
+.synapse-review-editor--elaboration {
+  border-color: var(--synapse-color-elaboration);
+}
 .synapse-review-editor:focus {
   outline: none;
-  border-color: var(--interactive-accent-hover);
+  border-color: var(--text-accent);
 }
 
 /* ── Enrichment Review (checklist) ── */
@@ -727,7 +805,7 @@
   letter-spacing: 0.5px;
   padding: 4px 8px;
   border-radius: 4px;
-  background: var(--color-green);
+  background: var(--synapse-color-enrichment);
   color: var(--text-on-accent);
   margin-bottom: 4px;
 }
@@ -755,10 +833,10 @@
 
 /* ── Deep Dive ── */
 .synapse-card--deep-dive {
-  border-left-color: var(--color-purple);
+  border-left-color: var(--synapse-color-deep-dive);
 }
 .synapse-badge--deep-dive {
-  background: var(--color-purple);
+  background: var(--synapse-color-deep-dive);
   color: var(--text-on-accent);
 }
 .synapse-badge-row {
@@ -788,32 +866,32 @@
   margin-bottom: 6px;
 }
 .synapse-review-pane-label--deep-dive {
-  background: var(--color-purple);
+  background: var(--synapse-color-deep-dive);
   color: var(--text-on-accent);
 }
 .synapse-review-editor--deep-dive {
-  border-color: var(--color-purple);
+  border-color: var(--synapse-color-deep-dive);
 }
 
 /* ── Title ── */
 .synapse-card--title {
-  border-left-color: var(--color-cyan);
+  border-left-color: var(--synapse-color-title);
 }
 .synapse-badge--title {
-  background: var(--color-cyan);
+  background: var(--synapse-color-title);
   color: var(--text-on-accent);
 }
 .synapse-review-pane-label--title {
-  background: var(--color-cyan);
+  background: var(--synapse-color-title);
   color: var(--text-on-accent);
 }
 
 /* ── REM ── */
 .synapse-card--rem {
-  border-left-color: var(--color-pink);
+  border-left-color: var(--synapse-color-rem);
 }
 .synapse-badge--rem {
-  background: var(--color-pink);
+  background: var(--synapse-color-rem);
   color: var(--text-on-accent);
 }
 .synapse-badge--rem-title {
@@ -868,12 +946,19 @@
 
 /* ── Organize Review ── */
 .synapse-review-pane-label--organize {
-  background: var(--color-orange);
+  background: var(--synapse-color-organize);
   color: var(--text-on-accent);
 }
 .synapse-organize-detail {
   margin-bottom: 12px;
 }
+/*
+ * `.synapse-organize-directory` / `.synapse-organize-reasoning` are the generic
+ * "detail box" styles, shared by the organize, deep-dive, and title reviews.
+ * The base border is neutral structural chrome; the action-type hue is applied
+ * per box via a `.synapse-review-box--<type>` modifier (below) so each review's
+ * box matches its label and card instead of all defaulting to one hue.
+ */
 .synapse-organize-directory {
   font-size: 14px;
   font-weight: 600;
@@ -881,7 +966,7 @@
   color: var(--text-normal);
   padding: 8px;
   background: var(--background-primary);
-  border: 1px solid var(--color-orange);
+  border: 1px solid var(--background-modifier-border);
   border-top: none;
   border-radius: 0 0 4px 4px;
   margin: 0;
@@ -892,10 +977,20 @@
   color: var(--text-normal);
   padding: 8px;
   background: var(--background-primary);
-  border: 1px solid var(--color-orange);
+  border: 1px solid var(--background-modifier-border);
   border-top: none;
   border-radius: 0 0 4px 4px;
   margin: 0;
+}
+/* Per-type accent for detail boxes — keeps each box on its own action token. */
+.synapse-review-box--organize {
+  border-color: var(--synapse-color-organize);
+}
+.synapse-review-box--deep-dive {
+  border-color: var(--synapse-color-deep-dive);
+}
+.synapse-review-box--title {
+  border-color: var(--synapse-color-title);
 }
 
 /* ── Checkpoint Banner ── */
@@ -1139,6 +1234,40 @@
   letter-spacing: 0.05em;
   color: var(--text-muted);
   margin: 8px 0 4px;
+  /*
+   * Subtle per-feature accent: a colored left marker on the group heading,
+   * driven by the same action-type tokens as the cards/badges. Per-feature
+   * overrides below recolor it; `main` keeps the neutral default.
+   */
+  padding-left: 8px;
+  border-left: 3px solid var(--synapse-color-main);
+}
+.synapse-actions-group--elaboration .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-elaboration);
+}
+.synapse-actions-group--enrichment .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-enrichment);
+}
+.synapse-actions-group--organize .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-organize);
+}
+.synapse-actions-group--deep-dive .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-deep-dive);
+}
+.synapse-actions-group--summarize .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-summarize);
+}
+.synapse-actions-group--tidy .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-tidy);
+}
+.synapse-actions-group--rem .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-rem);
+}
+.synapse-actions-group--video .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-video);
+}
+.synapse-actions-group--main .synapse-actions-group-heading {
+  border-left-color: var(--synapse-color-main);
 }
 .synapse-actions-button {
   display: block;


### PR DESCRIPTION
## Summary

Action-type colors (elaboration, enrichment, organize, deep-dive, title, rem — plus the feature-only summarize/tidy/video/main) were duplicated across many `styles.css` selectors, incomplete, and the same type appeared in different hues on different surfaces. This introduces **one semantic CSS token per action type** and consumes it everywhere, so a type is the same color across all surfaces and re-theming a type is a one-line change.

closes #342

> **Stacked on #343 (#340).** Base is `feat/issue-340-review-toast-action`; if #340 merges first, rebase this branch onto `main`. The two PRs touch disjoint `styles.css` sections (this PR never touches the "Notification toasts" block), so the stack stays conflict-free.

## What changed

**Single source of truth** — one block in `styles.css` (`.theme-light, .theme-dark`) defines `--synapse-color-<type>` per type, mapped to Obsidian `--color-*` base vars (auto-adapts to theme + light/dark), with `-rgb` companions for callout tints. No action-type hue is hardcoded outside this block.

- **elaboration moved OFF `--interactive-accent`** → `--color-blue`.

**Tokens consumed on every action-type surface:**
- Cards, badges, review pane labels (added the missing **enrichment** + **rem** label rules), checklist heading.
- Organize/title/deep-dive detail boxes + the elaboration/deep-dive editors now carry their own type token via a neutral structural base + `--<type>` modifier (previously these shared a single hardcoded orange/accent border regardless of type).
- Callouts point `--callout-color` at the `-rgb` companions, aligned to features (`synapse-summary`↔summarize, `synapse-transcription`↔video).

**New colored surfaces:**
- Actions sidebar: each group div emits `synapse-actions-group--<feature>`; headings get a subtle colored left marker.
- Detail modals (elaboration + enrichment): type-colored title underline.

**Centralized mapping + compile-time guard** (`src/views/proposal-styles.ts`):
- `SYNAPSE_COLOR_TOKENS: Record<ProposalKind, string>` and `FEATURE_COLOR_TOKENS: Record<FeatureKey, string>` — the `Record` types are the exhaustiveness guard (CSS tokens are invisible to TS), so the build fails if a kind/feature loses its token. Class helpers (`cardClass`/`badgeClass`/`reviewPaneLabelClass`/`actionsGroupClass`) replace the inline hardcoded class strings.

## Token → hue mapping

| Type | Token | Base var |
|------|-------|----------|
| elaboration | `--synapse-color-elaboration` | `--color-blue` |
| enrichment | `--synapse-color-enrichment` | `--color-green` |
| organize | `--synapse-color-organize` | `--color-orange` |
| deep-dive | `--synapse-color-deep-dive` | `--color-purple` |
| title | `--synapse-color-title` | `--color-cyan` |
| rem | `--synapse-color-rem` | `--color-pink` |
| summarize | `--synapse-color-summarize` | `--color-red` |
| tidy | `--synapse-color-tidy` | `--color-orange` (sibling of organize; own token, independently editable) |
| video | `--synapse-color-video` | `--color-yellow` |
| main | `--synapse-color-main` | `--text-muted` (neutral "General") |

There are 8 Obsidian base hues and 9 chromatic types, so `tidy` deliberately reuses organize's hue (conceptual sibling: structural cleanup) while keeping its own token. REM **match-type** sub-badges (title/alias/semantic) are an orthogonal taxonomy and intentionally left as-is.

## Testing
- `npx tsc --noEmit --skipLibCheck` ✅
- `npm test` ✅ (1511 tests; new `proposal-styles.test.ts` asserts token coverage, helper output, and that `styles.css` declares each token)
- `node esbuild.config.mjs production` ✅
- `node scripts/check-top-level-requires.mjs` ✅
- `node scripts/version-bump.mjs --check` ✅
- `npm run lint` ✅
- Guard verified: removing a token entry produces `error TS2741: Property '<kind>' is missing … required in type 'Record<…>'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
