### PR TITLE
chore: codebase audit (architecture, security, compliance, docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,24 @@ main.js
 *.js.map
 dist/
 data.json
+data.json.*
 .env
 .env.*
 .synapse/
 .auto-notes/
 *.bak
 *.tmp
+
+# Secrets / credentials (defense-in-depth: keys live only in Obsidian's
+# saveData() / data.json, never committed; these patterns stop any stray
+# credential file from being staged accidentally)
+secrets.json
+credentials.json
+*.secret
+*.pem
+*.key
+*.p12
+*.pfx
 .DS_Store
 coverage/
 .obsidian/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-19
 ---
 
 # Synapse — Agent Reference
@@ -48,15 +48,15 @@ Output: `main.js` (single bundle, Obsidian loads this)
 
 ```
 main.ts
-  |-- settings.ts  (type-only import of views/types for ProposalKind; no runtime cycle)
+  |-- settings.ts  (type-only imports only: ProposalKind from views/types, ExclusionRule from shared/exclusions; both erased at compile time, no runtime cycle)
   |-- settings-tab.ts
   |-- commands/   (depends on NOTHING in src/ — never in a cycle)
   |-- shared/     (base layer: depends on NO feature module; owns url-detector)
   |-- pipeline/ --> commands/ (isPipelineKeyInFlow); modules injected via PipelineModuleMap
   |-- views/unified-proposal-view.ts --> elaboration/types, enrichment/types, organize/types, deep-dive/types, title/types, rem/types, shared/checkpoint-types
   |-- elaboration/ --> shared/, commands/, image/ (ImageAnalyzer uses shared AIClient + image/preprocessImage)
-  |-- audio/ --> shared/, commands/
-  |-- video/ --> shared/ (CheckpointManager, url-detector), commands/, audio/ (reuses transcription pipeline)
+  |-- audio/ --> shared/, commands/; type-only edge to video/ (`import type { AudioExtractor }` — erased at compile time, no runtime cycle)
+  |-- video/ --> shared/ (CheckpointManager, url-detector), commands/, audio/ (reuses transcription pipeline; runtime value edge)
   |-- image/ --> shared/ (CheckpointManager, AIClient, callouts, validation), commands/
   |-- transcription/ --> audio/ (types), video/ (types), image/ (types), shared/ (detectPlatform, TimeRange, validation)
   |-- enrichment/ --> shared/, commands/
@@ -76,7 +76,7 @@ Key constraints:
 - `commands` imports nothing in `src/`; `pipeline` imports `commands` but never the feature modules
   (they are injected via `PipelineModuleMap` in main.ts).
 - `intake` imports only `obsidian` + `src/shared/*`; all cross-module work goes through `IntakeDeps`.
-- `video` depends on `audio` (reuses transcription pipeline)
+- `video` depends on `audio` (reuses transcription pipeline, runtime value import). `audio` has only a type-only back-edge to `video` (`import type { AudioExtractor }`), so the value-level dependency stays one-directional `video → audio` (no runtime cycle)
 - `transcription` is UI-only; delegates work to `audio`, `video`, and `image` modules
 - `summarize` has NO static import of `video`; URL-platform helpers (`isSupportedUrl`/`detectPlatform`) resolve from `shared/url-detector`. It receives `video.transcribeUrl` and an audio transcribe callback via constructor injection
 - `deep-dive` reuses `organize` for auto-organize nesting mode
@@ -85,6 +85,34 @@ Key constraints:
 - All feature modules depend on `shared`; no circular dependencies
 - Modules with resumable scans (elaboration, enrichment, audio, video, image, summarize, organize, deep-dive, rem) receive `CheckpointManager`; `tidy`, `title`, `transcription`, `intake` do not
 - `views` imports types only from feature modules (incl. `rem`) and `Checkpoint` from shared
+- Path exclusion is centralized (#307): the single `settings.exclusions: ExclusionRule[]` (model + matcher in `shared/exclusions.ts`) replaces the former per-module `excludeFolders` fields. Modules gate via `isPathExcluded(path, FeatureId, settings)` / `findMatchingRule`. Tag exclusion (`excludeTags`) stays per-module. `main.loadSettings()` runs a one-time `buildMigratedExclusions()` migration for upgraders whose persisted data has no `exclusions` key
+
+## Plugin Lifecycle (main.ts)
+
+```
+onload()
+  |-- loadSettings()  (deepMerge over DEFAULT_SETTINGS; one-time excludeFolders -> exclusions migration, #307)
+  |-- addIcon('synapse', ...)  (brand S-Signal mark; registered before any ribbon use)
+  |-- migrateDataFolder()  (.auto-notes -> .synapse, one-time)
+  |-- new NotificationManager(); status bar attached on desktop only
+  |-- new CheckpointManager(app)  (single instance, injected into all modules)
+  |-- new CommandRegistrar(this)
+  |-- construct modules (audio before video; video desktop-only); each gets a () => autoAccept[kind] getter
+  |-- registerView(UNIFIED_VIEW_TYPE), registerView(SYNAPSE_ACTIONS_VIEW_TYPE)
+  |-- wire onViewRefreshNeeded / onOpenProposalView / cross-module callbacks
+  |-- await <module>.onload() for each settings.<feature>.enabled module
+  |-- addRibbonIcon x3; registrar.register(...) for main commands
+  |-- startupTimeout = setTimeout(checkForIncompleteCheckpoints, 3000)
+  |-- build PipelineModuleMap + SynapseRunner; construct IntakeModule (deps injected)
+  |-- auditCommands(registrar.getAttempted())  (logs drift)
+  +-- runFirstRunOnboarding()  (#89)
+
+onunload()
+  |-- clearTimeout(startupTimeout)
+  |-- <module>?.onunload() for every module (optional-chained; video may be null)
+  +-- notifications.dispose()  (tears down in-flight operation ellipsis intervals + hides notices so a
+                                disable mid-operation never leaks an orphaned 400ms setInterval on a detached toast)
+```
 
 ## Command Registry
 
@@ -96,7 +124,7 @@ Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries
 | `synapse:manage-checkpoints` | Manage interrupted operations | callback | main | p | active | |
 | `synapse:transcribe-media` | Transcribe media | callback | main | p | disabled | |
 | `synapse:transcribe-note-media` | Transcribe media from current note | editorCallback | main | p | active | |
-| `synapse:fire` | Fire Synapse: run all features on a directory | callback | main | p | active | |
+| `synapse:fire` | Run all features on a directory | callback | main | p | active | |
 | `synapse:scan-vault` | Scan vault for stub notes | callback | elaboration | p, f, s | active | elaboration |
 | `synapse:scan-current-note` | Scan current note for elaboration | editorCallback | elaboration | p | active | |
 | `synapse:clear-proposals` | Clear all pending proposals | callback | elaboration | p | disabled | |
@@ -115,7 +143,7 @@ Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries
 | `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | rem | p | active | |
 | `synapse:rem-directory` | REM: Discover links in directory | callback | rem | p, f | active | rem |
 | `synapse:check-dependencies` | Check external tool availability | callback | video | p | active | |
-| `synapse:tidy-vault` | Tidy vault (Fire Synapse) | (synthetic) | tidy | f | active | tidy |
+| `synapse:tidy-vault` | Tidy vault | (synthetic) | tidy | f | active | tidy |
 
 `synapse:tidy-vault` is synthetic and pipeline-only: it gates the tidy Fire Synapse phase independently of any palette command and is never passed to `registrar.register()`. Fire Synapse phase order: elaboration → summarize → enrichment → rem → tidy → organize.
 
@@ -172,7 +200,6 @@ SynapseSettings {
       detectTodoMarkers: boolean                    // default: true
       detectEmptySections: boolean                  // default: true
       detectSparseLinks: boolean                    // default: true
-      excludeFolders: string[]                      // default: ['templates', '.synapse']
       excludeTags: string[]                         // default: ['no-elaborate']
     }
     proposal: ProposalSettings {
@@ -190,6 +217,7 @@ SynapseSettings {
     whisperModel: string                            // default: 'whisper-1'
     localWhisperPath: string                        // default: ''
     language: string                                // default: ''
+    autoFormatLyrics: boolean                       // default: true (auto-detect song transcripts, format as lyrics, #234)
     postProcessing: PostProcessingSettings {
       enabled: boolean                              // default: true
       removeFiller: boolean                         // default: true
@@ -230,7 +258,6 @@ SynapseSettings {
     internalLinkThreshold: number                   // default: 0.3
     weights: EnrichmentWeightSettings               // sameFolder, siblingFolder, cousinFolder, distantFolder, decayPerLevel, minWeight
     enrichmentFolderPath: string                    // default: '.synapse/enrichments'
-    excludeFolders: string[]                        // default: ['templates', '.synapse']
     excludeTags: string[]                           // default: ['no-enrich']
     relatedNotesHeading: string                     // default: 'Related Notes'
     referencesHeading: string                       // default: 'References'
@@ -241,7 +268,6 @@ SynapseSettings {
     summaryStyle: 'bullets' | 'paragraph' | 'key-points'  // default: 'bullets'
     customPrompt: string                            // default: ''
     autoDetectTemplates: boolean                    // default: true
-    excludeFolders: string[]                        // default: ['templates', '.synapse']
     excludeTags: string[]                           // default: ['no-summarize']
     autoOrganizeOnSummarize: boolean                // default: false
   }
@@ -253,7 +279,6 @@ SynapseSettings {
     enabled: boolean                                // default: true
     proposalFolderPath: string                      // default: '.synapse/organize/proposals'
     snapshotFolderPath: string                      // default: '.synapse/organize/snapshots'
-    excludeFolders: string[]                        // default: ['templates', '.synapse']
     excludeTags: string[]                           // default: ['no-organize']
     organizeConfidenceThreshold: number             // default: 0.9
   }
@@ -264,8 +289,7 @@ SynapseSettings {
     qualityThreshold: number                        // default: 0.4
     maxNotesPerRun: number                          // default: 50
     noteOutputFolder: string                        // default: 'Deep Dives'
-    nestingMode: 'nested' | 'flat' | 'auto-organize'  // default: 'nested'
-    excludeFolders: string[]                        // default: ['templates', '.synapse']
+    nestingMode: 'nested' | 'flat' | 'auto-organize'  // DeepDiveNestingMode, default: 'nested'
     excludeTags: string[]                           // default: ['no-deep-dive']
     autoEnrichOnAccept: boolean                     // default: true
     autoOrganizeOnAccept: boolean                   // default: false
@@ -305,8 +329,24 @@ SynapseSettings {
   onboarding: OnboardingSettings {
     hasSeenWelcome: boolean                         // default: false (first-run welcome gate, #89)
   }
+  exclusions: ExclusionRule[]                        // centralized per-path exclusion (#307); default 2 rules (see below)
 }
 ```
+
+Centralized path exclusion (#307). `ExclusionRule` and the glob matcher live in
+`src/shared/exclusions.ts`; type-only-imported into `settings.ts`:
+
+```ts
+type FeatureId = 'elaboration' | 'enrichment' | 'summarize' | 'tidy' | 'organize'
+               | 'deep-dive' | 'audio' | 'video' | 'title' | 'image' | 'rem' | 'intake'
+interface ExclusionRule { pattern: string; features: 'all' | FeatureId[] }
+// ALL_FEATURE_IDS (exclusions.ts) is a compile-time exhaustiveness guard over this union.
+```
+
+Default `exclusions`: `[{ pattern: '.synapse/**', features: 'all' }, { pattern: 'templates/**', features: 'all' }]`.
+Modules gate paths via `isPathExcluded(path, featureId, settings)` / `findMatchingRule`. The legacy
+per-module `excludeFolders` fields were removed; `main.loadSettings()` runs a one-time
+`buildMigratedExclusions()` migration for upgraders whose persisted data lacks an `exclusions` key.
 
 Provider model dropdowns: `MODEL_OPTIONS: Record<AIProvider, Record<id, label>>` in `src/settings.ts`.
 openai: gpt-4o, gpt-4o-mini, o3, o3-mini, o4-mini. anthropic: opus, sonnet, haiku (resolved to full

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,10 @@
 # Architecture Overview
 
+**Last updated**: 2026-06-20 · **Version**: 1.0.3
+
 Synapse is an Obsidian plugin that layers AI-powered features over a vault: note elaboration (with image analysis), audio transcription, video transcription, image OCR, note enrichment, summarization, note tidying, semantic organization, recursive deep-dive note generation, title proposals, and in-place wikilink discovery (REM). Two coordination layers tie them together — a **Fire Synapse pipeline** that runs the features in a fixed order over a folder or note, and an **intake** watcher that auto-processes notes dropped into an inbox. It runs on both desktop and mobile (video and media-clipping features are desktop-only).
 
-The codebase has **17 modules under `src/`** (audio, commands, deep-dive, elaboration, enrichment, image, intake, organize, pipeline, rem, shared, summarize, tidy, title, transcription, video, views) plus the top-level `main.ts`, `settings.ts`, and `settings-tab.ts`.
+The codebase has **17 modules under `src/`** (audio, commands, deep-dive, elaboration, enrichment, image, intake, organize, pipeline, rem, shared, summarize, tidy, title, transcription, video, views) plus the top-level `main.ts`, `settings.ts`, `settings-tab.ts`, and a small pure `onboarding.ts` (first-run welcome, #89).
 
 > **Note**: This plugin was previously named "Auto Notes" and was rebranded to "Synapse" in March 2026. The data folder was renamed from `.auto-notes/` to `.synapse/`, with automatic one-time migration on load.
 
@@ -12,6 +14,8 @@ The codebase has **17 modules under `src/`** (audio, commands, deep-dive, elabor
 - **`shared/`** is the foundation everything stands on — the AI client, validation, checkpoints, callouts, and URL detection. It depends on no feature module.
 - **`commands/`** is a developer-level master switch for every command, sitting *above* user settings. It also depends on nothing else in `src/`.
 - **`pipeline/`** runs features in order; **`intake/`** decides what to feed the pipeline. Neither imports a feature module directly — `main.ts` injects the features into them. This is what keeps the dependency graph acyclic.
+- **`views/`** holds the two sidebars: the **unified proposal view** (review/accept every proposal type) and the **Synapse actions view** (registry-driven, touch-friendly buttons so mobile users reach any command without the palette).
+- **Mobile safety**: the plugin ships `isDesktopOnly: false`. Anything that needs Node.js (yt-dlp, ffmpeg, the filesystem) is funneled through one guarded loader (`shared/node-loader.ts`) that refuses to run off-desktop, so the bundle loads cleanly on mobile and desktop-only features degrade gracefully.
 
 ---
 
@@ -23,6 +27,7 @@ graph TB
         Main["main.ts<br/>SynapsePlugin"]
         Settings["Settings + Tab"]
         Sidebar["Unified Proposal View<br/>(sidebar)"]
+        Actions["Synapse Actions View<br/>(registry-driven sidebar)"]
         CkptMgr["CheckpointManager<br/>(shared, singleton)"]
 
         subgraph Coord["Coordination Layers"]
@@ -57,10 +62,12 @@ graph TB
 
     Main --> Settings
     Main --> Sidebar
+    Main --> Actions
     Main --> CkptMgr
     Main --> Commands
     Main --> Coord
     Main --> Features
+    Commands -.->|derives buttons| Actions
     Pipe -.->|injected modules| Features
     Intake -.->|injected fireOnFile| Pipe
     Features --> Shared
@@ -81,6 +88,7 @@ graph TB
 
     style Trans fill:#f9f,stroke:#333
     style Sidebar fill:#bbf,stroke:#333
+    style Actions fill:#bbf,stroke:#333
     style CkptMgr fill:#ffd,stroke:#333
     style Commands fill:#fde,stroke:#333
     style Shared fill:#def,stroke:#333
@@ -96,14 +104,15 @@ Both `shared/` and `commands/` are **base layers**: every feature may depend on 
 ```
 src/
 ├── main.ts                 # Plugin entry, module orchestration, callback wiring, dependency injection
-├── settings.ts             # Type definitions, defaults, model options
-├── settings-tab.ts         # Obsidian settings UI
+├── settings.ts             # Type definitions, defaults, model options (type-only imports of ProposalKind + ExclusionRule)
+├── settings-tab.ts         # Obsidian settings UI (video section gated behind Platform.isDesktop)
+├── onboarding.ts           # Pure first-run welcome logic (#89): planFirstRun, needsApiKey
 │
 ├── commands/               # Command registry (base layer; imports nothing in src/)
-│   ├── registry.ts         #   COMMAND_REGISTRY source of truth + flow gates
+│   ├── registry.ts         #   COMMAND_REGISTRY source of truth + flow/status/context gates
 │   ├── registrar.ts        #   Single wiring point to plugin.addCommand
 │   ├── audit.ts            #   Registry <-> handler drift detection
-│   └── index.ts            #   Barrel export
+│   └── index.ts            #   Barrel export (listPaletteActions for the actions sidebar)
 │
 ├── pipeline/               # Fire Synapse: ordered multi-phase runner
 │   ├── synapse-runner.ts   #   Sequential phase executor (fire / fireOnFile)
@@ -201,12 +210,17 @@ src/
 ├── shared/                 # Cross-cutting utilities (base layer)
 │   ├── ai-client.ts        #   Multi-provider AI (OpenAI, Anthropic, Gemini, Ollama); re-exports redactSecrets
 │   ├── redact.ts           #   redactSecrets() — single source of truth for API-key/token redaction
+│   ├── node-loader.ts      #   loadNodeModules/assertDesktop/DesktopOnlyError/shellEnv — the ONE guarded Node-builtin site
+│   ├── exclusions.ts       #   Centralized path-exclusion model + glob matcher (#307); tag-exclusion helper
+│   ├── credential-validator.ts # validateCredentials() — one minimal authenticated probe per provider (#335)
+│   ├── provider-metadata.ts#   Per-provider get-key URL, placeholder, probe spec (#335)
+│   ├── credential-field.ts #   Settings decorator: "Get an API key →" link + Test button + status chip (#335)
 │   ├── encoding.ts         #   arrayBufferToBase64 / base64EncodedLength (shared by audio/image/elaboration)
 │   ├── url-detector.ts     #   YouTube/TikTok/Instagram URL parsing (moved here 2026-06-08)
 │   ├── checkpoint-manager.ts #  Checkpoint/resume for long-running operations
 │   ├── checkpoint-types.ts #   Checkpoint type definitions
 │   ├── id-utils.ts         #   ID generation and validation
-│   ├── notifications.ts    #   Centralized notification system
+│   ├── notifications.ts    #   Centralized notification system (+ dispose() teardown on unload)
 │   ├── validation.ts       #   URL, path, AI response sanitization
 │   ├── file-utils.ts       #   Vault file operations
 │   ├── frontmatter-utils.ts#   YAML frontmatter parsing/serialization
@@ -214,7 +228,7 @@ src/
 │   ├── diagram-generator.ts#   Mermaid diagram generation
 │   ├── slider-helper.ts    #   Settings UI helper for range sliders
 │   ├── folder-picker-modal.ts # Modal for folder selection
-│   ├── api-utils.ts        #   Retry logic, error handling
+│   ├── api-utils.ts        #   Retry logic, error handling (notifyError routes through redactSecrets)
 │   └── index.ts            #   Barrel export
 │
 └── views/                  # UI components
@@ -378,21 +392,78 @@ sequenceDiagram
     participant CK as CheckpointManager
 
     O->>M: onload()
-    M->>M: loadSettings() (deep-merge)
+    M->>M: loadSettings() (deep-merge + one-time excludeFolders→exclusions migration, #307)
+    M->>M: addIcon('synapse') (brand S-Signal mark, before any ribbon use)
     M->>M: migrateDataFolder() (.auto-notes -> .synapse)
     M->>M: addSettingTab()
-    M->>M: NotificationManager()
+    M->>M: NotificationManager() (status bar on desktop only)
     M->>CK: new CheckpointManager(app)
     M->>Reg: new CommandRegistrar(plugin)
-    M->>Mod: Initialize feature modules<br/>(Audio before Video; inject CheckpointManager, registrar, shouldAutoAccept)
-    M->>Coord: Build SynapseRunner (inject PipelineModuleMap)<br/>+ IntakeModule (inject IntakeDeps.fireOnFile)
-    M->>M: registerView(UnifiedProposalView)
+    M->>Mod: Initialize feature modules<br/>(Audio before Video; Video desktop-only; inject CheckpointManager, registrar, shouldAutoAccept getter)
+    M->>M: registerView(UnifiedProposalView) + registerView(SynapseActionsView)
+    M->>M: Wire view refresh + onOpenProposalView + cross-module callbacks<br/>(enrichment, title, organize)
     M->>Mod: Conditional module.onload()<br/>(registers commands via registrar if enabled)
-    M->>M: Wire cross-module callbacks<br/>(enrichment, title, organize, view refresh)
-    M->>M: addRibbonIcon (sparkles, mic)
+    M->>M: addRibbonIcon x3 (synapse; mic [desktop]; layout-grid)
+    M->>Reg: registrar.register(main commands)
+    M->>CK: startupTimeout = checkForIncompleteCheckpoints() (delayed 3s)
+    M->>Coord: Build SynapseRunner (inject PipelineModuleMap)<br/>+ IntakeModule (inject IntakeDeps.fireOnFile)
     M->>Reg: auditCommands(attempted) — warn on drift
-    M->>CK: checkForIncompleteCheckpoints() (delayed 3s)
+    M->>M: runFirstRunOnboarding() (#89, fresh installs only)
+
+    O->>M: onunload()
+    M->>M: clearTimeout(startupTimeout)
+    M->>Mod: module?.onunload() for every module (video may be null)
+    M->>M: notifications.dispose() (tear down ellipsis timers + hide notices)
 ```
+
+---
+
+## Desktop Gating Model
+
+Synapse ships `isDesktopOnly: false` in `manifest.json`, so the **single bundle must load on Obsidian mobile** — which has no `os`, `path`, `fs`, or `child_process`. esbuild marks those Node builtins as `external`, so any *top-level* `require('fs')` would throw on mobile at module-load time, before any platform check could run. The plugin closes that hole structurally:
+
+```mermaid
+graph TB
+    Caller["Audio / Video / Duration detector<br/>(needs ffmpeg / yt-dlp / fs)"]
+    Caller --> Guard["assertDesktop()<br/>throws DesktopOnlyError off-desktop"]
+    Guard --> Load["loadNodeModules()<br/>lazy require os/path/fs/execFile (inside the fn body)"]
+    Load --> Env["shellEnv()<br/>allowlisted PATH/HOME/TMPDIR/proxy for subprocesses"]
+    Env --> Tools["execFile yt-dlp / ffmpeg / ffprobe"]
+
+    style Guard fill:#fde,stroke:#333
+    style Load fill:#def,stroke:#333
+```
+
+- **One sanctioned site.** `shared/node-loader.ts` is the *only* place Node builtins are required, and it's the only file allowed to disable the `no-var-requires` lint rule. Every desktop-only path routes through it.
+- **Explicit assertion, not truthiness.** Code paths call `assertDesktop()` (which throws a descriptive `DesktopOnlyError`) rather than relying on a `this.extractor` being defined.
+- **Construction-time gating too.** `main.ts` only builds `VideoModule` and the shared `AudioExtractor` when `Platform.isDesktop`; the `mic` ribbon icon and the settings-tab video section are desktop-only.
+- **Graceful degradation.** On mobile, media clipping/duration detection fall back to full-file processing or surface a clear "not available on mobile" message. All non-Node features (elaboration, enrichment, summarize, tidy, organize, deep-dive, title, REM, audio API transcription, image OCR) run on both platforms.
+
+---
+
+## Path Exclusions (#307)
+
+A single `settings.exclusions` list controls which folders each feature may touch, replacing the old per-module `excludeFolders` fields. The model and matcher live in `shared/exclusions.ts`.
+
+```ts
+interface ExclusionRule { pattern: string; features: 'all' | FeatureId[] }
+// FeatureId is a closed 12-member union with an ALL_FEATURE_IDS exhaustiveness guard.
+```
+
+- **First-match-wins.** `findMatchingRule(path, featureId, settings)` walks `exclusions` in order and returns the first rule that applies to the feature *and* matches the path; `isPathExcluded(...)` is the boolean wrapper.
+- **Glob forms.** `dir/**` (folder + all descendants), `dir/*` (direct children), a bare token (recursive prefix), or an exact `dir/file.md` path. Patterns are normalized and anchored; `.` is escaped so `.synapse/**` can't over-match.
+- **Defaults.** Fresh installs get `[{ pattern: '.synapse/**', features: 'all' }, { pattern: 'templates/**', features: 'all' }]`.
+- **One-time migration.** `loadSettings()` runs `buildMigratedExclusions()` for upgraders whose persisted data lacks an `exclusions` key, preserving their old per-module folders exactly (a folder excluded by *every* legacy feature collapses to `features: 'all'`).
+- **Tags stay per-module.** `excludeTags` remains per feature but routes through a shared `matchesExcludeTag` helper (handles inline + frontmatter tags, case-insensitively).
+
+---
+
+## Synapse Actions Sidebar (#289)
+
+A second sidebar (`SynapseActionsView`, `synapse-actions` view, opened by the `layout-grid` ribbon icon) gives mobile users — where the command palette is hardest to reach — a touch-friendly button for every enabled command.
+
+- **Registry-derived.** Buttons come from `listPaletteActions(registrar.getRegistered())`; no command behavior is re-declared. Each button dispatches the already-registered command via Obsidian's `executeCommandById`, honoring the same editor/check gating as the palette.
+- **Context-aware.** Every registry entry carries a `context` (`note` | `vault` | `global`). Per-note buttons disable when no note is active; for `note` commands the opener re-activates the note's markdown leaf first, so opening the panel (which can steal editor focus) never makes a button silently no-op.
 
 ---
 
@@ -466,7 +537,7 @@ graph TB
 
 The transcription module replaced 4 modal files across audio/ and video/ with 2 unified modals. The `NoteMediaModal` also handles image OCR extraction. All callbacks are wired in `main.ts`.
 
-### Time-Range Clipping (v0.3.2)
+### Time-Range Clipping
 
 When a user selects an audio file or enters a video URL, the modal auto-detects media duration via ffprobe (local) or yt-dlp (URLs). If duration >= 10 seconds, a dual-handle `TimeRangeSlider` appears allowing sub-range selection. Clipping uses ffmpeg on the extracted audio (desktop only; mobile falls back to full-file transcription).
 
@@ -698,7 +769,7 @@ graph TB
     AIC["AIClient<br/>(shared/ai-client.ts)"]
 
     AIC -->|"'openai'"| OAI["POST api.openai.com/v1/chat/completions<br/>Auth: Bearer {ai.apiKey}"]
-    AIC -->|"'anthropic'"| ANT["POST api.anthropic.com/v1/messages<br/>Auth: x-api-key<br/>Models: opus->claude-opus-4-6, etc."]
+    AIC -->|"'anthropic'"| ANT["POST api.anthropic.com/v1/messages<br/>Auth: x-api-key<br/>Models: opus/sonnet/haiku resolved to full IDs in ai-client.ts"]
     AIC -->|"'gemini'"| GEM["POST generativelanguage.googleapis.com/v1beta/models/{model}:generateContent<br/>Auth: x-goog-api-key · system -> system_instruction"]
     AIC -->|"'ollama'"| OLL["POST {ollamaEndpoint}/api/chat<br/>HTTPS required (HTTP localhost only)"]
 
@@ -751,31 +822,36 @@ All AI-generated content uses Obsidian callouts from a shared registry:
 SynapseSettings
 +-- ai              -> Provider, API key, model, temperature, max tokens
 +-- elaboration     -> Detection thresholds, scan behavior, proposal storage
-|   +-- detection   -> Word threshold, TODO markers, empty sections, excludes
+|   +-- detection   -> Word threshold, TODO markers, empty sections, exclude tags
 |   +-- proposal    -> Max per note, preserve frontmatter, include context
-+-- audio           -> Transcription provider, API keys, post-processing
++-- audio           -> Transcription provider, API keys, post-processing, auto-format lyrics (#234)
 |   +-- postProcessing -> Filler removal, structure, key points, custom prompt
 +-- video           -> yt-dlp/ffmpeg paths, download folder, embed setting
 |   +-- frameExtraction -> (Not implemented) interval, vision model, max frames
-+-- image           -> Enabled, vision model override, language hint
-+-- enrichment      -> Auto-enrich, max tags/links, vocabulary, proximity weights
++-- image           -> Enabled, vision model override, language hint, max image size MB (auto-downscale)
++-- enrichment      -> Auto-enrich, max tags/links, vocabulary, proximity weights, exclude tags
 |   +-- tagVocabulary   -> TagVocabularyEntry[] (category, tags, description)
 |   +-- weights         -> Same/sibling/cousin/distant folder, decay, minimum
-+-- summarize       -> Style (bullets/paragraph/key-points), max length, templates
++-- summarize       -> Style (bullets/paragraph/key-points), max length, templates,
+|                     exclude tags, auto-organize on summarize
 +-- tidy            -> Snapshot folder path
-+-- organize        -> Proposal/snapshot folder paths, confidence threshold, excludes
++-- organize        -> Proposal/snapshot folder paths, confidence threshold, exclude tags
 +-- deepDive        -> Max depth, quality threshold, max notes, output folder,
-|                     nesting mode, auto-enrich/organize on accept, excludes
+|                     nesting mode, auto-enrich/organize on accept, exclude tags
 +-- title           -> Enabled, proposal folder path, check after operations
 +-- rem             -> Enabled, semantic matching, confidence threshold,
 |                     max links per note, proposal folder path
 +-- intake          -> Enabled, watched folder, mark-processed, move-when-done,
 |                     settle seconds, capture log + capture-log folder
++-- ui              -> collapsedSections (settings accordion state)
 +-- autoAccept      -> Per-kind booleans (elaboration, enrichment, organize,
-                      deep-dive, title, rem) — all default false (#228)
+|                     deep-dive, title, rem) — all default false (#228)
++-- onboarding      -> hasSeenWelcome (first-run welcome gate, #89)
++-- exclusions      -> ExclusionRule[] — centralized per-path exclusion (#307);
+                      replaces all former per-module excludeFolders fields
 ```
 
-Modules access settings via `getSettings()` closure -- always reads latest values, no event subscriptions needed.
+Path exclusion is centralized (#307): the per-module `excludeFolders` fields were removed in favor of one `exclusions` list (see "Path Exclusions" above). Tag exclusion (`excludeTags`) stays per-module. Modules access settings via the `getSettings()` closure -- always reads latest values, no event subscriptions needed.
 
 ---
 
@@ -785,16 +861,19 @@ Modules access settings via `getSettings()` closure -- always reads latest value
 |-------|-----------|----------|
 | Input validation | `sanitizeUrl()`, `sanitizePath()` | `shared/validation.ts` |
 | Output sanitization | `sanitizeAIResponse()` strips scripts, event handlers, dangerous URIs | `shared/validation.ts` |
-| Subprocess security | `execFile` with argument arrays (no shell) | `video/audio-extractor.ts`, `transcription/duration-detector.ts` |
+| Subprocess security | `execFile` with argument arrays (no shell); narrowed allowlist env via `shellEnv()` | `video/audio-extractor.ts`, `transcription/duration-detector.ts`, `shared/node-loader.ts` |
+| Desktop gating | `assertDesktop()`/`loadNodeModules()` — Node builtins resolve only on desktop, behind one guarded site; keeps `isDesktopOnly: false` mobile-safe | `shared/node-loader.ts` |
 | Temp-path hardening | Vault-derived basenames sanitized before composing temp paths (2026-06-08) | `transcription/duration-detector.ts` |
 | Multipart header hardening | Vault-/settings-derived field + file names sanitized (`sanitizeMultipartHeaderValue`: strip CR/LF, replace `"`/`\`) before `Content-Disposition` lines — blocks multipart/header injection (2026-06-11) | `audio/transcriber.ts` |
 | API key protection | `redactSecrets()` — **single source of truth** scrubbing keys from error messages/console; covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Gemini `AIza`. Password-masked inputs; keys live only in gitignored `data.json` | `shared/redact.ts` (used by `ai-client.ts` + `api-utils.ts`) |
 | Frontmatter safety | Key validation regex + forbidden keys blocklist | `enrichment/enrichment-applier.ts` |
 | Network security | Ollama HTTPS required (HTTP for localhost only), 2min timeouts | `shared/ai-client.ts` |
+| Credential validation | Live key probe is one minimal authenticated GET; result is **ephemeral** (never persisted) and routed through `redactSecrets` so an echoed key can't reach the status chip | `shared/credential-validator.ts`, `shared/provider-metadata.ts` |
 | Idempotent updates | `%% synapse-enrichment-start/end %%` markers | `enrichment/enrichment-applier.ts` |
 | Prototype pollution | `deepMerge` skips `__proto__`, `constructor`, `prototype` keys | `main.ts` |
+| Lifecycle hygiene | `NotificationManager.dispose()` tears down in-flight ellipsis timers + hides notices on unload (no orphaned `setInterval`) | `shared/notifications.ts`, `main.ts:onunload()` |
 
-**Audit status:** The full audit (2026-06-08) found no critical or high vulnerabilities. The 2026-06-11 re-audit added two defense-in-depth hardenings — canonical secret redaction (now covering Gemini `AIza` keys everywhere) and multipart header-injection hardening. `data.json` (live API keys) is gitignored and never committed.
+**Audit status:** The full audit (2026-06-08) found no critical or high vulnerabilities. The 2026-06-11 re-audit added two defense-in-depth hardenings — canonical secret redaction (now covering Gemini `AIza` keys everywhere) and multipart header-injection hardening. The 2026-06-20 audit pass re-verified architecture, security, and Obsidian-guideline compliance as clean; its one fix was a lifecycle leak (in-flight notification ellipsis timers now torn down on unload). `data.json` (live API keys) is gitignored and never committed.
 
 **Known posture / not-yet-enforced:**
 - `ensureWithinVault()` exists in `shared/validation.ts` but is **not yet wired into write paths** — there is no active vault-boundary enforcement on writes today.
@@ -807,9 +886,10 @@ Modules access settings via `getSettings()` closure -- always reads latest value
 1. Clone into Obsidian vault's plugin directory
 2. `npm install` then `npm run dev` (watch mode)
 3. Module pattern: each feature in `src/<module>/` with `index.ts` exporting the module class
-4. Follow the FeatureModule contract: `constructor(plugin, getSettings, notifications, checkpointManager)`, `onload()`, `onunload()`
+4. Follow the FeatureModule contract: `constructor(plugin, getSettings, notifications, …)`, `onload()`, `onunload()`. `main.ts` injects the rest — the shared `CheckpointManager` (for resumable scans), the `CommandRegistrar`, and a `() => settings.autoAccept[kind]` getter where applicable — never reach for globals.
 5. Types go in `<module>/types.ts`, tests co-located as `<name>.test.ts`
-6. All shared utilities imported from `../shared` (barrel export)
-7. Build check: `npm run build` (type-checks + bundles)
-8. Tests: `npm test`
-9. Git: create a feature branch, push, open PR. See `.claude/skills/git-workflow/SKILL.md` for full protocol.
+6. All shared utilities imported from `../shared` (barrel export) — never from a sibling feature module or an internal `shared/` file. Where you only need a *type* from a higher layer, use `import type` (erased at compile time, no runtime cycle).
+7. Need a Node builtin (`fs`/`path`/`os`/`child_process`)? Go through `loadNodeModules()`/`assertDesktop()` only — never `require` at module top level (keeps the bundle mobile-loadable).
+8. Gate vault paths with `isPathExcluded(path, featureId, settings)` and tags with the shared `matchesExcludeTag` helper.
+9. Build check: `npm run build` (type-checks + bundles); tests: `npm test`
+10. Git: create a feature branch, push, open PR. See `.claude/skills/git-workflow/SKILL.md` for full protocol.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,178 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-06-20: Notification timers torn down on unload; audit reaffirms the layering
+
+**Context**: A periodic codebase audit (architecture, security, and Obsidian-guideline compliance) reviewed the plugin at version 1.0.3. It found the code security-mature and the module graph acyclic, but surfaced one lifecycle leak: `NotificationManager` starts a 400 ms `setInterval` to animate the "…" ellipsis on every in-flight operation toast. If the plugin was disabled (or reloaded) while an operation was still running, that interval kept firing against a detached toast — an orphaned timer, exactly the class of leak Obsidian's reviewer guidelines call out.
+
+**Decision**: Add `NotificationManager.dispose()` — it stops every tracked operation's ellipsis interval, hides the notice, and clears the operation map — and call it from `SynapsePlugin.onunload()` after every module's `onunload()`. The audit's other touch-ups were hygiene/doc-only: shared-utility imports normalized to the `../shared` barrel (the `SettingsSectionContext` import), `.gitignore` hardened against stray credential files, and the machine-readable `AGENTS.md` set refreshed.
+
+**Alternatives considered**:
+- **Switch the ellipsis to `registerInterval()`** — rejected for now; the manager is a plain class (not an Obsidian `Component`), and a targeted `dispose()` is a smaller, more explicit change that also hides the toasts.
+- **Leave it (low impact)** — rejected; a timer firing against a destroyed plugin can throw, and clean unload is a hard requirement for an Obsidian community plugin (and for dev reloads).
+
+**Rationale**: One teardown method, called once on unload, closes the leak without changing any running-operation behavior. It extends the earlier resource-cleanup work (#170) to cover the ellipsis timers added since.
+
+**Impact**: `shared/notifications.ts` (`dispose()`), `main.ts:onunload()`. No user-visible change. The audit otherwise found no critical/high security issues; `data.json` (live keys) remains gitignored.
+
+---
+
+## 2026-06-20: Type-only imports are the sanctioned escape hatch for the acyclic graph
+
+**Context**: The value-level module graph is deliberately acyclic (`shared`/`commands` are base layers; features depend down; the coordination layers inject features rather than importing them). But a few places genuinely need a *type* that lives "above" them in the graph. Importing the value would close a cycle; re-declaring the type locally would drift.
+
+**Decision**: Where only a type is needed, use a TypeScript `import type`, which esbuild erases at compile time — so it creates **no runtime edge** and cannot form a runtime cycle. Three sanctioned cases:
+- `audio/index.ts` → `import type { AudioExtractor } from '../video'` for time-range clipping. The runtime value edge stays one-directional `video → audio`; the type-only back-edge carries no JS.
+- `settings.ts` → `import type { ProposalKind } from './views/types'` (the single source of truth for proposal kinds / `autoAccept` keys).
+- `settings.ts` → `import type { ExclusionRule } from './shared/exclusions'` (the centralized exclusion model, #307).
+
+Both `settings.ts` imports are type-only precisely because `views/types` and `shared/exclusions` sit above `settings` in the value graph; a runtime import would invert the layering.
+
+**Alternatives considered**:
+- **Move `AudioExtractor` into `shared/`** (or pass a structural interface) — still the preferred *eventual* cleanup for that one edge, but unnecessary for correctness while the import is type-only. Flagged, not blocking.
+- **Re-declare the shared types locally** — rejected; guarantees drift between `ProposalKind`/`ExclusionRule` and their real definitions. A compile-time guard already asserts `ProposalKind` matches the `UnifiedItem` union exactly.
+
+**Rationale**: `import type` lets the codebase share a single authoritative type across layers without paying a runtime dependency. The distinction (erased type edge vs. real value edge) is what keeps the dependency graph provably acyclic at runtime even though a couple of type arrows point "the wrong way."
+
+**Impact**: Documents an intentional, enforced pattern rather than an oversight. The audio→video type edge is the one remaining structural back-edge, slated for a future move of `AudioExtractor` into `shared/`.
+
+---
+
+## 2026-06-19: Registry-driven "Synapse actions" sidebar for mobile reach (#289)
+
+**Context**: On Obsidian mobile the command palette is buried, and there is no `removeRibbonIcon` API, so piling per-feature ribbon icons on isn't viable. Mobile users had no fast path to the plugin's ~20 commands.
+
+**Decision**: Add a second sidebar view, `SynapseActionsView` (`views/`), that renders a touch-friendly button for every *enabled* palette command. The button list is derived from the command registry via `listPaletteActions(registrar.getRegistered())` — no command behavior is re-declared; each button runs the already-registered command through Obsidian's own `executeCommandById`. A `layout-grid` ribbon icon opens it (unconditional, so it's reachable on mobile). Each registry entry now carries a `context` (`note` | `vault` | `global`); per-note buttons disable when no note is active, and for `note` commands the opener re-activates the note's markdown leaf first (opening the sidebar can steal editor focus, which previously made those buttons silently no-op).
+
+**Alternatives considered**:
+- **More ribbon icons** — rejected; there's no way to remove them, and they don't scale to ~20 commands.
+- **A bespoke action list hand-maintained beside the registry** — rejected; it re-creates exactly the drift the command registry exists to kill. Deriving from `getRegistered()` keeps it authoritative.
+
+**Rationale**: Reusing the registry as the source of truth means the sidebar can never list a command that isn't actually wired, and gating by `context` gives correct enable/disable state per active note. Dispatching via `executeCommandById` honors the same editor/check gating the palette uses.
+
+**Impact**: New `views/synapse-actions-view.ts` + `SYNAPSE_ACTIONS_VIEW_TYPE`; `layout-grid` ribbon icon; `context` field on registry entries; `listPaletteActions` in `commands/`. Mobile users reach any enabled command in ≤2 taps.
+
+---
+
+## 2026-06-19: "Review" action button on proposal-generation toasts (#340)
+
+**Context**: After a scan generated proposals, users got a success toast but still had to find and open the proposal sidebar by hand.
+
+**Decision**: Extend `NotificationManager` notices with an optional `NoticeAction` (a labeled button). Proposal-producing modules surface a "Review" button on their completion toasts that opens the unified proposal view via a shared `onOpenProposalView` callback wired in `main.ts` (the same six modules: elaboration, enrichment, organize, deep-dive, title, rem). Actionable toasts stay up longer (8 s) so the button is clickable.
+
+**Rationale**: One shared opener callback keeps the wiring consistent with the existing `onViewRefreshNeeded` pattern, and the action lives on the toast the user is already looking at.
+
+**Impact**: `shared/notifications.ts` (`NoticeAction`, `showActionNotice`), `main.ts` (`onOpenProposalView` wiring). Purely additive UX.
+
+---
+
+## 2026-06-19: Action-type colors unified into semantic theme tokens (#342)
+
+**Context**: Proposal card colors (blue/green/orange/purple/yellow) and action accents were hard-coded across the UI, making them inconsistent and unfriendly to community themes.
+
+**Decision**: Route action-type colors through semantic CSS theme tokens rather than literal color values, so they adapt to the active Obsidian theme and stay consistent across surfaces.
+
+**Rationale**: Theme tokens are the Obsidian-idiomatic way to color UI; centralizing them removes drift and respects light/dark and community themes.
+
+**Impact**: Styling only (`styles.css` + view code). No behavior change.
+
+---
+
+## 2026-06-19: Defer settings-DOM mutation to a macrotask to avoid an Obsidian freeze (#335)
+
+**Context**: The guided-key "Test" button (added with #335) mutates the settings DOM to show its ✓/✗ result. Doing that synchronously from within the click handler's promise *microtask* could hard-freeze Obsidian's settings pane — a reproducible hang that looked like a CSS or network problem but was neither.
+
+**Decision**: Defer the result-rendering DOM update to a *macrotask* (`setTimeout(…, 0)`) instead of mutating from within the resolving microtask, render the get-key link and status chip outside the settings row so the field keeps focus, and don't return the promise from the button's `onClick`.
+
+**Alternatives considered**:
+- **Tweak CSS / drop the `:has()` selector** — tried during diagnosis; `:has()` was one contributor but not the root cause.
+- **Mutate synchronously** — that *is* the freezing path; rejected.
+
+**Rationale**: Settling settings-DOM changes onto a macrotask lets Obsidian's own layout/reflow complete first, side-stepping the re-entrant freeze. This generalizes: heavy or focus-sensitive settings-DOM work belongs on a macrotask, not on a microtask chained off a click handler.
+
+**Impact**: The credential-field decorator (`shared/credential-field.ts`) and its settings rendering. The "Test" button now reports results without freezing — captured as an Obsidian engineering lesson for future settings UI.
+
+---
+
+## 2026-06-16: Hoist transcription provider + API key into AI Configuration (#332)
+
+**Context**: Each transcription provider key (Whisper, Deepgram, Gemini) was configured deep inside the Audio settings, far from the primary AI provider/key. Users setting up transcription had to hunt for the right field.
+
+**Decision**: Surface the transcription provider selector and its API key alongside the main AI provider in the "AI Configuration" settings section, so credential setup lives in one place. The underlying fallbacks (`whisperApiKey || ai.apiKey`, `geminiApiKey || ai.apiKey`) are unchanged.
+
+**Rationale**: Co-locating credentials reduces onboarding friction and pairs naturally with the guided key validation (#335) decorator applied to those same fields.
+
+**Impact**: Settings-tab layout only; no schema change.
+
+---
+
+## 2026-06-15: Content-type auto-formatting registry; lyrics formatting (#233, #234)
+
+**Context**: Content-type–specific formatting (recipe, receipt) was wired ad hoc inside the summarize/OCR paths. A new case — song transcripts, which read far better as structured lyrics — needed the same treatment without bolting more special cases onto each caller.
+
+**Decision**: Promote a shared content-type auto-formatting **registry** into `src/shared` (#233), then add a lyrics schema/template that auto-detects song transcripts and formats them as structured lyrics (#234, `audio.autoFormatLyrics`, default on). New content types register against the shared registry instead of editing each consumer.
+
+**Rationale**: A registry makes content-type formatting extensible and testable in one place; the existing recipe/receipt templates proved the pattern, and lyrics slot in cleanly.
+
+**Impact**: New shared content-type registry; `audio.autoFormatLyrics` setting. Song transcripts render as lyrics; other content is unaffected.
+
+---
+
+## 2026-06-14: Centralized path-exclusion model with one-time migration (#307)
+
+**Context**: Every feature carried its own `excludeFolders` list in settings, and several modules hand-rolled near-identical folder/tag matching. The same folder (e.g. `templates/`, `.synapse/`) had to be repeated per feature, and the duplicated matchers drifted (case sensitivity, inline vs. frontmatter tags).
+
+**Decision**: Replace the per-module `excludeFolders` fields with a single `settings.exclusions: ExclusionRule[]`. The model and a glob matcher live in `shared/exclusions.ts`: each rule is `{ pattern, features: 'all' | FeatureId[] }`; `isPathExcluded(path, featureId, settings)` / `findMatchingRule` are first-match-wins. A 12-member `FeatureId` union (with an `ALL_FEATURE_IDS` compile-time exhaustiveness guard) defines who can be excluded. Tag exclusion (`excludeTags`) stays per-module but now routes through a shared `matchesExcludeTag` helper. `main.loadSettings()` runs a one-time `buildMigratedExclusions()` migration, gated on the *raw persisted data* lacking an `exclusions` key, so upgraders' folders are preserved exactly (a folder excluded by every legacy feature collapses to `features: 'all'`). Fresh installs get default rules (`.synapse/**`, `templates/**`) and skip migration. Exclusions are also applied at vault-enumeration sites (#323).
+
+**Alternatives considered**:
+- **Keep per-module lists** — rejected; the duplication and matcher drift were the problem.
+- **A settings-version system to drive migration** — deferred (#93); gating on the missing `exclusions` key runs the migration exactly once without one.
+- **A glob library** — rejected (zero-runtime-deps policy); a small, documented matcher (`dir/**`, `dir/*`, bare token, exact path) covers the needed forms.
+
+**Rationale**: One authoritative list plus one tested matcher removes the per-feature duplication and the drift it caused, and lets a user scope an exclusion to specific features or to all of them. The exhaustiveness guard forces every new flow to make an explicit exclusion decision.
+
+**Impact**: New `shared/exclusions.ts`; `settings.exclusions` replaces all per-module `excludeFolders`; chip multi-select UI for feature scoping (#328); one-time migration in `loadSettings()`. Behavior-preserving for upgraders.
+
+---
+
+## 2026-06-14: Desktop-only Node access behind a single guarded loader (#299)
+
+**Context**: The plugin ships `isDesktopOnly: false`, so the bundle must load on Obsidian mobile, which has no `os`/`path`/`fs`/`child_process`. esbuild marks those builtins `external`, so any *top-level* `require('fs')` would throw on mobile at module-load time — before any `Platform.isDesktop` guard could run. The earlier fix (#198) used lazy getters scattered across modules; that worked but spread the invariant thin.
+
+**Decision**: Centralize every Node-builtin access in one module, `shared/node-loader.ts`:
+- `loadNodeModules()` lazily `require`s `os`/`path`/`fs`/`child_process.execFile` *inside the function body* and returns typed handles. It calls `assertDesktop()` first.
+- `assertDesktop(context?)` throws a descriptive `DesktopOnlyError` off-desktop, instead of a raw `Cannot find module 'fs'`.
+- `shellEnv()` builds a narrowed, allowlisted environment (augmented `PATH`, plus `HOME`, `TMPDIR`, and proxy vars when present) for spawning yt-dlp/ffmpeg/ffprobe.
+
+This is the single sanctioned `no-var-requires` site; audio, video, and transcription/duration-detection route through it after an explicit desktop assertion.
+
+**Alternatives considered**:
+- **Keep scattered lazy getters (#198)** — worked, but the mobile-safety invariant lived in many files; one loader makes it auditable in one place.
+- **Separate mobile/desktop builds** — rejected; doubles build complexity for a single bundle artifact.
+- **`isDesktopOnly: true`** — rejected; would lock mobile users out of all the text/AI features that need no Node builtins.
+
+**Rationale**: One guarded entry point makes the "never touch Node at module top level" rule structural rather than a convention each file must remember, and a distinct `DesktopOnlyError` makes any violation obvious in logs. Desktop-only features degrade gracefully; everything else runs on mobile.
+
+**Impact**: New `shared/node-loader.ts` (`loadNodeModules`, `assertDesktop`, `DesktopOnlyError`, `shellEnv`). Audio/video/duration-detector call it behind a desktop guard. `manifest.json` stays `isDesktopOnly: false`; the bundle loads on mobile. Supersedes the scattered lazy-getter approach from the 2026-03-19 "Lazy Node.js requires" decision.
+
+---
+
+## 2026-06-11: First-run onboarding welcome (#89)
+
+**Context**: A brand-new install dropped users into a fully-featured plugin with no API key set and no pointer to where to start; AI operations would simply fail until a key was configured.
+
+**Decision**: Add a pure, testable `onboarding` module (`src/onboarding.ts`). On a genuine fresh install (`loadData()` returns nothing), show a one-time welcome notice pointing at the settings tab, then persist `onboarding.hasSeenWelcome` so it never fires again; existing upgraders are marked seen silently. The settings tab additionally emphasizes the AI provider API-key field as "required" while the active hosted provider still lacks a key. All decision logic is pure (`planFirstRun`, `needsApiKey`); the caller performs the side effects, so every branch is unit-testable without rendering a settings tab.
+
+**Alternatives considered**:
+- **A multi-step onboarding modal/wizard** — rejected as heavier than warranted; a single notice plus a "required" field cue is enough to unblock setup.
+- **Show the welcome to upgraders too** — rejected; only genuine fresh installs need it.
+
+**Rationale**: Keeping the logic pure makes onboarding deterministic and testable, and gating on a missing-persisted-data signal cleanly distinguishes fresh installs from upgrades without a settings-version system.
+
+**Impact**: New `src/onboarding.ts`; `settings.onboarding.hasSeenWelcome`; `runFirstRunOnboarding()` runs last in `onload()` and never blocks load.
+
+---
+
 ## 2026-06-16: Guided key onboarding + live validation (OAuth deferred)
 
 **Context**: Every AI/transcription provider was configured by pasting a raw API key into a password field with no validation. A typo, wrong-provider, or expired key failed *silently* and only surfaced later when an elaboration/transcription operation errored out — the single biggest onboarding-friction point. The original ask (#335) was an OAuth/OIDC "click to connect your provider" button to replace keys.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,9 @@
 # Project Status
 
-**Last updated**: 2026-06-11
-**Version**: 0.3.2
+**Last updated**: 2026-06-20
+**Version**: 1.0.3
 **Branch**: `main`
-**Health**: Green — `tsc` clean, 1256/1256 tests passing (98 files), dependency graph acyclic, no critical/high security findings.
+**Health**: Green — `tsc` clean, **1511/1511 tests passing (114 files)**, dependency graph acyclic, no critical/high security findings.
 
 > Snapshot only. Decision history lives in `DECISIONS.md`; architecture in `ARCHITECTURE.md`.
 
@@ -11,10 +11,12 @@
 
 ## At a Glance
 
-- **17 feature modules** under `src/` plus `main.ts`, `settings.ts`, `settings-tab.ts`.
+- **17 modules** under `src/` plus top-level `main.ts`, `settings.ts`, `settings-tab.ts`, and `onboarding.ts`.
 - **Fire Synapse pipeline** runs features in order: elaboration → summarize → enrichment → REM → tidy → organize.
 - **Intake folder** auto-processes dropped notes/URLs through that same pipeline.
 - All AI output is reviewed in one **unified proposal sidebar**; per-feature **auto-accept** (#228) is available and defaults off.
+- A second **Synapse actions sidebar** (#289) gives mobile users touch-friendly buttons for every enabled command.
+- **Path exclusions** are centralized in one `exclusions` list (#307); **first-run onboarding** (#89) and **guided key validation** (#335) ease setup.
 
 ---
 
@@ -23,9 +25,9 @@
 | Module | Path | Role | Status |
 |--------|------|------|--------|
 | elaboration | `src/elaboration/` | Detect stub notes, propose content (image-aware) | Working |
-| audio | `src/audio/` | Transcribe audio (Whisper / Deepgram / Gemini) | Working (local-whisper not impl.) |
-| video | `src/video/` | Download + transcribe YouTube/TikTok/Instagram | Working (local file + frames not impl.) |
-| image | `src/image/` | OCR via vision models, batch + checkpoints | Working |
+| audio | `src/audio/` | Transcribe audio (Whisper / Deepgram / Gemini); auto-lyrics (#234) | Working (local-whisper not impl.) |
+| video | `src/video/` | Download + transcribe YouTube/TikTok/Instagram | Working (desktop only; local file + frames not impl.) |
+| image | `src/image/` | OCR via vision models, auto-downscale, batch + checkpoints | Working |
 | transcription | `src/transcription/` | Unified transcription/OCR UI + time-range clipping | Working (desktop-only clipping) |
 | enrichment | `src/enrichment/` | Tags, links, refs, frontmatter | Working |
 | summarize | `src/summarize/` | URL + transcription summaries, content templates | Working |
@@ -37,28 +39,32 @@
 | intake | `src/intake/` | Watch folder, auto-process notes (#111) | Working (media branch stubbed, #112) |
 | pipeline | `src/pipeline/` | Fire Synapse ordered multi-phase runner | Working |
 | commands | `src/commands/` | Command registry + registrar + drift audit | Working |
-| shared | `src/shared/` | AIClient, validation, checkpoints, callouts, URL detection | Working (base layer) |
-| views | `src/views/` | Unified proposal + checkpoint sidebar | Working |
+| shared | `src/shared/` | AIClient, validation, checkpoints, callouts, URL detection, exclusions, node-loader, credential validation | Working (base layer) |
+| views | `src/views/` | Unified proposal sidebar + Synapse actions sidebar | Working |
+
+Top-level `onboarding.ts` is a small pure module powering the first-run welcome (#89).
 
 ---
 
 ## Current Focus
 
-- **Codebase audit (2026-06-11)** — architecture, machine + human docs refreshed; security re-audit in final pass. Changes: secret redaction consolidated into one canonical `shared/redact.ts` (now covers Gemini `AIza` keys); multipart transcription bodies hardened against header injection from vault-derived file names; shared-utility imports normalized to the `../shared` barrel and the stale static `summarize → video` import removed (injection-only now).
-- **Decycling** — `shared ⇄ video` cycle eliminated; graph is acyclic. One **type-only** `audio → video` back-edge remains (no runtime cycle; flagged for cleanup).
+- **Codebase audit (2026-06-20)** — architecture, security, and Obsidian-guideline compliance verified clean. The graph is acyclic and the code is security-mature; the one fix was a lifecycle leak: in-flight notification ellipsis timers are now torn down on unload via `NotificationManager.dispose()`. Companion hygiene: barrel-import normalization, `.gitignore` credential hardening, and a refresh of the machine-readable `AGENTS.md` docs.
+- **Recent feature work (1.0.x)**: centralized path exclusions + migration (#307); guarded desktop-only Node loader (#299); Synapse actions sidebar for mobile (#289); first-run onboarding (#89); guided API-key validation, OAuth deferred (#335); transcription credentials hoisted to AI Configuration (#332); content-type registry + lyrics auto-format (#233/#234); "Review" action on proposal toasts (#340); semantic theme color tokens (#342).
 
 ---
 
 ## Security Posture
 
-- Full audit found **no critical or high vulnerabilities**; the codebase is security-mature.
+- The full audit found **no critical or high vulnerabilities**; the codebase is security-mature.
 - API keys live in `data.json`, which is **gitignored and never committed** — no secrets in the repo.
 - Subprocess calls use `execFile` with argument arrays (no shell); API auth is header-based and HTTPS-only; AI responses are sanitized before being written to notes.
-- Secret redaction now has a single source of truth (`shared/redact.ts`), used by both the AI client and `notifyError` — closes a drift where Gemini `AIza` keys could surface unredacted.
-- Multipart Whisper upload bodies sanitize vault-derived field/file names (`sanitizeMultipartHeaderValue`) to block header/multipart injection.
-- One low-severity hardening applied earlier: sanitize a vault-derived basename before a temp path in `duration-detector.ts`.
+- Secret redaction has a single source of truth (`shared/redact.ts`), used by the AI client and `api-utils:notifyError` — covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Google `AIza` keys.
+- Credential validation (#335) probes each provider with one minimal GET; results route through redaction and are **ephemeral** (never persisted).
+- Multipart Whisper upload bodies sanitize vault-derived field/file names (`sanitizeMultipartHeaderValue`) to block header/multipart injection; Gemini audio places its instruction in `system_instruction` (prompt-injection hardening).
+- Desktop-only Node access is gated behind `assertDesktop()`/`loadNodeModules()` (`shared/node-loader.ts`), keeping `isDesktopOnly: false` mobile-safe.
+- Notification ellipsis timers are now torn down on unload (no orphaned `setInterval` after disable/reload).
 - **Accepted risk**: `sanitizeUrl` permits arbitrary hosts (an SSRF surface on user-supplied URLs) — accepted because URLs are author-supplied within the user's own vault.
-- **Not yet wired**: an `ensureWithinVault` helper exists but is **not** yet enforced on write paths — there is no active vault-boundary check on writes today.
+- **Not yet wired**: an `ensureWithinVault` helper exists but is **not** yet enforced on write paths.
 
 ---
 
@@ -73,6 +79,7 @@
 | `ensureWithinVault` not wired to writes | Low | Helper exists; no write-boundary enforcement yet |
 | Ribbon icons always visible | Low | Obsidian has no `removeRibbonIcon` API |
 | Image checkpoint resume is a no-op | Low | Discards + asks user to re-run (same as deep-dive) |
+| `audio → video` type-only back-edge | Low | No runtime cycle; cleanup = move `AudioExtractor` into `shared/` |
 
 ---
 
@@ -80,12 +87,14 @@
 
 | Dependency | Required for | Status |
 |------------|--------------|--------|
-| yt-dlp | Video download | User-installed; PATH auto-resolved |
-| ffmpeg / ffprobe | Audio extraction, duration, clipping | User-installed; PATH auto-resolved |
+| yt-dlp | Video download | User-installed; PATH auto-resolved (desktop only) |
+| ffmpeg / ffprobe | Audio extraction, duration, clipping | User-installed; PATH auto-resolved (desktop only) |
 | OpenAI API key | Whisper, GPT models (incl. vision) | User-configured |
 | Anthropic API key | Claude models (incl. vision) | User-configured |
 | Gemini API key | Gemini models + Gemini audio transcription (optional) | User-configured |
 | Deepgram API key | Deepgram transcription (optional) | User-configured |
+
+No npm runtime dependencies.
 
 ---
 
@@ -95,5 +104,5 @@
 |---------|---------|
 | `npm run dev` | esbuild watch (development) |
 | `npm run build` | `tsc -noEmit -skipLibCheck` + esbuild production bundle |
-| `npm test` | Vitest — **1256/1256 passing** (98 files) |
+| `npm test` | Vitest — **1511/1511 passing** (114 files) |
 | `npm run test:coverage` | Vitest with coverage |

--- a/src/audio/AGENTS.md
+++ b/src/audio/AGENTS.md
@@ -1,14 +1,14 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-19
 ---
 
 # Audio Module
 
-Transcribes audio files from the vault using configurable providers (Whisper API, Deepgram, Gemini, local Whisper stub), with optional AI post-processing. Exposes public methods for unified transcription UI. All HTTP goes through Obsidian `requestUrl` (CSP-safe on mobile), not native `fetch`.
+Transcribes audio files from the vault using configurable providers (Whisper API, Deepgram, Gemini, local Whisper stub), with optional AI post-processing and optional lyrics auto-formatting. Exposes public methods for the unified transcription UI. All HTTP goes through Obsidian `requestUrl` (CSP-safe on mobile), not native `fetch`.
 
 ## Public API
 
-Exported from `index.ts`:
+Barrel (`index.ts`) re-exports: `AudioModule`, `findAudioEmbeds`, `AUDIO_EXTENSIONS`, `AUDIO_EMBED_REGEX`, and types `AudioEmbed`, `TranscribeOptions`, `TranscriptionResult`, `TimestampEntry`. `transcriber.ts` symbols below are module-internal (reached via `audio/transcriber`, not the barrel) and consumed by tests + `transcription-credentials.ts`.
 
 ```ts
 class AudioModule {
@@ -19,12 +19,14 @@ class AudioModule {
   transcribe(audioData: ArrayBuffer, fileName: string, options?: TranscribeOptions): Promise<TranscriptionResult>
   transcribeFileToActiveNote(file: TFile, timeRange?: TimeRange): Promise<void>
   transcribeAndInsert(noteFile: TFile, embeds: AudioEmbed[]): Promise<void>
+  transcribeAndInsertCombined(noteFile: TFile, embeds: AudioEmbed[]): Promise<void>   // #214; <2 embeds falls back to transcribeAndInsert
+  transcribeAudioCombined(files: TFile[]): Promise<string>                            // #214; concat (ffmpeg) or sequential fallback -> combined text
   onTranscriptionComplete: ((filePath: string) => void) | null
 }
 
 function findAudioEmbeds(content: string, sourcePath: string, metadataCache: MetadataCache): AudioEmbed[]
 
-// transcriber.ts (exported for reuse + tests)
+// transcriber.ts (module-internal: imported directly, NOT via the barrel)
 function buildMultipartBody(
   fields: { name: string; value: string }[],
   file: { name: string; fieldName: string; data: ArrayBuffer }
@@ -61,9 +63,10 @@ interface AudioEmbed { fileName: string; file: TFile; line: number }
 | `transcriber.test.ts` | Tests | Transcriber + multipart + provider routing tests |
 | `post-processor.ts` | `PostProcessor` | AI transcript cleanup via `AIClient` |
 | `settings-section.ts` | `renderAudioSettings` | Audio settings UI section |
+| `transcription-credentials.ts` | `renderTranscriptionCredentials(body: HTMLElement, ctx: SettingsSectionContext)` | Transcription-provider dropdown + per-provider API-key fields rendered into the AI Configuration section (#332/#335). Imports `PROVIDER_METADATA`/`decorateCredentialField` and types `CredentialProvider`/`CredentialFieldHandle`/`SettingsSectionContext` via the `../shared` barrel (audit Stage-1 barrel-import refactor — no deep `../shared/<file>` imports) |
 | `note-scanner.ts` | `findAudioEmbeds`, `hasTranscriptionBelow`, `AUDIO_EXTENSIONS`, `AUDIO_EMBED_REGEX` | Scan note content for audio embeds |
 | `note-scanner.test.ts` | Tests | Note scanner tests |
-| `index.ts` | `AudioModule` | Orchestrator, public transcription methods |
+| `index.ts` | `AudioModule` (+ note-scanner & type re-exports) | Orchestrator, public transcription methods; gates writes via `isPathExcluded`/`findMatchingRule` (#307) |
 
 ## Data Flow
 
@@ -120,7 +123,10 @@ All under `settings.audio`:
 | `geminiApiKey` | Dedicated Gemini key (fallback: `ai.apiKey`) |
 | `whisperModel` | Whisper model name |
 | `language` | Language hint |
+| `autoFormatLyrics` | Auto-detect song transcripts and reformat as structured lyrics (#234); default `true` |
 | `postProcessing.*` | AI cleanup flags |
+
+Path exclusion: write paths gate on the centralized `settings.exclusions` (#307) via `isPathExcluded(path, 'audio', settings)` (batch insert = silent skip; single-file = `findMatchingRule` Notice). No per-module `excludeFolders`/`excludeTags`.
 
 ## Time-Range Clipping
 
@@ -145,10 +151,12 @@ never interpreted as text.
 
 ## Video Module Integration
 
-`AudioModule.transcribe()` is called by `VideoModule.processUrl()` at `video/index.ts:L118`. Video passes extracted audio as `ArrayBuffer` with `sourceName` set to video title.
+`AudioModule.transcribe()` is called by `VideoModule.processUrl()` (video passes extracted audio as `ArrayBuffer` with `sourceName` set to the video title) — a runtime `video → audio` edge.
+
+`audio/index.ts` has only a type-only back-edge to video: `import type { AudioExtractor } from '../video'` (constructor `extractor?` param, desktop-only clipping/concat). Type-only = erased at compile time, so there is no runtime `audio ⇄ video` cycle.
 
 ## Commands
 
-No commands registered directly. Commands are registered in `main.ts` (unified transcription):
-- `synapse:transcribe-media` -> `AudioModule.transcribeFileToActiveNote(file)`
-- `synapse:transcribe-note-media` -> `AudioModule.transcribeAndInsert(file, embeds)`
+No commands registered directly by this module; `main.ts` registers the unified transcription commands and routes them here:
+- `synapse:transcribe-media` (registry `status: disabled` — gated out) -> `UnifiedTranscriptionModal` -> `AudioModule.transcribeFileToActiveNote(file, timeRange?)`
+- `synapse:transcribe-note-media` (active) -> `NoteMediaModal` -> `transcribeAndInsert(file, embeds)` or `transcribeAndInsertCombined(file, embeds)` when the user opts to combine (ffmpeg-gated)

--- a/src/audio/transcription-credentials.ts
+++ b/src/audio/transcription-credentials.ts
@@ -1,7 +1,6 @@
 import { Setting } from 'obsidian';
-import type { SettingsSectionContext } from '../shared/settings-section';
 import { PROVIDER_METADATA, decorateCredentialField } from '../shared';
-import type { CredentialProvider, CredentialFieldHandle } from '../shared';
+import type { CredentialProvider, CredentialFieldHandle, SettingsSectionContext } from '../shared';
 import { GEMINI_MAX_INLINE_AUDIO_BYTES } from './transcriber';
 
 /**

--- a/src/commands/AGENTS.md
+++ b/src/commands/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-19
 ---
 
 # Commands Module
@@ -14,17 +14,22 @@ Exported from `index.ts`:
 // types.ts
 type CommandStatus = 'active' | 'deprecated' | 'disabled'   // only 'active' registers/runs
 type CommandFlow = 'palette' | 'fire-synapse' | 'startup'
+type CommandContext = 'note' | 'vault' | 'global'           // runtime env; drives per-note gating in actions sidebar
 type FeatureKey = 'main' | 'elaboration' | 'enrichment' | 'organize' | 'deep-dive'
                 | 'summarize' | 'tidy' | 'rem' | 'video'
 interface CommandDefinition {
-  id: string                       // Obsidian command id, e.g. 'synapse:scan-vault'
+  id: string                       // command id WITHOUT plugin prefix, e.g. 'scan-vault' (Obsidian prepends -> 'synapse:scan-vault')
   name: string                     // palette display name
   feature: FeatureKey
   status: CommandStatus
   flows: readonly CommandFlow[]
+  context: CommandContext          // required: 'note' | 'vault' | 'global'
   pipelineKey?: string             // links to a PipelineModuleKey; typed string to avoid pipeline import cycle
   note?: string
 }
+
+// actions.ts
+function listPaletteActions(registered: ReadonlySet<string>): CommandDefinition[]   // registry entries whose id passed the full register() gate, in registry order
 
 // registry.ts
 const COMMAND_REGISTRY: readonly CommandDefinition[]
@@ -49,11 +54,12 @@ function auditCommands(attempted: ReadonlySet<string>): string[]   // drift warn
 
 | File | Exports | Purpose |
 |------|---------|---------|
-| `types.ts` | `CommandStatus`, `CommandFlow`, `FeatureKey`, `CommandDefinition` | Registry type model |
+| `types.ts` | `CommandStatus`, `CommandFlow`, `CommandContext`, `FeatureKey`, `CommandDefinition` | Registry type model |
 | `registry.ts` | `COMMAND_REGISTRY`, `REGISTRY_BY_ID`, `REGISTRY_BY_PIPELINE_KEY`, `isInFlow`, `isPipelineKeyInFlow`, `buildPipelineKeyMap` | Source-of-truth registry + flow gates |
 | `registrar.ts` | `CommandRegistrar` | Single wiring point to `plugin.addCommand`; gates by status + palette flow + userEnabled |
+| `actions.ts` | `listPaletteActions` | Derives the Synapse actions sidebar's button list from the registry + `getRegistered()` (no hand-maintained list) |
 | `audit.ts` | `auditCommands` | Drift detection between registry and wired handlers |
-| `registry.test.ts`, `registrar.test.ts`, `audit.test.ts` | Tests | |
+| `registry.test.ts`, `registrar.test.ts`, `actions.test.ts`, `audit.test.ts` | Tests | |
 | `index.ts` | re-exports | Barrel |
 
 ## Registration Gate
@@ -94,6 +100,8 @@ Run once at the end of `main.ts` `onload()` and reused by `registry`/`audit` tes
 | `isPipelineKeyInFlow` | `pipeline/synapse-runner.ts` |
 | `isInFlow` | `elaboration/index.ts` (startup flow gating) |
 | `auditCommands` | `main.ts` (end of onload) |
+| `listPaletteActions` | `main.ts` (Synapse actions sidebar factory) -> rendered by `views/synapse-actions-view.ts` |
+| `context` field | `views/synapse-actions-view.ts` (disables `note` buttons when no markdown note is active); `main.runCommand` re-activates the note leaf for `context: 'note'` commands |
 
 ## Command Registry (active palette + pipeline)
 

--- a/src/deep-dive/AGENTS.md
+++ b/src/deep-dive/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-19
 ---
 
-# Deep Dive Module
+# deep-dive module
 
-Recursively explores a note by extracting topics and generating child notes. Uses quality scoring to control recursion depth. Generates syllabus index and inter-note navigation. Supports checkpointed generation for resumability.
+Recursively explores a note by extracting topics and generating child notes via AI. Uses quality scoring to control recursion depth. Generates a syllabus index and inter-note navigation. Supports checkpointed generation for resumability.
 
 ## Public API (`index.ts`)
 
@@ -13,19 +13,36 @@ class DeepDiveModule {
   onViewRefreshNeeded: (() => Promise<void>) | null
   onNoteAccepted: ((filePath: string) => void) | null
   onOrganizeRequested: ((file: TFile) => void) | null
+  onOpenProposalView: (() => void) | null  // wired by main.ts (#340)
 
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager)
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    checkpointManager: CheckpointManager,
+    registrar: CommandRegistrar,
+    shouldAutoAccept?: () => boolean
+  )
+
   onload(): Promise<void>
   onunload(): void
-  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   getPendingProposals(): Promise<DeepDiveProposal[]>
-  acceptProposal(id: string): Promise<void>
+  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
+  acceptProposal(id: string, options?: { silent?: boolean }): Promise<void>
   rejectProposal(id: string): Promise<void>
 }
 
-function buildDeepDivePath(topicTitle: string, rootFile: TFile, settings: {...}, parentProposedPath?: string): string
+function buildDeepDivePath(
+  topicTitle: string,
+  rootFile: TFile,
+  settings: { noteOutputFolder: string; nestingMode?: DeepDiveNestingMode },
+  parentProposedPath?: string
+): string
+```
 
-// Syllabus navigator exports
+Re-exported syllabus navigator functions:
+
+```ts
 function computeTraversalOrder(proposals: DeepDiveProposal[], run: DeepDiveRun): TraversalNode[]
 function buildNavigationContext(proposalId: string, nodes: TraversalNode[], run: DeepDiveRun, syllabusPath: string): NavigationContext | null
 function renderNavigationBlock(ctx: NavigationContext): string
@@ -38,27 +55,32 @@ function injectNavigationBlock(content: string, navBlock: string): string
 
 Exported types: `DeepDiveProposal`, `DeepDiveRun`, `ExtractedTopic`, `QualityScore`, `DeepDiveProposalStatus`, `DeepDiveRunStatus`, `TraversalNode`, `NavigationContext`
 
-## Internal Components
+Re-exported settings renderer: `renderDeepDiveSettings` (from `./settings-section`)
+
+## Internal File Map
 
 | File | Class/Function | Role |
 |------|---------------|------|
-| `topic-analyzer.ts` | `TopicAnalyzer` | AI topic extraction from note content, checks vault for existing notes |
-| `topic-analyzer.test.ts` | Tests | TopicAnalyzer tests |
+| `index.ts` | `DeepDiveModule`, `buildDeepDivePath` | Module entry point and public API |
+| `topic-analyzer.ts` | `TopicAnalyzer` | AI topic extraction; checks vault for existing notes |
 | `note-generator.ts` | `NoteGenerator` | AI content generation for a topic given parent context |
 | `quality-scorer.ts` | `scoreQuality` | Local heuristic scoring: word count, child topics, overlap, genericity |
-| `quality-scorer.test.ts` | Tests | Quality scorer tests |
 | `syllabus-navigator.ts` | Navigation utilities | Traversal ordering, syllabus index, prev/next navigation blocks |
-| `syllabus-navigator.test.ts` | Tests | Syllabus navigator tests |
 | `deep-dive-store.ts` | `DeepDiveStore` | JSON persistence for proposals and runs |
-| `deep-dive-store.test.ts` | Tests | DeepDiveStore tests |
 | `depth-selector-modal.ts` | `DepthSelectorModal`, `selectDepth`, `MIN_DEPTH`, `MAX_DEPTH` | Modal for user to select recursion depth (1-6) |
-| `depth-selector-modal.test.ts` | Tests | DepthSelectorModal tests |
+| `settings-section.ts` | `renderDeepDiveSettings` | Settings UI renderer |
 | `types.ts` | -- | All deep-dive types |
+
+## Dependency on `organize` module
+
+`deep-dive` imports `ContentAnalyzer` and `DirectoryMatcher` directly from `../organize` (the public barrel). These are used only in `auto-organize` nesting mode: `buildAutoOrganizedPath` calls `ContentAnalyzer.extractTopics(topicTitle, [])` to get topic labels, then passes a synthetic `ContentAnalysis` to `DirectoryMatcher.scoreDirectories`. Falls back to `buildDeepDivePath` (nested mode) on AI failure or low score.
+
+Note: `ContentAnalyzer.extractTopics` in the organize module takes `(body: string, tags: string[])`, not the same signature as `TopicAnalyzer.extractTopics` in this module.
 
 ## Data Flow
 
 ```
-deepDive(file)
+deepDive(file)  [private, called by command]
   Phase 1: Extract topics
     --> TopicAnalyzer.extractTopics(content, title, [])  [AI]
     --> filter new vs existing topics
@@ -68,32 +90,33 @@ deepDive(file)
   Phase 3: Recursive generation (BFS queue, checkpointed)
     --> checkpointManager.create(module: 'deep-dive', items: root topics)
     --> addDeferredTask('refresh-sidebar-view')
-    for each topic:
+    for each topic in BFS queue:
       --> NoteGenerator.generateContent(topic, parentTitle, parentContent)  [AI]
-      --> buildProposedPath(title, rootFile, parentPath)
+      --> buildProposedPath(title, rootFile, parentProposedPath)
       --> if depth < maxDepth: TopicAnalyzer.extractTopics(childContent)  [AI]
       --> scoreQuality({title, childTopics, wordCount, depth, ancestors})
       --> DeepDiveStore.saveProposal()
-      --> checkpointManager.completeItem(checkpoint, topic-title)
-      --> if quality >= threshold && depth+1 < maxDepth: queue children
+      --> checkpointManager.completeItem(checkpoint, 'topic-<title>')
+      --> if quality >= threshold && depth+1 < maxDepth: enqueue children
     --> DeepDiveStore.saveRun()
     --> on cancel: checkpointManager.discard()
     --> on success: checkpointManager.complete(), dispatch deferred tasks
     --> on error: checkpointManager.discard()
+    --> maybeAutoAcceptRun(run.proposalIds)  [if shouldAutoAccept()]
 
 resumeFromCheckpoint(checkpoint)
   --> Deep dive cannot directly resume (recursive BFS state not serializable)
   --> Discards checkpoint, notifies user to re-run on source note
   --> Completed proposals from partial run are already saved
 
-acceptProposal(id)
+acceptProposal(id, options?)
+  --> DeepDiveStore.updateProposalStatus('accepted')
   --> updateRunNavigation(runId, proposedPath, proposedContent)
     --> computeTraversalOrder(proposals, run)
     --> renderSyllabusContent() -> writeNote(syllabusPath)
     --> for each accepted node: injectNavigationBlock() -> writeNote()
-  --> DeepDiveStore.updateProposalStatus('accepted')
   --> onNoteAccepted?.(proposedPath)  [triggers enrichment]
-  --> onOrganizeRequested?.(file)  [triggers organize if enabled]
+  --> onOrganizeRequested?.(file)  [triggers organize if deepDive.autoOrganizeOnAccept]
 
 rejectProposal(id)
   --> DeepDiveStore.cascadeReject(id)  [rejects children too]
@@ -102,11 +125,13 @@ rejectProposal(id)
 
 ## Path Building (nestingMode)
 
+`DeepDiveNestingMode = 'nested' | 'flat' | 'auto-organize'`
+
 | Mode | Behavior |
 |------|----------|
 | `nested` | Children placed in subfolder named after parent: `Deep Dives/ML/Neural Networks/Backprop.md` |
 | `flat` | All notes in root subfolder: `Deep Dives/ML/Backprop.md` |
-| `auto-organize` | Uses organize module's ContentAnalyzer + DirectoryMatcher; falls back to nested |
+| `auto-organize` | Uses organize module's `ContentAnalyzer` + `DirectoryMatcher`; falls back to nested on failure or score < 0.6 |
 
 ## Key Types
 
@@ -121,7 +146,7 @@ interface ExtractedTopic {
 }
 
 interface QualityScore {
-  score: number        // 0-1; below threshold stops recursion
+  score: number         // 0-1; below qualityThreshold stops recursion
   topicCount: number
   wordCount: number
   isTooGeneric: boolean
@@ -155,8 +180,57 @@ interface DeepDiveRun {
 }
 ```
 
+## Commands Registered
+
+| Command ID | Enabled When | Description |
+|------------|-------------|-------------|
+| `deep-dive` | `settings.deepDive.enabled` | Deep dive into current note |
+| `clear-deep-dive` | `settings.deepDive.enabled` | Clear all deep dive proposals |
+
+## Settings Keys
+
+Path exclusion is centralized (#307): `settings.exclusions: ExclusionRule[]` consulted via `isPathExcluded(path, 'deep-dive', settings)` and `findMatchingRule`. There is no per-module `excludeFolders` key.
+
+| Key | Type | Default |
+|-----|------|---------|
+| `settings.deepDive.enabled` | `boolean` | `true` |
+| `settings.deepDive.proposalFolderPath` | `string` | `.synapse/deep-dive` |
+| `settings.deepDive.maxDepth` | `number` | `3` |
+| `settings.deepDive.qualityThreshold` | `number` | `0.4` |
+| `settings.deepDive.maxNotesPerRun` | `number` | `50` |
+| `settings.deepDive.noteOutputFolder` | `string` | `Deep Dives` |
+| `settings.deepDive.nestingMode` | `DeepDiveNestingMode` | `'nested'` |
+| `settings.deepDive.excludeTags` | `string[]` | `['no-deep-dive']` |
+| `settings.deepDive.autoEnrichOnAccept` | `boolean` | `true` |
+| `settings.deepDive.autoOrganizeOnAccept` | `boolean` | `false` |
+| `settings.autoAccept['deep-dive']` | `boolean` | `false` |
+| `settings.exclusions` | `ExclusionRule[]` | see `settings.ts` defaults |
+
 ## Dependencies
 
-- `shared/` (NotificationManager, ensureFolder, readNote, writeNote, wordCount, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask)
-- `organize/` (ContentAnalyzer, DirectoryMatcher -- for auto-organize nesting mode)
-- `settings.ts` (SynapseSettings, DeepDiveNestingMode)
+In: `shared/` (NotificationManager, readNote, writeNote, wordCount, CheckpointManager, generateId, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule, Checkpoint, CheckpointWorkItem, DeferredTask), `organize/` (ContentAnalyzer, DirectoryMatcher — auto-organize mode only), `settings.ts` (SynapseSettings, DeepDiveNestingMode), `commands.ts` (CommandRegistrar)
+
+Out: Nothing consumed by other feature modules.
+
+## Invariants / Gotchas
+
+- `acceptProposal` guards against double-acceptance: no-ops if `proposal.status !== 'pending'`.
+- `rejectProposal` cascades to all child proposals (`DeepDiveStore.cascadeReject`).
+- Checkpoint item IDs use the stable format `'topic-<title>'` (C2) so completed items survive restart.
+- Deep-dive checkpoint cannot be resumed via BFS reconstruction — `resumeFromCheckpoint` discards the checkpoint and prompts user to re-run.
+- Auto-accept runs AFTER the full generation loop completes, in creation order (parents before children) so navigation resolves correctly.
+- Syllabus note path: `syllabusPath(rootNotePath, deepDive.noteOutputFolder)` — trashed (not hard-deleted) if all proposals in a run are rejected.
+- `onNoteAccepted` and `onOrganizeRequested` fire even under `silent: true` (batch auto-accept); they are the intended acyclic follow-on chain.
+
+## Tests
+
+| File | Covers |
+|------|--------|
+| `topic-analyzer.test.ts` | TopicAnalyzer.extractTopics |
+| `note-generator.test.ts` | NoteGenerator.generateContent |
+| `quality-scorer.test.ts` | scoreQuality heuristics |
+| `syllabus-navigator.test.ts` | computeTraversalOrder, buildNavigationContext, render functions |
+| `deep-dive-store.test.ts` | DeepDiveStore persistence and cascadeReject |
+| `depth-selector-modal.test.ts` | DepthSelectorModal, selectDepth |
+| `auto-accept.test.ts` | Auto-accept flow (#228) |
+| `settings-section.test.ts` | Settings UI renderer |

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-19
 ---
 
 # Elaboration Module
@@ -12,17 +12,25 @@ Exported from `index.ts`:
 
 ```ts
 class ElaborationModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager)
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    checkpointManager: CheckpointManager,
+    registrar: CommandRegistrar,
+    shouldAutoAccept?: () => boolean
+  )
   onload(): Promise<void>
   onunload(): void
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
-  scanVault(folderPath?: string): Promise<number>
-  scanNote(file: TFile): Promise<void>
-  acceptProposal(id: string, editedContent?: string): Promise<void>
+  scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
+  scanNote(file: TFile, userInvoked?: boolean): Promise<void>
+  acceptProposal(id: string, editedContent?: string, options?: { silent?: boolean }): Promise<void>
   rejectProposal(id: string): Promise<void>
   getPendingProposals(): Promise<Proposal[]>
   onProposalAccepted: ((filePath: string) => void) | null
   onViewRefreshNeeded: (() => Promise<void>) | null
+  onOpenProposalView: (() => void) | null
 }
 
 type DetectionReason =
@@ -47,23 +55,34 @@ interface Proposal {
   insertionPoint: 'append' | 'after-heading' | 'replace-section'
   insertionTarget?: string
   status: 'pending' | 'accepted' | 'rejected'
+  imageAnalysis?: ImageAnalysis[]
 }
+
+// settings-section.ts (also exported from index.ts)
+function renderElaborationSettings(ctx: SettingsSectionContext): void
 ```
+
+`ImageAnalysis` and `ImageAnalyzer` are internal to `image-analyzer.ts` (not re-exported from `index.ts`).
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
 | `types.ts` | `DetectionReason`, `DetectionResult`, `Proposal` | Type definitions |
-| `detector.ts` | `PlaceholderDetector` | Scans notes for stub signals |
-| `proposer.ts` | `ProposalGenerator` | AI proposal generation with context gathering |
-| `proposal-store.ts` | `ProposalStore` | CRUD for proposal JSON files |
-| `proposal-store.test.ts` | Tests | ProposalStore tests |
-| `proposal-view.ts` | `ProposalReviewView`, `PROPOSAL_VIEW_TYPE` | Legacy sidebar view (not registered by main.ts) |
+| `detector.ts` | `PlaceholderDetector` | Scans notes for stub signals; applies centralized path exclusions + per-module tag exclusion |
+| `proposer.ts` | `ProposalGenerator` | AI proposal generation; gathers linked-note context, image context, and external URL context |
+| `proposal-store.ts` | `ProposalStore` | CRUD for proposal JSON files in `.synapse/` storage |
+| `proposal-view.ts` | `ProposalReviewView`, `PROPOSAL_VIEW_TYPE` | Legacy sidebar view (not registered by `main.ts`) |
 | `proposal-modal.ts` | `ProposalDetailModal` | Legacy modal for editing proposals |
 | `image-analyzer.ts` | `ImageAnalyzer`, `ImageAnalysis`, `MAX_IMAGES_PER_NOTE` | Multi-modal AI image analysis for enriching elaboration proposals |
-| `scan-note.test.ts` | Tests | ScanNote integration tests |
-| `index.ts` | `ElaborationModule` | Orchestrator, commands, scan intervals |
+| `settings-section.ts` | `renderElaborationSettings` | Settings accordion renderer |
+| `auto-accept.test.ts` | Tests | Auto-accept elaboration proposal tests |
+| `scan-note.test.ts` | Tests | `scanNote` integration tests |
+| `startup-flow.test.ts` | Tests | Startup scan + interval timer tests |
+| `proposer.test.ts` | Tests | `ProposalGenerator` tests |
+| `proposal-store.test.ts` | Tests | `ProposalStore` tests |
+| `settings-section.test.ts` | Tests | Settings section rendering tests |
+| `index.ts` | `ElaborationModule`, re-exports | Orchestrator, commands, scan intervals |
 
 ## Data Flow
 
@@ -72,7 +91,7 @@ interface Proposal {
    |
 2. PlaceholderDetector.detect(file)
    |  Checks: word count, TODO markers, empty sections, sparse links
-   |  Filters: centralized isPathExcluded (feature 'elaboration'), excludeTags
+   |  Filters: isPathExcluded('elaboration', settings), matchesExcludeTag(excludeTags)
    |  Returns: DetectionResult | null
    |
 3. Two-phase confirmation (vault scan only):
@@ -82,16 +101,20 @@ interface Proposal {
    |
 4. ProposalGenerator.generate(detection)
    |  Gathers context from up to 5 linked notes (500 chars each)
+   |  Gathers image context via ImageAnalyzer (if image.enabled)
+   |  Gathers external URL context (Twitter/article fetching, up to 3 URLs)
    |  AIClient.complete() with system prompt
-   |  sanitizeAIResponse() on output
+   |  stripCodeFences(sanitizeAIResponse()) on output
    |  Returns: Proposal (status: 'pending')
    |
 5. ProposalStore.save(proposal)
    |
-6. onViewRefreshNeeded() --> main.refreshUnifiedView()
+6. maybeAutoAccept(proposal) if shouldAutoAccept() === true
    |
-7. User action via UnifiedProposalView:
-   Accept --> blockquoteOriginal(content), sanitizeAIResponse(additions), append
+7. onViewRefreshNeeded() --> main.refreshUnifiedView()
+   |
+8. User action via UnifiedProposalView:
+   Accept --> sanitizeAIResponse(additions), buildCallout(CALLOUT_TYPES.elaboration), append
    Reject --> status = 'rejected'
 ```
 
@@ -99,24 +122,25 @@ interface Proposal {
 
 | Rule | Setting | Logic |
 |------|---------|-------|
-| Short note | `detection.minWordThreshold` | `wordCount(body) < threshold` |
-| TODO markers | `detection.detectTodoMarkers` | Regex: `\bTODO\b`, `\bTBD\b`, `\bFIXME\b`, `\bPLACEHOLDER\b` |
-| Empty sections | `detection.detectEmptySections` | Heading with no content before next same-or-higher heading |
-| Sparse links | `detection.detectSparseLinks` | Inbound links AND word count below threshold |
+| Short note | `elaboration.detection.minWordThreshold` | `wordCount(body) < threshold` |
+| TODO markers | `elaboration.detection.detectTodoMarkers` | Regex: `\bTODO\b`, `\bTBD\b`, `\bFIXME\b`, `\bPLACEHOLDER\b` |
+| Empty sections | `elaboration.detection.detectEmptySections` | Heading with no content before next same-or-higher heading |
+| Sparse links | `elaboration.detection.detectSparseLinks` | Inbound links AND word count below threshold |
 
 ## Accept Behavior
 
-On accept, sanitized AI additions are wrapped in an `synapse-elaboration` callout and appended to the note via `buildCallout(CALLOUT_TYPES.elaboration, 'Elaboration', additions)`.
+On accept, additions are sanitized via `stripCodeFences(sanitizeAIResponse())`, then wrapped in a `synapse-elaboration` callout via `buildCallout(CALLOUT_TYPES.elaboration, 'Elaboration', additions)` and appended to the note.
 
 ## Image Analysis
 
-`ImageAnalyzer` (in `image-analyzer.ts`) uses multi-modal `AIClient.chat()` with `ContentBlock[]` to analyze images embedded in notes during proposal generation:
+`ImageAnalyzer` (`image-analyzer.ts`) uses multi-modal `AIClient.chat()` with `ContentBlock[]` to analyze images embedded in notes during proposal generation. Internal; not exported from `index.ts`.
 
 ```ts
 class ImageAnalyzer {
   constructor(app: App, getSettings: () => SynapseSettings)
   findImageReferences(content: string): Array<{ reference: string; path: string; isInternal: boolean }>
   analyzeImagesInNote(notePath: string, content: string): Promise<ImageAnalysis[]>
+  parseAnalysisResponse(reference: string, response: string): ImageAnalysis
 }
 
 interface ImageAnalysis {
@@ -130,15 +154,56 @@ const MAX_IMAGES_PER_NOTE = 5
 ```
 
 - Finds both wiki-link (`![[image.png]]`) and markdown (`![alt](path)`) image references
-- Skips external URLs (only vault images)
-- Caps at 5 images per note to avoid token overflow
-- Uses `image.visionModel` override if configured (same pattern as `ImageExtractor`)
-- Graceful degradation: skips individual image failures
-- Imports `AIClient` and `arrayBufferToBase64` from the `shared` barrel and reuses `image/preprocessImage` (from the `image` barrel) to downscale oversized images before they reach the API — no duplicate base64/encoding logic
+- Skips external URLs (vault images only)
+- Caps at 5 images per note (`MAX_IMAGES_PER_NOTE`)
+- Applies `settings.image.visionModel` override (same pattern as `ImageExtractor`)
+- Graceful degradation: logs warning, skips individual image failures
+- Imports `AIClient`, `arrayBufferToBase64` from the `shared` barrel; reuses `image/preprocessImage` (via the `image` barrel) for downscaling — no duplicate encoding logic
+- Uses `settings.image.maxImageSizeMb` (default 5) as the downscale threshold
 
-## Error Handling
+## Settings Keys
 
-- `scanVault`: two-phase with cancellation; auto-rejects created proposals on error/cancel
-- `scanNote`: catches errors, reports via `NotificationManager.startOperation()`
-- `ProposalStore.loadAll`: silently skips unparseable JSON
-- `acceptProposal`: no-ops if proposal or source file not found
+All under `settings.elaboration`:
+
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `enabled` | boolean | false | Module activation |
+| `scanOnStartup` | boolean | false | Trigger vault scan 5 s after load |
+| `autoScanInterval` | number | 0 | Periodic scan interval (minutes; 0 = off) |
+| `detection.minWordThreshold` | number | 50 | Notes below this word count are stubs |
+| `detection.detectTodoMarkers` | boolean | true | Flag TODO/TBD/FIXME/PLACEHOLDER markers |
+| `detection.detectEmptySections` | boolean | true | Flag headings with no body content |
+| `detection.detectSparseLinks` | boolean | true | Flag notes with inbound links but sparse content |
+| `detection.excludeTags` | string[] | `['no-elaborate']` | Per-note opt-out via frontmatter tags |
+| `proposal.includeSourceContext` | boolean | true | Gather up to 5 linked notes as context |
+
+Path-based exclusions use centralized `settings.exclusions: ExclusionRule[]` (#307) via `isPathExcluded('elaboration', settings)` from the `shared` barrel. There is no per-module `excludeFolders` field.
+
+Auto-accept is controlled by `settings.autoAccept.elaboration: boolean` (default `false`), wired into the module at construction via `shouldAutoAccept: () => boolean`.
+
+## Commands Registered
+
+All registered via `CommandRegistrar` in `onload()`:
+
+| Command suffix | Name | Condition |
+|---------------|------|-----------|
+| `scan-vault` | Scan vault for stub notes | `elaboration.enabled` |
+| `scan-current-note` | Scan current note for elaboration | `elaboration.enabled` |
+| `clear-proposals` | Clear all pending proposals | `elaboration.enabled` |
+
+## Dependencies
+
+| Import | From |
+|--------|------|
+| `buildCallout`, `CALLOUT_TYPES`, `NotificationManager`, `sanitizeAIResponse`, `stripCodeFences`, `CheckpointManager`, `generateId`, `fireAndForget`, `FolderPickerModal`, `getMarkdownFiles`, `isPathExcluded`, `matchesExcludeTag`, `getIncludedMarkdownFiles`, `wordCount`, `AIClient`, `arrayBufferToBase64`, `isTwitterUrl`, `fetchTweetContent`, `fetchArticleContent` | `../shared` |
+| `CommandRegistrar`, `isInFlow` | `../commands` |
+| `preprocessImage` | `../image` (barrel) |
+
+## Invariants / Gotchas
+
+- `scanVault` creates a checkpoint before the generation phase; cancellation or error auto-rejects all proposals created in that run and discards the checkpoint.
+- `acceptProposal` guards against double-acceptance: no-ops if `proposal.status !== 'pending'`.
+- `scanNote` with `userInvoked=true` bypasses the stub gate — always generates a proposal even if detection finds no reasons.
+- `ProposalGenerator` imports `preprocessImage` from the `image` barrel (`../image`), not directly from `image/preprocess.ts` — respects the "import from module index" architecture rule.
+- `detector.ts` uses `getIncludedMarkdownFiles` (which already respects path exclusions) for inbound link resolution.
+- `onOpenProposalView` callback (#340) was added after the original AGENTS.md; it is a third wired callback alongside `onProposalAccepted` and `onViewRefreshNeeded`.

--- a/src/enrichment/AGENTS.md
+++ b/src/enrichment/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-19
 ---
 
 # Enrichment Module
@@ -12,18 +12,36 @@ Exported from `index.ts`:
 
 ```ts
 class EnrichmentModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager)
+  // Wired by main.ts to refresh the unified proposal view
+  onViewRefreshNeeded: (() => Promise<void>) | null
+
+  // Wired by main.ts to open the unified proposal view (#340)
+  onOpenProposalView: (() => void) | null
+
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    checkpointManager: CheckpointManager,
+    registrar: CommandRegistrar,
+    shouldAutoAccept?: () => boolean
+  )
+
   onload(): Promise<void>
   onunload(): void
-  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
-  enrich(filePath: string, trigger: EnrichmentTrigger): Promise<void>
-  scanVault(folderPath?: string): Promise<number>
-  getPendingProposals(): Promise<EnrichmentProposal[]>
-  acceptSelectedFromView(id: string, accepted: AcceptedItems): Promise<void>
-  rejectFromView(id: string): Promise<void>
-  onViewRefreshNeeded: (() => Promise<void>) | null
-}
 
+  enrich(filePath: string, trigger: EnrichmentTrigger): Promise<void>
+  scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
+  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
+  getPendingProposals(): Promise<EnrichmentProposal[]>
+  acceptSelectedFromView(id: string, accepted: AcceptedItems, options?: { silent?: boolean }): Promise<void>
+  rejectFromView(id: string): Promise<void>
+}
+```
+
+Re-exported types from `types.ts`:
+
+```ts
 type EnrichmentTrigger = 'elaboration' | 'transcription' | 'summarization' | 'deep-dive' | 'manual'
 type EnrichmentStatus = 'pending' | 'accepted' | 'partially-accepted' | 'rejected'
 
@@ -51,161 +69,225 @@ interface AcceptedItems {
   frontmatter: string[]
 }
 
-interface TagCandidate { tag: string; category: string; confidence: number; rawScore: number; weightedScore: number; sources: string[] }
-interface TagVocabularyEntry { category: string; tags: string[]; description: string }
+interface TagCandidate {
+  tag: string
+  category: string       // vocabulary category, e.g. "Status", "Type"
+  confidence: number     // AI classification confidence (0–1)
+  rawScore: number       // always 0 for classifier-produced candidates
+  weightedScore: number  // equals confidence for classifier-produced candidates
+  sources: string[]      // file paths that contributed this tag (empty for classifier)
+}
+
 interface InternalLinkCandidate { targetPath: string; displayText: string; relevanceScore: number; reason: string }
 interface ExternalLinkCandidate { url: string; title: string; reason: string }
 interface FrontmatterEnrichment { key: string; value: string | string[]; action: 'add' | 'merge' }
 interface WeightConfig { sameFolder: number; siblingFolder: number; cousinFolder: number; distantFolder: number; decayPerLevel: number; minWeight: number }
+
+// Vault topology snapshots (types.ts)
+interface TagIndex { tags: Map<string, { count: number; files: string[] }> }
+interface LinkGraph { outgoing: Map<string, Set<string>>; incoming: Map<string, Set<string>> }
 ```
+
+Note: `TagVocabularyEntry` and `EnrichmentWeightSettings` are defined in `src/settings.ts`, not in `types.ts`.
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `types.ts` | All interfaces and types | Type definitions, `TagIndex`, `LinkGraph` |
-| `vault-analyzer.ts` | `VaultAnalyzer` | Cached vault-wide tag index and link graph from MetadataCache |
-| `vault-analyzer.test.ts` | Tests | VaultAnalyzer tests |
-| `weight-calculator.ts` | `computeProximityWeight` | Pure function: folder proximity scoring |
-| `weight-calculator.test.ts` | Tests | Weight calculator tests |
-| `metadata-classifier.ts` | `MetadataClassifier` | AI-powered tag classification using user-defined vocabulary |
-| `metadata-classifier.test.ts` | Tests | MetadataClassifier tests |
-| `topic-extractor.ts` | `TopicExtractor` | AI-powered topic extraction, converts topics to internal link candidates |
-| `topic-extractor.test.ts` | Tests | TopicExtractor tests |
-| `link-resolver.ts` | `LinkResolver` | Graph-based internal link candidates, merges with topic candidates |
-| `link-resolver.test.ts` | Tests | LinkResolver tests |
-| `prompt-builder.ts` | `PromptBuilder` | AI-generated external links and frontmatter suggestions |
-| `enrichment-store.ts` | `EnrichmentStore` | CRUD for enrichment proposal JSON files |
-| `enrichment-store.test.ts` | Tests | EnrichmentStore tests |
-| `enrichment-applier.ts` | `EnrichmentApplier` | Applies/undoes enrichments to notes |
-| `enrichment-modal.ts` | `EnrichmentDetailModal` | Legacy per-item toggle modal |
-| `enrichment-view.ts` | `EnrichmentReviewView` | Legacy sidebar view (not registered) |
-| `index.ts` | `EnrichmentModule` | Orchestrator, commands, exclusion logic, vault scan |
+| `types.ts` | All interfaces and types | `TagCandidate`, `InternalLinkCandidate`, `ExternalLinkCandidate`, `FrontmatterEnrichment`, `EnrichmentResult`, `EnrichmentProposal`, `AcceptedItems`, `TagIndex`, `LinkGraph`, `WeightConfig` |
+| `index.ts` | `EnrichmentModule`, re-exports | Orchestrator; registers commands; exclusion checks; vault scan; checkpoint resume |
+| `vault-analyzer.ts` | `VaultAnalyzer` | Cached vault-wide `TagIndex` and `LinkGraph` from `MetadataCache`; invalidated on `'resolved'` event |
+| `weight-calculator.ts` | `computeProximityWeight` | Pure function: folder-proximity scoring |
+| `metadata-classifier.ts` | `MetadataClassifier` | AI-powered tag classification against user-defined vocabulary; replaces former `TagScorer` |
+| `topic-extractor.ts` | `TopicExtractor` | AI topic extraction; matched topics → `InternalLinkCandidate`; unmatched topics accumulated for multi-note resolution |
+| `link-resolver.ts` | `LinkResolver` | Graph-based internal link candidates (link hops, shared tags, folder proximity); merges with topic candidates |
+| `prompt-builder.ts` | `PromptBuilder` | AI prompts for external link and frontmatter suggestions |
+| `enrichment-store.ts` | `EnrichmentStore` | CRUD for enrichment proposal JSON files in `.synapse/enrichments/` |
+| `enrichment-applier.ts` | `EnrichmentApplier` | Applies/undoes accepted enrichments to note content non-destructively |
+| `enrichment-modal.ts` | `EnrichmentDetailModal` | Per-item toggle modal for reviewing a single proposal |
+| `settings-section.ts` | `renderEnrichmentSettings` | Settings UI accordion for the enrichment feature (#243) |
+| `vault-analyzer.test.ts` | Tests | `VaultAnalyzer` |
+| `weight-calculator.test.ts` | Tests | `computeProximityWeight` |
+| `metadata-classifier.test.ts` | Tests | `MetadataClassifier` |
+| `topic-extractor.test.ts` | Tests | `TopicExtractor` |
+| `link-resolver.test.ts` | Tests | `LinkResolver` |
+| `enrichment-store.test.ts` | Tests | `EnrichmentStore` |
+| `enrichment-applier.test.ts` | Tests | `EnrichmentApplier` |
+| `settings-section.test.ts` | Tests | `renderEnrichmentSettings` |
+| `auto-accept.test.ts` | Tests | Auto-accept behavior (#228) |
+
+## Internal Class Signatures
+
+```ts
+// vault-analyzer.ts
+class VaultAnalyzer {
+  constructor(app: App, getSettings: () => SynapseSettings)
+  invalidate(): void
+  buildTagIndex(): TagIndex
+  buildLinkGraph(): LinkGraph
+  getFileTags(file: TFile): string[]
+  getOutgoingLinks(filePath: string): Set<string>
+  getIncomingLinks(filePath: string): Set<string>
+}
+
+// weight-calculator.ts
+function computeProximityWeight(sourcePath: string, targetPath: string, config: WeightConfig): number
+
+// metadata-classifier.ts
+class MetadataClassifier {
+  constructor(getSettings: () => SynapseSettings)
+  classify(noteContent: string, existingTags: string[]): Promise<TagCandidate[]>
+}
+
+// topic-extractor.ts
+class TopicExtractor {
+  constructor(app: App, analyzer: VaultAnalyzer, getSettings: () => SynapseSettings)
+  extractTopics(noteContent: string, notePath: string, existingLinkPaths: string[]): Promise<InternalLinkCandidate[]>
+  resolveNewNoteCandidates(): Map<string, InternalLinkCandidate[]>  // notePath → candidates
+  clearPending(): void
+}
+
+// link-resolver.ts
+class LinkResolver {
+  constructor(app: App, analyzer: VaultAnalyzer, getSettings: () => SynapseSettings)
+  findInternalLinks(file: TFile, existingLinkPaths: string[]): InternalLinkCandidate[]
+  mergeTopicCandidates(topicCandidates: InternalLinkCandidate[], graphCandidates: InternalLinkCandidate[]): InternalLinkCandidate[]
+}
+
+// prompt-builder.ts
+class PromptBuilder {
+  constructor(getSettings: () => SynapseSettings)
+  suggestExternalLinks(noteContent: string, existingUrls: string[]): Promise<ExternalLinkCandidate[]>
+  suggestFrontmatter(noteContent: string, existingFrontmatter: Record<string, unknown>): Promise<FrontmatterEnrichment[]>
+}
+
+// enrichment-store.ts
+class EnrichmentStore {
+  constructor(app: App, getSettings: () => SynapseSettings)
+  init(): Promise<void>
+  save(proposal: EnrichmentProposal): Promise<void>
+  load(id: string): Promise<EnrichmentProposal | null>
+  loadAll(): Promise<EnrichmentProposal[]>
+  loadPending(): Promise<EnrichmentProposal[]>
+  loadForNote(notePath: string): Promise<EnrichmentProposal[]>
+  updateStatus(id: string, status: EnrichmentStatus, acceptedItems?: AcceptedItems): Promise<void>
+  delete(id: string): Promise<void>
+}
+
+// enrichment-applier.ts
+class EnrichmentApplier {
+  constructor(app: App, getSettings: () => SynapseSettings)
+  apply(proposal: EnrichmentProposal, accepted: AcceptedItems): Promise<void>
+  undo(proposal: EnrichmentProposal): Promise<void>
+}
+
+// settings-section.ts
+function renderEnrichmentSettings(ctx: SettingsSectionContext): void
+```
+
+## Registered Commands
+
+| Command ID | Name | Condition |
+|-----------|------|-----------|
+| `enrich-current-note` | Enrich current note | `settings.enrichment.enabled` |
+| `scan-vault-enrichment` | Scan vault for enrichment | `settings.enrichment.enabled` |
+| `undo-enrichment` | Undo last enrichment on current note | `settings.enrichment.enabled` |
+
+## Dependencies
+
+In (consumed by this module):
+- `src/shared`: `isPathExcluded`, `matchesExcludeTag`, `findMatchingRule`, `getIncludedMarkdownFiles`, `NotificationManager`, `CheckpointManager`, `CommandRegistrar`, `AIClient`, `parseFrontmatter`, `serializeFrontmatter`, `mergeTags`, `buildCallout`, `ENRICHMENT_START`, `ENRICHMENT_END`, `sanitizeAIResponse`, `parseJson`, `generateId`, `isTwitterUrl`, `fetchTweetContent`, `fireAndForget`, `getMarkdownFiles`, `ensureFolder`, `readJsonFile`, `isRecord`
+- `src/settings`: `SynapseSettings`, `TagVocabularyEntry`, `EnrichmentWeightSettings`
+
+Out (consumed by other modules):
+- `src/main.ts`: imports `EnrichmentModule`, wires `onViewRefreshNeeded`, `onOpenProposalView`, `shouldAutoAccept`; calls `enrich()`, `scanVault()`, `getPendingProposals()`, `acceptSelectedFromView()`, `rejectFromView()`, `resumeFromCheckpoint()`
+
+No feature module dependencies (enrichment does not import from elaboration, transcription, etc.).
 
 ## Data Flow
 
 ```
-1. enrich(filePath, trigger) -- triggered by callback or command
-   |
-2. Exclusion check: centralized isPathExcluded (feature 'enrichment') + excludeTags
-   |
-3. Parallel enrichment (enrichFile):
-   |  MetadataClassifier.classify() -- vocabulary-based tag classification via AI
-   |  TopicExtractor.extractTopics() -- AI topic extraction -> internal link candidates
-   |  LinkResolver.findInternalLinks() -- graph hops + shared tags + folder proximity
-   |  PromptBuilder.suggestExternalLinks() -- AI with conservative prompt
-   |  PromptBuilder.suggestFrontmatter() -- AI with allowlisted keys
-   |
-4. LinkResolver.mergeTopicCandidates(topicLinks, graphLinks) -- merge and deduplicate
-   |
-5. EnrichmentStore.save(proposal)
-   |
-6. onViewRefreshNeeded() --> main.refreshUnifiedView()
-   |
-7. User review via UnifiedProposalView:
-   Accept Selected --> EnrichmentApplier.apply(proposal, accepted)
-   Reject --> status = 'rejected'
+enrich(filePath, trigger)
+  └─ isExcluded(file)  ← isPathExcluded('enrichment', settings) + matchesExcludeTag
+  └─ enrichFile(file, trigger) [private]
+       ├─ MetadataClassifier.classify()        → TagCandidate[]
+       ├─ LinkResolver.findInternalLinks()      → InternalLinkCandidate[] (graph)
+       ├─ TopicExtractor.extractTopics()        → InternalLinkCandidate[] (topics)
+       ├─ PromptBuilder.suggestExternalLinks()  → ExternalLinkCandidate[]
+       └─ PromptBuilder.suggestFrontmatter()    → FrontmatterEnrichment[]
+       └─ LinkResolver.mergeTopicCandidates(topicLinks, graphLinks)
+       └─ EnrichmentStore.save(proposal)
+  └─ maybeAutoAccept(id)  [if shouldAutoAccept()]
+  └─ onViewRefreshNeeded()
 ```
 
-## Vault Scan Flow (scanVault)
-
 ```
-Phase 1: Collect eligible files, warm VaultAnalyzer caches (tag index, link graph)
-Phase 2: User confirmation via NotificationManager.confirm()
-Phase 3: Cancellable per-file enrichFile() -- accumulates TopicExtractor pending topics
-Phase 4: TopicExtractor.resolveNewNoteCandidates() -- topics referenced by 2+ notes
-         become new-note link suggestions, injected into existing proposals via
-         LinkResolver.mergeTopicCandidates()
-```
-
-On error or cancel in Phase 3: clears pending topics, rejects all created proposals.
-
-## Metadata Classification (metadata-classifier.ts)
-
-Replaces the former `TagScorer`. Tags are now rare, purposeful metadata classifiers (status, type, source) rather than topic labels.
-
-```
-1. AI classifies note content against user-defined tagVocabulary
-2. Validates results against vocabulary lookup -- rejects hallucinated tags
-3. Filters out tags already on the note
-4. Validates tag format: ^[a-zA-Z0-9][a-zA-Z0-9_/-]{0,49}$
-5. Sorts by confidence descending, caps at maxTags
+scanVault(folderPath?, skipConfirmation?, onlyFile?)
+  Phase 1: collect eligible files; warm VaultAnalyzer caches
+  Phase 2: user confirmation via NotificationManager.confirm() [skipped if skipConfirmation]
+  Phase 3: cancellable per-file enrichFile(); CheckpointManager tracks progress
+  Phase 4: TopicExtractor.resolveNewNoteCandidates()
+           → topics cited by 2+ notes → new-note InternalLinkCandidates
+           → injected into existing proposals via LinkResolver.mergeTopicCandidates()
+  On cancel/error: discard checkpoint, rejectProposalBatch(), clearPending()
 ```
 
-TagCandidate output: `{ tag, category, confidence, rawScore: 0, weightedScore: confidence, sources: [] }`
-
-## Topic Extraction (topic-extractor.ts)
-
-Converts note content into internal link candidates via AI-identified topics.
-
 ```
-1. AI extracts 5-15 key concepts/topics from note content
-2. Matched topics (existing vault notes by title) become InternalLinkCandidate immediately
-   - Score: 0.7 base + proximity * 0.2
-3. Unmatched topics accumulated in pendingNewTopics (Map<normalized, {displayText, notePaths}>)
-4. resolveNewNoteCandidates(): only topics with 2+ referencing notes become suggestions
-   - Score: 0.5 fixed
-5. clearPending(): discards accumulated state (called after single-note enrichment)
+User review (UnifiedProposalView):
+  Accept Selected → acceptSelectedFromView(id, accepted)
+                    → EnrichmentApplier.apply(proposal, accepted)
+                    → EnrichmentStore.updateStatus(id, 'accepted'|'partially-accepted')
+  Reject          → rejectFromView(id)
+                    → EnrichmentStore.updateStatus(id, 'rejected')
 ```
 
-## Link Resolution Strategy (link-resolver.ts)
+## Exclusion Handling (#307)
 
-Graph-based candidates from three sources (scored by proximity):
-1. Files 1-2 hops away in link graph (proximity * 0.25)
-2. Files sharing 2+ tags (proximity * sharedCount * 0.15)
-3. Files in same/sibling folders (proximity * 0.15)
+Exclusion uses the centralized `src/shared/exclusions.ts` API. `excludeFolders` per module was removed; path exclusions are stored in `settings.exclusions: ExclusionRule[]` at the top level and scoped by feature name.
 
-`mergeTopicCandidates(topicCandidates, graphCandidates)`:
-- Topic relevance dominates; graph proximity adds a small bonus (existing.score * 0.2)
-- Deduplicates by targetPath, combines reasons
+```ts
+// index.ts:639-644
+private isExcluded(file: TFile): boolean {
+  const settings = this.getSettings();
+  return (
+    isPathExcluded(file.path, 'enrichment', settings) ||
+    matchesExcludeTag(file, settings.enrichment.excludeTags, this.plugin.app.metadataCache)
+  );
+}
+```
 
-Filtered by `internalLinkThreshold`, capped at `maxInternalLinks`.
-
-## Proximity Weight Algorithm (weight-calculator.ts)
-
-Pure function `computeProximityWeight(sourcePath, targetPath, config)`:
-1. Split paths into folder segments
-2. Find longest common prefix (shared ancestor depth)
-3. Hops = (sourceDepth - shared) + (targetDepth - shared)
-4. Map to tier: 0 hops = sameFolder, 1 = sibling, 2 = cousin, 3+ = distant
-5. Apply linear decay per hop beyond tier minimum
-6. Clamp to [minWeight, tierWeight]
-
-## Enrichment Application (enrichment-applier.ts)
-
-- Tags: merged into frontmatter `tags` array via `mergeTags()`
-- Internal links: appended as `## Related Notes` section with markers
-- External links: appended as `## References` section with markers
-- Frontmatter: keys added (never overwrites existing)
-- Markers: `%% synapse-enrichment-start/end %%` for idempotent updates
-- Undo: removes accepted tags, deletes added frontmatter keys, strips marker sections
-
-## Security
-
-- External URLs validated via `isValidExternalUrl()` (HTTP/HTTPS only)
-- Frontmatter keys validated: `^[a-z][a-z0-9_-]{0,49}$`, forbidden keys blocked (`__proto__`, `constructor`, etc.)
-- AI-generated display text/reasons sanitized (strips `[](){}|<>`)
-- Tags validated against alphanumeric pattern
-- `sanitizeAIResponse()` applied to all AI outputs
+`findMatchingRule(file.path, 'enrichment', settings)` is called on the manual-trigger path to surface the matching rule name in the user-facing notice.
 
 ## Settings Keys
 
-All under `settings.enrichment`:
+All under `settings.enrichment` unless noted:
 
-| Key | Controls |
-|-----|----------|
-| `enabled` | Module activation |
-| `autoEnrich` | Auto-trigger after elaboration/transcription |
-| `maxTags` | Max tags to suggest (default: 5) |
-| `maxInternalLinks` | Max related note links |
-| `maxExternalLinks` | Max external references (0 = disable) |
-| `maxTopicLinks` | Max topic-extracted link candidates per note (default: 10) |
-| `suggestNewNotes` | Enable new-note suggestions for unmatched topics (default: true) |
-| `tagVocabulary` | TagVocabularyEntry[] defining classification categories |
-| `internalLinkThreshold` | Min relevance score for links |
-| `weights.*` | Proximity weight configuration |
-| `enrichmentFolderPath` | Proposal JSON storage |
-| `exclusions` (top-level, feature `'enrichment'`) | Paths to skip (centralized) |
-| `excludeTags` | Tags that suppress enrichment |
-| `relatedNotesHeading` | Heading for internal links section |
-| `referencesHeading` | Heading for external refs section |
+| Key | Type | Controls |
+|-----|------|----------|
+| `enabled` | `boolean` | Module activation; gates command registration |
+| `autoEnrich` | `boolean` | Auto-trigger after elaboration/transcription/summarization |
+| `maxTags` | `number` | Max tags to suggest (default: 5) |
+| `maxInternalLinks` | `number` | Max related-note link suggestions |
+| `maxExternalLinks` | `number` | Max external references (0 = disable) |
+| `maxTopicLinks` | `number` | Max topic-extracted link candidates per note (default: 10) |
+| `suggestNewNotes` | `boolean` | Enable new-note suggestions for unmatched topics (default: true) |
+| `tagVocabulary` | `TagVocabularyEntry[]` | Classification categories and valid tags for `MetadataClassifier` |
+| `internalLinkThreshold` | `number` | Min relevance score to include a link candidate |
+| `weights` | `EnrichmentWeightSettings` | Proximity weight tiers for `computeProximityWeight` |
+| `enrichmentFolderPath` | `string` | Path to proposal JSON storage (default: `.synapse/enrichments`) |
+| `excludeTags` | `string[]` | Tags that suppress enrichment for a note |
+| `relatedNotesHeading` | `string` | Heading for the internal-links section |
+| `referencesHeading` | `string` | Heading for the external-links section |
+| `settings.exclusions` (top-level) | `ExclusionRule[]` | Path/glob exclusions scoped by feature `'enrichment'`; replaces removed per-module `excludeFolders` |
+| `settings.autoAccept.enrichment` (top-level) | `boolean` | Wired to `shouldAutoAccept` constructor param (#228) |
+
+## Invariants
+
+- Idempotency markers: `%% synapse-enrichment-start %%` / `%% synapse-enrichment-end %%` (constants `ENRICHMENT_START` / `ENRICHMENT_END` from `src/shared`). Applier strips existing marker sections before re-writing; undo deletes them. `enrichment-applier.ts:L36`
+- Frontmatter keys: never overwritten; `action: 'add'` skips if key exists; `action: 'merge'` appends to arrays
+- Frontmatter key allowlist: `^[a-z][a-z0-9_-]{0,49}$`; forbidden keys (`__proto__`, `constructor`, `prototype`, etc.) blocked (`prompt-builder.ts:L9-16`)
+- Tag format: `^[a-zA-Z0-9][a-zA-Z0-9_/-]{0,49}$` (`metadata-classifier.ts:L5`)
+- External URL validation: HTTP/HTTPS only (`prompt-builder.ts:L19-24`)
+- New-note topic threshold: topic must appear in 2+ notes during a vault scan to become a suggestion (`topic-extractor.ts:L118`)
+- Double-acceptance guard: `acceptSelected` and `maybeAutoAccept` bail immediately if `proposal.status !== 'pending'`
+- Auto-accept (#228) runs after Phase 4 in `scanVault` so merged cross-note candidates are included before acceptance

--- a/src/image/AGENTS.md
+++ b/src/image/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-19
 ---
 
 # Image Module
@@ -12,7 +12,12 @@ Exported from `index.ts`:
 
 ```ts
 class ImageModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager)
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    checkpointManager: CheckpointManager
+  )
   onload(): Promise<void>
   onunload(): void
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
@@ -21,16 +26,23 @@ class ImageModule {
   onExtractionComplete: ((filePath: string) => void) | null
 }
 
+// note-scanner.ts (also exported from index.ts)
 function findImageEmbeds(content: string, sourcePath: string, metadataCache: MetadataCache): ImageEmbed[]
+function hasExtractionBelow(lines: string[], embedLine: number, fileName: string): boolean
+const IMAGE_EXTENSIONS: RegExp  // /\.(png|jpg|jpeg|gif|webp|bmp|tiff)$/i
+const IMAGE_EMBED_REGEX: RegExp  // /!\[\[([^\]]+\.(?:png|jpg|jpeg|gif|webp|bmp|tiff))\]\]/gi
 
 // preprocess.ts (also exported from index.ts)
-function preprocessImage(data: ArrayBuffer, mediaType: string, maxSizeMb: number): Promise<{ data: string; mediaType: string }>
+function preprocessImage(data: ArrayBuffer, mediaType: string, maxBytes: number): Promise<PreprocessResult>
 // re-exported from shared/encoding.ts for back-compat (canonical home is shared):
 function arrayBufferToBase64(buffer: ArrayBuffer): string
 function base64EncodedLength(byteLength: number): number
 
-const IMAGE_EXTENSIONS: RegExp   // /\.(png|jpg|jpeg|gif|webp|bmp|tiff)$/i
-const IMAGE_EMBED_REGEX: RegExp  // /!\[\[([^\]]+\.(?:png|jpg|jpeg|gif|webp|bmp|tiff))\]\]/gi
+interface PreprocessResult {
+  data: ArrayBuffer
+  mediaType: string
+  downscaled: boolean
+}
 
 interface ImageEmbed {
   fileName: string
@@ -42,6 +54,9 @@ interface OCRResult {
   text: string
   sourceName?: string
 }
+
+// settings-section.ts (also exported from index.ts)
+function renderImageSettings(ctx: SettingsSectionContext): void
 ```
 
 ## File Inventory
@@ -49,34 +64,46 @@ interface OCRResult {
 | File | Class/Export | Purpose |
 |------|-------------|---------|
 | `types.ts` | `ImageEmbed`, `OCRResult` | Type definitions |
-| `extractor.ts` | `ImageExtractor` | Multi-modal AI OCR via `AIClient.chat()` with `ContentBlock[]` |
-| `preprocess.ts` | `preprocessImage`; re-exports `arrayBufferToBase64`, `base64EncodedLength` | Auto-downscale/re-encode when payload exceeds `maxImageSizeMb`. Base64 helpers now live in `shared/encoding.ts` (imported via the `shared` barrel, not `shared/encoding` directly) and are re-exported here for back-compat |
-| `note-scanner.ts` | `findImageEmbeds`, `hasExtractionBelow`, `IMAGE_EXTENSIONS`, `IMAGE_EMBED_REGEX` | Scan note content for image embeds |
-| `note-scanner.test.ts`, `extractor.test.ts`, `preprocess.test.ts` | Tests | |
-| `index.ts` | `ImageModule` | Orchestrator, public extraction methods, checkpoint management |
+| `extractor.ts` | `ImageExtractor` | Multi-modal AI OCR via `AIClient.chat()` with `ContentBlock[]`; applies vision model override |
+| `preprocess.ts` | `preprocessImage`, re-exports `arrayBufferToBase64`, `base64EncodedLength` | Auto-downscale/re-encode when payload exceeds `maxImageSizeMb`. Base64 helpers live in `shared/encoding.ts` and are re-exported here for back-compat |
+| `note-scanner.ts` | `findImageEmbeds`, `hasExtractionBelow`, `IMAGE_EXTENSIONS`, `IMAGE_EMBED_REGEX` | Scan note content for image embeds; skip embeds with existing OCR callouts |
+| `settings-section.ts` | `renderImageSettings` | Settings accordion renderer |
+| `index.ts` | `ImageModule`, re-exports | Orchestrator, public extraction methods, checkpoint management |
+| `extractor.test.ts` | Tests | `ImageExtractor` tests |
+| `note-scanner.test.ts` | Tests | `findImageEmbeds` tests |
+| `preprocess.test.ts` | Tests | `preprocessImage` tests |
+| `index.test.ts` | Tests | `ImageModule` integration tests |
+| `settings-section.test.ts` | Tests | Settings section rendering tests |
 
 ## Data Flow
 
 ```
 1. User triggers via NoteMediaModal (in transcription/) or direct API call
    |
-2a. extractFromFile(file) -- single file to active note
-   |  Reads binary, calls ImageExtractor.extract(), builds callout, appends to active note
+2a. extractFromFile(file) -- single image file to active note
+   |  findMatchingRule(activeFile.path, 'image', settings) -- skip if excluded (with Notice)
+   |  Reads binary, calls ImageExtractor.extract(), sanitizeAIResponse()
+   |  buildCallout(CALLOUT_TYPES.ocr, 'OCR of filename', text, true)
+   |  Appends to active note
    |
 2b. extractAndInsert(noteFile, embeds) -- batch from note scan
-   |  Creates checkpoint, processes embeds in reverse line order, 2s delay between API calls
+   |  isPathExcluded(noteFile.path, 'image', settings) -- silent skip
+   |  Creates checkpoint (module: 'image')
+   |  Processes embeds in reverse line order, 2 s delay between API calls
+   |  All inserts applied atomically to fresh content
    |  Cancellable via NotificationManager operation handle
    |
 3. ImageExtractor.extract(imageData, fileName)
-   |  Converts ArrayBuffer to base64
-   |  Determines MIME type from extension
-   |  Builds ContentBlock[] with image + text prompt
-   |  Overrides ai.model with image.visionModel if set (restores in finally block)
+   |  preprocessImage(data, sourceMediaType, maxBytes) -- downscale if needed
+   |  arrayBufferToBase64(processed.data)
+   |  Builds ContentBlock[]: image block + text prompt
+   |  Overrides settings.ai.model with image.visionModel if set (restores in finally)
    |  AIClient.chat() with system prompt "You are an OCR assistant"
+   |  Returns: OCRResult { text, sourceName }
    |
-4. sanitizeAIResponse() on output
+4. sanitizeAIResponse(result.text)
    |
-5. Result wrapped in callout block:
+5. Result wrapped in callout block (collapsed):
    > [!synapse-ocr]- OCR of filename.png
    > ...extracted text...
 ```
@@ -86,18 +113,27 @@ interface OCRResult {
 `findImageEmbeds(content, sourcePath, metadataCache)` in `note-scanner.ts`:
 - Regex: `![[*.png|jpg|jpeg|gif|webp|bmp|tiff]]`
 - Resolves files via `metadataCache.getFirstLinkpathDest()`
-- Skips embeds with existing OCR callout below (checks 3 lines)
+- Skips embeds with an existing OCR callout in the 3 lines below (`hasExtractionBelow`)
 - Returns `ImageEmbed[]` with file references and line numbers
 
 ## Vision Model Override
 
-The `ImageExtractor` temporarily swaps `settings.ai.model` with `settings.image.visionModel` for the duration of the API call. If `visionModel` is empty, falls back to `ai.model`.
+`ImageExtractor.extract()` temporarily mutates `settings.ai.model` to `settings.image.visionModel` for the duration of the API call. Restored in a `finally` block. If `visionModel` is empty, falls back to `ai.model`.
+
+## Exclusion Behavior
+
+Path-based exclusions use centralized `settings.exclusions: ExclusionRule[]` (#307):
+- `extractFromFile`: uses `findMatchingRule(path, 'image', settings)` — emits a Notice naming the matched rule.
+- `extractAndInsert`: uses `isPathExcluded(path, 'image', settings)` — silent skip.
+- No per-module `excludeFolders` field exists.
+
+The image module has no `excludeTags` setting.
 
 ## Checkpoint Behavior
 
-- `extractAndInsert()` creates a checkpoint with module `'image'`
-- Items tracked per embed (id: `image-{index}-{fileName}`)
-- `resumeFromCheckpoint()` cannot directly resume (similar to deep-dive) -- discards checkpoint and notifies user to re-run
+- `extractAndInsert()` creates a checkpoint with `module: 'image'`
+- Items tracked per embed (`id: 'image-{index}-{fileName}'`)
+- `resumeFromCheckpoint()` cannot resume mid-batch: discards the checkpoint and notifies the user to re-run
 
 ## Settings Keys
 
@@ -105,31 +141,45 @@ All under `settings.image`:
 
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
-| `enabled` | boolean | true | Module activation |
-| `visionModel` | string | '' | Override AI model for vision (empty = use `ai.model`) |
-| `language` | string | '' | Language hint (reserved for future use) |
-| `maxImageSizeMb` | number | 5 | Max base64 payload (MB) before `preprocessImage` auto-downscales (API limit is 5 MB) |
+| `enabled` | boolean | true | Module activation; also gates image analysis in elaboration proposer |
+| `visionModel` | string | `''` | Override AI model for vision calls (empty = use `ai.model`) |
+| `language` | string | `''` | Language hint (reserved, not yet consumed) |
+| `maxImageSizeMb` | number | 5 | Max base64 payload (MB) before `preprocessImage` auto-downscales |
 
-## Commands
+## Commands Registered
 
-No commands registered directly. Image OCR is accessible via:
-- `synapse:transcribe-note-media` -> `ImageModule.extractAndInsert(file, embeds)`
+No commands registered directly by `ImageModule.onload()`. Image OCR is accessible via:
+- Command `synapse:transcribe-note-media` (registered by `transcription` module) calls `ImageModule.extractAndInsert(file, embeds)`
 - Direct API: `ImageModule.extractFromFile(file)`
 
 ## Dependencies
 
-All imports resolve through the `shared` barrel (`../shared`), never an internal `shared/*` file.
+All imports resolve through the `shared` barrel (`../shared`), never an internal `shared/*` file directly.
 
 | Import | From |
 |--------|------|
 | `AIClient`, `ContentBlock` | `shared` |
-| `base64EncodedLength` (preprocess) | `shared` (canonical: `shared/encoding`) |
 | `NotificationManager` | `shared` |
 | `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `shared` |
 | `buildCallout`, `CALLOUT_TYPES` | `shared` |
 | `sanitizeAIResponse` | `shared` |
 | `generateId` | `shared` |
+| `isPathExcluded`, `findMatchingRule` | `shared` |
+| `base64EncodedLength` (in `preprocess.ts`) | `shared` (canonical: `shared/encoding`) |
+
+Consumed by:
+- `elaboration/image-analyzer.ts` imports `preprocessImage` and `arrayBufferToBase64` from the `image` barrel
+- `transcription/` module invokes `ImageModule.extractAndInsert()`
 
 ## Supported Image Formats
 
-png, jpg, jpeg, gif, webp, bmp, tiff
+`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `tiff`
+
+GIF payloads that exceed `maxImageSizeMb` are passed through untouched (non-rasterizable; no downscale attempted).
+
+## Invariants / Gotchas
+
+- `extractAndInsert` processes embeds in **reverse line order** so that inserts at higher line numbers do not shift lower line numbers. All inserts are applied atomically via `vault.process()`.
+- A 2 s delay (`window.setTimeout`) is inserted between successive API calls to respect rate limits.
+- `preprocessImage` is only available in Obsidian's Electron renderer (needs `createEl` + `createImageBitmap` or `Image`). In unit tests without DOM mocks it degrades gracefully (returns original bytes, `downscaled: false`).
+- `arrayBufferToBase64` and `base64EncodedLength` canonical home is `shared/encoding.ts`; `preprocess.ts` re-exports them for back-compat so callers that previously imported from `image` continue to work.

--- a/src/intake/AGENTS.md
+++ b/src/intake/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-19
 ---
 
 # Intake Module
@@ -36,22 +36,27 @@ interface IntakeDeps {
 class IntakeDispatcher {
   route(file: TFile, parsed: ParsedNote): IntakeRoute   // classifies note into a route
 }
+
+// settings-section.ts
+function renderIntakeSettings(ctx: SettingsSectionContext): void
 ```
 
 ## File Inventory
 
 | File | Exports | Purpose |
 |------|---------|---------|
-| `index.ts` | `IntakeModule`, `IntakeDispatcher`, `IntakeDeps`, `IntakeRoute`, `SYNAPSE_PROCESSED_FLAG`, `SYNAPSE_PROCESSED_AT_FLAG` | Folder watcher + processor |
+| `index.ts` | `IntakeModule`, `IntakeDispatcher`, `IntakeDeps`, `IntakeRoute`, `SYNAPSE_PROCESSED_FLAG`, `SYNAPSE_PROCESSED_AT_FLAG`, `renderIntakeSettings` | Barrel + folder watcher |
 | `intake-dispatcher.ts` | `IntakeDispatcher` | Routes a parsed note to an `IntakeRoute` |
-| `types.ts` | route + deps types, flag constants | Type model |
-| `intake-module.test.ts`, `intake-dispatcher.test.ts` | Tests | |
+| `types.ts` | `IntakeRoute`, `IntakeDeps`, `SYNAPSE_PROCESSED_FLAG`, `SYNAPSE_PROCESSED_AT_FLAG` | Type model |
+| `settings-section.ts` | `renderIntakeSettings` | Settings UI accordion (#243) |
+| `intake-module.test.ts`, `intake-dispatcher.test.ts`, `intake-organize-e2e.test.ts`, `settings-section.test.ts` | Tests | |
 
 ## Data Flow
 
 ```
 vault create/modify event
-  --> handleEvent: cheap sync guards (is .md, intake.enabled, in intake folder, not in-flight)
+  --> handleEvent: cheap sync guards (is .md, intake.enabled, in intake folder,
+                   not capture-log subfolder, not path-excluded, not in-flight)
   --> scheduleFlush(path): per-path debounce, resets timer on every event (settle window)
         settleWindowMs = intake.settleSeconds * 1000 (fallback 5000ms if missing/invalid)
   --> flush(path) after the note is quiet for the full window:
@@ -70,6 +75,7 @@ vault create/modify event
 
 - Idempotency: a note carrying `synapse-processed` (boolean `true` or string `'true'`) is never reprocessed; this also suppresses the modify echo from the flag-stamp write.
 - In-flight guard: paths being flushed are tracked so the stamp/move rename echo does not re-enter `flush`.
+- Path exclusion: `isPathExcluded(file.path, 'intake', settings)` is checked before scheduling; excluded notes are silently skipped (#307).
 - Primary mover is organize (last pipeline phase). `moveWhenDone` is a FALLBACK mover, applied only when organize left the note inside the intake folder (low-confidence / no-op).
 - Stamp-before-move: the processed flag is written before any relocation so idempotency survives the move's rename echo.
 - Failure leaves the note un-stamped (retriable); errors surface via `notifications.notifyError`.
@@ -77,9 +83,12 @@ vault create/modify event
 ## Capture Log (#224)
 
 When `intake.captureLog` is true and a processed note actually left the intake folder, a dated breadcrumb
-is written to `‹intakeFolder›/‹captureLogFolder›/‹YYYY-MM-DD› — ‹title›.md` (default subfolder `_captured`).
+is written to `<intakeFolder>/<captureLogFolder>/<YYYY-MM-DD> — <title>.md` (default subfolder `_captured`).
 The capture-log subfolder is excluded from the watcher and breadcrumbs are stamped `synapse-processed: true`
 (defense-in-depth) so they are never re-ingested — preventing an infinite ingest loop.
+
+Collision policy (#227): two distinct notes that sanitize to the same dated title get a uniqueness suffix
+(` (2)`, ` (3)`, ...). Re-processing the same note overwrites its own breadcrumb idempotently.
 
 ## Settings Keys
 
@@ -99,7 +108,7 @@ All under `settings.intake` (`IntakeSettings`):
 
 | Import | From |
 |--------|------|
-| `NotificationManager`, `ensureFolder`, `fetchArticleContent`, `parseFrontmatter`, `serializeFrontmatter`, `writeNote` | `../shared` |
+| `NotificationManager`, `ensureFolder`, `fetchArticleContent`, `isPathExcluded`, `parseFrontmatter`, `serializeFrontmatter`, `writeNote`, `classifyUrl`, `extractUrls`, `ParsedNote`, `SettingsSectionContext` | `../shared` |
 | `fireOnFile`, `transcribeUrlToNote` | injected via `IntakeDeps` (wired in `main.ts`) |
 
 Architecture rule: intake imports no feature module. `fireOnFile` is `SynapseRunner.fireOnFile` injected by `main.ts`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -454,6 +454,9 @@ export default class SynapsePlugin extends Plugin {
 		this.title?.onunload();
 		this.rem?.onunload();
 		this.intake?.onunload();
+		// Stop any animated-ellipsis intervals left running by in-flight
+		// operations so a disable mid-operation leaves no orphaned timer.
+		this.notifications?.dispose();
 	}
 
 	async loadSettings(): Promise<void> {

--- a/src/organize/AGENTS.md
+++ b/src/organize/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-07
+last-updated: 2026-06-19
 ---
 
 # organize module
@@ -11,58 +11,105 @@ AI-powered semantic directory structuring. Analyzes note content to determine th
 ```ts
 class OrganizeModule {
   onViewRefreshNeeded: (() => Promise<void>) | null
+  onOpenProposalView: (() => void) | null  // wired by main.ts (#340)
 
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, checkpointManager: CheckpointManager)
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    checkpointManager: CheckpointManager,
+    registrar: CommandRegistrar,
+    shouldAutoAccept?: () => boolean
+  )
+
   onload(): Promise<void>
   onunload(): void
-  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   getPendingProposals(): Promise<OrganizeProposal[]>
+  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   organizeNote(file: TFile): Promise<OrganizeResult | null>
-  scanDirectory(folderPath?: string): Promise<number>
-  acceptProposal(id: string): Promise<void>
+  scanDirectory(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
+  acceptProposal(id: string, options?: { silent?: boolean }): Promise<void>
   rejectProposal(id: string): Promise<void>
 }
+
+function buildSummaryPath(timestamp: string): string
 ```
 
-Exported: `ContentAnalyzer`, `DirectoryMatcher`, `buildSummaryPath(timestamp: string): string`
+Re-exported classes: `ContentAnalyzer`, `DirectoryMatcher`
 
 Exported types: `OrganizeProposal`, `OrganizeSnapshot`, `OrganizeResult`, `ContentAnalysis`, `DirectoryScore`, `NoteTopic`, `OrganizeAction`, `OrganizeProposalStatus`
 
-## Internal Components
+Re-exported settings renderer: `renderOrganizeSettings` (from `./settings-section`)
+
+## ContentAnalyzer (`content-analyzer.ts`)
+
+```ts
+class ContentAnalyzer {
+  constructor(app: App, getSettings: () => SynapseSettings)
+  analyze(file: TFile): Promise<ContentAnalysis>
+  extractTopics(body: string, tags: string[]): Promise<NoteTopic[]>
+  parseTopicResponse(raw: string): NoteTopic[]
+  topicsFromTags(tags: string[]): NoteTopic[]
+}
+```
+
+Note: `extractTopics` on `ContentAnalyzer` takes `(body: string, tags: string[])` — different from `TopicAnalyzer.extractTopics` in `deep-dive` which takes `(content, title, ancestorTopics)`.
+
+## DirectoryMatcher (`directory-matcher.ts`)
+
+```ts
+class DirectoryMatcher {
+  constructor(app: App)
+  scoreDirectories(analysis: ContentAnalysis): DirectoryScore[]
+  determineAction(
+    analysis: ContentAnalysis,
+    minScoreThreshold?: number,    // default 0.6
+    confidenceThreshold?: number   // default 0.9
+  ): OrganizeAction
+  scoreDirectory(dirPath: string, analysis: ContentAnalysis, noteDir: string): number
+  collectDirectories(): string[]
+  buildDirectoryPath(topicLabel: string): string
+}
+```
+
+## Internal File Map
 
 | File | Class/Function | Role |
 |------|---------------|------|
-| `content-analyzer.ts` | `ContentAnalyzer` | AI topic extraction from note content, tags, and links |
-| `directory-matcher.ts` | `DirectoryMatcher` | Matches topics to existing directories or proposes new ones |
+| `index.ts` | `OrganizeModule`, `buildSummaryPath` | Module entry point and public API |
+| `content-analyzer.ts` | `ContentAnalyzer` | AI topic extraction from note body, tags, and links |
+| `directory-matcher.ts` | `DirectoryMatcher` | Scores existing directories; proposes new ones |
 | `folder-normalize.ts` | `singularize`, `canonicalKey`, `editDistance`, `isFuzzyMatch` | Morphology-aware canonical keys for coalescing similar folder names (#172) |
 | `organize-store.ts` | `OrganizeStore` | JSON persistence for proposals and move snapshots |
+| `settings-section.ts` | `renderOrganizeSettings` | Settings UI renderer |
 | `types.ts` | -- | All organize types |
 
-`folder-normalize` is the single source of truth for folder-name coalescing,
-reused in three places: `DirectoryMatcher.buildDirectoryPath` emits new folders
-in canonical (singular) form; `DirectoryMatcher.scoreDirectory` matches topics to
-existing folders on canonical keys plus a conservative edit-distance tier; and
-`OrganizeModule` deduplicates proposed directories across a batch scan.
+`folder-normalize` is the single source of truth for folder-name coalescing, reused in three places: `DirectoryMatcher.buildDirectoryPath` emits new folders in canonical (singular) form; `DirectoryMatcher.scoreDirectory` matches topics to existing folders on canonical keys plus a conservative edit-distance tier; and `OrganizeModule` deduplicates proposed directories across a batch scan.
 
 ## Data Flow
 
 ```
 organizeNote(file) / scanDirectory()
   --> ContentAnalyzer.analyze(file)  [AI: extract topics]
-  --> DirectoryMatcher.determineAction(analysis)
+  --> DirectoryMatcher.determineAction(analysis, confidenceThreshold)
     if existing dir matches:
       --> vault.rename(file, newPath)  [direct move]
       --> OrganizeStore.saveSnapshot()  [undo backup]
     if new dir needed:
-      --> OrganizeStore.saveProposal()  [user review]
+      --> OrganizeStore.saveProposal()
+      --> maybeAutoAccept()  [if shouldAutoAccept() -> acceptProposal()]
 
-acceptProposal(id)
+acceptProposal(id, options?)
   --> ensureFolder(proposedDirectory)
   --> OrganizeStore.saveSnapshot()
   --> vault.rename(file, newPath)
   --> OrganizeStore.updateProposalStatus('accepted')
+  --> writeOrganizeSummary(moveRecords)  [.synapse/organize/summaries/]
 
-undoOrganize(file)
+rejectProposal(id)
+  --> OrganizeStore.updateProposalStatus('rejected')
+
+undoOrganize(file)  [command: 'undo-organize', private]
   --> OrganizeStore.loadSnapshot(filePath)
   --> vault.rename(file, originalPath)
   --> OrganizeStore.removeSnapshot()
@@ -71,9 +118,9 @@ undoOrganize(file)
 ## Directory Scan (checkpointed)
 
 ```
-scanDirectory(folderPath?)
-  Phase 1: Collect eligible files
-  Phase 2: User confirmation
+scanDirectory(folderPath?, skipConfirmation?, onlyFile?)
+  Phase 1: Collect eligible files (filtered by isExcluded)
+  Phase 2: User confirmation (skipped when skipConfirmation=true)
   Phase 3: Checkpointed processing
     --> checkpointManager.create(module: 'organize', items)
     --> addDeferredTask('refresh-sidebar-view')
@@ -117,19 +164,56 @@ interface OrganizeResult {
   action: OrganizeAction
   proposalCreated: boolean
   movedDirectly: boolean
+  autoAccepted?: boolean  // true when a new-dir proposal was immediately accepted (#228)
 }
 ```
 
+## Commands Registered
+
+| Command ID | Enabled When | Description |
+|------------|-------------|-------------|
+| `organize-current-note` | `settings.organize.enabled` | Organize the active note |
+| `scan-directory-organize` | `settings.organize.enabled` | Scan a directory for organization (opens FolderPickerModal) |
+| `undo-organize` | `settings.organize.enabled` | Undo the last organize move on the active note |
+
+## Settings Keys
+
+Path exclusion is centralized (#307): `settings.exclusions: ExclusionRule[]` consulted via `isPathExcluded(path, 'organize', settings)` and `findMatchingRule`. There is no per-module `excludeFolders` key.
+
+| Key | Type | Default |
+|-----|------|---------|
+| `settings.organize.enabled` | `boolean` | `true` |
+| `settings.organize.proposalFolderPath` | `string` | `.synapse/organize/proposals` |
+| `settings.organize.snapshotFolderPath` | `string` | `.synapse/organize/snapshots` |
+| `settings.organize.excludeTags` | `string[]` | `['no-organize']` |
+| `settings.organize.organizeConfidenceThreshold` | `number` | `0.9` |
+| `settings.autoAccept.organize` | `boolean` | `false` |
+| `settings.exclusions` | `ExclusionRule[]` | `[{pattern:'.synapse/**',features:'all'}, {pattern:'templates/**',features:'all'}]` |
+
 ## Dependencies
 
-- `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder, writeNote, generateOrganizeSummary, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask, MoveRecord)
-- `settings.ts` (SynapseSettings)
+In: `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder, writeNote, generateOrganizeSummary, CheckpointManager, generateId, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule, Checkpoint, CheckpointWorkItem, DeferredTask, MoveRecord), `settings.ts` (SynapseSettings), `commands.ts` (CommandRegistrar)
+
+Out: `ContentAnalyzer` and `DirectoryMatcher` are re-exported for use by `deep-dive` (auto-organize nesting mode).
+
+## Invariants / Gotchas
+
+- `acceptProposal` guards against double-acceptance: no-ops if `proposal.status !== 'pending'`.
+- Move skips if a file already exists at the destination (returns null, does not overwrite).
+- Batch scan coalesces near-identical proposed directories via `batchProposedDirs` map — variants like "model"/"models" resolve to a single folder (#172).
+- `organizeConfidenceThreshold` gates new-directory proposals; `minScoreThreshold` (0.6, hardcoded in `determineAction` call site) gates existing-directory moves.
+- Summary notes written to `.synapse/organize/summaries/{YYYY-MM-DD}-organize-summary.md`.
+- `deep-dive` calls `onOrganizeRequested` which invokes `organizeNote` on accepted deep-dive notes (when `deepDive.autoOrganizeOnAccept` is true).
 
 ## Tests
 
-- `content-analyzer.test.ts`
-- `directory-matcher.test.ts`
-- `folder-normalize.test.ts`
-- `organize-store.test.ts`
-- `auto-accept.test.ts`
-- `batch-dedup.test.ts`
+| File | Covers |
+|------|--------|
+| `content-analyzer.test.ts` | ContentAnalyzer.analyze, extractTopics, parseTopicResponse |
+| `directory-matcher.test.ts` | DirectoryMatcher.scoreDirectories, determineAction, buildDirectoryPath |
+| `folder-normalize.test.ts` | singularize, canonicalKey, editDistance, isFuzzyMatch |
+| `organize-store.test.ts` | OrganizeStore persistence |
+| `auto-accept.test.ts` | Auto-accept flow (#228) |
+| `batch-dedup.test.ts` | Batch directory coalescing (#172) |
+| `settings-section.test.ts` | Settings UI renderer |
+| `review-toast.test.ts` | Review toast notification |

--- a/src/pipeline/AGENTS.md
+++ b/src/pipeline/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-19
 ---
 
 # Pipeline Module
@@ -42,8 +42,8 @@ class SynapseRunner {
 |------|---------|---------|
 | `types.ts` | `PipelineModuleKey`, `PipelineModuleMap`, `PipelinePhase`, `PipelineScanFn`, `SYNAPSE_PIPELINE` | Phase model + ordered phase list |
 | `synapse-runner.ts` | `SynapseRunner` | Sequential phase executor with per-phase progress + error isolation |
+| `index.ts` | re-exports all of the above | Barrel |
 | `synapse-runner.test.ts`, `fire-flow-gate.test.ts` | Tests | |
-| `index.ts` | re-exports | Barrel |
 
 ## Ordered Phases (`SYNAPSE_PIPELINE`)
 

--- a/src/rem/AGENTS.md
+++ b/src/rem/AGENTS.md
@@ -1,63 +1,80 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-19
 ---
 
 # REM Module
 
 REM (Re-link & Enrich Mappings): discovers linkable references in note text (literal title/alias matches plus optional AI semantic matches) and proposes in-place `[[wikilink]]` insertions. Accepting a proposal rewrites the note body. Participates in the Fire Synapse pipeline (phase 4) and the unified proposal view.
 
-## Public API
-
-Exported from `index.ts`:
+## Public API (`index.ts`)
 
 ```ts
 class RemModule {
+  onViewRefreshNeeded: (() => Promise<void>) | null
+  onOpenProposalView: (() => void) | null
+
   constructor(
     plugin: Plugin,
     getSettings: () => SynapseSettings,
     notifications: NotificationManager,
     checkpointManager: CheckpointManager,
     registrar: CommandRegistrar,
-    shouldAutoAccept?: () => boolean,        // #228; default () => false
+    shouldAutoAccept?: () => boolean    // #228; default () => false
   )
-  onload(): Promise<void>                    // inits store/scanner/matcher/applier, registers commands
+  onload(): Promise<void>
   onunload(): void
   remScanNote(filePath: string): Promise<RemProposal | null>
-  remScanDirectory(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>  // PipelineScanFn
+  remScanDirectory(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   acceptProposal(id: string, acceptedMatchTexts: string[], options?: { silent?: boolean }): Promise<void>
   rejectProposal(id: string): Promise<void>
-  undoProposal(id: string): Promise<void>    // restore originalContent snapshot
+  undoProposal(id: string): Promise<void>
   getPendingProposals(): Promise<RemProposal[]>
-  onViewRefreshNeeded: (() => Promise<void>) | null
 }
+```
 
-// types.ts
+Exported types: `RemProposal`, `RemLinkCandidate`, `RemOccurrence`, `RemSettings`
+
+Note: `RemMatchType` and `RemProposalStatus` are defined in `types.ts` but not re-exported from `index.ts`. Import them directly from `./types` if needed.
+
+Exported functions: `renderRemSettings(ctx: SettingsSectionContext): void`
+
+## Types (`types.ts`)
+
+```ts
 type RemMatchType = 'title' | 'alias' | 'semantic'
 type RemProposalStatus = 'pending' | 'accepted' | 'partially-accepted' | 'rejected'
 
-interface RemOccurrence { lineNumber: number; lineText: string; startOffset: number; endOffset: number }
+interface RemOccurrence {
+  lineNumber: number      // zero-based line number in source note
+  lineText: string        // full text of the matched line
+  startOffset: number     // start offset within line
+  endOffset: number       // end offset within line (exclusive)
+}
+
 interface RemLinkCandidate {
-  targetPath: string
-  targetDisplayName: string
-  matchedText: string
+  targetPath: string          // vault path of target note
+  targetDisplayName: string   // basename without extension
+  matchedText: string         // text in source note that was matched
   matchType: RemMatchType
   occurrences: RemOccurrence[]
   confidence: number          // 1.0 for title/alias; AI-assigned for semantic
 }
+
 interface RemProposal {
   id: string
   sourceNotePath: string
   createdAt: string
   candidates: RemLinkCandidate[]
   status: RemProposalStatus
-  acceptedLinks?: string[]    // accepted matchedTexts (set on accept)
-  originalContent?: string    // pre-apply snapshot (set on accept, for undo)
+  acceptedLinks?: string[]      // accepted matchedTexts (set on accept)
+  originalContent?: string      // pre-apply snapshot (set on accept, for undo)
 }
+
 interface RemSettings {
   enabled: boolean
   semanticMatching: boolean
-  confidenceThreshold: number
+  confidenceThreshold: number   // minimum confidence for semantic matches (0-1)
   maxLinksPerNote: number
   remFolderPath: string
 }
@@ -67,58 +84,118 @@ interface RemSettings {
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `index.ts` | `RemModule`, type re-exports | Orchestrator, commands, scan + accept/reject/undo |
+| `index.ts` | `RemModule`, type + fn re-exports | Orchestrator, commands, scan + accept/reject/undo |
 | `types.ts` | `RemProposal`, `RemLinkCandidate`, `RemOccurrence`, `RemMatchType`, `RemProposalStatus`, `RemSettings` | Type model |
 | `mention-scanner.ts` | `MentionScanner` | Phase 1: literal title/alias mention scanning |
 | `semantic-matcher.ts` | `SemanticMatcher` | Phase 2: optional AI semantic matching |
 | `rem-applier.ts` | `RemApplier` | Inserts `[[wikilinks]]` into note body for accepted candidates |
 | `rem-store.ts` | `RemStore` | Proposal persistence under `rem.remFolderPath` |
-| `mention-scanner.test.ts`, `auto-accept.test.ts` | Tests | |
+| `settings-section.ts` | `renderRemSettings` | REM settings UI section |
+| `mention-scanner.test.ts` | Tests | MentionScanner tests |
+| `auto-accept.test.ts` | Tests | Auto-accept behavior tests (#228) |
+| `rem-applier.test.ts` | Tests | RemApplier tests |
+| `semantic-matcher.test.ts` | Tests | SemanticMatcher tests |
+| `index.test.ts` | Tests | RemModule integration tests |
+| `settings-section.test.ts` | Tests | Settings section tests |
 
 ## Data Flow
 
 ```
-remScanNote(path) / remScanDirectory(folder?, skip?, onlyFile?)
-  --> isExcluded? (centralized isPathExcluded under 'rem' + reuses enrichment.excludeTags)
-  --> MentionScanner.scan(file, content, maxLinksPerNote)            // literal candidates
-  --> if semanticMatching: SemanticMatcher.match(...) filtered by confidenceThreshold
+remScanNote(filePath)
+  --> isExcluded? (isPathExcluded 'rem' + enrichment.excludeTags)
+  --> MentionScanner.scan(file, content, maxLinksPerNote)   // literal candidates
+  --> if semanticMatching:
+        SemanticMatcher.match(file, content, alreadyMatched, remaining)
+        filter by confidenceThreshold
   --> RemProposal { candidates, status: 'pending' } --> RemStore.save
-  --> maybeAutoAccept(proposal)  (#228, when shouldAutoAccept())
+  --> maybeAutoAccept(proposal)   (#228, when shouldAutoAccept())
+  --> onOpenProposalView callback offered in Notice (when NOT auto-accepting)
   --> refreshView()
-  (directory scan: CheckpointManager-backed, per-file completeItem, reverse-rollback on error/cancel)
 
-acceptProposal(id, acceptedMatchTexts)
-  --> guard: only 'pending' proposals (cascade safety — never rewrite body twice)
-  --> RemApplier.apply(originalContent, accepted) --> vault.modify
-  --> status: 'accepted' | 'partially-accepted'; stores acceptedLinks + originalContent (undo)
+remScanDirectory(folderPath?, skipConfirmation?, onlyFile?)
+  --> getMarkdownFiles filtered by isExcluded
+  --> CheckpointManager.create(module: 'rem', items)
+  --> addDeferredTask('refresh-sidebar-view')
+  --> for each file: scan literals + semantic, save proposal, maybeAutoAccept(batch=true)
+  --> completeItem() per file
+  --> on error: rejectProposalBatch(createdIds) + return 0
+  --> on cancel: discard() + rejectProposalBatch()
+  --> on success: complete() + dispatchDeferredTasks
+  --> Review action shown in finish Notice only when pending proposals remain
+
+acceptProposal(id, acceptedMatchTexts, options?)
+  --> guard: only 'pending' proposals (cascade safety)
+  --> vault.process(file, (data) => { originalContent = data; applier.apply(data, accepted) })
+  --> store.updateStatus(id, 'accepted'|'partially-accepted', acceptedLinks, originalContent)
+
+undoProposal(id)
+  --> load proposal.originalContent snapshot
+  --> vault.process(file, () => originalContent)
+  --> store.updateStatus(id, 'pending', undefined, undefined)   // resets to pending
 ```
 
 ## Commands
 
 Registered in `onload()` (both gated by `rem.enabled`):
 
-| ID | Name | Type | Flows |
-|----|------|------|-------|
+| ID | Name | Type | Pipeline |
+|----|------|------|---------|
 | `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | palette |
 | `synapse:rem-directory` | REM: Discover links in directory | callback (FolderPickerModal) | palette, fire-synapse (`pipelineKey: rem`) |
 
 ## Auto-Accept (#228)
 
-`shouldAutoAccept` is wired by `main.ts` to `() => settings.autoAccept.rem` (default false). When true, a freshly
-generated proposal is accepted in full as generated. NOTE: REM auto-accept REWRITES note body text (inserts
-`[[wikilinks]]`), unlike proposal kinds that only add separate sections.
+`shouldAutoAccept` is wired by `main.ts` to `() => settings.autoAccept.rem` (default false).
+
+When true, a freshly generated proposal is accepted in full immediately after creation. Batch directory scans use `silent=true` per proposal and emit one summary Notice.
+
+WARNING: REM auto-accept REWRITES note body text (inserts `[[wikilinks]]`). This is unlike proposal kinds that only add separate sections.
 
 ## Checkpoint Behavior
 
-`remScanDirectory` and `resumeFromCheckpoint` use `CheckpointManager` with module `'rem'`. Items tracked per file
-(`rem-{index}-{path}`). On error/cancel, proposals created in the run are batch-rejected.
+`remScanDirectory` and `resumeFromCheckpoint` use `CheckpointManager` with module `'rem'`. Items tracked as `rem-{index}-{path}`. On error or cancel, all proposals created in the run are batch-rejected via `rejectProposalBatch()`.
+
+Resume re-checks exclusion rules silently (a path may have been excluded after checkpoint creation).
+
+## Exclusion Rules
+
+```ts
+// index.ts:L495-500
+private isExcluded(file: TFile): boolean {
+  const settings = this.getSettings();
+  return (
+    isPathExcluded(file.path, 'rem', settings) ||
+    matchesExcludeTag(file, settings.enrichment.excludeTags, this.plugin.app.metadataCache)
+  );
+}
+```
+
+Path exclusion: centralized `settings.exclusions: ExclusionRule[]` (#307). No per-module `excludeFolders` field.
+Tag exclusion: reuses `settings.enrichment.excludeTags` (REM has no separate `excludeTags` field).
+
+Single-note command (`rem-current-note`) names the matched rule in the Notice. Directory scan silently skips.
+
+## Settings Keys
+
+All under `settings.rem` (`RemSettings`):
+
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `enabled` | `boolean` | — | Module + command activation |
+| `semanticMatching` | `boolean` | — | Enable AI-based conceptual matching |
+| `confidenceThreshold` | `number` | — | Min confidence for semantic candidates (0-1) |
+| `maxLinksPerNote` | `number` | — | Max link candidates per scanned note |
+| `remFolderPath` | `string` | `.synapse/rem` | Storage folder for proposal JSON files |
 
 ## Dependencies
 
 | Import | From |
 |--------|------|
-| `NotificationManager`, `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask`, `generateId`, `getMarkdownFiles`, `FolderPickerModal` | `../shared` |
-| `CommandRegistrar` | `../commands` |
-| `isPathExcluded` (centralized, feature `'rem'`) / `enrichment.excludeTags` (settings) | path + tag exclusion |
-
-Exclusion rules reuse the enrichment settings rather than defining REM-specific ones.
+| `generateId`, `getMarkdownFiles`, `FolderPickerModal`, `fireAndForget`, `isPathExcluded`, `matchesExcludeTag`, `findMatchingRule`, `NotificationManager`, `CheckpointManager` | `../shared` |
+| `DeferredTask`, `CheckpointWorkItem`, `Checkpoint` | `../shared` (type-only) |
+| `CommandRegistrar` | `../commands` (type-only) |
+| `SynapseSettings`, `RemSettings` | `../settings` (type-only) |
+| `MentionScanner` | `./mention-scanner` |
+| `SemanticMatcher` | `./semantic-matcher` |
+| `RemApplier` | `./rem-applier` |
+| `RemStore` | `./rem-store` |

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-19
 ---
 
 # Shared Module
 
-Cross-cutting base layer used by all feature modules: AI client, secret redaction, file operations, base64 encoding, notifications, validation, frontmatter parsing, checkpoint management, ID generation, URL platform detection / classification, and web content fetching. Depends on NO feature module — this is the bottom of the dependency graph.
+Cross-cutting base layer used by all feature modules: AI client, secret redaction, file operations, base64 encoding, notifications, validation, frontmatter parsing, checkpoint management, ID generation, URL platform detection / classification, web content fetching, credential validation, JSON utilities, and Node.js desktop-only loader. Depends on NO feature module — this is the bottom of the dependency graph.
 
 Canonical homes (re-exported elsewhere for back-compat — import from the `shared` barrel, never an internal file):
 - `url-detector.ts` (`detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult`) — moved here from `src/video/` to break the former shared⇄video import cycle; `video` re-exports for back-compat.
@@ -39,21 +39,27 @@ type ContentBlock = TextContentBlock | ImageContentBlock
 interface ChatMessage { role: 'system' | 'user' | 'assistant'; content: string | ContentBlock[] }
 
 // notifications.ts
+type NoticeLevel = 'info' | 'progress' | 'success' | 'warning' | 'error'
+interface NoticeAction {
+  label: string
+  onClick: () => void
+}
+interface OperationHandle {
+  update(message: string): void
+  progress(current: number, total: number, label?: string): void
+  finish(message?: string, action?: NoticeAction): void
+  error(message: string): void
+  readonly cancelled: boolean
+}
 class NotificationManager {
   setStatusBarEl(el: HTMLElement): void
   startOperation(label: string, id?: string): OperationHandle
   confirm(message: string, options?: { proceedLabel?: string; cancelLabel?: string; level?: NoticeLevel }): Promise<boolean>
   cancelOperation(id: string): void
-  info(message: string, duration?: number): void
-  success(message: string, duration?: number): void
+  info(message: string, duration?: number, action?: NoticeAction): void
+  success(message: string, duration?: number, action?: NoticeAction): void
   notifyError(context: string, error: unknown): void
-}
-interface OperationHandle {
-  update(message: string): void
-  progress(current: number, total: number, label?: string): void
-  finish(message?: string): void
-  error(message: string): void
-  readonly cancelled: boolean
+  dispose(): void
 }
 
 // file-utils.ts
@@ -61,6 +67,7 @@ function ensureFolder(app: App, path: string): Promise<void>
 function readNote(app: App, path: string): Promise<string | null>
 function writeNote(app: App, path: string, content: string): Promise<TFile>
 function getMarkdownFiles(app: App, folder?: string): TFile[]
+function getIncludedMarkdownFiles(app: App, feature: FeatureId, settings: ExclusionSettings, folder?: string): TFile[]
 function wordCount(text: string): number
 
 // api-utils.ts
@@ -112,6 +119,7 @@ interface ParsedNote { frontmatter: Record<string, unknown>; body: string; hasFr
 function parseFrontmatter(content: string): ParsedNote
 function serializeFrontmatter(frontmatter: Record<string, unknown>, body: string): string
 function mergeTags(frontmatter: Record<string, unknown>, newTags: string[]): void
+function normalizeFrontmatterTags(value: unknown): string[]   // array|comma-string|other → string[]
 
 // tweet-fetcher.ts
 function fetchTweetContent(url: string, maxLength: number): Promise<string>
@@ -119,12 +127,23 @@ function isTwitterUrl(url: string): boolean
 interface TweetContent { author: string; text: string; url: string }
 
 // callouts.ts
-const CALLOUT_TYPES: { summary, transcription, enrichment, elaboration, deepDive, nav, ocr }
-type CalloutType = 'synapse-summary' | 'synapse-transcription' | 'synapse-enrichment'
-                 | 'synapse-elaboration' | 'synapse-deep-dive' | 'synapse-nav' | 'synapse-ocr'
-const ENRICHMENT_START: string   // '%% synapse-enrichment-start %%' marker
-const ENRICHMENT_END: string     // '%% synapse-enrichment-end %%' marker
+const CALLOUT_TYPES: {
+  summary: 'synapse-summary'
+  transcription: 'synapse-transcription'
+  lyrics: 'synapse-lyrics'
+  verse: 'synapse-verse'
+  chorus: 'synapse-chorus'
+  enrichment: 'synapse-enrichment'
+  elaboration: 'synapse-elaboration'
+  deepDive: 'synapse-deep-dive'
+  nav: 'synapse-nav'
+  ocr: 'synapse-ocr'
+}
+type CalloutType = (typeof CALLOUT_TYPES)[keyof typeof CALLOUT_TYPES]
+const ENRICHMENT_START: string   // '%% synapse-enrichment-start %%'
+const ENRICHMENT_END: string     // '%% synapse-enrichment-end %%'
 function buildCallout(type: CalloutType, title: string, body: string, collapsed?: boolean): string
+function calloutForTranscriptionResult(result: { reformatted?: boolean; schemaId?: string }): { type: CalloutType; verb: string }
 
 // diagram-generator.ts
 function generateTreeDiagram(root: TreeNode): string
@@ -175,6 +194,115 @@ interface Checkpoint {
   deferredTasks: DeferredTask[]
   metadata: Record<string, unknown>
 }
+
+// provider-metadata.ts
+type CredentialProvider = 'openai' | 'anthropic' | 'gemini' | 'deepgram' | 'ollama'
+interface ProbeSpec { method: 'GET'; url: string; headers: Record<string, string> }
+interface ProviderMetadata {
+  label: string
+  getKeyUrl: string
+  placeholder: string
+  formatHint: string
+  requiresKey: boolean
+  buildProbe(input: { key: string; endpoint?: string }): ProbeSpec | null
+}
+const PROVIDER_METADATA: Record<CredentialProvider, ProviderMetadata>
+function aiProviderToCredential(provider: AIProvider): CredentialProvider
+
+// credential-validator.ts
+type ValidationStatus = 'valid' | 'invalid' | 'error' | 'skipped'
+interface ValidationResult { status: ValidationStatus; provider: CredentialProvider; message: string }
+interface ValidateOptions { endpoint?: string; timeoutMs?: number }
+function validateCredentials(provider: CredentialProvider, key: string, opts?: ValidateOptions): Promise<ValidationResult>
+
+// credential-field.ts
+interface CredentialFieldOptions {
+  setting: Setting
+  container: HTMLElement
+  provider: CredentialProvider
+  getKey: () => string
+  getEndpoint?: () => string
+  validate?: typeof validateCredentials
+}
+interface CredentialFieldHandle { reset(): void }
+function decorateCredentialField(opts: CredentialFieldOptions): CredentialFieldHandle
+
+// feature-chip-select.ts
+interface FeatureChipSelectOptions {
+  value: 'all' | FeatureId[]
+  labels: Record<FeatureId, string>
+  order: FeatureId[]
+  onChange: (next: 'all' | FeatureId[]) => void
+}
+function renderFeatureChipSelect(container: HTMLElement, options: FeatureChipSelectOptions): void
+
+// fire-and-forget.ts
+interface FireAndForgetOptions {
+  notifications?: NotificationManager
+  background?: boolean
+}
+function fireAndForget(promise: Promise<unknown>, label: string, options?: FireAndForgetOptions): void
+
+// json-utils.ts
+function parseJson(text: string): unknown                                         // throws SyntaxError on malformed input
+function isRecord(v: unknown): v is Record<string, unknown>
+function asStringArray(v: unknown): string[]
+function readJsonFile<T>(adapter: DataAdapter, path: string, guard: (v: unknown) => v is T): Promise<T | null>
+
+// node-loader.ts
+interface NodeModules { os: typeof import('os'); path: typeof import('path'); fs: typeof import('fs'); execFile: typeof import('child_process')['execFile'] }
+class DesktopOnlyError extends Error { constructor(message?: string) }
+function assertDesktop(context?: string): void
+function loadNodeModules(): NodeModules
+function shellEnv(): NodeJS.ProcessEnv
+
+// settings-section.ts
+interface SettingsSectionContext {
+  containerEl: HTMLElement
+  plugin: SynapsePlugin
+  featureSection(key: string, title: string, getEnabled: () => boolean, setEnabled: (value: boolean) => void, toggleDesc?: string): HTMLElement
+  configSection(key: string, title: string): HTMLElement
+  rerender: () => void
+}
+interface SettingsSectionContextOptions {
+  containerEl: HTMLElement
+  plugin: SynapsePlugin
+  onFeatureToggle?: () => void | Promise<void>
+  rerender?: () => void
+}
+function createSettingsSectionContext(options: SettingsSectionContextOptions): SettingsSectionContext
+function isSectionCollapsed(plugin: SynapsePlugin, key: string, enabled: boolean | null): boolean
+function persistCollapse(plugin: SynapsePlugin, key: string, collapsed: boolean): Promise<void>
+
+// exclusions.ts
+type FeatureId = 'elaboration' | 'enrichment' | 'summarize' | 'tidy' | 'organize' | 'deep-dive' | 'audio' | 'video' | 'title' | 'image' | 'rem' | 'intake'
+const ALL_FEATURE_IDS: Record<FeatureId, true>
+interface ExclusionRule { pattern: string; features: 'all' | FeatureId[] }
+interface ExclusionSettings { exclusions: ExclusionRule[] }
+interface LegacyModuleExclusions {
+  elaboration?: { detection?: { excludeFolders?: unknown } }
+  enrichment?: { excludeFolders?: unknown }
+  summarize?: { excludeFolders?: unknown }
+  organize?: { excludeFolders?: unknown }
+  deepDive?: { excludeFolders?: unknown }
+}
+function findMatchingRule(path: string, feature: FeatureId, settings: ExclusionSettings): ExclusionRule | null
+function isPathExcluded(path: string, feature: FeatureId, settings: ExclusionSettings): boolean
+function matchesExcludeTag(file: TFile, excludeTags: string[], metadataCache: MetadataCache): boolean
+function buildMigratedExclusions(data: LegacyModuleExclusions): ExclusionRule[]
+
+// content-schemas.ts
+type PipelineStage = 'transcription' | 'summary'
+type SchemaMode = 'reformat' | 'summarize'
+interface ContentSchema { id: string; name: string; appliesTo: PipelineStage[]; mode: SchemaMode; detect: (content: string) => boolean; prompt: string }
+const CONTENT_SCHEMAS: ContentSchema[]
+function detectSchemaFor(stage: PipelineStage, content: string): ContentSchema | null
+function isRecipeContent(content: string): boolean
+function scoreRecipeContent(content: string): number
+function isReceiptContent(content: string): boolean
+function scoreReceiptContent(content: string): number
+function isLyricsContent(content: string): boolean
+function scoreLyricsContent(content: string): number
 ```
 
 ## File Inventory
@@ -186,9 +314,9 @@ interface Checkpoint {
 | `encoding.ts` | `arrayBufferToBase64`, `base64EncodedLength` | Base64 encode + exact encoded-length calc; canonical home reused by audio/image/elaboration |
 | `encoding.test.ts` | Tests | Encoding tests |
 | `types.ts` | `ChatMessage`, `ContentBlock`, `TextContentBlock`, `ImageContentBlock` | Shared types including multi-modal content blocks |
-| `notifications.ts` | `NotificationManager`, `OperationHandle`, `NoticeLevel` | Centralized notifications with cancellation, progress, confirmation snackbars |
+| `notifications.ts` | `NotificationManager`, `OperationHandle`, `NoticeLevel`, `NoticeAction` | Centralized notifications with cancellation, progress, confirmation snackbars, and action buttons. `dispose()` tears down all in-flight operations (called from `main.ts` `onunload()`). `info()` and `success()` accept optional `action?: NoticeAction`. `OperationHandle.finish()` accepts optional `action?: NoticeAction`. |
 | `notifications.test.ts` | Tests | NotificationManager tests |
-| `file-utils.ts` | `ensureFolder`, `readNote`, `writeNote`, `getMarkdownFiles`, `wordCount` | Vault file operations |
+| `file-utils.ts` | `ensureFolder`, `readNote`, `writeNote`, `getMarkdownFiles`, `getIncludedMarkdownFiles`, `wordCount` | Vault file operations. `getIncludedMarkdownFiles` drops notes excluded by centralized exclusion rules for a given `FeatureId` |
 | `api-utils.ts` | `withRetry`, `sleep`, `notifyError`, `classifyNetworkError`, `isTransientNetworkError`, `describeNetworkError` | Retry with exponential backoff, network-error classification/disclosure, redacted error display (via `redactSecrets`) |
 | `validation.ts` | `sanitizeUrl`, `sanitizePath`, `ensureWithinVault`, `sanitizeAIResponse`, `stripCodeFences`, `blockquoteOriginal`, `parseTimestamp`, `validateTimeRange`, `formatTimeRange`, `TimeRange` | Input validation, output sanitization, time-range parsing |
 | `validation.test.ts` | Tests | Validation tests |
@@ -200,9 +328,9 @@ interface Checkpoint {
 | `content-fetcher.test.ts` | Tests | Content fetcher tests |
 | `collapsible-section.ts` | `addCollapsibleSection`, `CollapsibleSection`, `CollapsibleSectionOptions` | Reusable collapsible UI section (settings accordions) |
 | `collapsible-section.test.ts` | Tests | Collapsible section tests |
-| `frontmatter-utils.ts` | `parseFrontmatter`, `serializeFrontmatter`, `mergeTags`, `ParsedNote` | YAML frontmatter parsing and serialization |
+| `frontmatter-utils.ts` | `parseFrontmatter`, `serializeFrontmatter`, `mergeTags`, `normalizeFrontmatterTags`, `ParsedNote` | YAML frontmatter parsing and serialization. `normalizeFrontmatterTags` coerces array/comma-string/other → `string[]` |
 | `frontmatter-utils.test.ts` | Tests | Frontmatter tests |
-| `callouts.ts` | `CALLOUT_TYPES`, `buildCallout`, `CalloutType` | Unified callout registry and builder for AI content |
+| `callouts.ts` | `CALLOUT_TYPES`, `buildCallout`, `calloutForTranscriptionResult`, `ENRICHMENT_START`, `ENRICHMENT_END`, `CalloutType` | Unified callout registry and builder for AI content. `CALLOUT_TYPES` adds `lyrics`/`verse`/`chorus` entries. `calloutForTranscriptionResult` selects callout type and verb based on `schemaId` |
 | `callouts.test.ts` | Tests | Callout tests |
 | `diagram-generator.ts` | `generateTreeDiagram`, `generateMoveDiagram`, `generateOrganizeSummary`, `TreeNode`, `MoveRecord` | Mermaid diagram generation for organize summaries |
 | `diagram-generator.test.ts` | Tests | Diagram generator tests |
@@ -214,11 +342,19 @@ interface Checkpoint {
 | `checkpoint-manager.ts` | `CheckpointManager` | CRUD and lifecycle management for resumable operation checkpoints |
 | `checkpoint-manager.test.ts` | Tests | CheckpointManager tests |
 | `tweet-fetcher.ts` | `fetchTweetContent`, `isTwitterUrl`, `TweetContent` | Twitter/X.com tweet fetching with oEmbed → fxtwitter → vxtwitter fallback chain |
-| `exclusions.ts` | `FeatureId`, `ExclusionRule`, `findMatchingRule`, `isPathExcluded`, `matchesExcludeTag`, `ALL_FEATURE_IDS`, `buildMigratedExclusions`, `LegacyModuleExclusions` | Centralized per-path exclusion (#307): case-sensitive glob→regex matcher (`/**`, `/*`, exact, bare-token recursive; escapes metacharacters), shared tag-exclusion check, and the legacy `excludeFolders`→`exclusions` migration builder |
-| `exclusions.test.ts` | Tests | Exclusion matcher + migration tests |
 | `tweet-fetcher.test.ts` | Tests | Tweet fetcher tests |
-| `content-schemas.ts` | `ContentSchema`, `PipelineStage`, `SchemaMode`, `CONTENT_SCHEMAS`, `detectSchemaFor`, `isRecipeContent`, `scoreRecipeContent`, `isReceiptContent`, `scoreReceiptContent` | Content-aware formatting registry (#233): recipe/receipt detection heuristics + prompts, stage-gated via `appliesTo` (`'transcription' \| 'summary'`) and `mode` (`'reformat' \| 'summarize'`). Promoted out of `summarize/` so both summarize and transcription stages can consult it via `detectSchemaFor(stage, content)` |
+| `exclusions.ts` | `FeatureId`, `ExclusionRule`, `ExclusionSettings`, `LegacyModuleExclusions`, `ALL_FEATURE_IDS`, `findMatchingRule`, `isPathExcluded`, `matchesExcludeTag`, `buildMigratedExclusions` | Centralized per-path exclusion (#307): case-sensitive glob→regex matcher (`/**`, `/*`, exact, bare-token recursive; escapes metacharacters), shared tag-exclusion check, and the legacy `excludeFolders`→`exclusions` migration builder |
+| `exclusions.test.ts` | Tests | Exclusion matcher + migration tests |
+| `content-schemas.ts` | `ContentSchema`, `PipelineStage`, `SchemaMode`, `CONTENT_SCHEMAS`, `detectSchemaFor`, `isRecipeContent`, `scoreRecipeContent`, `isReceiptContent`, `scoreReceiptContent`, `isLyricsContent`, `scoreLyricsContent` | Content-aware formatting registry (#233): recipe/receipt/lyrics detection heuristics + prompts, stage-gated via `appliesTo` and `mode`. `isLyricsContent`/`scoreLyricsContent` added for audio transcription lyric reformatting (#234) |
 | `content-schemas.test.ts` | Tests | Schema detection + scoring + stage-gate lock tests |
+| `provider-metadata.ts` | `PROVIDER_METADATA`, `aiProviderToCredential`, `CredentialProvider`, `ProviderMetadata`, `ProbeSpec` | Per-provider credential metadata: console URL, placeholder, format hint, minimal authenticated probe spec. Pure data module (no Obsidian runtime import). Covers openai/anthropic/gemini/deepgram/ollama |
+| `credential-validator.ts` | `validateCredentials`, `ValidationResult`, `ValidationStatus`, `ValidateOptions` | Live credential validation via provider probe; 10s timeout; never throws; redacts secrets from all error messages. Status: `valid`/`invalid`/`error`/`skipped` |
+| `credential-field.ts` | `decorateCredentialField`, `CredentialFieldOptions`, `CredentialFieldHandle` | Decorates a Setting row with a Test button, get-key deep link, and live status chip. Result applied via `setTimeout(0)` (macrotask) to avoid Obsidian settings DOM freeze (#335) |
+| `feature-chip-select.ts` | `renderFeatureChipSelect`, `FeatureChipSelectOptions` | Renders a chip multi-select for exclusion rule feature scope. Self-redraws its container on every edit; caller's `onChange` only needs to persist |
+| `fire-and-forget.ts` | `fireAndForget`, `FireAndForgetOptions` | Attaches rejection handling to an intentionally un-awaited promise. Routes errors through `NotificationManager.notifyError` when available; supports background mode (log only, no toast) |
+| `json-utils.ts` | `parseJson`, `isRecord`, `asStringArray`, `readJsonFile` | Type-safe JSON helpers. `parseJson` returns `unknown` (not `any`). `readJsonFile` reads via `DataAdapter`, validates with a type guard, returns `null` on any failure |
+| `node-loader.ts` | `loadNodeModules`, `assertDesktop`, `shellEnv`, `DesktopOnlyError`, `NodeModules` | Single sanctioned entry point for desktop-only Node.js builtins (os/path/fs/child_process). Lazy-loads inside function body so importing never triggers a module load on mobile. `shellEnv()` builds a narrowed subprocess environment with PATH augmented for common tool install locations |
+| `settings-section.ts` | `createSettingsSectionContext`, `isSectionCollapsed`, `persistCollapse`, `SettingsSectionContext`, `SettingsSectionContextOptions` | Shared accordion plumbing for the settings tab (#243). Feature renderers receive a `SettingsSectionContext` and call `featureSection()`/`configSection()` to build accordions without importing `settings-tab.ts` |
 | `index.ts` | re-exports | Barrel file |
 
 ## AIClient Provider Routing
@@ -282,6 +418,9 @@ Write concurrency: per-checkpoint mutex via `withLock()` prevents concurrent rea
 - Status bar integration (shows active operation count)
 - CSS injection for styled notices
 - API key redaction in error messages
+- `info()` and `success()` accept optional `action?: NoticeAction` 3rd param — renders an action button on the toast (8s auto-dismiss)
+- `OperationHandle.finish(message?, action?)` accepts optional `action?: NoticeAction` — completion toast includes a button that runs `action.onClick()` then hides the toast
+- `dispose()` — tears down every in-flight tracked operation (stops its `setInterval` + hides its notice, clears the map). Called from `main.ts` `onunload()` so disabling the plugin mid-operation never leaves an orphaned 400ms timer firing against a detached toast. Source ref: `notifications.ts:L139`
 
 ## Validation Rules
 
@@ -293,6 +432,25 @@ Write concurrency: per-checkpoint mutex via `withLock()` prevents concurrent rea
 | `sanitizeAIResponse` | script tags, event handlers, javascript/data/vbscript URIs, iframe/embed/object |
 | `blockquoteOriginal` | (transforms) wraps body in blockquote, preserves frontmatter |
 | `isValidCheckpointId` | anything not matching `/^[a-z0-9]+$/` |
+
+## Exclusion Pattern Forms
+
+| Pattern form | Matches |
+|---|---|
+| `dir/**` | folder and all descendants, NOT the folder itself |
+| `dir/*` | direct children only |
+| `dir/file.md` (has `/`, no wildcard) | that exact vault-relative path |
+| `templates` (bare token, no `/`, no wildcard) | the token itself and every descendant |
+
+Mid-segment wildcards (e.g. `dir/*.md`) are out of scope for v1 and fall through to exact-path matching.
+
+## Content Schema Registry
+
+| Schema id | Stage | Mode | Detection threshold |
+|---|---|---|---|
+| `recipe` | `summary` | `summarize` | score >= 5 (structural + cooking verbs + measurement terms) |
+| `receipt` | `summary` | `summarize` | score >= 5 (currency + total headers + line items + payment terms) |
+| `lyrics` | `transcription` | `reformat` | score >= 5 (section markers + repetition ratio + short-segment profile + stanza structure) |
 
 ## Consumers
 
@@ -312,6 +470,7 @@ Write concurrency: per-checkpoint mutex via `withLock()` prevents concurrent rea
 | `wordCount` | elaboration/detector, deep-dive/index |
 | `readNote` | deep-dive/index |
 | `writeNote` | deep-dive/index, organize/index |
+| `getIncludedMarkdownFiles` | candidate/index enumerations (tag indexes, title maps, link/mention targets) |
 | `fetchTweetContent` | summarize/index, elaboration/proposer, enrichment/index |
 | `isTwitterUrl` | elaboration/proposer, enrichment/index |
 | `sanitizeUrl` | video/index, video/audio-extractor |
@@ -320,7 +479,22 @@ Write concurrency: per-checkpoint mutex via `withLock()` prevents concurrent rea
 | `parseFrontmatter` | enrichment/index, enrichment/enrichment-applier, tidy/index |
 | `serializeFrontmatter` | enrichment/enrichment-applier, tidy/index |
 | `mergeTags` | enrichment/enrichment-applier |
+| `normalizeFrontmatterTags` | exclusions/matchesExcludeTag, json-utils docs |
 | `blockquoteOriginal` | elaboration/index |
 | `withRetry` | tidy/index |
 | `generateId` | elaboration, enrichment, summarize, organize, deep-dive (proposal/run IDs) |
 | `notifyError` | (legacy, replaced by NotificationManager in most modules) |
+| `PROVIDER_METADATA` / `aiProviderToCredential` | credential-field, credential-validator, settings-tab |
+| `validateCredentials` | credential-field (injected; default impl used by Test button) |
+| `decorateCredentialField` | settings-tab (per provider credential row) |
+| `renderFeatureChipSelect` | settings-tab (exclusion rule feature scope editor) |
+| `fireAndForget` | feature modules (non-blocking background operations) |
+| `parseJson` / `isRecord` / `asStringArray` / `readJsonFile` | checkpoint-manager, proposal-store, enrichment-store, and other JSON stores |
+| `loadNodeModules` / `assertDesktop` / `shellEnv` | audio/transcriber, video/audio-extractor (yt-dlp/ffmpeg/ffprobe subprocess calls) |
+| `createSettingsSectionContext` | settings-tab (orchestrator) |
+| `findMatchingRule` / `isPathExcluded` | file-utils/getIncludedMarkdownFiles, all feature entry points |
+| `matchesExcludeTag` | elaboration, enrichment, summarize, tidy, organize, deep-dive, rem |
+| `buildMigratedExclusions` | settings migration (on load, if legacy excludeFolders present) |
+| `detectSchemaFor` | summarize/index (summary stage), audio/transcriber (transcription stage) |
+| `isLyricsContent` / `scoreLyricsContent` | content-schemas (internal detection), audio transcription pipeline |
+| `calloutForTranscriptionResult` | audio/transcriber, video transcription pipeline |

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -131,6 +131,21 @@ export class NotificationManager {
 	}
 
 	/**
+	 * Tear down every in-flight operation: stop its animated-ellipsis interval and
+	 * hide its notice. Called from the plugin's `onunload` so disabling Synapse
+	 * while an operation is still running never leaves an orphaned 400ms
+	 * `setInterval` firing against a detached toast (Obsidian lifecycle hygiene).
+	 */
+	dispose(): void {
+		for (const op of this.operations.values()) {
+			stopEllipsis(op.ellipsisInterval);
+			op.ellipsisInterval = null;
+			op.notice.hide();
+		}
+		this.operations.clear();
+	}
+
+	/**
 	 * Begin a tracked operation. Returns a handle for updating progress.
 	 * The notice is non-dismissible and includes a Cancel button.
 	 */

--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-11
+last-updated: 2026-06-19
 ---
 
 # Summarize Module
@@ -18,173 +18,201 @@ class SummarizeModule {
     getSettings: () => SynapseSettings,
     notifications: NotificationManager,
     checkpointManager: CheckpointManager,
+    registrar: CommandRegistrar,
     transcribeUrl?: TranscribeUrlFn,
-    transcribeAudio?: TranscribeAudioFn
+    transcribeAudio?: TranscribeAudioFn,
+    transcribeAudioCombined?: TranscribeAudioCombinedFn
   )
   onload(): Promise<void>
   onunload(): void
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
+  scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<void>
 }
 
+// Injected callback: transcribes a video URL (from VideoModule)
 type TranscribeUrlFn = (
   url: string,
   parentOp?: { update: (msg: string) => void }
 ) => Promise<string>
 
+// Injected callback: transcribes a single audio TFile (from AudioModule)
 type TranscribeAudioFn = (file: TFile) => Promise<string>
+
+// Injected callback: transcribes multiple audio TFiles as one combined recording (#214)
+type TranscribeAudioCombinedFn = (files: TFile[]) => Promise<string>
 ```
 
-Exported types: `SummarizeTarget`, `SummarizeSettings`, `TranscribeUrlFn`, `TranscribeAudioFn`
+Exported types: `SummarizeTarget`, `TranscribeUrlFn`, `TranscribeAudioFn`, `TranscribeAudioCombinedFn`
 
-## Internal Components
+Exported functions: `renderSummarizeSettings(ctx: SettingsSectionContext): void`
 
-| File | Class/Function | Role |
-|------|---------------|------|
+## Internal File Map
+
+| File | Class/Export | Role |
+|------|-------------|------|
+| `index.ts` | `SummarizeModule`, type + fn re-exports | Orchestrator, commands, scan + summarize flows |
+| `types.ts` | `SummarizeTarget` | Target type model |
 | `summarizer.ts` | `Summarizer` | AI summarization with style (bullets/paragraph/key-points) |
-| `summarizer.test.ts` | Tests | Summarizer tests |
+| `note-scanner.ts` | `findSummarizeTargets`, `hasSummaryBelow` | Finds URLs, transcription blocks in note content |
+| `summarize-modal.ts` | `SummarizeSelectionModal` | Selection modal when multiple targets found; offers combine option for 2+ audio targets |
 | `settings-section.ts` | `renderSummarizeSettings` | Summarize settings UI section |
-| `note-scanner.ts` | `findSummarizeTargets`, `hasSummaryBelow` | Finds URLs, transcription blocks, and audio embed summary gaps in note content |
+| `summarizer.test.ts` | Tests | Summarizer tests |
 | `note-scanner.test.ts` | Tests | Note scanner tests |
-| `summarize-modal.ts` | `SummarizeSelectionModal` | Selection modal when multiple targets found |
 | `summarize-module.test.ts` | Tests | SummarizeModule integration tests |
 | `audio-summarize.test.ts` | Tests | Audio-embed summarization tests |
-| `types.ts` | -- | `SummarizeTarget` |
+| `combine-summarize.test.ts` | Tests | Combined-audio summarization tests (#214) |
 
-> Content-aware formatting schemas (recipe/receipt detection + prompts) live in the shared `content-schemas.ts` registry (`shared/content-schemas.ts`), consumed here via `detectSchemaFor('summary', content)`. See [Content-Aware Schemas](#content-aware-schemas).
+## Target Types (`types.ts`)
+
+```ts
+interface SummarizeTarget {
+  type: 'url' | 'transcription' | 'audio'
+  source: string          // URL or audio filename or transcription source label
+  line: number            // zero-based line number in note
+  endLine: number         // end of target block (for transcriptions)
+  content?: string        // pre-extracted content (for transcription blocks)
+  inEnrichmentSection?: boolean  // found inside enrichment markers
+  linkTitle?: string      // display text from markdown link (enrichment refs)
+}
+```
 
 ## Data Flow
 
 ```
 summarizeNote(file)
   --> collectTargets(content, sourcePath)
-        findSummarizeTargets(content)  [regex: URLs, transcription blocks]
-        findAudioEmbeds(content)  [audio embeds without existing summary]
-  --> if multiple: SummarizeSelectionModal
-  --> processTargets(file, targets, content)
+        findSummarizeTargets(content)    [URLs, transcription blocks]
+        findAudioEmbeds(content, ...)    [audio embeds without existing summary below]
+  --> if 1 target: processTargets(file, targets, content)
+  --> if 2+ targets: SummarizeSelectionModal
+        if combine + 2+ audio: processTargetsCombined(file, selected, content)
+        else: processTargets(file, selected, content)
 
 processFileTargets(file, targets, op, content)
   For each target (reverse line order):
-    if inEnrichmentSection:
-      --> fetchContentForUrl(url)  [HTTP or video transcription]
-      --> Summarizer.summarize(content, url, style, comprehensive prompt)
-      --> create standalone note (deferred until after source modify)
-      --> replace external link with [[internal link]]
+    if inEnrichmentSection + linkTitle:
+      --> fetchContentForUrl(url)  [video transcription or HTTP fetch]
+      --> Summarizer.summarize(content, url, style, COMPREHENSIVE_SUMMARY_PROMPT)
+      --> pendingNotes.push(path, content)
+      --> replace external link with [[internal link]] in lines[]
     elif target.type === 'audio':
       --> fetchContentForAudio(fileName, sourceFile)  [transcribeAudio callback]
-      --> Summarizer.summarize(transcript, source, style)
-      --> insert callout after target line
-    else (inline target):
-      --> fetchContentForUrl(url) or use transcription content
-      --> determine effectivePrompt:
-            customPrompt > detectSchemaFor('summary', content) > style default
+      --> Summarizer.summarize(transcript, source, style, effectivePrompt)
+      --> lines.splice(endLine+1, callout)
+    else (inline URL / transcription):
+      --> fetchContentForUrl(url) or use target.content
+      --> effectivePrompt: customPrompt > detectSchemaFor('summary', content) > style default
       --> Summarizer.summarize(content, url, style, effectivePrompt)
-      --> insert callout after target line
-  --> vault.modify(sourceFile)
-  --> vault.create() for pending notes
+      --> lines.splice(endLine+1, callout)
+  --> vault.process(file, () => lines.join('\n'))   [source written FIRST]
+  --> vault.create() for each pendingNote            [new notes AFTER source]
   --> onSummaryComplete?.(filePath)
-  --> onOrganizeRequested?.(file) [if autoOrganizeOnSummarize]
+  --> onOrganizeRequested?.(file)  [if autoOrganizeOnSummarize]
+
+processTargetsCombined(file, targets, content)   [#214]
+  --> otherTargets processed via processFileTargets first
+  --> transcribeAudioCombined(audioFiles) --> combined transcript
+  --> Summarizer.summarize(transcript, ..., COMPREHENSIVE_SUMMARY_PROMPT)
+  --> vault.process(file, insert combined callout after last audio embed)
+  --> onSummaryComplete?.(file.path)
 ```
 
 ## Vault Scan (checkpointed)
 
 ```
-scanVault(folderPath?)
-  Phase 1: Collect files with targets (cancellable scan)
-  Phase 2: User confirmation
-  Phase 3: Checkpointed processing
+scanVault(folderPath?, skipConfirmation?, onlyFile?)
+  Phase 1: collect files with targets (cancellable scan)
+  Phase 2: user confirmation (skipped when skipConfirmation=true)
+  Phase 3: checkpointed processing
     --> checkpointManager.create(module: 'summarize', items)
     --> addDeferredTask('refresh-sidebar-view')
-    --> for each file: processFileTargets(), completeItem()
+    --> for each file: re-read + re-scan + processFileTargets(), completeItem()
     --> on cancel: checkpointManager.discard()
-    --> on success: checkpointManager.complete(), dispatch deferred tasks
+    --> on success: checkpointManager.complete(), dispatchDeferredTasks
 
 resumeFromCheckpoint(checkpoint)
   --> re-processes remaining items from saved checkpoint
   --> completeItem() after each file
   --> on cancel: discard()
-  --> on success: complete(), dispatch deferred tasks
+  --> on success: complete(), dispatchDeferredTasks
 ```
 
-## Target Types
+## Commands
 
-```ts
-interface SummarizeTarget {
-  type: 'url' | 'transcription' | 'audio'
-  source: string
-  line: number
-  endLine: number
-  content?: string
-  inEnrichmentSection?: boolean
-  linkTitle?: string
-}
-```
+Registered in `onload()` (both gated by `summarize.enabled`):
+
+| ID | Name | Type |
+|----|------|------|
+| `synapse:summarize-current-note` | Summarize current note | editorCallback |
+| `synapse:scan-vault-summarize` | Scan vault for notes to summarize | callback (FolderPickerModal) |
 
 ## Video URL Auto-Transcription
 
-When `transcribeUrl` is injected (from `VideoModule.transcribeUrl`):
-- `fetchContentForUrl()` checks `isSupportedUrl(url)` first (`isSupportedUrl` from `shared/url-detector`)
-- If video URL detected, transcribes via the injected `transcribeUrl` callback instead of HTTP fetch
-- Falls back to `fetchPageContent()` (from `shared/content-fetcher`) for non-video URLs
+`transcribeUrl` is injected by `main.ts` from `VideoModule.transcribeUrl`. When set:
+- `fetchContentForUrl()` calls `isSupportedUrl(url)` (from `shared`) before deciding
+- If supported video URL: calls injected `transcribeUrl` callback
+- Falls back to `fetchTweetContent()` for Twitter URLs, then `fetchPageContent()` for others
 
-## Audio Embed Summarization
+`isSupportedUrl` and `detectPlatform` both resolve from `shared` barrel. There is NO static import of `video/` anywhere in this module.
 
-When `transcribeAudio` is injected (from main.ts closure over `AudioModule.transcribe`):
-- `collectTargets()` scans for `![[*.mp3|wav|...]]` embeds via `findAudioEmbeds()`
-- Skips embeds with existing summary below (checked via `hasSummaryBelow()`)
-- `fetchContentForAudio()` resolves file via MetadataCache, calls `transcribeAudio(file)`
-- Resulting transcript is summarized and inserted as callout
+## Combined Audio (#214)
+
+When `transcribeAudioCombined` is injected and 2+ audio targets are selected via the modal:
+- `processTargetsCombined()` resolves all audio `TFile` objects via `MetadataCache`
+- Calls `transcribeAudioCombined(files)` for one transcript spanning all files
+- Inserts a single `Combined summary (N files)` callout after the last audio embed
+- Insert line is re-derived from fresh content inside `vault.process()` callback (safe against phase-1 line shifts)
 
 Injected in `main.ts`:
 ```ts
 this.summarize = new SummarizeModule(
-  this, getSettings, this.notifications, this.checkpointManager,
+  this, getSettings, this.notifications, this.checkpointManager, this.registrar,
   (url, parentOp) => this.video.transcribeUrl(url, parentOp),
   async (audioFile) => {
     const data = await this.app.vault.readBinary(audioFile);
     const result = await this.audio.transcribe(data, audioFile.name);
     return result.processed || result.raw;
-  }
+  },
+  (files) => this.audio.transcribeCombined(files)
 );
 ```
 
-## Dependencies
+## Settings Keys
 
-- `shared/` (FolderPickerModal, getMarkdownFiles, NotificationManager, OperationHandle, buildCallout, CALLOUT_TYPES, CheckpointManager, generateId, Checkpoint, CheckpointWorkItem, DeferredTask, fetchPageContent, fetchTweetContent, isSupportedUrl, detectPlatform, detectSchemaFor)
-- `audio/` (findAudioEmbeds -- used in collectTargets)
-- `settings.ts` (SynapseSettings, SummarizeSettings)
-- NO static `video/` import. URL-platform helpers (`isSupportedUrl`/`detectPlatform`) and content fetchers (`fetchPageContent`/`fetchTweetContent`) resolve from `shared`. Video transcription happens only through the injected `transcribeUrl` callback (`TranscribeUrlFn`).
+All under `settings.summarize` (`SummarizeSettings`):
+
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `enabled` | `boolean` | `true` | Module + command activation |
+| `maxContentLength` | `number` | — | Truncation limit for fetched content |
+| `summaryStyle` | `'bullets' \| 'paragraph' \| 'key-points'` | — | AI output style |
+| `customPrompt` | `string` | `''` | Overrides style-based prompt (highest priority) |
+| `autoDetectTemplates` | `boolean` | `true` | Enable content-schema detection |
+| `excludeTags` | `string[]` | `['no-summarize']` | Skip notes with these tags |
+| `autoOrganizeOnSummarize` | `boolean` | — | Trigger organize after single-note summarize |
+
+Path exclusion: centralized `settings.exclusions: ExclusionRule[]` (#307). No per-module `excludeFolders` field. Checked via `isPathExcluded(path, 'summarize', settings)` from `shared`.
 
 ## Content-Aware Schemas
 
-The content-aware formatting registry lives in the **shared** module (`shared/content-schemas.ts`) so both the summarize and transcription stages can consult it. Each `ContentSchema` declares which `appliesTo` pipeline stage(s) it targets (`'transcription' | 'summary'`) and a `mode` (`'reformat' | 'summarize'`). The summarize module only ever asks for the `'summary'` stage.
+Registry: `shared/content-schemas.ts`. Called via `detectSchemaFor('summary', content)`.
 
-When `autoDetectTemplates` is enabled (default: true) and no `customPrompt` is set, the module runs `detectSchemaFor('summary', content)` on inline-target content before summarization. If a schema matches, its specialized prompt replaces the style-based default.
+Priority chain for inline targets: `customPrompt` > schema match > style default.
+Enrichment targets always use `COMPREHENSIVE_SUMMARY_PROMPT` regardless.
 
-Priority chain: `customPrompt` > schema match > style default.
+| ID | Detection | Stage |
+|----|-----------|-------|
+| `recipe` | Keyword scoring >= 5 (headers, cooking verbs, measurements) | `'summary'` |
+| `receipt` | Keyword scoring >= 5 (currency, totals, payment terms) | `'summary'` |
 
-Enrichment targets (standalone notes) always use `COMPREHENSIVE_SUMMARY_PROMPT` and are not affected by schema detection.
+## Dependencies
 
-### Summary-stage schemas
+| Import | From |
+|--------|------|
+| `FolderPickerModal`, `getMarkdownFiles`, `NotificationManager`, `OperationHandle`, `buildCallout`, `CALLOUT_TYPES`, `CheckpointManager`, `generateId`, `fireAndForget`, `isPathExcluded`, `matchesExcludeTag`, `detectSchemaFor`, `isSupportedUrl`, `detectPlatform`, `fetchPageContent`, `fetchTweetContent` | `../shared` |
+| `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `../shared` (type-only) |
+| `findAudioEmbeds` | `../audio` |
+| `CommandRegistrar` | `../commands` |
+| `SynapseSettings`, `SummarizeSettings` | `../settings` |
 
-| ID | Name | Detection | Prompt Format |
-|----|------|-----------|---------------|
-| `recipe` | Recipe | Keyword scoring (structural headers, cooking verbs, measurements); threshold >= 5 | Structured recipe: title, times, servings, ingredients with exact amounts, numbered instructions with step images, notes |
-| `receipt` | Receipt | Keyword scoring (currency/total headers, line items, payment terms, identifiers, date/time); threshold >= 5 | Structured receipt: store, date, item table, totals, payment method, notes |
-
-### Adding new schemas
-
-Schemas are defined centrally in `shared/content-schemas.ts`:
-
-1. Create a detection function (pure function, no side effects).
-2. Define the specialized prompt string.
-3. Add a `ContentSchema` entry to the `CONTENT_SCHEMAS` array with `appliesTo` + `mode` set, and export anything needed from `shared/index.ts`.
-4. Add tests in `shared/content-schemas.test.ts` for both positive and negative detection (and the stage gate).
-
-## Tests
-
-- `summarizer.test.ts`
-- `note-scanner.test.ts`
-- `summarize-module.test.ts`
-- `audio-summarize.test.ts`
-
-> Content-schema detection tests live in `shared/content-schemas.test.ts`.
+NO static import of `../video`. Video transcription is callback-only (`TranscribeUrlFn`).

--- a/src/tidy/AGENTS.md
+++ b/src/tidy/AGENTS.md
@@ -1,21 +1,25 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-19
 ---
 
 # Tidy Module
 
-Spelling correction and markdown formatting for notes via AI. No content changes -- only fixes typos and applies structural formatting.
+Spelling correction and markdown formatting for notes via AI. No content changes — only fixes typos and applies structural formatting. Supports undo via pre-tidy snapshots.
 
-## Public API
-
-Exported from `index.ts`:
+## Public API (`index.ts`)
 
 ```ts
 class TidyModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager)
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    registrar: CommandRegistrar
+  )
   onload(): Promise<void>
   onunload(): void
   tidy(file: TFile): Promise<void>
+  scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
 }
 
 interface TidySnapshot {
@@ -26,73 +30,105 @@ interface TidySnapshot {
 }
 ```
 
+Exported types: `TidySnapshot`
+
+Exported functions: `renderTidySettings(ctx: SettingsSectionContext): void`
+
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
+| `index.ts` | `TidyModule`, type + fn re-exports | Orchestrator, commands, AI interaction, undo |
 | `types.ts` | `TidySnapshot` | Snapshot type for undo |
-| `tidy-store.ts` | `TidyStore` | Stores pre-tidy snapshots (one per file) |
+| `tidy-store.ts` | `TidyStore` | Stores pre-tidy snapshots (one per file path) |
+| `settings-section.ts` | `renderTidySettings` | Tidy settings UI section (no configurable options; placeholder only) |
 | `tidy-store.test.ts` | Tests | TidyStore tests |
 | `tidy-module.test.ts` | Tests | TidyModule tests |
-| `index.ts` | `TidyModule` | Orchestrator, commands, AI interaction |
+| `settings-section.test.ts` | Tests | Settings section tests |
 
 ## Data Flow
 
 ```
-1. User triggers synapse:tidy-current-note
-   |
-2. TidyStore.save(snapshot) -- saves original content for undo
-   |
-3. parseFrontmatter(content) -- separate frontmatter from body
-   |
-4. AIClient.complete(body, SYSTEM_PROMPT) via withRetry(3, 2000ms)
-   |  System prompt constrains AI to:
-   |  - Spelling correction only (no grammar changes)
-   |  - Markdown formatting (lists, headers, code blocks, emphasis)
-   |  - No content addition/removal/rephrasing
-   |
-5. sanitizeAIResponse() --> stripCodeFences()
-   |
-6. serializeFrontmatter(original_frontmatter, tidied_body)
-   |
-7. vault.modify(file, finalContent)
+tidy(file)
+  1. vault.read(file) --> content
+  2. TidyStore.save(snapshot)        -- saves original for undo
+  3. parseFrontmatter(content)       -- separate frontmatter from body
+  4. withRetry(3, 2000ms):
+       AIClient.complete(body, SYSTEM_PROMPT)
+     System prompt constrains AI to:
+       - Spelling correction only (no grammar/word choice/meaning changes)
+       - Markdown formatting (lists, headers, code blocks, emphasis)
+       - No content addition/removal/rephrasing
+       - Preserve all links, tags, embeds, Obsidian syntax
+  5. sanitizeAIResponse() --> stripCodeFences()
+  6. vault.process(file, (data) => {
+       fm = parseFrontmatter(data).frontmatter
+       return fm ? serializeFrontmatter(fm, cleaned) : cleaned
+     })                              -- atomic write; frontmatter re-parsed from fresh content
 ```
 
 ## Undo Flow
 
 ```
-1. User triggers synapse:undo-tidy
-   |
-2. TidyStore.load(filePath) -- retrieves snapshot
-   |
-3. vault.modify(file, snapshot.originalContent)
-   |
-4. TidyStore.remove(filePath)
+undoTidy(file)   [triggered by synapse:undo-tidy command]
+  1. TidyStore.load(file.path) --> snapshot | null
+  2. vault.process(file, () => snapshot.originalContent)
+  3. TidyStore.remove(file.path)   -- trashes snapshot file (recoverable)
 ```
+
+## Vault Scan
+
+```
+scanVault(folderPath?, skipConfirmation?, onlyFile?)
+  --> getMarkdownFiles(app, folderPath)
+  --> if onlyFile: narrow to single file
+  --> optional confirmation prompt
+  --> for each file:
+        isPathExcluded(path, 'tidy', settings) --> skip silently (batch)
+        findMatchingRule(path, 'tidy', settings) --> named in Notice (single-note command)
+        tidy(file)
+  --> returns count of tidied files
+```
+
+Note: `tidy` module does NOT use `CheckpointManager`. Vault scan has no resume capability.
 
 ## TidyStore
 
-- Storage: `settings.tidy.snapshotFolderPath` (default: `.synapse/tidy-snapshots`)
-- One snapshot per file path (overwrites previous)
-- Filename: `{path-with-double-underscores}.json` (deterministic)
-- Uses `vault.adapter.write()` for atomic overwrites
+- Storage path: `settings.tidy.snapshotFolderPath` (default: `.synapse/tidy-snapshots`)
+- One snapshot per file path (overwrites previous on re-tidy)
+- Filename: `{path-with-double-underscores}.json` (deterministic, no collisions)
+- Write: `vault.adapter.write()` (atomic overwrite)
+- Delete: `app.fileManager.trashFile()` (respects user's "Deleted files" preference; recoverable)
+
+## Commands
+
+Registered in `onload()` (both gated by `tidy.enabled`):
+
+| ID | Name | Type |
+|----|------|------|
+| `synapse:tidy-current-note` | Tidy current note | editorCallback |
+| `synapse:undo-tidy` | Undo last tidy on current note | editorCallback |
+
+Single-note command shows an exclusion Notice naming the matched rule. Batch scan silently skips.
 
 ## Settings Keys
 
-All under `settings.tidy`:
+All under `settings.tidy` (`TidySettings`):
 
-| Key | Controls |
-|-----|----------|
-| `enabled` | Module activation |
-| `snapshotFolderPath` | Snapshot storage location |
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `enabled` | `boolean` | — | Module + command activation |
+| `snapshotFolderPath` | `string` | `.synapse/tidy-snapshots` | Snapshot storage location |
+
+Path exclusion: centralized `settings.exclusions: ExclusionRule[]` (#307). No per-module `excludeFolders` field and no `excludeTags` field. Checked via `isPathExcluded(path, 'tidy', settings)` and `findMatchingRule(path, 'tidy', settings)` from `shared`.
 
 ## Dependencies
 
 | Import | From |
 |--------|------|
-| `AIClient` | `shared/ai-client` |
-| `NotificationManager` | `shared/notifications` |
-| `parseFrontmatter`, `serializeFrontmatter` | `shared/frontmatter-utils` |
-| `sanitizeAIResponse` | `shared/validation` |
-| `withRetry` | `shared/api-utils` |
+| `AIClient`, `NotificationManager`, `getMarkdownFiles`, `parseFrontmatter`, `sanitizeAIResponse`, `stripCodeFences`, `serializeFrontmatter`, `withRetry`, `generateId`, `isPathExcluded`, `findMatchingRule` | `../shared` |
+| `CommandRegistrar` | `../commands` |
+| `SynapseSettings`, `TidySettings` | `../settings` |
 | `TidyStore` | `./tidy-store` |
+
+No `CheckpointManager` dependency. No `excludeTags` per-module field.

--- a/src/title/AGENTS.md
+++ b/src/title/AGENTS.md
@@ -1,93 +1,166 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-19
 ---
 
-# title — Agent Reference
+# title module
 
-Detects notes with "Untitled" filenames or content-mismatched titles and proposes AI-generated alternatives.
+Detects notes with "Untitled" filenames or content-mismatched titles and proposes AI-generated alternatives. No commands — triggered via cross-module callbacks wired in `main.ts`.
 
-## Public API
-
-### TitleModule
+## Public API (`index.ts`)
 
 ```ts
 class TitleModule {
+  onViewRefreshNeeded: (() => Promise<void>) | null
+  onOpenProposalView: (() => void) | null  // wired by main.ts (#340)
+
   constructor(
     plugin: Plugin,
     getSettings: () => SynapseSettings,
-    notifications: NotificationManager
+    notifications: NotificationManager,
+    shouldAutoAccept?: () => boolean
   )
 
-  async onload(): Promise<void>
+  onload(): Promise<void>
   onunload(): void
-
-  async getPendingProposals(): Promise<TitleProposal[]>
-  async checkUntitled(filePath: string): Promise<void>
-  async checkMismatch(filePath: string): Promise<void>
-  async checkTitle(filePath: string): Promise<void>
-  async acceptProposal(id: string): Promise<void>
-  async rejectProposal(id: string): Promise<void>
-
-  onViewRefreshNeeded?: () => Promise<void>
+  getPendingProposals(): Promise<TitleProposal[]>
+  checkTitle(filePath: string): Promise<void>
+  checkUntitled(filePath: string): Promise<void>
+  checkMismatch(filePath: string): Promise<void>
+  acceptProposal(id: string, options?: { silent?: boolean }): Promise<void>
+  rejectProposal(id: string): Promise<void>
 }
-```
 
-### Exported Functions
-
-```ts
 function isUntitled(basename: string): boolean
 ```
 
-### Types
+Note: `TitleModule` does NOT take a `CheckpointManager`. Title proposals are single-note operations; no checkpoint support.
+
+Exported types: `TitleProposal`, `TitleProposalTrigger`, `TitleProposalStatus`
+
+## Internal File Map
+
+| File | Class/Function | Role |
+|------|---------------|------|
+| `index.ts` | `TitleModule`, re-exports | Module entry point and public API |
+| `title-suggester.ts` | `TitleSuggester` | AI title suggestion and mismatch detection |
+| `title-store.ts` | `TitleProposalStore` | JSON persistence in `settings.title.proposalFolderPath` |
+| `title-detector.ts` | `isUntitled` | Regex check for Obsidian "Untitled" default pattern |
+| `types.ts` | -- | All title types |
+
+## TitleSuggester (`title-suggester.ts`)
+
+```ts
+class TitleSuggester {
+  constructor(aiClient: AIClient)
+  suggestTitle(content: string, currentTitle: string): Promise<{ title: string; reasoning: string }>
+  checkTitleMismatch(content: string, currentTitle: string): Promise<{ isMismatch: boolean; suggestedTitle?: string; reasoning?: string }>
+}
+```
+
+Content truncated to 4000 chars before AI call.
+
+## isUntitled (`title-detector.ts`)
+
+```ts
+function isUntitled(title: string): boolean
+// Matches "Untitled", "Untitled 1", "Untitled 2", etc. (case-insensitive)
+// Pattern: /^untitled(\s+\d+)?$/i
+```
+
+## Data Flow
+
+```
+checkTitle(filePath)  [called by main.ts after enrichment/elaboration/transcription/etc.]
+  --> isPathExcluded(file.path, 'title', settings)  [silent skip if excluded]
+  --> if isUntitled(basename): checkUntitled(filePath)
+  --> else: checkMismatch(filePath)
+
+checkUntitled(filePath)
+  --> skip if existing pending proposal for this note
+  --> TitleSuggester.suggestTitle(content, basename)  [AI]
+  --> TitleProposalStore.save(proposal)
+  --> maybeAutoAccept(proposal)  [if shouldAutoAccept(): acceptProposal(id, {silent:true})]
+  --> if not auto-accepted: notifications.success('Title proposal ready', ..., Review toast)
+  --> onViewRefreshNeeded?()
+
+checkMismatch(filePath)
+  --> skip if isUntitled (handled by checkUntitled)
+  --> skip if existing pending proposal for this note
+  --> TitleSuggester.checkTitleMismatch(content, basename)  [AI]
+  --> if mismatch: TitleProposalStore.save(proposal)
+  --> maybeAutoAccept(proposal)
+  --> if not auto-accepted: notifications.success('Title proposal ready', ..., Review toast)
+  --> onViewRefreshNeeded?()
+
+acceptProposal(id, options?)
+  --> guard: no-op if proposal.status !== 'pending'
+  --> check no file exists at target path (in-folder rename collision)
+  --> vault.rename(file, newPath)
+  --> TitleProposalStore.updateStatus(id, 'accepted')
+  --> if !silent: notifications.success, onViewRefreshNeeded?()
+
+rejectProposal(id)
+  --> TitleProposalStore.updateStatus(id, 'rejected')
+  --> onViewRefreshNeeded?()
+```
+
+## Key Types
 
 ```ts
 type TitleProposalTrigger = 'untitled' | 'content-mismatch'
 type TitleProposalStatus = 'pending' | 'accepted' | 'rejected'
 
 interface TitleProposal {
-  id: string; sourceNotePath: string; currentTitle: string
-  proposedTitle: string; trigger: TitleProposalTrigger
-  reasoning: string; createdAt: string; status: TitleProposalStatus
+  id: string
+  sourceNotePath: string
+  currentTitle: string
+  proposedTitle: string
+  trigger: TitleProposalTrigger
+  reasoning: string
+  createdAt: string
+  status: TitleProposalStatus
 }
-```
-
-## Internal Architecture
-
-| File | Purpose |
-|------|---------|
-| `index.ts` | Re-exports module, types, `isUntitled` |
-| `title-module.ts` | Main module: title checking, proposal lifecycle |
-| `title-suggester.ts` | AI title generation and mismatch detection |
-| `title-proposal-store.ts` | JSON persistence in `.synapse/title-proposals/` |
-| `types.ts` | `TitleProposal`, trigger/status types |
-
-## Data Flow
-
-```
-checkTitle(filePath) [called after enrichment/elaboration/transcription/summarize/deep-dive]
-  --> checkUntitled(filePath): if "Untitled*" → suggestTitle()
-  --> checkMismatch(filePath): AI evaluates title vs content
-  --> TitleProposalStore.save(proposal)
-  --> onViewRefreshNeeded()
-
-acceptProposal(id)
-  --> rename file to proposedTitle
-  --> TitleProposalStore.updateStatus('accepted')
 ```
 
 ## Commands
 
-No direct commands. Title checks are triggered via cross-module callbacks wired in main.ts.
+None. Title checks are triggered via cross-module callbacks in `main.ts` (post-elaboration, post-enrichment, post-transcription, post-summarize, post-deep-dive accept). The `checkTitle` method is the single entry point.
 
-## Configuration
+## Settings Keys
+
+Path exclusion is centralized (#307): `settings.exclusions: ExclusionRule[]` consulted via `isPathExcluded(path, 'title', settings)`. There is no per-module `excludeFolders` key. Title module has no `excludeTags` field.
 
 | Key | Type | Default |
 |-----|------|---------|
-| `title.enabled` | boolean | true |
-| `title.proposalFolderPath` | string | `.synapse/title-proposals` |
-| `title.checkAfterOperations` | boolean | true |
+| `settings.title.enabled` | `boolean` | `true` |
+| `settings.title.proposalFolderPath` | `string` | `.synapse/title-proposals` |
+| `settings.title.checkAfterOperations` | `boolean` | `true` |
+| `settings.autoAccept.title` | `boolean` | `false` |
+| `settings.exclusions` | `ExclusionRule[]` | see `settings.ts` defaults |
 
 ## Dependencies
 
-- `shared/` — AIClient, NotificationManager, file-utils
-- No CheckpointManager (single-note operation)
+In: `shared/` (AIClient, NotificationManager, generateId, readNote, isPathExcluded), `settings.ts` (SynapseSettings)
+
+Out: Nothing. No other feature module imports from `title/`.
+
+## Invariants / Gotchas
+
+- No `CheckpointManager` — title proposals are always single-note, never batched.
+- `acceptProposal` guards against double-acceptance: no-ops if `proposal.status !== 'pending'`.
+- `acceptProposal` does an in-folder rename: the new path is `<parentFolder>/<proposedTitle>.md`. Aborts if a file already exists at that path.
+- Auto-accept for title RENAMES the file on the filesystem (same as accept, just silent).
+- `checkTitle` is silent: no notifications until a proposal is confirmed or auto-accepted.
+- The Review toast fires via `notifications.success('Title proposal ready', undefined, { label: 'Review', onClick: ... })` — only when a proposal remains pending after generation.
+- `checkMismatch` skips notes that are already untitled (let `checkUntitled` handle those).
+- Both check methods skip if any pending proposal already exists for the note (prevents duplicate proposals).
+
+## Tests
+
+| File | Covers |
+|------|--------|
+| `title-detector.test.ts` | isUntitled pattern matching |
+| `title-suggester.test.ts` | TitleSuggester.suggestTitle, checkTitleMismatch |
+| `title-store.test.ts` | TitleProposalStore persistence |
+| `auto-accept.test.ts` | Auto-accept flow (#228) |
+| `review-toast.test.ts` | Review toast notification behavior |

--- a/src/transcription/AGENTS.md
+++ b/src/transcription/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-19
 ---
 
 # Transcription Module
 
-Unified transcription and OCR UI modals with duration-aware time-range clipping. Replaces the former separate modals in audio/ and video/ modules. Also handles image OCR selection.
+UI-only module providing unified transcription modals with duration-aware time-range clipping. Imports types and delegates all media processing work to the `audio`, `video`, and `image` modules. No transcription logic lives here.
 
 ## Public API
 
@@ -30,10 +30,11 @@ class NoteMediaModal extends Modal {
     videoEmbeds: VideoUrlEmbed[],
     imageEmbeds: ImageEmbed[],
     callbacks: {
-      onTranscribeAudio: (embeds: AudioEmbed[]) => Promise<void>;
+      onTranscribeAudio: (embeds: AudioEmbed[], combine: boolean) => Promise<void>;
       onTranscribeVideo: (embeds: VideoUrlEmbed[]) => Promise<void>;
       onExtractImages: (embeds: ImageEmbed[]) => Promise<void>;
-    }
+    },
+    ffmpegAvailable?: boolean   // default false; controls combine-audio description text
   )
 }
 
@@ -58,8 +59,19 @@ interface TimeRangeToastOptions {
   duration: number
 }
 
-function detectLocalFileDuration(file: TFile, readBinary: (file: TFile) => Promise<ArrayBuffer>, getSettings: () => SynapseSettings): Promise<DurationResult>
-function detectUrlDuration(url: string, getSettings: () => SynapseSettings): Promise<DurationResult>
+function detectLocalFileDuration(
+  file: TFile,
+  readBinary: (file: TFile) => Promise<ArrayBuffer>,
+  getSettings: () => SynapseSettings,
+  deps?: NodeDeps
+): Promise<DurationResult>
+
+function detectUrlDuration(
+  url: string,
+  getSettings: () => SynapseSettings,
+  deps?: NodeDeps
+): Promise<DurationResult>
+
 function formatTimestamp(totalSeconds: number): string
 
 const MIN_SLIDER_DURATION: number  // 10 seconds
@@ -68,115 +80,133 @@ interface DurationResult {
   durationSeconds: number | undefined
   title: string
 }
+
+type NodeDeps = NodeModules  // injection seam for tests; alias of shared NodeModules
 ```
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `unified-modal.ts` | `UnifiedTranscriptionModal` | File picker + URL input modal with duration detection and time-range slider |
-| `note-media-modal.ts` | `NoteMediaModal` | Selection modal for media found in current note |
-| `time-range-slider.ts` | `TimeRangeSlider`, `TimeRangeSliderOptions` | Dual-handle range slider for time selection (pure DOM component) |
-| `time-range-toast.ts` | `showTimeRangeToast`, `TimeRangeToastOptions` | Confirmation toast with embedded time-range slider |
-| `duration-detector.ts` | `detectLocalFileDuration`, `detectUrlDuration`, `formatTimestamp`, `MIN_SLIDER_DURATION`, `DurationResult` | Duration detection via ffprobe (local) and yt-dlp (URL) |
-| `duration-detector.test.ts` | Tests | Duration detector tests |
+| `unified-modal.ts` | `UnifiedTranscriptionModal` | File picker + URL input modal with duration detection, platform badge, time-range slider |
+| `note-media-modal.ts` | `NoteMediaModal` | Selection modal for media found in current note; audio/video/image toggles; combine-audio option |
+| `time-range-slider.ts` | `TimeRangeSlider`, `TimeRangeSliderOptions` | Dual-handle range slider (pure DOM, no Obsidian deps beyond createEl) |
+| `time-range-toast.ts` | `showTimeRangeToast`, `TimeRangeToastOptions` | Non-dismissible Notice with embedded TimeRangeSlider |
+| `duration-detector.ts` | `detectLocalFileDuration`, `detectUrlDuration`, `formatTimestamp`, `MIN_SLIDER_DURATION`, `DurationResult`, `NodeDeps` | Duration detection via ffprobe (local) and yt-dlp (URL); desktop-only, mobile returns undefined |
+| `duration-detector.test.ts` | Tests | Duration detector unit tests with NodeDeps injection |
+| `note-media-modal.test.ts` | Tests | NoteMediaModal unit tests |
 | `index.ts` | Re-exports | Barrel file |
 
 ## UnifiedTranscriptionModal
 
-Single modal combining audio file selection and video URL input:
-- Dropdown lists all audio files in vault (filtered by `AUDIO_EXTENSIONS`)
-- URL text field with platform detection badge (YouTube/TikTok/Instagram)
-- Post-processing status display
-- Duration detection: auto-detects media length when file selected or URL entered
-- Time-range slider: shown when duration >= `MIN_SLIDER_DURATION` (10s)
-- Validates URL via `detectPlatform()` before allowing transcription
+Single modal combining audio file selection and video URL input (`unified-modal.ts`):
+- Dropdown lists all audio files in vault (filtered by `AUDIO_EXTENSIONS`, honors audio path exclusions from settings #323)
+- URL text field with platform detection badge (YouTube/TikTok/Instagram etc.)
+- URL section shown only on `Platform.isDesktop`
 - File selection and URL input are mutually exclusive
-- Callbacks pass `timeRange` when user selects a sub-range
+- On submit: attempts duration detection (ffprobe for files, yt-dlp for URLs)
+  - Duration >= `MIN_SLIDER_DURATION` (10s): shows `showTimeRangeToast`
+  - Duration < 10s: transcribes full file (no slider)
+  - Duration unknown: shows fallback text-input toast (MM:SS/HH:MM:SS manual entry)
+- Callbacks receive `timeRange?: TimeRange` (undefined = full file)
 
-Opened via:
-- Ribbon icon (`mic`)
-- Command `synapse:transcribe-media`
+Opened via ribbon icon (`mic`) and command `synapse:transcribe-media`.
 
 ## NoteMediaModal
 
-Selection modal for media embedded in the current note:
+Selection modal for media embedded in the current note (`note-media-modal.ts`):
 - Displays count of audio files, video URLs, and images found
-- Toggle checkboxes for each audio embed, video URL, and image embed
-- Select All / Select None buttons
-- Process Selected button dispatches to separate audio/video/image callbacks
+- Toggle checkboxes per embed (audio, video, image sections)
+- "Select all" / "Select none" buttons
+- "Combine audio" toggle (#214): shown for 2+ audio embeds; with ffmpeg concatenates audio before transcribing (single API call); without ffmpeg merges text transcriptions
+  - `ffmpegAvailable` param controls the toggle description text only; actual concat logic is in `AudioModule`
+  - `onTranscribeAudio` receives `combine: boolean` as second arg; caller decides behavior
+- "Process selected" dispatches to separate audio/video/image callbacks
 
-Opened via:
-- Command `synapse:transcribe-note-media`
+Opened via command `synapse:transcribe-note-media`.
 
 ## Duration Detection
 
-`duration-detector.ts` provides two detection strategies:
+`duration-detector.ts` — both functions return early with `{ durationSeconds: undefined }` on mobile (`!Platform.isDesktop`).
 
-### Local Files (`detectLocalFileDuration`)
-1. Writes audio binary to temp file
-2. Runs ffprobe (derived from `video.ffmpegPath` setting)
-3. Parses `-show_entries format=duration` output
-4. Returns `DurationResult` (undefined duration on failure/mobile)
+Local files (`detectLocalFileDuration`):
+1. Writes audio binary to OS temp dir (`synapse-probe-<ts>-<safeName>`)
+2. Runs ffprobe (derived from `video.ffmpegPath` by replacing `ffmpeg` with `ffprobe`)
+3. Parses `-show_entries format=duration -of csv=p=0` output
+4. Cleans up temp file in `execFile` callback (fire-and-forget)
 
-### URLs (`detectUrlDuration`)
-1. Runs `yt-dlp --dump-json --no-download` on validated URL
-2. Parses `duration` and `title` from JSON metadata
-3. Returns `DurationResult` (undefined duration on failure/mobile)
+URLs (`detectUrlDuration`):
+1. Validates URL via `sanitizeUrl`
+2. Runs `yt-dlp --dump-json --no-download` (timeout: 30s, maxBuffer: 10MB)
+3. Parses `duration` and `title` from JSON; narrows with `asYtDlpDurationJson`
 
-Both use `shellEnv()` to append common tool paths (`/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin`).
+`NodeDeps` is the injection seam for tests; production code passes `undefined` and the function resolves real builtins via `loadNodeModules()`.
 
 ## Time-Range Slider
 
-`TimeRangeSlider` is a pure DOM component (no Obsidian dependencies beyond `createEl`):
-- Two overlapping HTML range inputs on a shared track
-- Visual highlight for the selected region
-- Timestamp labels update live (MM:SS or HH:MM:SS)
-- Step size: 1s for media <= 10min, 5s otherwise
-- Handles cannot cross each other (enforced via input handlers)
+`TimeRangeSlider` (`time-range-slider.ts`): pure DOM component with no Obsidian dependencies beyond `createEl`/`createDiv`:
+- Two overlapping `<input type="range">` on a shared track
+- Visual highlight for selected region (percentage-based CSS left/width)
+- Timestamp labels update live (`MM:SS` or `HH:MM:SS`)
+- Step size: 1s for media <= 600s (10min), 5s otherwise
+- Handles cannot cross (enforced via input event handlers; clamped to `end - 1` / `start + 1`)
 
 ## Time-Range Toast
 
-`showTimeRangeToast()` shows a non-dismissible Obsidian Notice with:
-- Media title
-- Embedded `TimeRangeSlider`
-- "Transcribe Selection" button (returns `TimeRange` if range adjusted)
-- "Full File" button (returns `undefined`)
+`showTimeRangeToast()` (`time-range-toast.ts`): non-dismissible Obsidian Notice (duration = 0):
+- Title display
+- Embedded `TimeRangeSlider` spanning full duration
+- "Transcribe selection" button: resolves `TimeRange` only if range was adjusted from full; resolves `undefined` if full range unchanged
+- "Full file" button: resolves `undefined`
+- Background click blocked via capture-phase listener; button/input clicks pass through
 
-## Dependencies
+## Data Flow
 
-| Import | From |
-|--------|------|
-| `AUDIO_EXTENSIONS` | `../audio` (regex constant) |
-| `AudioEmbed` | `../audio` (type) |
-| `detectPlatform` | `../video` (function) |
-| `VideoUrlEmbed` | `../video` (type) |
-| `ImageEmbed` | `../image` (type) |
-| `TimeRange` | `../shared` (type) |
-| `sanitizePath`, `sanitizeUrl` | `../shared` (validation) |
-| `SynapseSettings` | `../settings` |
+```
+main.ts constructs modals and wires callbacks:
 
-## Wiring (in main.ts)
+UnifiedTranscriptionModal
+  onTranscribeFile(file, timeRange?) --> AudioModule.transcribeFileToActiveNote(file, timeRange)
+  onTranscribeUrl(url, timeRange?)   --> VideoModule.transcribeUrlToActiveNote(url, timeRange)
 
-```ts
-// UnifiedTranscriptionModal
-new UnifiedTranscriptionModal(app, getSettings, enabledModules, {
-  onTranscribeFile: (file, timeRange) => audio.transcribeFileToActiveNote(file, timeRange),
-  onTranscribeUrl: (url, timeRange) => video.transcribeUrlToActiveNote(url, timeRange),
-})
-
-// NoteMediaModal (after scanning note content)
-new NoteMediaModal(app, audioEmbeds, videoEmbeds, imageEmbeds, {
-  onTranscribeAudio: (selected) => audio.transcribeAndInsert(file, selected),
-  onTranscribeVideo: (selected) => video.transcribeAndInsert(file, selected),
-  onExtractImages: (selected) => image.extractAndInsert(file, selected),
-})
+NoteMediaModal
+  onTranscribeAudio(embeds, combine) --> AudioModule.transcribeAndInsert(file, embeds, combine)
+  onTranscribeVideo(embeds)          --> VideoModule.transcribeAndInsert(file, embeds)
+  onExtractImages(embeds)            --> ImageModule.extractAndInsert(file, embeds)
 ```
 
-## Migration Notes
+## Module Dependencies
 
-This module was created in issue #20 (unified transcription). Replaces:
-- `src/audio/transcription-modal.ts` (deleted)
-- `src/audio/note-audio-modal.ts` (deleted)
-- `src/video/video-modal.ts` (deleted)
-- `src/video/note-video-modal.ts` (deleted)
+In (all imports; type-only where noted):
+
+| Import | From | Type-only |
+|--------|------|-----------|
+| `AUDIO_EXTENSIONS` | `../audio` | no (runtime constant) |
+| `AudioEmbed` | `../audio` | yes |
+| `detectPlatform` | `../video` | no (runtime function) |
+| `VideoUrlEmbed` | `../video` | yes |
+| `ImageEmbed` | `../image` | yes |
+| `TimeRange` | `../shared` | yes |
+| `sanitizePath`, `sanitizeUrl`, `validateTimeRange`, `isPathExcluded` | `../shared` | no |
+| `loadNodeModules`, `shellEnv`, `isRecord`, `parseJson` | `../shared` | no |
+| `SynapseSettings` | `../settings` | yes |
+
+Out: nothing — this module is consumed only by `main.ts` (modal construction) and has no downstream module consumers.
+
+## Settings Keys Referenced
+
+| Key | Source module | Used by |
+|-----|--------------|---------|
+| `audio.postProcessing.enabled` | audio | `UnifiedTranscriptionModal` (display only) |
+| `video.ffmpegPath` | video | `detectLocalFileDuration` (derives ffprobe path) |
+| `video.ytDlpPath` | video | `detectUrlDuration` |
+| Folder exclusion rules | shared | `UnifiedTranscriptionModal` file filter (#323) |
+
+## Invariants / Gotchas
+
+- This module contains NO transcription logic; it is a pure UI delegation layer
+- `detectPlatform` is imported from `../video` (not `../shared` directly); `../video` re-exports it from `../shared` for back-compat
+- `NoteMediaModal` constructor signature changed: added `ffmpegAvailable?: boolean` parameter and `onTranscribeAudio` callback now receives `combine: boolean` as second arg (#214)
+- Duration detection is desktop-only; mobile always receives `durationSeconds: undefined` (graceful degradation to full-file transcription)
+- `TimeRangeSlider` has no Obsidian Modal/View coupling — safe to embed in Notice DOM
+- `showTimeRangeToast` resolves `undefined` (not a `TimeRange`) when the user clicks "Transcribe selection" with the slider at its default full-range position

--- a/src/video/AGENTS.md
+++ b/src/video/AGENTS.md
@@ -1,14 +1,12 @@
 ---
-last-updated: 2026-06-08
+last-updated: 2026-06-19
 ---
 
 # Video Module
 
-Downloads videos from YouTube/TikTok via yt-dlp, extracts audio, delegates transcription to Audio module, optionally saves video to vault. Exposes public methods for unified transcription UI.
+Downloads videos from YouTube/TikTok/Instagram/Twitter via yt-dlp, extracts audio, delegates transcription to AudioModule, optionally saves video to vault. Exposes public methods consumed by the unified transcription UI. Desktop-only: VideoModule is only constructed when `Platform.isDesktop`.
 
-URL platform detection now lives in `src/shared/url-detector.ts` (moved out of this module to break the old
-shared⇄video cycle). Video re-exports `detectPlatform`, `isSupportedUrl`, `Platform`, and `UrlDetectionResult`
-from `../shared` for back-compat; new code should import them directly from `shared`.
+URL platform detection lives in `src/shared/url-detector.ts` (moved out of this module to break the shared-video cycle). Video re-exports `detectPlatform`, `isSupportedUrl`, `Platform`, and `UrlDetectionResult` from `../shared` for back-compat; new code should import them directly from `shared`.
 
 ## Public API
 
@@ -16,18 +14,35 @@ Exported from `index.ts`:
 
 ```ts
 class VideoModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, audioModule: AudioModule, notifications: NotificationManager, checkpointManager: CheckpointManager, registrar: CommandRegistrar)
+  onTranscriptionComplete: ((filePath: string) => void) | null
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    audioModule: AudioModule,
+    notifications: NotificationManager,
+    checkpointManager: CheckpointManager,
+    registrar: CommandRegistrar
+  )
   onload(): Promise<void>
   onunload(): void
-  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   transcribeUrl(url: string, parentOp?: { update: (msg: string) => void }): Promise<string>
   processUrl(url: string, options?: VideoProcessOptions, parentOp?: { update: (msg: string) => void }): Promise<TranscriptionResult & { videoVaultPath?: string }>
   transcribeUrlToActiveNote(url: string, timeRange?: TimeRange): Promise<void>
   transcribeAndInsert(noteFile: TFile, embeds: VideoUrlEmbed[]): Promise<void>
-  onTranscriptionComplete: ((filePath: string) => void) | null
+  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
 }
 
-// Re-exported from ../shared (canonical home is shared/url-detector.ts)
+class AudioExtractor {
+  constructor(getSettings: () => SynapseSettings)
+  extractFromUrl(url: string): Promise<ExtractionResult>
+  extractFromFile(filePath: string): Promise<ExtractionResult>
+  downloadVideo(url: string): Promise<string>
+  clipAudio(inputPath: string, startSeconds: number, endSeconds: number): Promise<string>
+  concatAudio(inputPaths: string[]): Promise<string>
+  checkDependencies(): Promise<{ ytDlp: boolean; ffmpeg: boolean }>
+}
+
+// Re-exported from ../shared (canonical home: shared/url-detector.ts)
 function detectPlatform(url: string): UrlDetectionResult | null
 function isSupportedUrl(url: string): boolean
 type Platform = 'youtube' | 'tiktok' | 'instagram' | 'twitter' | 'unknown'
@@ -35,22 +50,56 @@ interface UrlDetectionResult { platform: Platform; videoId: string; url: string 
 
 // Owned by this module
 function findVideoUrls(content: string): VideoUrlEmbed[]
-interface VideoProcessOptions { postProcess?: boolean; extractFrames?: boolean; outputPath?: string; insertMode?: boolean; timeRange?: TimeRange }
+function hasTranscriptionBelow(lines: string[], embedLine: number, url: string): boolean
+
+// Settings renderer (#243)
+function renderVideoSettings(ctx: SettingsSectionContext): void
+
+// Types
+interface VideoProcessOptions {
+  postProcess?: boolean
+  extractFrames?: boolean
+  outputPath?: string
+  insertMode?: boolean
+  timeRange?: TimeRange
+}
 interface ExtractionResult { audioPath: string; metadata: VideoMetadata }
-interface VideoMetadata { title: string; channel?: string; duration?: number; uploadDate?: string; description?: string; platform?: string; url?: string }
+interface VideoMetadata {
+  title: string
+  channel?: string
+  duration?: number
+  uploadDate?: string
+  description?: string
+  platform?: string
+  url?: string
+}
 interface VideoUrlEmbed { url: string; platform: Platform; line: number }
+interface VideoSource {
+  type: 'url' | 'file'
+  platform?: Platform
+  url?: string
+  filePath?: string
+  title?: string
+  channel?: string
+  duration?: number
+}
 ```
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `types.ts` | All type interfaces | Type definitions |
+| `types.ts` | `VideoProcessOptions`, `ExtractionResult`, `VideoMetadata`, `VideoUrlEmbed`, `VideoSource` | Type definitions |
 | `note-scanner.ts` | `findVideoUrls`, `hasTranscriptionBelow` | Scan note content for video URLs |
-| `note-scanner.test.ts` | Tests | Note scanner tests |
-| `audio-extractor.ts` | `AudioExtractor` | yt-dlp/ffmpeg via `execFile` (no shell) |
-| `frame-extractor.ts` | `FrameExtractor` | Placeholder (not implemented) |
-| `index.ts` | `VideoModule` | Orchestrator, public transcription methods |
+| `note-scanner.test.ts` | Tests | Note scanner unit tests |
+| `audio-extractor.ts` | `AudioExtractor` | yt-dlp/ffmpeg via `execFile` (no shell); URL download, file extract, clip, concat, dependency check |
+| `audio-extractor.test.ts` | Tests | AudioExtractor unit tests |
+| `frame-extractor.ts` | `FrameExtractor` | Placeholder; throws on use (unimplemented) |
+| `settings-section.ts` | `renderVideoSettings` | Video settings accordion renderer for settings-tab.ts |
+| `settings-section.test.ts` | Tests | Settings section tests |
+| `mobile-safety.test.ts` | Tests | Desktop-only guard tests |
+| `index.ts` | `VideoModule` | Orchestrator; public API barrel |
+| `index.test.ts` | Tests | VideoModule integration tests |
 
 ## Data Flow
 
@@ -58,22 +107,22 @@ interface VideoUrlEmbed { url: string; platform: Platform; line: number }
 1. User triggers via UnifiedTranscriptionModal or NoteMediaModal (in transcription/)
    |
 2a. transcribeUrlToActiveNote(url, timeRange?) -- single URL to active note
-   |  Calls processUrl(url, {insertMode:true, timeRange}), clips audio if timeRange provided
-   |  Builds callout with time-range label + optional video embed, appends to active note
+   |  Checks path exclusion (#307); calls processUrl; builds callout; appends to note
    |
 2b. transcribeAndInsert(noteFile, embeds) -- batch from note scan
-   |  Processes embeds in reverse line order, 2s delay between API calls
-   |  Cancellable via NotificationManager operation handle
+   |  Creates checkpoint; processes embeds in reverse line order; 2s delay between
+   |  API calls; atomic splice via vault.process; cancellable via NotificationManager
    |
 2c. transcribeUrl(url, parentOp) -- returns transcript text only
    |  Used by SummarizeModule to auto-transcribe video URLs before summarizing
    |
 3. sanitizeUrl(url) -- validates HTTP(S), rejects shell chars
    |
-4. detectPlatform(url)  [from shared/url-detector.ts]
+4. detectPlatform(url) [from shared/url-detector.ts]
    |  YouTube: youtube.com/watch, youtu.be, youtube.com/shorts|embed|live
    |  TikTok: tiktok.com/@user/video/id, tiktok.com/t/..., vm/vt.tiktok.com
-   |  Instagram: instagram.com/reel|reels|p/CODE ; Twitter/X: (mobile.)twitter.com|x.com/.../status/id
+   |  Instagram: instagram.com/reel|reels|p/CODE
+   |  Twitter/X: (mobile.)twitter.com|x.com/.../status/id
    |  isSupportedUrl() returns true for all detected platforms EXCEPT twitter
    |
 5. AudioExtractor.extractFromUrl(url)
@@ -81,52 +130,80 @@ interface VideoUrlEmbed { url: string; platform: Platform; line: number }
    |  Download audio --> yt-dlp -x --audio-format mp3
    |  Tool paths via sanitizePath(), env via shellEnv()
    |
-5a. [if timeRange] AudioExtractor.clipAudio(audioPath, start, end)
-   |  Clips extracted audio via ffmpeg -ss/-to, validates end < duration
-   |  Cleans up original unclipped audio
+5a. [if timeRange] AudioExtractor.clipAudio(audioPath, startSeconds, endSeconds)
+   |  ffmpeg -ss/-to; cleans up original unclipped audio
    |
-6. downloadVideoToVault() [if downloadFolder configured]
-   |  yt-dlp -f mp4/best, writes to vault via adapter.writeBinary
+6. downloadVideoToVault() [if video.downloadFolder configured]
+   |  AudioExtractor.downloadVideo() --> yt-dlp -f mp4/best to tmp
+   |  vault.createBinary() with collision-safe path; cleans up temp file
    |
-7. AudioModule.transcribe(audioData, fileName)
+7. AudioModule.transcribe(audioData, fileName, { sourceName })
    |
-8. Result wrapped in callout block + optional video embed
+8. Result wrapped in callout block + optional video embed (![[file.mp4]])
 ```
 
 ## Note Scanning
 
-`findVideoUrls(content)` in `note-scanner.ts`:
-- Regex: `https?://[^\s)\]>]+`
-- Skips blockquote lines (transcription output)
-- Skips URLs with existing transcription callout below
+`findVideoUrls(content)` in `note-scanner.ts` (index.ts:L25):
+- Regex: `/https?:\/\/[^\s)\]>]+/g`
+- Skips blockquote lines (transcription output, `>` prefix)
+- Skips Twitter/X URLs (`detected.platform === 'twitter'`)
+- Skips URLs with existing transcription callout within 3 lines below
 - Returns `VideoUrlEmbed[]` with line numbers
 
-## Commands
+`hasTranscriptionBelow(lines, embedLine, url)` checks legacy `**Transcription of ...**` and callout formats.
 
-Only one command registered directly:
-- `synapse:check-dependencies` -- checks yt-dlp and ffmpeg availability
+## Commands Registered
 
-Transcription commands registered in `main.ts` (unified):
-- `synapse:transcribe-media` -> `VideoModule.transcribeUrlToActiveNote(url)` (registry status: `disabled`)
-- `synapse:transcribe-note-media` -> `VideoModule.transcribeAndInsert(file, embeds)` (active)
+| Command ID | Enabled condition | Description |
+|-----------|------------------|-------------|
+| `synapse:check-dependencies` | `video.enabled` | Check yt-dlp and ffmpeg availability |
 
-## External Dependencies
+Transcription commands are registered in `main.ts` (not here):
+- `synapse:transcribe-media` -> `VideoModule.transcribeUrlToActiveNote` via `UnifiedTranscriptionModal`
+- `synapse:transcribe-note-media` -> `VideoModule.transcribeAndInsert` via `NoteMediaModal`
 
-| Tool | Setting | Default | Purpose |
-|------|---------|---------|---------|
+## Settings Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `video.enabled` | `boolean` | `false` | Feature gate |
+| `video.ytDlpPath` | `string` | `'yt-dlp'` | yt-dlp binary path |
+| `video.ffmpegPath` | `string` | `'ffmpeg'` | ffmpeg binary path |
+| `video.tempFolder` | `string` | - | Vault folder for temp audio extraction |
+| `video.downloadFolder` | `string` | `''` | Vault folder to save downloaded videos (empty = do not save) |
+| `video.embedInNote` | `boolean` | `false` | Add `![[video.mp4]]` embed to note when saving video |
+
+## External Runtime Dependencies
+
+| Tool | Setting key | Default | Purpose |
+|------|-------------|---------|---------|
 | yt-dlp | `video.ytDlpPath` | `'yt-dlp'` | Video download and metadata |
-| ffmpeg | `video.ffmpegPath` | `'ffmpeg'` | Audio extraction from local files |
+| ffmpeg | `video.ffmpegPath` | `'ffmpeg'` | Audio extraction, clipping, concatenation |
 
 `shellEnv()` appends `/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin` to PATH.
+`execFile` timeout: 300s; maxBuffer: 10MB.
+
+## Module Dependencies
+
+In:
+- `../audio` — `AudioModule`, `TranscriptionResult`
+- `../shared` — `CheckpointManager`, `NotificationManager`, `CommandRegistrar`, `sanitizeUrl`, `sanitizePath`, `buildCallout`, `calloutForTranscriptionResult`, `ensureFolder`, `formatTimeRange`, `detectPlatform`, `isSupportedUrl`, `loadNodeModules`, `shellEnv`, `isPathExcluded`, `findMatchingRule`, `generateId`, `TimeRange`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask`
+
+Out (consumed by):
+- `src/transcription/` — `UnifiedTranscriptionModal`, `NoteMediaModal` import `VideoUrlEmbed`, `detectPlatform` from here
+- `src/summarize/` — imports `transcribeUrl` behavior via `VideoModule` instance
 
 ## Security
 
-- URLs validated via `sanitizeUrl()` (double-validated: in VideoModule and AudioExtractor)
+- URLs validated via `sanitizeUrl()` (called in both `VideoModule.processUrl` and `AudioExtractor.extractFromUrl`)
 - Tool paths validated via `sanitizePath()`
-- Commands run via `execFile` with argument arrays (no shell)
-- Command timeout: 300s, max buffer: 10MB
+- All subprocess calls use `execFile` with explicit argument arrays (no shell interpolation)
 
-## Unimplemented
+## Invariants / Gotchas
 
-- `FrameExtractor`: placeholder, throws on use
-- The `supportedPlatforms` setting was removed from `VideoSettings`; platform support is determined by `isSupportedUrl()` in `shared/url-detector.ts`
+- Desktop-only: `loadNodeModules()` throws `DesktopOnlyError` off-desktop; VideoModule is only constructed after `Platform.isDesktop` check in `main.ts`
+- `FrameExtractor` in `frame-extractor.ts` is a placeholder and throws on use
+- `AudioExtractor.concatAudio` re-encodes via ffmpeg filter (handles mixed formats: mp3/wav/m4a/ogg/flac/webm/aac)
+- `downloadVideoToVault` uses `vault.createBinary()` (not adapter API) for first-class vault citizenship; collision-safe naming appends `-1`, `-2`, etc.
+- Back-compat re-exports: `detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult` are re-exported from `../shared`; direct `shared` imports preferred in new code

--- a/src/views/AGENTS.md
+++ b/src/views/AGENTS.md
@@ -1,17 +1,51 @@
 ---
-last-updated: 2026-03-19
+last-updated: 2026-06-19
 ---
 
 # Views Module
 
-Unified sidebar view combining elaboration, enrichment, organize, deep-dive, and title proposals in a single pane. Displays checkpoint recovery banner for interrupted operations. Supports batch Accept All.
+Two Obsidian sidebar views: `UnifiedProposalView` (proposal review with checkpoint recovery) and `SynapseActionsView` (touch-friendly command palette). Also exports the semantic color token system and BEM class helpers used by both views.
 
 ## Public API
 
-Exported from `unified-proposal-view.ts`:
+Exported from `index.ts`:
 
 ```ts
+// unified-proposal-view.ts
 const UNIFIED_VIEW_TYPE = 'synapse-proposals'
+
+class UnifiedProposalView extends ItemView {
+  constructor(leaf: WorkspaceLeaf, callbacks: UnifiedViewCallbacks)
+  setItems(items: UnifiedItem[]): void
+  setCheckpoints(checkpoints: Checkpoint[]): void
+  getViewType(): string    // 'synapse-proposals'
+  getDisplayText(): string // 'Synapse Proposals'
+  getIcon(): string        // 'synapse'  (brand S-Signal mark, not 'sparkles')
+}
+
+// synapse-actions-view.ts
+const SYNAPSE_ACTIONS_VIEW_TYPE = 'synapse-actions'
+
+interface SynapseActionsCallbacks {
+  getActions: () => CommandDefinition[]
+  runAction: (id: string) => void
+  isNoteActive: () => boolean
+}
+
+class SynapseActionsView extends ItemView {
+  constructor(leaf: WorkspaceLeaf, callbacks: SynapseActionsCallbacks)
+  getViewType(): string    // 'synapse-actions'
+  getDisplayText(): string // 'Synapse actions'
+  getIcon(): string        // 'layout-grid'
+  refresh(): void          // re-render; called by main.ts on active-leaf-change
+}
+
+// types.ts
+const PROPOSAL_KINDS = [
+  'elaboration', 'enrichment', 'organize', 'deep-dive', 'title', 'rem',
+] as const
+
+type ProposalKind = (typeof PROPOSAL_KINDS)[number]
 
 type UnifiedItem =
   | { kind: 'elaboration'; data: Proposal }
@@ -19,6 +53,7 @@ type UnifiedItem =
   | { kind: 'organize'; data: OrganizeProposal }
   | { kind: 'deep-dive'; data: DeepDiveProposal }
   | { kind: 'title'; data: TitleProposal }
+  | { kind: 'rem'; data: RemProposal }
 
 interface UnifiedViewCallbacks {
   onElaborationAccept: (id: string, editedContent: string) => Promise<void>
@@ -31,68 +66,79 @@ interface UnifiedViewCallbacks {
   onDeepDiveReject: (id: string) => Promise<void>
   onTitleAccept: (id: string) => Promise<void>
   onTitleReject: (id: string) => Promise<void>
+  onRemAcceptSelected: (id: string, acceptedMatchTexts: string[]) => Promise<void>
+  onRemReject: (id: string) => Promise<void>
   onCheckpointDiscard: (id: string) => Promise<void>
   onCheckpointResume: (id: string) => Promise<void>
 }
 
-class UnifiedProposalView extends ItemView {
-  constructor(leaf: WorkspaceLeaf, callbacks: UnifiedViewCallbacks)
-  setItems(items: UnifiedItem[]): void
-  setCheckpoints(checkpoints: Checkpoint[]): void
-  getViewType(): string   // 'synapse-proposals'
-  getDisplayText(): string // 'Synapse Proposals'
-  getIcon(): string        // 'sparkles'
-}
+// proposal-styles.ts
+const SYNAPSE_COLOR_TOKENS: Record<ProposalKind, string>   // e.g. 'elaboration' -> '--synapse-color-elaboration'
+const FEATURE_COLOR_TOKENS: Record<FeatureKey, string>     // superset; covers main/summarize/tidy/video too
+
+function cardClass(kind: ProposalKind): string             // 'synapse-card--<kind>'
+function badgeClass(kind: ProposalKind): string            // 'synapse-badge--<kind>'
+function reviewPaneLabelClass(kind: ProposalKind): string  // 'synapse-review-pane-label--<kind>'
+function actionsGroupClass(feature: FeatureKey): string    // 'synapse-actions-group--<feature>'
 ```
 
 ## File Inventory
 
-| File | Class/Export | Purpose |
-|------|-------------|---------|
+| File | Exports | Purpose |
+|------|---------|---------|
 | `unified-proposal-view.ts` | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE` | Combined proposal sidebar with checkpoint banner |
-| `types.ts` | `UnifiedItem`, `UnifiedViewCallbacks` | View type definitions |
+| `synapse-actions-view.ts` | `SynapseActionsView`, `SYNAPSE_ACTIONS_VIEW_TYPE`, `SynapseActionsCallbacks` | Touch-friendly command palette sidebar |
+| `types.ts` | `UnifiedItem`, `UnifiedViewCallbacks`, `ProposalKind`, `PROPOSAL_KINDS` | View type definitions; compile-time guard asserts `PROPOSAL_KINDS` matches `UnifiedItem['kind']` |
+| `proposal-styles.ts` | `SYNAPSE_COLOR_TOKENS`, `FEATURE_COLOR_TOKENS`, `cardClass`, `badgeClass`, `reviewPaneLabelClass`, `actionsGroupClass` | Semantic color tokens + BEM class helpers (#342) |
+| `index.ts` | re-exports all of the above | Barrel |
+| `unified-proposal-view.test.ts`, `synapse-actions-view.test.ts`, `proposal-styles.test.ts` | Tests | |
 
-## Rendering Modes
+## Compile-Time Guards
 
-1. **Checkpoint banner**: When incomplete checkpoints exist, shows a banner per checkpoint with module label, progress (done/total), and Resume/Discard buttons.
+`types.ts:L43-L46` asserts `PROPOSAL_KINDS` exactly covers `UnifiedItem['kind']` in both directions via two
+typed `const` assertions. Build fails if a new proposal kind is added to only one.
 
-2. **List mode**: Groups all pending proposals by source note path. Accept All button when 2+ proposals. Each card shows badge, reasons/summary, preview, and action buttons (Review/Accept/Reject).
+`proposal-styles.ts:L15` types `SYNAPSE_COLOR_TOKENS` as `Record<ProposalKind, string>` — build fails if a
+kind lacks a CSS token. `FEATURE_COLOR_TOKENS` does the same for `FeatureKey`.
 
-3. **Elaboration review**: Back button, source note link, detection reasons, editable textarea for proposed additions. Accept sends edited content.
+## Rendering Modes (UnifiedProposalView)
 
-4. **Enrichment review**: Back button, source note link, per-item checkboxes for tags/links/refs/frontmatter. Accept Selected/All/None/Reject buttons.
-
-5. **Organize review**: Back button, source note link, proposed directory path, AI reasoning text. Accept/Reject buttons.
-
-6. **Deep-dive review**: Back button, topic title, depth badge, quality score, source note link, quality reasoning, proposed path, read-only content preview, child count warning. Accept/Reject buttons.
-
-7. **Title review**: Back button, source note link, current vs proposed title, trigger reason (untitled/mismatch), AI reasoning. Accept (rename)/Reject buttons.
-
-## Accept All
-
-- Available when 2+ proposals pending
-- Processes sequentially (organize proposals may affect file paths)
-- Shows progress bar during batch
-- Stops on first failure, reports count
-- For enrichment: accepts all suggested items (tags + links + refs + frontmatter)
+1. Checkpoint banner: incomplete checkpoints → banner per checkpoint with module label, progress (done/total), Resume/Discard buttons.
+2. List mode: all pending proposals grouped by source note path. Accept All button when 2+ proposals. Each card shows badge, reasons/summary, preview, and action buttons (Review/Accept/Reject).
+3. Elaboration review: editable textarea for proposed additions; Accept sends edited content.
+4. Enrichment review: per-item checkboxes for tags/links/refs/frontmatter; Accept Selected/All/None/Reject.
+5. Organize review: proposed directory path + AI reasoning; Accept/Reject.
+6. Deep-dive review: topic title, depth badge, quality score, proposed path, read-only content preview, child count warning; Accept/Reject.
+7. Title review: current vs proposed title, trigger reason, AI reasoning; Accept (rename)/Reject.
+8. REM review: per-match checkboxes for link suggestions; Accept Selected/Reject.
 
 ## Card Types
 
-| Kind | Badge Color | Border Color |
-|------|------------|--------------|
-| elaboration | `interactive-accent` (blue) | `interactive-accent` |
-| enrichment | `color-green` | `color-green` |
-| organize | `color-orange` | `color-orange` |
-| deep-dive | `color-purple` | `color-purple` |
-| title | `color-yellow` | `color-yellow` |
+| Kind | CSS token |
+|------|-----------|
+| elaboration | `--synapse-color-elaboration` |
+| enrichment | `--synapse-color-enrichment` |
+| organize | `--synapse-color-organize` |
+| deep-dive | `--synapse-color-deep-dive` |
+| title | `--synapse-color-title` |
+| rem | `--synapse-color-rem` |
 
-Deep-dive cards additionally show depth badge and quality score badge.
+CSS custom properties declared in `styles.css` (`.theme-light, .theme-dark` block). TypeScript tokens in
+`proposal-styles.ts` are the exhaustiveness guard — they are NOT the authoritative color values.
+
+## Accept All (UnifiedProposalView)
+
+- Available when 2+ proposals pending.
+- Processes sequentially (organize proposals may affect file paths).
+- Shows progress bar during batch; stops on first failure.
+- Enrichment: accepts all suggested items (tags + links + refs + frontmatter).
+- REM: accepts all suggested match texts.
 
 ## Wiring (in main.ts)
 
 ```ts
-this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {
-  return new UnifiedProposalView(leaf, {
+this.registerView(UNIFIED_VIEW_TYPE, (leaf) =>
+  new UnifiedProposalView(leaf, {
     onElaborationAccept: (id, content) => this.elaboration.acceptProposal(id, content),
     onElaborationReject: (id) => this.elaboration.rejectProposal(id),
     onEnrichmentAcceptSelected: (id, accepted) => this.enrichment.acceptSelectedFromView(id, accepted),
@@ -103,13 +149,24 @@ this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {
     onDeepDiveReject: (id) => this.deepDive.rejectProposal(id),
     onTitleAccept: (id) => this.title.acceptProposal(id),
     onTitleReject: (id) => this.title.rejectProposal(id),
+    onRemAcceptSelected: (id, texts) => this.rem.acceptSelectedFromView(id, texts),
+    onRemReject: (id) => this.rem.rejectFromView(id),
     onCheckpointDiscard: (id) => this.discardCheckpoint(id),
     onCheckpointResume: (id) => this.resumeCheckpoint(id),
-  });
-});
+  })
+);
+
+this.registerView(SYNAPSE_ACTIONS_VIEW_TYPE, (leaf) =>
+  new SynapseActionsView(leaf, {
+    getActions: () => this.commands.listPaletteActions(),
+    runAction: (id) => (this.app as any).commands.executeCommandById(id),
+    isNoteActive: () => this.app.workspace.getActiveViewOfType(MarkdownView) !== null,
+  })
+);
 ```
 
-Refreshed via `main.refreshUnifiedView()` which gathers items from all five modules and incomplete checkpoints.
+Refreshed via `main.refreshUnifiedView()` which gathers items from all six modules plus incomplete checkpoints.
+`SynapseActionsView.refresh()` called on `active-leaf-change` to enable/disable per-note buttons.
 
 ## Dependencies
 
@@ -120,12 +177,8 @@ Refreshed via `main.refreshUnifiedView()` which gathers items from all five modu
 | `OrganizeProposal` | `../organize` (type only) |
 | `DeepDiveProposal` | `../deep-dive` (type only) |
 | `TitleProposal` | `../title` (type only) |
-| `Checkpoint` | `../shared` (type only) |
+| `RemProposal` | `../rem` (type only) |
+| `Checkpoint`, `fireAndForget` | `../shared` |
+| `CommandDefinition`, `FeatureKey` | `../commands` (type only, in synapse-actions-view.ts) |
 
-## Features
-
-- Clickable note headings open the source note in main editor
-- Auto-exits review mode if reviewed proposal is no longer in pending list
-- Styles live in `styles.css` (section "Unified Proposal View"), loaded/unloaded by Obsidian automatically
-- Color-coded cards: blue for elaboration, green for enrichment, orange for organize, purple for deep-dive, yellow for title
-- Checkpoint banner with progress display and Resume/Discard actions
+`unified-proposal-view.ts` imports TYPES ONLY from feature modules (no runtime feature-module code in the view layer).


### PR DESCRIPTION
## Summary

Full 6-stage codebase audit pass over Synapse v1.0.3. Each stage audited the codebase and implemented fixes; the next stage ran only after the previous one verified the build was green. Three small code fixes were found; the rest of the codebase audited clean and the docs were refreshed to match current code.

### Stages & outcomes

| # | Stage | Result |
|---|-------|--------|
| 1 | **Architecture** | 1 fix — `transcription-credentials.ts` was the lone consumer reaching past `shared/index.ts`; folded the type-only import into the `../shared` barrel. Deliberate patterns (type-only audio→video back-edge, settings.ts type-only deep imports, desktop gating) verified and left intact. |
| 2 | **Security (pass 1)** | 0 crit/high/med, 1 low — hardened `.gitignore` against stray credential files (`data.json.*`, `secrets.json`, `*.pem/*.key/*.p12/*.pfx`, …). Subprocess safety (`execFile`+arg-arrays), API-key handling (headers, redaction), FS-boundary sanitization, and AI-response sanitization all audited clean. |
| 3 | **Obsidian compliance** | 1 fix — animated-ellipsis `setInterval` had no teardown path; added `NotificationManager.dispose()` wired into `onunload()` so disabling mid-operation leaves no orphaned timer. `isDesktopOnly: false` verified correct (mobile-safe via lazy `loadNodeModules`/`assertDesktop`). |
| 4 | **Docs (agent)** | Refreshed 18 machine-readable `AGENTS.md` (root + 17 per-feature): module registry, dependency graph, public APIs, command registry, settings schema; corrected pre-existing drift. |
| 5 | **Docs (human)** | Refreshed `DECISIONS.md`, `STATUS.md`, `ARCHITECTURE.md` for v1.0.3 (decision log entries, status snapshot, architecture diagrams). |
| 6 | **Security (pass 2)** | Clean — 0 new issues, all prior fixes intact, documentation leak scan clean (no secrets / absolute paths / cross-project refs in any committed doc). |

### Code changes (4 files)
- `src/audio/transcription-credentials.ts` — barrel import (type-only, no behavior change)
- `.gitignore` — credential-file hardening
- `src/shared/notifications.ts` + `src/main.ts` — `dispose()` teardown of ellipsis timers on unload

### Docs changes (21 files)
- 18 × `AGENTS.md`, plus `DECISIONS.md`, `STATUS.md`, `ARCHITECTURE.md`

## Test plan
- [x] Type check (`npx tsc --noEmit --skipLibCheck`)
- [x] Lint (`npm run lint`)
- [x] Top-level requires guard (`node scripts/check-top-level-requires.mjs`)
- [x] Version consistency (`node scripts/version-bump.mjs --check`)
- [x] Tests (`npm test`) — 1511 passed (114 files)
- [x] Production build (`node esbuild.config.mjs production`)

Co-Authored-By: Claude <bot@wafflenet.io>