### PR TITLE
feat: animated progress border on operation toast cancel button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "synapse",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "synapse",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"license": "AGPL-3.0-only",
 			"devDependencies": {
 				"@emnapi/core": "^1.7.1",

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -104,6 +104,10 @@ function createStubEl(tag = 'div'): any {
 		const child = createStubEl(childTag);
 		applyInfo(child, info);
 		children.push(child);
+		// Track the parent's child list so child.remove() can detach itself —
+		// mirrors native Element.remove(), which the SVG progress overlay uses
+		// during teardown (notifications.ts).
+		child._parentChildren = children;
 		if (cb) cb(child);
 		return child;
 	};
@@ -132,6 +136,12 @@ function createStubEl(tag = 'div'): any {
 			children.length = 0;
 		}),
 		createEl: vi.fn((t: string, info?: any, cb?: (el: any) => void) =>
+			make(t)(info, cb),
+		),
+		// SVG-aware counterpart of createEl (real Obsidian exposes createSvg with
+		// SvgElementInfo). Shares the same builder, so cls/attr/text all apply and
+		// the resulting <svg>/<rect>/<path> stubs are introspectable in tests.
+		createSvg: vi.fn((t: string, info?: any, cb?: (el: any) => void) =>
 			make(t)(info, cb),
 		),
 		createDiv: vi.fn(make('div')),
@@ -163,6 +173,15 @@ function createStubEl(tag = 'div'): any {
 		},
 		closest: vi.fn().mockReturnValue(null),
 		style: {},
+		/** Back-reference to the parent's child array, set by make() on append. */
+		_parentChildren: null as any[] | null,
+		/** Detach from the parent (mirrors native Element.remove()). */
+		remove: vi.fn(() => {
+			const siblings = el._parentChildren;
+			if (!siblings) return;
+			const i = siblings.indexOf(el);
+			if (i !== -1) siblings.splice(i, 1);
+		}),
 	};
 	return el;
 }

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, parseFrontmatter,
 	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, filterYielding,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { EnrichmentApplier } from './enrichment-applier';
@@ -220,15 +220,14 @@ export class EnrichmentModule {
 		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
 		// Per-file scoping (#111): narrow to the single requested note.
 		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
-		const eligible: TFile[] = [];
 
+		let eligible: TFile[];
 		try {
-			for (let i = 0; i < allFiles.length; i++) {
-				scanOp.progress(i + 1, allFiles.length, scopeLabel);
-				if (!this.isExcluded(allFiles[i])) {
-					eligible.push(allFiles[i]);
-				}
-			}
+			// The scan is unmeasured, fast work: leave the toast in its
+			// indeterminate (orbiting) mode and yield periodically so that orbit
+			// actually paints. A plain synchronous loop here blocked the main
+			// thread start-to-finish, so the border never animated (#354).
+			eligible = await filterYielding(allFiles, f => !this.isExcluded(f));
 
 			// Warm the vault-wide caches so every note benefits from
 			// the full tag index and link graph during enrichment

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder,
 	writeNote, generateOrganizeSummary, CheckpointManager, generateId, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, filterYielding,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import type { MoveRecord } from '../shared';
@@ -272,15 +272,14 @@ export class OrganizeModule {
 		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
 		// Per-file scoping (#111): narrow to the single requested note.
 		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
-		const eligible: TFile[] = [];
 
+		let eligible: TFile[];
 		try {
-			for (let i = 0; i < allFiles.length; i++) {
-				scanOp.progress(i + 1, allFiles.length, scopeLabel);
-				if (!this.isExcluded(allFiles[i])) {
-					eligible.push(allFiles[i]);
-				}
-			}
+			// The scan is unmeasured, fast work: leave the toast in its
+			// indeterminate (orbiting) mode and yield periodically so that orbit
+			// actually paints. A plain synchronous loop here blocked the main
+			// thread start-to-finish, so the border never animated (#354).
+			eligible = await filterYielding(allFiles, f => !this.isExcluded(f));
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			scanOp.error(`Scan failed -- ${msg}`);

--- a/src/shared/api-utils.test.ts
+++ b/src/shared/api-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	classifyNetworkError,
 	describeNetworkError,
+	filterYielding,
 	isTransientNetworkError,
 	notifyError,
 	withRetry,
@@ -116,6 +117,55 @@ describe('withRetry', () => {
 		await vi.runAllTimersAsync();
 		await expect(promise).resolves.toBe('done');
 		expect(fn).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('filterYielding', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('keeps only items matching the predicate, preserving order', async () => {
+		const promise = filterYielding([1, 2, 3, 4, 5], n => n % 2 === 1);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual([1, 3, 5]);
+	});
+
+	it('filters correctly on the throttled path for large inputs', async () => {
+		// Beyond the per-item-yield threshold the helper yields every Nth item;
+		// the result must still contain exactly the matching items, in order.
+		const input = Array.from({ length: 130 }, (_, i) => i);
+		const promise = filterYielding(input, n => n % 10 === 0);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);
+	});
+
+	it('returns an empty array for empty input without scheduling a yield', async () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		const promise = filterYielding<number>([], () => true);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual([]);
+		expect(setTimeoutSpy).not.toHaveBeenCalled();
+	});
+
+	it('yields to the event loop instead of running synchronously (#354)', async () => {
+		// The whole point of the helper: it must suspend on a macrotask so a
+		// running progress toast can paint between batches. Verify it has not
+		// resolved before the pending timers run.
+		let resolved = false;
+		const promise = filterYielding([1, 2, 3], () => true).then(r => {
+			resolved = true;
+			return r;
+		});
+		await Promise.resolve();
+		expect(resolved).toBe(false);
+		await vi.runAllTimersAsync();
+		await promise;
+		expect(resolved).toBe(true);
 	});
 });
 

--- a/src/shared/api-utils.ts
+++ b/src/shared/api-utils.ts
@@ -51,6 +51,38 @@ export function sleep(ms: number): Promise<void> {
 	return new Promise(resolve => window.setTimeout(resolve, ms));
 }
 
+/**
+ * Number of times {@link filterYielding} hands control back to the event loop
+ * over a single pass. Bounds the added latency (each yield is one ~4ms
+ * macrotask) to a few hundred ms even for very large vaults, while still giving
+ * a running progress toast enough paints to animate smoothly (#354).
+ */
+const YIELD_FRAMES = 60;
+
+/**
+ * Filter `items` with a synchronous `keep` predicate, yielding to the event loop
+ * periodically so a running operation toast can paint and animate (#354).
+ *
+ * A tight synchronous scan (e.g. enrichment/organize collecting eligible notes)
+ * blocks the main thread from start to finish, so the toast's Cancel-button
+ * progress border — which animates on the main thread — never renders before the
+ * scan reaches `finish()`. Interleaving `await sleep(0)` lets the browser paint
+ * between batches. Yields are capped at ~{@link YIELD_FRAMES} so large vaults add
+ * only a few hundred ms regardless of size.
+ */
+export async function filterYielding<T>(
+	items: T[],
+	keep: (item: T) => boolean
+): Promise<T[]> {
+	const result: T[] = [];
+	const yieldEvery = Math.max(1, Math.ceil(items.length / YIELD_FRAMES));
+	for (let i = 0; i < items.length; i++) {
+		if (keep(items[i])) result.push(items[i]);
+		if ((i + 1) % yieldEvery === 0) await sleep(0);
+	}
+	return result;
+}
+
 export function notifyError(context: string, error: unknown): void {
 	const message = error instanceof Error ? error.message : String(error);
 	// Redact potential API keys/tokens before showing the error to the user or

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -3,6 +3,7 @@ export type { ChatMessage, ContentBlock, TextContentBlock, ImageContentBlock } f
 export {
 	withRetry,
 	sleep,
+	filterYielding,
 	notifyError,
 	classifyNetworkError,
 	isTransientNetworkError,

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -2,14 +2,29 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Notice } from 'obsidian';
 import { NotificationManager } from './notifications';
 
-/** Recursively locate the first <button> element in a stub-element tree. */
-function findButton(el: any): any | null {
+/** Recursively locate the first element with the given tagName in a stub tree. */
+function findByTag(el: any, tagName: string): any | null {
 	for (const child of el.children ?? []) {
-		if (child.tagName === 'BUTTON') return child;
-		const nested = findButton(child);
+		if (child.tagName === tagName) return child;
+		const nested = findByTag(child, tagName);
 		if (nested) return nested;
 	}
 	return null;
+}
+
+/** Recursively locate the first <button> element in a stub-element tree. */
+function findButton(el: any): any | null {
+	return findByTag(el, 'BUTTON');
+}
+
+/** The SVG progress overlay rendered on an operation toast's Cancel button. */
+function findProgressOverlay(noticeEl: any): any | null {
+	return findByTag(noticeEl, 'SVG');
+}
+
+/** The determinate fill <rect> (first child of the overlay). */
+function fillRect(overlay: any): any {
+	return overlay.children?.[0];
 }
 
 /** The most recently constructed Notice (the visible completion/success toast). */
@@ -172,6 +187,106 @@ describe('NotificationManager', () => {
 			const handle = manager.startOperation('Working', 'op-plain');
 			handle.finish('Done');
 			expect(findButton(lastNotice().noticeEl)).toBeNull();
+		});
+	});
+
+	describe('cancel-button progress border (#269)', () => {
+		/** The Notice backing the *running* operation toast (first one created). */
+		function runningNotice(): any {
+			return (Notice as unknown as { instances: any[] }).instances[0];
+		}
+
+		it('renders an SVG progress overlay on the Cancel button when an operation starts', () => {
+			manager.startOperation('Scanning', 'op-overlay');
+			const cancelBtn = findButton(runningNotice().noticeEl);
+			expect(cancelBtn?.textContent).toBe('Cancel');
+
+			const overlay = findProgressOverlay(runningNotice().noticeEl);
+			expect(overlay).not.toBeNull();
+			// The overlay is a child of the Cancel button (so it traces its border)…
+			expect(findProgressOverlay(cancelBtn)).toBe(overlay);
+			// …and must not swallow clicks meant for the button.
+			expect(overlay.classList.contains('synapse-notice-op-progress')).toBe(true);
+		});
+
+		it('starts in indeterminate (orbiting) mode before any progress() call', () => {
+			manager.startOperation('Working', 'op-indeterminate');
+			const overlay = findProgressOverlay(runningNotice().noticeEl);
+			expect(overlay.classList.contains('is-indeterminate')).toBe(true);
+			expect(overlay.classList.contains('is-determinate')).toBe(false);
+		});
+
+		it('switches to determinate fill on the first progress() call', () => {
+			const handle = manager.startOperation('Working', 'op-switch');
+			const overlay = findProgressOverlay(runningNotice().noticeEl);
+			expect(overlay.classList.contains('is-indeterminate')).toBe(true);
+
+			handle.progress(1, 4);
+			expect(overlay.classList.contains('is-determinate')).toBe(true);
+			expect(overlay.classList.contains('is-indeterminate')).toBe(false);
+		});
+
+		it('maps current/total to the fill via stroke-dashoffset (1/4 → 75)', () => {
+			const handle = manager.startOperation('Working', 'op-fill');
+			const overlay = findProgressOverlay(runningNotice().noticeEl);
+
+			handle.progress(1, 4);
+			// pathLength is normalized to 100; offset = 100 * (1 - current/total).
+			expect(fillRect(overlay).getAttribute('stroke-dashoffset')).toBe('75');
+
+			handle.progress(3, 4);
+			expect(fillRect(overlay).getAttribute('stroke-dashoffset')).toBe('25');
+
+			handle.progress(4, 4);
+			expect(fillRect(overlay).getAttribute('stroke-dashoffset')).toBe('0');
+		});
+
+		it('reverts to indeterminate when update() restarts the ellipsis', () => {
+			const handle = manager.startOperation('Working', 'op-revert');
+			const overlay = findProgressOverlay(runningNotice().noticeEl);
+
+			handle.progress(2, 4);
+			expect(overlay.classList.contains('is-determinate')).toBe(true);
+
+			handle.update('Re-scanning');
+			expect(overlay.classList.contains('is-indeterminate')).toBe(true);
+			expect(overlay.classList.contains('is-determinate')).toBe(false);
+		});
+
+		it('keeps the fill empty when total is zero (no division by zero)', () => {
+			const handle = manager.startOperation('Working', 'op-zero');
+			const overlay = findProgressOverlay(runningNotice().noticeEl);
+			handle.progress(0, 0);
+			expect(fillRect(overlay).getAttribute('stroke-dashoffset')).toBe('100');
+		});
+
+		it('tears the overlay down off the Cancel button on finish', () => {
+			const handle = manager.startOperation('Working', 'op-finish');
+			const notice = runningNotice();
+			expect(findProgressOverlay(notice.noticeEl)).not.toBeNull();
+
+			handle.finish('Done');
+			expect(findProgressOverlay(notice.noticeEl)).toBeNull();
+		});
+
+		it('tears the overlay down on error', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const handle = manager.startOperation('Working', 'op-err');
+			const notice = runningNotice();
+			expect(findProgressOverlay(notice.noticeEl)).not.toBeNull();
+
+			handle.error('Boom');
+			expect(findProgressOverlay(notice.noticeEl)).toBeNull();
+			consoleSpy.mockRestore();
+		});
+
+		it('tears the overlay down on cancel', () => {
+			manager.startOperation('Working', 'op-cancel-teardown');
+			const notice = runningNotice();
+			expect(findProgressOverlay(notice.noticeEl)).not.toBeNull();
+
+			manager.cancelOperation('op-cancel-teardown');
+			expect(findProgressOverlay(notice.noticeEl)).toBeNull();
 		});
 	});
 

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -39,6 +39,12 @@ interface TrackedOperation {
 	labelEl: HTMLElement;
 	/** Fixed-width span that holds the animated dots, preventing layout reflow */
 	dotsEl: HTMLElement;
+	/**
+	 * Absolutely-positioned SVG overlay on the Cancel button whose border doubles
+	 * as the progress track (indeterminate orbit before the first `progress()`
+	 * call, determinate fill after). Torn down with the notice.
+	 */
+	progressOverlay: SVGElement;
 	state: 'running' | 'done' | 'error' | 'cancelled';
 	ellipsisInterval: number | null;
 }
@@ -60,6 +66,104 @@ const ACTION_NOTICE_DURATION = 8000;
 /** Get the underlying DOM element from a Notice */
 function getNoticeEl(notice: Notice): HTMLElement {
 	return (notice as unknown as { noticeEl: HTMLElement }).noticeEl;
+}
+
+/**
+ * Perimeter geometry for the cancel-button progress overlay.
+ *
+ * The track is a rounded `<rect>` carrying `pathLength="100"`, which normalizes
+ * its perimeter to 100 user units regardless of the button's pixel size. That
+ * lets us drive progress with `stroke-dashoffset` purely from a 0..1 fraction —
+ * no runtime DOM measurement (so it works identically under the test mock).
+ *
+ * SVG `<rect>` strokes start at the top-left and run clockwise. The overlay is
+ * flipped vertically in CSS (`transform: scaleY(-1)`) so the fill instead grows
+ * from the BOTTOM-LEFT corner clockwise, as the issue specifies.
+ */
+const OVERLAY_PATH_LENGTH = 100;
+
+/** Length of the orbiting "comet" head dash in the indeterminate animation. */
+const OVERLAY_ORBIT_DASH = 14;
+
+/**
+ * Build the absolutely-positioned SVG progress overlay for an operation's
+ * Cancel button. The overlay traces the button's perimeter and is purely
+ * decorative — `pointer-events: none` (set in CSS) keeps the button clickable.
+ *
+ * Two stroked `<rect>` layers share the same normalized perimeter:
+ *  - `.synapse-notice-op-progress-fill` — the determinate fill (grows with
+ *    `progress(current,total)` via `stroke-dashoffset`).
+ *  - `.synapse-notice-op-progress-orbit` — the indeterminate traveling dot with
+ *    a fading trail (a short animated dash; CSS `@keyframes` move its offset).
+ *
+ * Mode is toggled by a class on the root `<svg>` (`is-determinate` /
+ * `is-indeterminate`); CSS shows exactly one layer per mode.
+ */
+function createCancelProgressOverlay(cancelBtn: HTMLElement): SVGElement {
+	const svg = cancelBtn.createSvg('svg', {
+		cls: `${CLS}-op-progress`,
+		attr: {
+			// A square viewBox keeps the corner radius visually consistent; the
+			// element itself is stretched to the button via width/height:100%.
+			viewBox: '0 0 100 100',
+			preserveAspectRatio: 'none',
+			'aria-hidden': 'true',
+		},
+	});
+
+	const rectAttrs = {
+		x: '2',
+		y: '2',
+		width: '96',
+		height: '96',
+		rx: '6',
+		ry: '6',
+		fill: 'none',
+		pathLength: String(OVERLAY_PATH_LENGTH),
+	};
+
+	svg.createSvg('rect', {
+		cls: `${CLS}-op-progress-fill`,
+		attr: rectAttrs,
+	});
+	svg.createSvg('rect', {
+		cls: `${CLS}-op-progress-orbit`,
+		attr: {
+			...rectAttrs,
+			'stroke-dasharray': `${OVERLAY_ORBIT_DASH} ${OVERLAY_PATH_LENGTH - OVERLAY_ORBIT_DASH}`,
+		},
+	});
+
+	return svg;
+}
+
+/**
+ * Switch the overlay to indeterminate mode — the orbiting dot animation. Used
+ * before the first `progress()` call and whenever the ellipsis is restarted
+ * (via `update()`), i.e. exactly while the activity is unmeasured.
+ */
+function setOverlayIndeterminate(overlay: SVGElement | null): void {
+	if (!overlay) return;
+	overlay.classList.remove('is-determinate');
+	overlay.classList.add('is-indeterminate');
+	const fill = overlay.children?.[0] as SVGElement | undefined;
+	// Reset the determinate fill so a later mode switch starts from empty.
+	fill?.setAttribute('stroke-dashoffset', String(OVERLAY_PATH_LENGTH));
+}
+
+/**
+ * Switch the overlay to determinate mode and set the fill to `fraction` of the
+ * perimeter (0..1). The CSS transition on `stroke-dashoffset` animates the
+ * change smoothly between successive `progress()` updates.
+ */
+function setOverlayDeterminate(overlay: SVGElement | null, fraction: number): void {
+	if (!overlay) return;
+	const clamped = Math.max(0, Math.min(1, fraction));
+	overlay.classList.remove('is-indeterminate');
+	overlay.classList.add('is-determinate');
+	const fill = overlay.children?.[0] as SVGElement | undefined;
+	const offset = OVERLAY_PATH_LENGTH * (1 - clamped);
+	fill?.setAttribute('stroke-dashoffset', String(offset));
 }
 
 /** Apply level styling to a Notice's DOM element */
@@ -140,6 +244,7 @@ export class NotificationManager {
 		for (const op of this.operations.values()) {
 			stopEllipsis(op.ellipsisInterval);
 			op.ellipsisInterval = null;
+			op.progressOverlay.remove();
 			op.notice.hide();
 		}
 		this.operations.clear();
@@ -190,6 +295,12 @@ export class NotificationManager {
 			this.cancelOperation(opId);
 		});
 
+		// The Cancel button's border doubles as the progress track. It starts in
+		// indeterminate mode (orbiting dot) because no progress() has run yet —
+		// tied to the ellipsis animation being active.
+		const progressOverlay = createCancelProgressOverlay(cancelBtn);
+		setOverlayIndeterminate(progressOverlay);
+
 		const ellipsisInterval = startEllipsisOnEl(dotsEl);
 
 		const op: TrackedOperation = {
@@ -200,6 +311,7 @@ export class NotificationManager {
 			textEl,
 			labelEl,
 			dotsEl,
+			progressOverlay,
 			state: 'running',
 			ellipsisInterval,
 		};
@@ -219,6 +331,9 @@ export class NotificationManager {
 				op.dotsEl.textContent = '.';
 				stopEllipsis(op.ellipsisInterval);
 				op.ellipsisInterval = startEllipsisOnEl(op.dotsEl);
+				// Activity is unmeasured again — revert the border to the orbiting
+				// (indeterminate) animation in lockstep with the ellipsis restart.
+				setOverlayIndeterminate(op.progressOverlay);
 				this.updateStatusBar();
 			},
 
@@ -234,6 +349,9 @@ export class NotificationManager {
 				op.labelEl.textContent = `Synapse: ${base}`;
 				op.dotsEl.textContent = '';
 				styleNotice(op.notice, 'progress');
+				// First/subsequent measured update — fill the Cancel border to
+				// current/total. Guard total<=0 so a zero-item run stays at empty.
+				setOverlayDeterminate(op.progressOverlay, total > 0 ? current / total : 0);
 				this.updateStatusBar();
 			},
 
@@ -396,6 +514,10 @@ export class NotificationManager {
 		if (!op) return;
 		op.state = newState;
 		stopEllipsis(op.ellipsisInterval);
+		// Tear the progress overlay down alongside the running notice (hiding the
+		// notice removes it from the DOM, but drop the overlay explicitly so it is
+		// never left orbiting against a detached node).
+		op.progressOverlay.remove();
 		op.notice.hide();
 		// Completion/error/cancel notices are normal dismissible toasts. When an
 		// action is supplied, build an interactive notice with a single button;

--- a/styles.css
+++ b/styles.css
@@ -551,7 +551,9 @@
  */
 .synapse-notice-op-progress-orbit {
   opacity: 0.9;
-  animation: synapse-notice-orbit 1.4s linear infinite;
+  /* A calm ~3s revolution. Slower than a typical busy spinner so the orbiting
+     dot reads as "working" without feeling frantic (#354). */
+  animation: synapse-notice-orbit 3s linear infinite;
 }
 
 /* Show exactly one layer per mode. */

--- a/styles.css
+++ b/styles.css
@@ -491,6 +491,9 @@
   text-align: left;
 }
 .synapse-notice-op-cancel {
+  /* `position: relative` anchors the absolutely-positioned SVG progress overlay
+     (.synapse-notice-op-progress) to the button. */
+  position: relative;
   flex-shrink: 0;
   padding: 2px 10px;
   border-radius: 4px;
@@ -504,6 +507,77 @@
 .synapse-notice-op-cancel:hover {
   color: var(--text-normal);
   border-color: var(--text-normal);
+}
+
+/*
+ * Cancel-button progress border (#269).
+ *
+ * An SVG overlay traces the button perimeter; its stroke is the progress track.
+ * It sits directly over the button's 1px border (inset to overlap) and is purely
+ * decorative — `pointer-events: none` keeps the button itself clickable. The
+ * track <rect>s carry pathLength="100", so dash math is a plain 0..100 space.
+ *
+ * `transform: scaleY(-1)` flips the SVG so the determinate fill grows from the
+ * BOTTOM-LEFT corner clockwise (SVG rect strokes natively start top-left).
+ */
+.synapse-notice-op-progress {
+  position: absolute;
+  inset: -1px;
+  width: calc(100% + 2px);
+  height: calc(100% + 2px);
+  overflow: visible;
+  pointer-events: none;
+  transform: scaleY(-1);
+}
+.synapse-notice-op-progress rect {
+  stroke: var(--interactive-accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+  /* Round the visual corners of the stroked outline to match the button. */
+  stroke-linejoin: round;
+}
+
+/* Determinate fill: a single dash sized to current/total, animated via offset. */
+.synapse-notice-op-progress-fill {
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100; /* start empty; JS lowers it toward 0 (full) */
+  transition: stroke-dashoffset 0.4s ease;
+}
+
+/*
+ * Indeterminate orbit: a short "comet" dash (the dot + fading trail) that travels
+ * the perimeter continuously. The fade is approximated with a rounded cap and a
+ * gentle accent so the leading end reads as a dot and the tail dissolves.
+ */
+.synapse-notice-op-progress-orbit {
+  opacity: 0.9;
+  animation: synapse-notice-orbit 1.4s linear infinite;
+}
+
+/* Show exactly one layer per mode. */
+.synapse-notice-op-progress.is-determinate .synapse-notice-op-progress-orbit,
+.synapse-notice-op-progress.is-indeterminate .synapse-notice-op-progress-fill {
+  display: none;
+}
+
+@keyframes synapse-notice-orbit {
+  from { stroke-dashoffset: 100; }
+  to   { stroke-dashoffset: 0; }
+}
+
+/*
+ * Accessibility: honor reduced-motion. The determinate fill keeps its position
+ * but drops the sliding transition (it snaps), and the orbiting dot is rendered
+ * as a static, faint partial outline instead of continuously animating.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .synapse-notice-op-progress-fill {
+    transition: none;
+  }
+  .synapse-notice-op-progress-orbit {
+    animation: none;
+    opacity: 0.5;
+  }
 }
 
 /* Prevent click-to-dismiss on running operations */


### PR DESCRIPTION
## Summary

Operation toasts (`NotificationManager.startOperation()`) now render an at-a-glance **visual** progress representation by turning the Cancel button's border into a progress track. An absolutely-positioned SVG overlay traces the button's perimeter; it is purely decorative (`pointer-events: none`), so the button stays fully clickable.

closes #269

### Determinate mode
After the first `progress(current, total)` call, the outline fills with `--interactive-accent` proportional to `current / total`. The track is a rounded `<rect>` carrying `pathLength="100"`, so the fill is driven entirely by `stroke-dashoffset` in a normalized 0–100 space (no runtime DOM measurement). A CSS transition on the offset animates smoothly between successive updates, and the SVG is flipped (`scaleY(-1)`) so the fill grows from the **bottom-left corner clockwise**.

### Indeterminate mode
Before any `progress()` call — and again whenever `update()` restarts the ellipsis animation — the border shows a short "comet" dash that orbits the perimeter continuously (a CSS `@keyframes` animating `stroke-dashoffset`), tied to the same activity signal as the animated ellipsis. The first `progress()` call switches it to the determinate fill; an `update()` reverts it to orbiting, in lockstep with the ellipsis.

### Theming & accessibility
- Theme variables only — `--interactive-accent` for the track; no hardcoded colors, consistent with existing notice styles.
- `prefers-reduced-motion: reduce`: the determinate fill drops its sliding transition (snaps to position) and the orbiting dot stops animating, rendering a static, faint partial outline instead.

### Teardown
The overlay is removed alongside the existing toast teardown on finish / error / cancel / `dispose()`.

### Test mock
This is the codebase's first runtime SVG. Added an SVG-aware `createSvg()` and an `Element.remove()` to the centralized obsidian mock, **confined to the `createStubEl` DOM-helper region** so the overlay is fully exercisable in tests.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` (1530 tests pass; 9 new in `notifications.test.ts` covering overlay lifecycle, progress→fill mapping, and indeterminate→determinate mode switch)
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

Co-Authored-By: Claude <bot@wafflenet.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)