### PR TITLE
refactor: normalize action command copy (Scan = folders, verb + current note)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,27 +123,27 @@ Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries
 | `synapse:review-proposals` | Open proposal review sidebar | callback | main | p | active | |
 | `synapse:manage-checkpoints` | Manage interrupted operations | callback | main | p | active | |
 | `synapse:transcribe-media` | Transcribe media | callback | main | p | disabled | |
-| `synapse:transcribe-note-media` | Transcribe media from current note | editorCallback | main | p | active | |
-| `synapse:fire` | Run all features on a directory | callback | main | p | active | |
-| `synapse:scan-vault` | Scan vault for stub notes | callback | elaboration | p, f, s | active | elaboration |
-| `synapse:scan-current-note` | Scan current note for elaboration | editorCallback | elaboration | p | active | |
+| `synapse:transcribe-note-media` | Transcribe current note | editorCallback | main | p | active | |
+| `synapse:fire` | Run all features on a folder | callback | main | p | active | |
+| `synapse:scan-vault` | Scan folder for stub notes | callback | elaboration | p, f, s | active | elaboration |
+| `synapse:scan-current-note` | Elaborate current note | editorCallback | elaboration | p | active | |
 | `synapse:clear-proposals` | Clear all pending proposals | callback | elaboration | p | disabled | |
 | `synapse:enrich-current-note` | Enrich current note | editorCallback | enrichment | p | active | |
-| `synapse:scan-vault-enrichment` | Scan vault for enrichment | callback | enrichment | p, f | active | enrichment |
+| `synapse:scan-vault-enrichment` | Scan folder for enrichment | callback | enrichment | p, f | active | enrichment |
 | `synapse:undo-enrichment` | Undo last enrichment on current note | editorCallback | enrichment | p | disabled | |
 | `synapse:organize-current-note` | Organize current note | editorCallback | organize | p | active | |
-| `synapse:scan-directory-organize` | Scan directory for organization | callback | organize | p, f | active | organize |
+| `synapse:scan-directory-organize` | Scan folder for organization | callback | organize | p, f | active | organize |
 | `synapse:undo-organize` | Undo last organize on current note | editorCallback | organize | p | disabled | |
-| `synapse:deep-dive` | Deep dive into current note | editorCallback | deep-dive | p | active | |
+| `synapse:deep-dive` | Deep dive current note | editorCallback | deep-dive | p | active | |
 | `synapse:clear-deep-dive` | Clear deep dive proposals | callback | deep-dive | p | disabled | |
 | `synapse:summarize-current-note` | Summarize current note | editorCallback | summarize | p | active | |
-| `synapse:scan-vault-summarize` | Scan vault for notes to summarize | callback | summarize | p, f | active | summarize |
+| `synapse:scan-vault-summarize` | Scan folder for notes to summarize | callback | summarize | p, f | active | summarize |
 | `synapse:tidy-current-note` | Tidy current note | editorCallback | tidy | p | active | |
 | `synapse:undo-tidy` | Undo last tidy on current note | editorCallback | tidy | p | disabled | |
 | `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | rem | p | active | |
-| `synapse:rem-directory` | REM: Discover links in directory | callback | rem | p, f | active | rem |
+| `synapse:rem-directory` | Scan folder for links | callback | rem | p, f | active | rem |
 | `synapse:check-dependencies` | Check external tool availability | callback | video | p | active | |
-| `synapse:tidy-vault` | Tidy vault | (synthetic) | tidy | f | active | tidy |
+| `synapse:tidy-vault` | Scan folder for notes to tidy | (synthetic) | tidy | f | active | tidy |
 
 `synapse:tidy-vault` is synthetic and pipeline-only: it gates the tidy Fire Synapse phase independently of any palette command and is never passed to `registrar.register()`. Fire Synapse phase order: elaboration → summarize → enrichment → rem → tidy → organize.
 

--- a/docs/PRD-MVP.md
+++ b/docs/PRD-MVP.md
@@ -225,7 +225,7 @@ Reference: [Obsidian Plugin Guidelines](https://docs.obsidian.md/Plugins/Releasi
 - [x] **Loading states for AI operations** -- `NotificationManager.startOperation()` creates a persistent, non-dismissible notice with animated ellipsis, progress counter updates, and a Cancel button. Status bar shows operation summary.
 - [x] **Error handling with user-friendly messages** -- All modules use `notifyError(context, error)` which: prefixes with "Synapse:", redacts API keys, shows for 8 seconds, logs to console. No raw stack traces shown to users.
 - [x] **Settings UI is organized and intuitive** -- Settings are grouped under clear headings: AI Configuration, Note Elaboration, Media Transcription (with Audio/Video subheadings), Note Enrichment (with Proximity Weights/Tag Vocabulary subsections), Summarize, Note Tidy, Note Organize, Deep Dive. Sliders have tick marks, labels, and current-value display.
-- [x] **Commands are well-named in the command palette** -- 21 commands follow "Action target" naming pattern. Examples: "Open proposal review sidebar", "Transcribe media", "Enrich current note", "Scan vault", "Undo enrichment".
+- [x] **Commands are well-named in the command palette** -- 21 commands follow "Action target" naming pattern. Examples: "Open proposal review sidebar", "Transcribe media", "Enrich current note", "Scan folder for stub notes", "Undo enrichment".
 - [x] **Confirmation dialogs for destructive operations** -- Vault-wide scans prompt "Found N eligible notes. Proceed?" before making AI calls. Cancel button on all long-running operations.
 - [x] **Visual identity for AI content** -- All AI-generated content uses Obsidian callouts from a shared registry (`synapse-summary`, `synapse-transcription`, etc.) with distinct colors and Lucide icons. Users can always identify which content was AI-generated.
 - [x] **Ribbon icons** -- Two ribbon icons: sparkles (proposal review sidebar) and mic (transcribe media).
@@ -278,22 +278,22 @@ Reference: [Obsidian Plugin Guidelines](https://docs.obsidian.md/Plugins/Releasi
 |--------|---------|-----|
 | Main | Open proposal review sidebar | `synapse:review-proposals` |
 | Main | Transcribe media | `synapse:transcribe-media` |
-| Main | Transcribe media from current note | `synapse:transcribe-note-media` |
-| Elaboration | Scan vault for stubs | `synapse:elaboration-scan-vault` |
-| Elaboration | Scan current note | `synapse:elaboration-scan-note` |
+| Main | Transcribe current note | `synapse:transcribe-note-media` |
+| Elaboration | Scan folder for stub notes | `synapse:elaboration-scan-vault` |
+| Elaboration | Elaborate current note | `synapse:elaboration-scan-note` |
 | Elaboration | Clear all proposals | `synapse:elaboration-clear` |
 | Video | Check dependencies | `synapse:video-check-deps` |
 | Enrichment | Enrich current note | `synapse:enrichment-enrich-note` |
-| Enrichment | Scan vault for enrichment | `synapse:enrichment-scan-vault` |
+| Enrichment | Scan folder for enrichment | `synapse:enrichment-scan-vault` |
 | Enrichment | Undo enrichment | `synapse:enrichment-undo` |
 | Summarize | Summarize current note | `synapse:summarize-note` |
-| Summarize | Scan vault for summarization | `synapse:summarize-scan-vault` |
+| Summarize | Scan folder for notes to summarize | `synapse:summarize-scan-vault` |
 | Tidy | Tidy current note | `synapse:tidy-note` |
 | Tidy | Undo tidy | `synapse:tidy-undo` |
 | Organize | Organize current note | `synapse:organize-note` |
-| Organize | Scan directory | `synapse:organize-scan-directory` |
+| Organize | Scan folder for organization | `synapse:organize-scan-directory` |
 | Organize | Undo organize | `synapse:organize-undo` |
-| Deep Dive | Deep dive into note | `synapse:deep-dive-note` |
+| Deep Dive | Deep dive current note | `synapse:deep-dive-note` |
 | Deep Dive | Clear deep dive proposals | `synapse:deep-dive-clear` |
 
 ## Appendix: External Dependencies

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -20,31 +20,31 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	{ id: 'review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'], context: 'global', icon: 'synapse' },
 	{ id: 'manage-checkpoints', name: 'Manage interrupted operations', feature: 'main', status: 'active', flows: ['palette'], context: 'global', icon: 'synapse-checkpoints' },
 	{ id: 'transcribe-media', name: 'Transcribe media', feature: 'main', status: 'disabled', flows: ['palette'], context: 'global', icon: 'synapse-transcribe' },
-	{ id: 'transcribe-note-media', name: 'Transcribe media from current note', feature: 'main', status: 'active', flows: ['palette'], context: 'note', icon: 'synapse-transcribe' },
-	{ id: 'fire', name: 'Run all features on a directory', feature: 'main', status: 'active', flows: ['palette'], context: 'vault', icon: 'synapse-fire' },
+	{ id: 'transcribe-note-media', name: 'Transcribe current note', feature: 'main', status: 'active', flows: ['palette'], context: 'note', icon: 'synapse-transcribe' },
+	{ id: 'fire', name: 'Run all features on a folder', feature: 'main', status: 'active', flows: ['palette'], context: 'vault', icon: 'synapse-fire' },
 
 	// --- elaboration (src/elaboration/index.ts) ---
-	{ id: 'scan-vault', name: 'Scan vault for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], context: 'vault', pipelineKey: 'elaboration' },
-	{ id: 'scan-current-note', name: 'Scan current note for elaboration', feature: 'elaboration', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'scan-vault', name: 'Scan folder for stub notes', feature: 'elaboration', status: 'active', flows: ['palette', 'fire-synapse', 'startup'], context: 'vault', pipelineKey: 'elaboration' },
+	{ id: 'scan-current-note', name: 'Elaborate current note', feature: 'elaboration', status: 'active', flows: ['palette'], context: 'note' },
 	{ id: 'clear-proposals', name: 'Clear all pending proposals', feature: 'elaboration', status: 'disabled', flows: ['palette'], context: 'global' },
 
 	// --- enrichment (src/enrichment/index.ts) ---
 	{ id: 'enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'], context: 'note' },
-	{ id: 'scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'enrichment' },
+	{ id: 'scan-vault-enrichment', name: 'Scan folder for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'enrichment' },
 	{ id: 'undo-enrichment', name: 'Undo last enrichment on current note', feature: 'enrichment', status: 'disabled', flows: ['palette'], context: 'note' },
 
 	// --- organize (src/organize/index.ts) ---
 	{ id: 'organize-current-note', name: 'Organize current note', feature: 'organize', status: 'active', flows: ['palette'], context: 'note' },
-	{ id: 'scan-directory-organize', name: 'Scan directory for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'organize' },
+	{ id: 'scan-directory-organize', name: 'Scan folder for organization', feature: 'organize', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'organize' },
 	{ id: 'undo-organize', name: 'Undo last organize on current note', feature: 'organize', status: 'disabled', flows: ['palette'], context: 'note' },
 
 	// --- deep-dive (src/deep-dive/index.ts) ---
-	{ id: 'deep-dive', name: 'Deep dive into current note', feature: 'deep-dive', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'deep-dive', name: 'Deep dive current note', feature: 'deep-dive', status: 'active', flows: ['palette'], context: 'note' },
 	{ id: 'clear-deep-dive', name: 'Clear deep dive proposals', feature: 'deep-dive', status: 'disabled', flows: ['palette'], context: 'global' },
 
 	// --- summarize (src/summarize/index.ts) ---
 	{ id: 'summarize-current-note', name: 'Summarize current note', feature: 'summarize', status: 'active', flows: ['palette'], context: 'note' },
-	{ id: 'scan-vault-summarize', name: 'Scan vault for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'summarize' },
+	{ id: 'scan-vault-summarize', name: 'Scan folder for notes to summarize', feature: 'summarize', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'summarize' },
 
 	// --- tidy (src/tidy/index.ts) ---
 	{ id: 'tidy-current-note', name: 'Tidy current note', feature: 'tidy', status: 'active', flows: ['palette'], context: 'note' },
@@ -52,7 +52,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 
 	// --- rem (src/rem/index.ts) ---
 	{ id: 'rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'], context: 'note' },
-	{ id: 'rem-directory', name: 'REM: Discover links in directory', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'rem' },
+	{ id: 'rem-directory', name: 'Scan folder for links', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'rem' },
 
 	// --- video (src/video/index.ts) ---
 	{ id: 'check-dependencies', name: 'Check external tool availability', feature: 'video', status: 'active', flows: ['palette'], context: 'global' },
@@ -63,7 +63,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	// palette command runs `tidy()` on a single note — a different operation. This
 	// entry carries `pipelineKey: 'tidy'` so the tidy pipeline phase is controlled
 	// independently of the palette command. It is never passed to registrar.register().
-	{ id: 'tidy-vault', name: 'Tidy vault', feature: 'tidy', status: 'active', flows: ['fire-synapse'], context: 'vault', pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
+	{ id: 'tidy-vault', name: 'Scan folder for notes to tidy', feature: 'tidy', status: 'active', flows: ['fire-synapse'], context: 'vault', pipelineKey: 'tidy', note: 'vault scan run only by Fire Synapse; no palette command' },
 ];
 
 /** Lookup by command id. */

--- a/src/deep-dive/AGENTS.md
+++ b/src/deep-dive/AGENTS.md
@@ -184,7 +184,7 @@ interface DeepDiveRun {
 
 | Command ID | Enabled When | Description |
 |------------|-------------|-------------|
-| `deep-dive` | `settings.deepDive.enabled` | Deep dive into current note |
+| `deep-dive` | `settings.deepDive.enabled` | Deep dive current note |
 | `clear-deep-dive` | `settings.deepDive.enabled` | Clear all deep dive proposals |
 
 ## Settings Keys

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -90,7 +90,7 @@ export class DeepDiveModule {
 		await this.store.init();
 
 		this.registrar.register('deep-dive', this.getSettings().deepDive.enabled, {
-			name: 'Deep dive into current note',
+			name: 'Deep dive current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.deepDive(ctx.file);

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -187,8 +187,8 @@ All registered via `CommandRegistrar` in `onload()`:
 
 | Command suffix | Name | Condition |
 |---------------|------|-----------|
-| `scan-vault` | Scan vault for stub notes | `elaboration.enabled` |
-| `scan-current-note` | Scan current note for elaboration | `elaboration.enabled` |
+| `scan-vault` | Scan folder for stub notes | `elaboration.enabled` |
+| `scan-current-note` | Elaborate current note | `elaboration.enabled` |
 | `clear-proposals` | Clear all pending proposals | `elaboration.enabled` |
 
 ## Dependencies

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -55,7 +55,7 @@ export class ElaborationModule {
 		await this.store.init();
 
 		this.registrar.register('scan-vault', this.getSettings().elaboration.enabled, {
-			name: 'Scan vault for stub notes',
+			name: 'Scan folder for stub notes',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -63,7 +63,7 @@ export class ElaborationModule {
 					(folder) => {
 						fireAndForget(
 							this.scanVault(folder.isRoot() ? undefined : folder.path),
-							'Scan vault for stub notes',
+							'Scan folder for stub notes',
 							{ notifications: this.notifications },
 						);
 					},
@@ -73,7 +73,7 @@ export class ElaborationModule {
 		});
 
 		this.registrar.register('scan-current-note', this.getSettings().elaboration.enabled, {
-			name: 'Scan current note for elaboration',
+			name: 'Elaborate current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.scanNote(ctx.file);
@@ -89,7 +89,7 @@ export class ElaborationModule {
 		const settings = this.getSettings().elaboration;
 		if (settings.scanOnStartup && isInFlow('scan-vault', 'startup')) {
 			this.startupTimeout = window.setTimeout(() => {
-				fireAndForget(this.scanVault(), 'Scan vault for stub notes', {
+				fireAndForget(this.scanVault(), 'Scan folder for stub notes', {
 					notifications: this.notifications,
 				});
 			}, 5000);
@@ -98,7 +98,7 @@ export class ElaborationModule {
 		if (settings.autoScanInterval > 0 && isInFlow('scan-vault', 'startup')) {
 			this.scanInterval = window.setInterval(
 				() => {
-					fireAndForget(this.scanVault(), 'Scan vault for stub notes', {
+					fireAndForget(this.scanVault(), 'Scan folder for stub notes', {
 						notifications: this.notifications,
 					});
 				},

--- a/src/elaboration/proposal-view.ts
+++ b/src/elaboration/proposal-view.ts
@@ -73,7 +73,7 @@ export class ProposalReviewView extends ItemView {
 		const pending = this.proposals.filter(p => p.status === 'pending');
 		if (pending.length === 0) {
 			contentEl.createEl('p', {
-				text: 'No pending proposals. Run "Scan vault" to find stub notes.',
+				text: 'No pending proposals. Run "Scan folder for stub notes" to find them.',
 				cls: 'synapse-empty',
 			});
 			return;

--- a/src/enrichment/AGENTS.md
+++ b/src/enrichment/AGENTS.md
@@ -190,7 +190,7 @@ function renderEnrichmentSettings(ctx: SettingsSectionContext): void
 | Command ID | Name | Condition |
 |-----------|------|-----------|
 | `enrich-current-note` | Enrich current note | `settings.enrichment.enabled` |
-| `scan-vault-enrichment` | Scan vault for enrichment | `settings.enrichment.enabled` |
+| `scan-vault-enrichment` | Scan folder for enrichment | `settings.enrichment.enabled` |
 | `undo-enrichment` | Undo last enrichment on current note | `settings.enrichment.enabled` |
 
 ## Dependencies

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -88,7 +88,7 @@ export class EnrichmentModule {
 		});
 
 		this.registrar.register('scan-vault-enrichment', this.getSettings().enrichment.enabled, {
-			name: 'Scan vault for enrichment',
+			name: 'Scan folder for enrichment',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -96,7 +96,7 @@ export class EnrichmentModule {
 					(folder) => {
 						fireAndForget(
 							this.scanVault(folder.isRoot() ? undefined : folder.path),
-							'Scan vault for enrichment',
+							'Scan folder for enrichment',
 							{ notifications: this.notifications },
 						);
 					},

--- a/src/main.ts
+++ b/src/main.ts
@@ -355,7 +355,7 @@ export default class SynapsePlugin extends Plugin {
 		});
 
 		registrar.register('transcribe-note-media', !!hasTranscription, {
-			name: 'Transcribe media from current note',
+			name: 'Transcribe current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.transcribeMediaFromNote(ctx.file);
@@ -396,7 +396,7 @@ export default class SynapsePlugin extends Plugin {
 		}
 
 		registrar.register('fire', true, {
-			name: 'Run all features on a directory',
+			name: 'Run all features on a folder',
 			callback: () => {
 				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -404,7 +404,7 @@ export default class SynapsePlugin extends Plugin {
 					(folder) => {
 						fireAndForget(
 							synapseRunner.fire(folder.isRoot() ? undefined : folder.path),
-							'Run all features on folder',
+							'Run all features on a folder',
 							{ notifications: this.notifications },
 						);
 					},

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -71,7 +71,7 @@ export class OrganizeModule {
 		});
 
 		this.registrar.register('scan-directory-organize', this.getSettings().organize.enabled, {
-			name: 'Scan directory for organization',
+			name: 'Scan folder for organization',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -79,7 +79,7 @@ export class OrganizeModule {
 					(folder) => {
 						fireAndForget(
 							this.scanDirectory(folder.isRoot() ? undefined : folder.path),
-							'Scan directory for organization',
+							'Scan folder for organization',
 							{ notifications: this.notifications },
 						);
 					},

--- a/src/rem/AGENTS.md
+++ b/src/rem/AGENTS.md
@@ -141,7 +141,7 @@ Registered in `onload()` (both gated by `rem.enabled`):
 | ID | Name | Type | Pipeline |
 |----|------|------|---------|
 | `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | palette |
-| `synapse:rem-directory` | REM: Discover links in directory | callback (FolderPickerModal) | palette, fire-synapse (`pipelineKey: rem`) |
+| `synapse:rem-directory` | Scan folder for links | callback (FolderPickerModal) | palette, fire-synapse (`pipelineKey: rem`) |
 
 ## Auto-Accept (#228)
 

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -67,13 +67,13 @@ export class RemModule {
 
 		// Command: scan directory
 		this.registrar.register('rem-directory', this.getSettings().rem.enabled, {
-			name: 'REM: Discover links in directory',
+			name: 'Scan folder for links',
 			callback: () => {
 				new FolderPickerModal(
 					this.plugin.app,
 					(folder) => {
 						const path = folder.isRoot() ? undefined : folder.path;
-						fireAndForget(this.remScanDirectory(path), 'Discover REM links in directory', {
+						fireAndForget(this.remScanDirectory(path), 'Discover REM links in folder', {
 							notifications: this.notifications,
 						});
 					}

--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -144,7 +144,7 @@ Registered in `onload()` (both gated by `summarize.enabled`):
 | ID | Name | Type |
 |----|------|------|
 | `synapse:summarize-current-note` | Summarize current note | editorCallback |
-| `synapse:scan-vault-summarize` | Scan vault for notes to summarize | callback (FolderPickerModal) |
+| `synapse:scan-vault-summarize` | Scan folder for notes to summarize | callback (FolderPickerModal) |
 
 ## Video URL Auto-Transcription
 

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -106,7 +106,7 @@ export class SummarizeModule {
 		});
 
 		this.registrar.register('scan-vault-summarize', this.getSettings().summarize.enabled, {
-			name: 'Scan vault for notes to summarize',
+			name: 'Scan folder for notes to summarize',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -114,7 +114,7 @@ export class SummarizeModule {
 					(folder) => {
 						fireAndForget(
 							this.scanVault(folder.isRoot() ? undefined : folder.path),
-							'Scan vault for notes to summarize',
+							'Scan folder for notes to summarize',
 							{ notifications: this.notifications },
 						);
 					},

--- a/src/views/synapse-actions-view.test.ts
+++ b/src/views/synapse-actions-view.test.ts
@@ -20,7 +20,7 @@ function sampleActions(): CommandDefinition[] {
 	return [
 		{ id: 'review-proposals', name: 'Open proposal review sidebar', feature: 'main', status: 'active', flows: ['palette'], context: 'global', icon: 'synapse' },
 		{ id: 'enrich-current-note', name: 'Enrich current note', feature: 'enrichment', status: 'active', flows: ['palette'], context: 'note' },
-		{ id: 'scan-vault-enrichment', name: 'Scan vault for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault' },
+		{ id: 'scan-vault-enrichment', name: 'Scan folder for enrichment', feature: 'enrichment', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault' },
 	];
 }
 
@@ -96,7 +96,7 @@ describe('SynapseActionsView', () => {
 		expect(labels).toEqual([
 			'Open proposal review sidebar',
 			'Enrich current note',
-			'Scan vault for enrichment',
+			'Scan folder for enrichment',
 		]);
 	});
 
@@ -134,7 +134,7 @@ describe('SynapseActionsView', () => {
 		const { view, contentEl } = makeView({ isNoteActive: () => false, runAction });
 		await view.onOpen();
 
-		const vaultButton = findButton(contentEl, 'Scan vault for enrichment');
+		const vaultButton = findButton(contentEl, 'Scan folder for enrichment');
 		expect(vaultButton.disabled).toBeFalsy();
 		vaultButton.dispatchEvent({ type: 'click' });
 		expect(runAction).toHaveBeenCalledWith('scan-vault-enrichment');


### PR DESCRIPTION
## Summary

Normalizes Synapse's command copy so the two action *shapes* read consistently:

1. **"Scan" is reserved for folder operations.** All folder-scope labels use the noun **"folder"** and the `Scan folder for {target}` pattern (folding in the two folder ops that didn't say "Scan").
2. **Active current-note commands read as a bare `{verb} current note`** (dropping `into` / `media from`).

**Command IDs are unchanged** (e.g. `scan-vault`, `rem-directory`, `tidy-vault`) — renaming them would break user hotkeys and the registry/audit wiring, so the ID↔label mismatch is intentional. No behavior changes.

### Renames

**Current-note:**
| id | before | after |
|----|--------|-------|
| `scan-current-note` | Scan current note for elaboration | **Elaborate current note** |
| `deep-dive` | Deep dive into current note | **Deep dive current note** |
| `transcribe-note-media` | Transcribe media from current note | **Transcribe current note** |

**Folder (noun → "folder"):**
| id | before | after |
|----|--------|-------|
| `scan-vault` | Scan vault for stub notes | **Scan folder for stub notes** |
| `scan-vault-enrichment` | Scan vault for enrichment | **Scan folder for enrichment** |
| `scan-directory-organize` | Scan directory for organization | **Scan folder for organization** |
| `scan-vault-summarize` | Scan vault for notes to summarize | **Scan folder for notes to summarize** |
| `rem-directory` | REM: Discover links in directory | **Scan folder for links** |
| `tidy-vault` (synthetic) | Tidy vault | **Scan folder for notes to tidy** |
| `fire` | Run all features on a directory | **Run all features on a folder** |

**Intentionally unchanged:** `rem-current-note` keeps its `REM: Discover links in current note` branding (the REM asymmetry is deliberate); all `enrich/organize/summarize/tidy-current-note`, `undo-*`, and global commands are untouched.

### What changed in code
- `src/commands/registry.ts` — the declarative source of truth (10 `name` fields).
- Each feature module's `register()` spec, kept in sync (the registrar spreads the module spec into `addCommand` and never reads the registry `name`).
- `fireAndForget` operation labels that mirror a renamed name; the two distinct folder op-labels (`rem`, `fire`) had their lingering "directory" noun normalized to "folder".
- Empty-state hint in `src/elaboration/proposal-view.ts`.
- `src/views/synapse-actions-view.test.ts` assertions.
- Docs: `AGENTS.md`, `docs/PRD-MVP.md` appendix, and the module `AGENTS.md` files.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` — 1521 tests pass
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`
- [ ] Manual: command palette shows the new labels; folder scans show `Scan folder for …` progress toasts; no single-note action uses "Scan"

Closes #355

Co-Authored-By: Claude <bot@wafflenet.io>