### PR TITLE
refactor: source command-palette names from COMMAND_REGISTRY

### DIFF
--- a/src/commands/AGENTS.md
+++ b/src/commands/AGENTS.md
@@ -41,7 +41,7 @@ function isPipelineKeyInFlow(pipelineKey: string, flow: CommandFlow): boolean  /
 // registrar.ts
 class CommandRegistrar {
   constructor(host: { addCommand: (command: Command) => unknown })
-  register(id: string, userEnabled: boolean, spec: Omit<Command, 'id'>): void
+  register(id: string, userEnabled: boolean, spec: Omit<Command, 'id' | 'name'>): void
   getAttempted(): ReadonlySet<string>
   getRegistered(): ReadonlySet<string>
 }
@@ -70,7 +70,7 @@ CommandRegistrar.register(id, userEnabled, spec)
   --> entry = REGISTRY_BY_ID.get(id)
   --> active   = entry ? entry.status === 'active' : true   (fail-open on unknown id)
   --> inPalette= entry ? entry.flows.includes('palette') : true
-  --> if (active && inPalette && userEnabled) plugin.addCommand({id, ...spec}); record in `registered`
+  --> if (active && inPalette && userEnabled) plugin.addCommand({id, name: entry?.name ?? id, ...spec}); record in `registered`
 ```
 
 Precedence (all ANDed, registry authoritative):

--- a/src/commands/registrar.test.ts
+++ b/src/commands/registrar.test.ts
@@ -18,7 +18,7 @@ import { CommandRegistrar } from './registrar';
 describe('CommandRegistrar', () => {
 	let host: { addCommand: ReturnType<typeof vi.fn> };
 	let registrar: CommandRegistrar;
-	const spec = { name: 'X', callback: () => {} };
+	const spec = { callback: () => {} };
 
 	beforeEach(() => {
 		host = { addCommand: vi.fn() };
@@ -29,18 +29,18 @@ describe('CommandRegistrar', () => {
 		registrar.register('cmd:active-palette', true, spec);
 		expect(host.addCommand).toHaveBeenCalledTimes(1);
 		// feature 'main' has no per-entry icon -> resolves to FEATURE_ICONS.main.
-		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:active-palette', icon: 'synapse-main', ...spec });
+		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:active-palette', name: 'Active', icon: 'synapse-main', ...spec });
 		expect(registrar.getRegistered().has('cmd:active-palette')).toBe(true);
 	});
 
 	it('passes through a per-entry icon override', () => {
 		registrar.register('cmd:icon-override', true, spec);
-		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:icon-override', icon: 'synapse-custom', ...spec });
+		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:icon-override', name: 'Override', icon: 'synapse-custom', ...spec });
 	});
 
 	it('lets a caller-supplied spec.icon win over the registry-resolved icon', () => {
 		registrar.register('cmd:active-palette', true, { ...spec, icon: 'caller-icon' });
-		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:active-palette', icon: 'caller-icon', name: 'X', callback: spec.callback });
+		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:active-palette', name: 'Active', icon: 'caller-icon', callback: spec.callback });
 	});
 
 	it('skips registration when userEnabled is false (still records the attempt)', () => {
@@ -69,7 +69,7 @@ describe('CommandRegistrar', () => {
 
 	it('fails open for an unknown id (registers + tracks it) so the command keeps working', () => {
 		registrar.register('cmd:unknown', true, spec);
-		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:unknown', ...spec });
+		expect(host.addCommand).toHaveBeenCalledWith({ id: 'cmd:unknown', name: 'cmd:unknown', ...spec });
 		expect(registrar.getAttempted().has('cmd:unknown')).toBe(true);
 		expect(registrar.getRegistered().has('cmd:unknown')).toBe(true);
 	});

--- a/src/commands/registrar.ts
+++ b/src/commands/registrar.ts
@@ -5,7 +5,9 @@
  *
  * A command is actually registered only when the registry says it's `active` and
  * in the `'palette'` flow AND the user has the owning feature enabled. The
- * registrar also tracks every attempted/registered id for drift detection (audit.ts).
+ * palette label is resolved from COMMAND_REGISTRY (single source of truth shared
+ * with the action panel; #357) — callers no longer pass a `name`. The registrar
+ * also tracks every attempted/registered id for drift detection (audit.ts).
  */
 
 import type { Command } from 'obsidian';
@@ -29,9 +31,11 @@ export class CommandRegistrar {
 	 * @param id          command id (must match a COMMAND_REGISTRY entry)
 	 * @param userEnabled user-level enablement (the feature's `enabled` flag, or a
 	 *                    runtime predicate such as `hasTranscription`)
-	 * @param spec        the rest of the Obsidian command (name + a callback)
+	 * @param spec        the rest of the Obsidian command (a callback, optional icon,
+	 *                    etc.) — NOT the label. The palette `name` is sourced from
+	 *                    COMMAND_REGISTRY (#357), not from the spec.
 	 */
-	register(id: string, userEnabled: boolean, spec: Omit<Command, 'id'>): void {
+	register(id: string, userEnabled: boolean, spec: Omit<Command, 'id' | 'name'>): void {
 		this.attempted.add(id);
 
 		const entry = REGISTRY_BY_ID.get(id);
@@ -45,7 +49,10 @@ export class CommandRegistrar {
 			// per-action override; #349). Spread `spec` last so a caller-supplied
 			// icon still wins.
 			const icon = entry ? resolveActionIcon(entry) : undefined;
-			this.host.addCommand({ id, ...(icon ? { icon } : {}), ...spec });
+			// Name comes from COMMAND_REGISTRY (single source of truth, shared with the
+			// action panel; #357). Fail-open to the id; auditCommands() flags the miss.
+			const name = entry ? entry.name : id;
+			this.host.addCommand({ id, name, ...(icon ? { icon } : {}), ...spec });
 			this.registered.add(id);
 		}
 	}

--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -90,7 +90,6 @@ export class DeepDiveModule {
 		await this.store.init();
 
 		this.registrar.register('deep-dive', this.getSettings().deepDive.enabled, {
-			name: 'Deep dive current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.deepDive(ctx.file);
@@ -99,7 +98,6 @@ export class DeepDiveModule {
 		});
 
 		this.registrar.register('clear-deep-dive', this.getSettings().deepDive.enabled, {
-			name: 'Clear deep dive proposals',
 			callback: async () => {
 				await this.clearProposals();
 			},

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -55,7 +55,6 @@ export class ElaborationModule {
 		await this.store.init();
 
 		this.registrar.register('scan-vault', this.getSettings().elaboration.enabled, {
-			name: 'Scan folder for stub notes',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -73,7 +72,6 @@ export class ElaborationModule {
 		});
 
 		this.registrar.register('scan-current-note', this.getSettings().elaboration.enabled, {
-			name: 'Elaborate current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.scanNote(ctx.file);
@@ -82,7 +80,6 @@ export class ElaborationModule {
 		});
 
 		this.registrar.register('clear-proposals', this.getSettings().elaboration.enabled, {
-			name: 'Clear all pending proposals',
 			callback: () => this.clearProposals(),
 		});
 

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -79,7 +79,6 @@ export class EnrichmentModule {
 		);
 
 		this.registrar.register('enrich-current-note', this.getSettings().enrichment.enabled, {
-			name: 'Enrich current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.enrich(ctx.file.path, 'manual');
@@ -88,7 +87,6 @@ export class EnrichmentModule {
 		});
 
 		this.registrar.register('scan-vault-enrichment', this.getSettings().enrichment.enabled, {
-			name: 'Scan folder for enrichment',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -106,7 +104,6 @@ export class EnrichmentModule {
 		});
 
 		this.registrar.register('undo-enrichment', this.getSettings().enrichment.enabled, {
-			name: 'Undo last enrichment on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.undoLastEnrichment(ctx.file.path);

--- a/src/main.ts
+++ b/src/main.ts
@@ -334,12 +334,10 @@ export default class SynapsePlugin extends Plugin {
 		});
 
 		registrar.register('review-proposals', true, {
-			name: 'Open proposal review sidebar',
 			callback: () => this.activateUnifiedView(),
 		});
 
 		registrar.register('manage-checkpoints', true, {
-			name: 'Manage interrupted operations',
 			callback: () => this.manageCheckpoints(),
 		});
 
@@ -350,12 +348,10 @@ export default class SynapsePlugin extends Plugin {
 		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
 		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
 		registrar.register('transcribe-media', !!hasTranscription, {
-			name: 'Transcribe media',
 			callback: () => this.openUnifiedModal(),
 		});
 
 		registrar.register('transcribe-note-media', !!hasTranscription, {
-			name: 'Transcribe current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.transcribeMediaFromNote(ctx.file);
@@ -396,7 +392,6 @@ export default class SynapsePlugin extends Plugin {
 		}
 
 		registrar.register('fire', true, {
-			name: 'Run all features on a folder',
 			callback: () => {
 				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -62,7 +62,6 @@ export class OrganizeModule {
 		await this.store.init();
 
 		this.registrar.register('organize-current-note', this.getSettings().organize.enabled, {
-			name: 'Organize current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.organizeNote(ctx.file);
@@ -71,7 +70,6 @@ export class OrganizeModule {
 		});
 
 		this.registrar.register('scan-directory-organize', this.getSettings().organize.enabled, {
-			name: 'Scan folder for organization',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(
@@ -89,7 +87,6 @@ export class OrganizeModule {
 		});
 
 		this.registrar.register('undo-organize', this.getSettings().organize.enabled, {
-			name: 'Undo last organize on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.undoOrganize(ctx.file);

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -57,7 +57,6 @@ export class RemModule {
 
 		// Command: scan current note
 		this.registrar.register('rem-current-note', this.getSettings().rem.enabled, {
-			name: 'REM: Discover links in current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.remScanNote(ctx.file.path);
@@ -67,7 +66,6 @@ export class RemModule {
 
 		// Command: scan directory
 		this.registrar.register('rem-directory', this.getSettings().rem.enabled, {
-			name: 'Scan folder for links',
 			callback: () => {
 				new FolderPickerModal(
 					this.plugin.app,

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -97,7 +97,6 @@ export class SummarizeModule {
 
 	async onload(): Promise<void> {
 		this.registrar.register('summarize-current-note', this.getSettings().summarize.enabled, {
-			name: 'Summarize current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.summarizeNote(ctx.file);
@@ -106,7 +105,6 @@ export class SummarizeModule {
 		});
 
 		this.registrar.register('scan-vault-summarize', this.getSettings().summarize.enabled, {
-			name: 'Scan folder for notes to summarize',
 			callback: () => {
 				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
 				new FolderPickerModal(

--- a/src/tidy/index.ts
+++ b/src/tidy/index.ts
@@ -47,7 +47,6 @@ export class TidyModule {
 		await this.store.init();
 
 		this.registrar.register('tidy-current-note', this.getSettings().tidy.enabled, {
-			name: 'Tidy current note',
 			editorCallback: async (_editor, ctx) => {
 				if (!ctx.file) return;
 				// Path exclusion (#307): explicit single-note command → Notice
@@ -64,7 +63,6 @@ export class TidyModule {
 		});
 
 		this.registrar.register('undo-tidy', this.getSettings().tidy.enabled, {
-			name: 'Undo last tidy on current note',
 			editorCallback: async (_editor, ctx) => {
 				if (ctx.file) {
 					await this.undoTidy(ctx.file);

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -48,7 +48,6 @@ export class VideoModule {
 		);
 
 		this.registrar.register('check-dependencies', this.getSettings().video.enabled, {
-			name: 'Check external tool availability',
 			callback: () => this.checkDependencies(),
 		});
 	}


### PR DESCRIPTION
## Summary

Makes `COMMAND_REGISTRY` (`src/commands/registry.ts`) the single source of truth for command-palette display names. Previously the palette label was hard-coded as an inline `name:` in each `registrar.register(id, enabled, { name, callback })` call, while the action panel already read `COMMAND_REGISTRY[].name` — two parallel sources that had to be hand-synced.

Now `CommandRegistrar.register()` resolves the name from the registry entry (fail-open to the command id), and the redundant inline `name:` has been removed from all 23 call sites.

## Changes

- `src/commands/registrar.ts`: tighten the spec type to `Omit<Command, 'id' | 'name'>`; resolve `name` from the registry entry (`entry ? entry.name : id`) just before `addCommand`, keeping `...spec` last so a caller-supplied icon still wins; update doc comments.
- 9 production files: delete the inline `name:` from all 23 `register()` specs (main 5, elaboration 3, enrichment 3, organize 3, deep-dive 2, summarize 2, tidy 2, rem 2, video 1). `callback`/`editorCallback` and every other field untouched.
- `src/commands/registrar.test.ts`: drop `name` from the shared spec; add the registry-sourced `name` to the four `addCommand` expectations (including the id-fallback case for an unknown id).
- Docs: update the `register(...)` signature and the registration-gate pseudocode in `src/commands/AGENTS.md`.

## Behavior-preserving

All 23 call-site `name:` values already matched their registry entry exactly, so this refactor changes no user-visible labels. The tightened type makes any future call site that passes a `name` a compile error, so the two sources can never drift again.

## Verification

- `npx tsc --noEmit --skipLibCheck` — clean (proves no call site still passes `name`)
- `npm test` — 1521 tests pass (115 files), incl. the updated registrar suite
- `npm run lint` — clean
- `node scripts/check-top-level-requires.mjs` — no top-level requires
- `node scripts/version-bump.mjs --check` — versions consistent
- `node esbuild.config.mjs production` — build succeeds

closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDJotanJXCs7oMRALSNmwu