### PR TITLE
feat: persist error toasts with soft color and copy-on-dismiss (#359)

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -181,10 +181,13 @@ export class Notice {
 	static instances: Notice[] = [];
 	noticeEl: any;
 	duration?: number;
+	/** Test helper: the raw string message the Notice was constructed with. */
+	message?: string;
 	constructor(_message: string | DocumentFragment, _duration?: number) {
 		this.noticeEl = createStubEl();
 		this.duration = _duration;
 		if (typeof _message === 'string') {
+			this.message = _message;
 			this.noticeEl.textContent = _message;
 		}
 		Notice.instances.push(this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,13 +77,15 @@ export default class SynapsePlugin extends Plugin {
 		// addRibbonIcon(...)/setIcon/view getIcon that references these names.
 		registerSynapseIcons();
 
+		// Centralized notification manager. Constructed before migrateDataFolder()
+		// so that path can surface a persistent, copyable error toast through it.
+		this.notifications = new NotificationManager();
+
 		// Migrate legacy .auto-notes folder to .synapse (one-time, backward compat)
 		await this.migrateDataFolder();
 
 		this.addSettingTab(new SynapseSettingTab(this.app, this));
 
-		// Centralized notification manager
-		this.notifications = new NotificationManager();
 		if (Platform.isDesktop) {
 			this.notifications.setStatusBarEl(this.addStatusBarItem());
 		}
@@ -150,7 +152,7 @@ export default class SynapsePlugin extends Plugin {
 				onRemReject: (id) => this.rem.rejectProposal(id),
 				onCheckpointDiscard: (id) => this.discardCheckpoint(id),
 				onCheckpointResume: (id) => this.resumeCheckpoint(id),
-			});
+			}, this.notifications);
 		});
 
 		// Registry-driven "Synapse actions" sidebar (#289): touch-friendly buttons
@@ -874,8 +876,10 @@ export default class SynapsePlugin extends Plugin {
 			);
 		} catch (error) {
 			console.error('[Synapse] Failed to migrate data folder:', error);
-			new Notice(
-				`Synapse: failed to migrate ${OLD_FOLDER}/ to ${NEW_FOLDER}/ -- ` +
+			// Persistent, copyable error toast (NotificationManager exists by now —
+			// it is constructed before migrateDataFolder() in onload).
+			this.notifications.error(
+				`failed to migrate ${OLD_FOLDER}/ to ${NEW_FOLDER}/ -- ` +
 				`please rename it manually.`
 			);
 		}

--- a/src/shared/api-utils.test.ts
+++ b/src/shared/api-utils.test.ts
@@ -3,7 +3,6 @@ import {
 	classifyNetworkError,
 	describeNetworkError,
 	isTransientNetworkError,
-	notifyError,
 	withRetry,
 } from './api-utils';
 
@@ -116,39 +115,5 @@ describe('withRetry', () => {
 		await vi.runAllTimersAsync();
 		await expect(promise).resolves.toBe('done');
 		expect(fn).toHaveBeenCalledTimes(2);
-	});
-});
-
-describe('notifyError redaction', () => {
-	let errorSpy: ReturnType<typeof vi.spyOn>;
-
-	beforeEach(() => {
-		errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-	});
-
-	afterEach(() => {
-		errorSpy.mockRestore();
-	});
-
-	const loggedMessage = () => String(errorSpy.mock.calls[0]?.[1] ?? '');
-
-	it('redacts Google AIza… keys (the gap the old inline regex missed)', () => {
-		notifyError('Gemini call failed', new Error('API key not valid: AIzaSyBadKey1234567890123456789012345'));
-		const msg = loggedMessage();
-		expect(msg).toContain('[REDACTED]');
-		expect(msg).not.toContain('AIzaSyBadKey');
-	});
-
-	it('redacts OpenAI sk- keys and Bearer tokens', () => {
-		notifyError('OpenAI call failed', new Error('rejected key sk-abcdef1234567890 via Bearer abcdefgh12345678'));
-		const msg = loggedMessage();
-		expect(msg).not.toContain('sk-abcdef1234567890');
-		expect(msg).not.toContain('abcdefgh12345678');
-		expect(msg).toContain('[REDACTED]');
-	});
-
-	it('leaves non-secret error text intact', () => {
-		notifyError('Parse failed', new Error('Unexpected token at position 12'));
-		expect(loggedMessage()).toContain('Unexpected token at position 12');
 	});
 });

--- a/src/shared/api-utils.ts
+++ b/src/shared/api-utils.ts
@@ -1,6 +1,3 @@
-import { Notice } from 'obsidian';
-import { redactSecrets } from './redact';
-
 export type NetworkErrorKind = 'connection-refused' | 'dns' | 'timeout' | 'offline' | null;
 
 /** Classify an error/message into a network failure category (Electron net::, Node errno, common phrasings). */
@@ -49,15 +46,4 @@ export async function withRetry<T>(
 
 export function sleep(ms: number): Promise<void> {
 	return new Promise(resolve => window.setTimeout(resolve, ms));
-}
-
-export function notifyError(context: string, error: unknown): void {
-	const message = error instanceof Error ? error.message : String(error);
-	// Redact potential API keys/tokens before showing the error to the user or
-	// logging it. Uses the shared canonical redactor (./redact) so this stays in
-	// sync with the AI client — an earlier inline copy here omitted the Google
-	// `AIza…` pattern and would have leaked Gemini keys.
-	const redacted = redactSecrets(message);
-	new Notice(`Synapse: ${context} - ${redacted}`);
-	console.error(`[Synapse] ${context}:`, redacted);
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -3,7 +3,6 @@ export type { ChatMessage, ContentBlock, TextContentBlock, ImageContentBlock } f
 export {
 	withRetry,
 	sleep,
-	notifyError,
 	classifyNetworkError,
 	isTransientNetworkError,
 	describeNetworkError,

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -17,16 +17,32 @@ function lastNotice(): any {
 	return (Notice as unknown as { instances: any[] }).instances.at(-1);
 }
 
+/**
+ * Drain the microtask queue (via a 0ms macrotask) so a click handler's clipboard
+ * promise chain (writeText().then()/.catch() → info()) has run before we assert
+ * on the resulting confirmation toast.
+ */
+function flushAsync(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('NotificationManager', () => {
 	let manager: NotificationManager;
 
 	beforeEach(() => {
 		manager = new NotificationManager();
 		(Notice as unknown as { instances: any[] }).instances.length = 0;
+		// Error toasts copy to the clipboard on click; the node test env has no
+		// navigator.clipboard, so stub a resolving one. Individual tests can
+		// override writeText (e.g. mockRejectedValueOnce) to exercise failure.
+		vi.stubGlobal('navigator', {
+			clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+		});
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
 	});
 
 	describe('startOperation', () => {
@@ -190,6 +206,82 @@ describe('NotificationManager', () => {
 			expect(consoleSpy).toHaveBeenCalledWith(
 				expect.stringContaining('[Synapse]'),
 				expect.stringContaining('[REDACTED]')
+			);
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('error toasts (#359)', () => {
+		/** Silence the console.error that every error path emits. */
+		function silenceConsole() {
+			return vi.spyOn(console, 'error').mockImplementation(() => {});
+		}
+		/** The stubbed clipboard writer (see top-level beforeEach). */
+		function writeText() {
+			return navigator.clipboard.writeText as unknown as ReturnType<typeof vi.fn>;
+		}
+
+		it('builds a persistent (duration 0) error toast on op.error()', () => {
+			const consoleSpy = silenceConsole();
+			manager.startOperation('Work', 'err-persist').error('Boom');
+			// duration 0 → Obsidian never auto-hides it; it stays until clicked.
+			expect(lastNotice().duration).toBe(0);
+			consoleSpy.mockRestore();
+		});
+
+		it('styles the error toast with synapse-notice--error', () => {
+			const consoleSpy = silenceConsole();
+			manager.startOperation('Work', 'err-style').error('Boom');
+			expect(lastNotice().noticeEl.classList.contains('synapse-notice--error')).toBe(true);
+			consoleSpy.mockRestore();
+		});
+
+		it('keeps the error toast click-dismissible (no --no-dismiss class)', () => {
+			const consoleSpy = silenceConsole();
+			manager.startOperation('Work', 'err-dismiss').error('Boom');
+			// Running/confirmation toasts carry --no-dismiss; error toasts must not.
+			expect(lastNotice().noticeEl.classList.contains('synapse-notice--no-dismiss')).toBe(false);
+			consoleSpy.mockRestore();
+		});
+
+		it('clicking copies the redacted text to the clipboard and hides the toast', () => {
+			const consoleSpy = silenceConsole();
+			manager.notifyError('API call', new Error('boom sk-1234567890abcdef'));
+			const notice = lastNotice();
+
+			notice.noticeEl.dispatchEvent({ type: 'click' });
+
+			expect(notice.hide).toHaveBeenCalledTimes(1);
+			expect(writeText()).toHaveBeenCalledTimes(1);
+			const copied = writeText().mock.calls[0][0];
+			expect(copied).toContain('[REDACTED]');
+			expect(copied).not.toContain('sk-1234567890abcdef');
+			consoleSpy.mockRestore();
+		});
+
+		it('shows a brief confirmation toast after a successful copy', async () => {
+			const consoleSpy = silenceConsole();
+			manager.notifyError('API call', new Error('kaboom'));
+			lastNotice().noticeEl.dispatchEvent({ type: 'click' });
+
+			await flushAsync(); // let writeText().then() → info() run
+
+			expect(lastNotice().noticeEl.textContent).toContain('Error copied to clipboard');
+			consoleSpy.mockRestore();
+		});
+
+		it('falls back to a "couldn\'t copy" notice when the clipboard write rejects', async () => {
+			const consoleSpy = silenceConsole();
+			writeText().mockRejectedValueOnce(new Error('document not focused'));
+			manager.notifyError('API call', new Error('kaboom'));
+			lastNotice().noticeEl.dispatchEvent({ type: 'click' });
+
+			await flushAsync(); // let writeText().catch() → info() run
+
+			expect(lastNotice().noticeEl.textContent).toContain("Couldn't copy");
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Could not copy error to clipboard'),
+				expect.anything()
 			);
 			consoleSpy.mockRestore();
 		});

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -1,4 +1,5 @@
 import { Notice } from 'obsidian';
+import { redactSecrets } from './redact';
 
 export type NoticeLevel = 'info' | 'progress' | 'success' | 'warning' | 'error';
 
@@ -251,7 +252,9 @@ export class NotificationManager {
 
 			error: (message: string) => {
 				if (op.state !== 'running') return;
-				this.completeOperation(opId, 'error', message, 'error', 8000);
+				// Duration is ignored for errors (showErrorNotice forces persist);
+				// pass 0 to document the persist-until-dismissed intent.
+				this.completeOperation(opId, 'error', message, 'error', 0);
 				console.error(`[Synapse] ${op.label}:`, message);
 			},
 		};
@@ -339,6 +342,17 @@ export class NotificationManager {
 	}
 
 	/**
+	 * Surface a one-shot error from a fully composed message. The toast is
+	 * persistent (stays until clicked) and copies its redacted text to the
+	 * clipboard on dismiss — see {@link showErrorNotice}. Use this when you
+	 * already have the message text; use {@link notifyError} when you have an
+	 * error object plus a context label.
+	 */
+	error(message: string): void {
+		this.showErrorNotice(message);
+	}
+
+	/**
 	 * Build an interactive one-shot notice carrying a single action button.
 	 * Mirrors the confirm() snackbar markup: a message div plus an actions
 	 * container holding one `.mod-cta` button. The notice blocks background
@@ -372,16 +386,45 @@ export class NotificationManager {
 		});
 	}
 
-	/** Show a one-shot error notice (dismissible, stays longer) */
+	/**
+	 * Render a persistent, click-to-dismiss error toast. The single shared sink
+	 * for every error path (operation errors via completeOperation, notifyError,
+	 * and the public error()), so error styling, persistence, secret redaction,
+	 * and copy-on-dismiss all live in exactly one place.
+	 *
+	 * Unlike running-operation and confirmation toasts, error toasts are NOT
+	 * preventDismiss()'d — clicking is how the user dismisses them. The same
+	 * click copies the (redacted) text to the clipboard for bug reports; the
+	 * copy is best-effort and never blocks dismissal.
+	 */
+	private showErrorNotice(message: string): void {
+		const redacted = redactSecrets(message);
+		// Duration 0 → Obsidian never auto-hides it; it persists until clicked.
+		const notice = new Notice(`Synapse: ${redacted}`, 0);
+		styleNotice(notice, 'error');
+		const el = getNoticeEl(notice);
+		if (!el) return;
+		el.addEventListener('click', () => {
+			// Always dismiss on click, even if the clipboard write fails.
+			notice.hide();
+			navigator.clipboard.writeText(redacted)
+				.then(() => this.info('Error copied to clipboard'))
+				.catch((err) => {
+					console.error('[Synapse] Could not copy error to clipboard:', err);
+					this.info("Couldn't copy error to clipboard");
+				});
+		});
+	}
+
+	/**
+	 * Surface an error (object + context label) as a persistent, copyable error
+	 * toast. Routes through {@link showErrorNotice} so the displayed and copied
+	 * text are redacted by the canonical redactor; also logs the redacted message.
+	 */
 	notifyError(context: string, error: unknown): void {
 		const message = error instanceof Error ? error.message : String(error);
-		const redacted = message.replace(
-			/(?:sk-|key-|dg-|anthropic-|Bearer\s+|Token\s+)[A-Za-z0-9_-]{8,}/g,
-			'[REDACTED]'
-		);
-		const notice = new Notice(`Synapse: ${context} — ${redacted}`, 8000);
-		styleNotice(notice, 'error');
-		console.error(`[Synapse] ${context}:`, redacted);
+		this.showErrorNotice(`${context} — ${message}`);
+		console.error(`[Synapse] ${context}:`, redactSecrets(message));
 	}
 
 	private completeOperation(
@@ -402,6 +445,9 @@ export class NotificationManager {
 		// otherwise keep the plain (unchanged) path.
 		if (action) {
 			this.showActionNotice(message, level, duration, action);
+		} else if (level === 'error') {
+			// Error completions get the persistent, copy-on-dismiss treatment.
+			this.showErrorNotice(message);
 		} else {
 			const notice = new Notice(`Synapse: ${message}`, duration);
 			styleNotice(notice, level);

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -404,7 +404,12 @@ export class NotificationManager {
 		styleNotice(notice, 'error');
 		const el = getNoticeEl(notice);
 		if (!el) return;
-		el.addEventListener('click', () => {
+		// Attach to the `.notice` container so the whole toast — the full surface
+		// the error wash + pointer cursor cover — copies on click. noticeEl is the
+		// inner `.notice-message` in current Obsidian; fall back to it when there
+		// is no container (e.g. the test mock).
+		const clickTarget = el.closest('.notice') ?? el;
+		clickTarget.addEventListener('click', () => {
 			// Always dismiss on click, even if the clipboard write fails.
 			notice.hide();
 			navigator.clipboard.writeText(redacted)

--- a/src/shared/redact.test.ts
+++ b/src/shared/redact.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { redactSecrets } from './redact';
+
+describe('redactSecrets', () => {
+	it('redacts Google AIza… keys (the gap an old inline regex once missed)', () => {
+		const out = redactSecrets('API key not valid: AIzaSyBadKey1234567890123456789012345');
+		expect(out).toContain('[REDACTED]');
+		expect(out).not.toContain('AIzaSyBadKey');
+	});
+
+	it('redacts OpenAI sk- keys and Bearer tokens', () => {
+		const out = redactSecrets('rejected key sk-abcdef1234567890 via Bearer abcdefgh12345678');
+		expect(out).not.toContain('sk-abcdef1234567890');
+		expect(out).not.toContain('abcdefgh12345678');
+		expect(out).toContain('[REDACTED]');
+	});
+
+	it.each([
+		['Deepgram dg-', 'token dg-abcdef1234567890'],
+		['generic key-', 'value key-abcdef1234567890'],
+		['anthropic-', 'id anthropic-abcdef1234567890'],
+		['Token header', 'auth Token abcdefgh12345678'],
+	])('redacts %s secrets', (_label, input) => {
+		expect(redactSecrets(input)).toContain('[REDACTED]');
+	});
+
+	it('leaves non-secret error text intact', () => {
+		const text = 'Unexpected token at position 12';
+		expect(redactSecrets(text)).toBe(text);
+	});
+
+	it('redacts every secret when several appear in one string', () => {
+		const out = redactSecrets('sk-abcdef1234567890 and AIzaSyBadKey1234567890123456789012345');
+		expect(out).not.toContain('sk-abcdef1234567890');
+		expect(out).not.toContain('AIzaSyBadKey');
+		expect(out.match(/\[REDACTED\]/g)).toHaveLength(2);
+	});
+});

--- a/src/views/unified-proposal-view.test.ts
+++ b/src/views/unified-proposal-view.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UnifiedProposalView, UnifiedItem, UnifiedViewCallbacks } from './unified-proposal-view';
+import { NotificationManager } from '../shared/notifications';
 import type { Proposal } from '../elaboration';
 import type { EnrichmentProposal } from '../enrichment';
 import type { OrganizeProposal } from '../organize';
@@ -131,7 +132,7 @@ describe('UnifiedProposalView reject-all', () => {
 
 	beforeEach(() => {
 		callbacks = mockCallbacks();
-		view = new UnifiedProposalView(mockLeaf(), callbacks);
+		view = new UnifiedProposalView(mockLeaf(), callbacks, new NotificationManager());
 		// Stub contentEl with a recursive mock so render calls don't throw
 		view.contentEl = stubEl();
 	});

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -5,7 +5,7 @@ import type { OrganizeProposal } from '../organize';
 import type { DeepDiveProposal } from '../deep-dive';
 import type { TitleProposal } from '../title';
 import type { RemProposal } from '../rem';
-import type { Checkpoint } from '../shared';
+import type { Checkpoint, NotificationManager } from '../shared';
 import { fireAndForget } from '../shared';
 import type { UnifiedItem, UnifiedViewCallbacks } from './types';
 import { badgeClass, cardClass, reviewPaneLabelClass } from './proposal-styles';
@@ -25,6 +25,7 @@ export class UnifiedProposalView extends ItemView {
 	private items: UnifiedItem[] = [];
 	private incompleteCheckpoints: Checkpoint[] = [];
 	private callbacks: UnifiedViewCallbacks;
+	private notifications: NotificationManager;
 
 	private reviewingElaboration: Proposal | null = null;
 	private reviewingEnrichment: EnrichmentProposal | null = null;
@@ -45,9 +46,14 @@ export class UnifiedProposalView extends ItemView {
 	private selectedRefs = new Set<string>();
 	private selectedFrontmatter = new Set<string>();
 
-	constructor(leaf: WorkspaceLeaf, callbacks: UnifiedViewCallbacks) {
+	constructor(
+		leaf: WorkspaceLeaf,
+		callbacks: UnifiedViewCallbacks,
+		notifications: NotificationManager,
+	) {
 		super(leaf);
 		this.callbacks = callbacks;
+		this.notifications = notifications;
 	}
 
 	getViewType(): string {
@@ -202,7 +208,7 @@ export class UnifiedProposalView extends ItemView {
 				this.acceptAllInProgress = false;
 				const label = this.itemLabel(item);
 				const message = err instanceof Error ? err.message : String(err);
-				new Notice(
+				this.notifications.error(
 					`Accept All stopped: failed on "${label}" -- ${message}. ` +
 					`${accepted}/${total} accepted, ${total - accepted} remaining.`
 				);
@@ -308,7 +314,7 @@ export class UnifiedProposalView extends ItemView {
 				this.rejectAllInProgress = false;
 				const label = this.itemLabel(item);
 				const message = err instanceof Error ? err.message : String(err);
-				new Notice(
+				this.notifications.error(
 					`Reject All stopped: failed on "${label}" -- ${message}. ` +
 					`${rejected}/${total} rejected, ${total - rejected} remaining.`
 				);

--- a/styles.css
+++ b/styles.css
@@ -457,29 +457,35 @@
 /* ── Notification toasts (severity + tracked operations) ── */
 
 /*
- * Compound `.notice.synapse-notice` selector beats core `.notice` padding on
- * specificity without `!important` (both classes co-occur on the toast el).
+ * Obsidian renders a toast as `.notice > .notice-message`, and styleNotice()
+ * adds the `synapse-notice*` classes to whatever `Notice.noticeEl` points at —
+ * the inner `.notice-message` in current Obsidian, not the `.notice` element.
+ * So the severity class is NOT reliably co-located with `.notice`. Match BOTH
+ * shapes for each rule:
+ *   - `.notice.synapse-notice`       — class on the `.notice` element itself
+ *   - `.notice:has(.synapse-notice)` — class on a descendant (`.notice-message`)
+ * `:has()` keeps the (0,2,0) specificity (so we still beat core `.notice`
+ * padding/background without `!important`) AND styles the real `.notice`
+ * container, so the error wash is full-bleed rather than inset to the message.
  */
-.notice.synapse-notice {
+.notice.synapse-notice,
+.notice:has(.synapse-notice) {
   border-left: 3px solid var(--text-muted);
   padding-left: 10px;
   transition: border-color 0.3s ease;
 }
-/*
- * Severity colors. Compounded with `.notice` so they match the base
- * `.notice.synapse-notice` specificity (0,2,0) and win on source order —
- * otherwise the base `border-left` shorthand would override the accent color.
- */
-.notice.synapse-notice--info     { border-left-color: var(--text-muted); }
-.notice.synapse-notice--progress { border-left-color: var(--interactive-accent); }
-.notice.synapse-notice--success  { border-left-color: var(--color-green); }
-.notice.synapse-notice--warning  { border-left-color: var(--color-yellow); }
+/* Severity colors (source order after the base wins on equal specificity). */
+.notice.synapse-notice--info,     .notice:has(.synapse-notice--info)     { border-left-color: var(--text-muted); }
+.notice.synapse-notice--progress, .notice:has(.synapse-notice--progress) { border-left-color: var(--interactive-accent); }
+.notice.synapse-notice--success,  .notice:has(.synapse-notice--success)  { border-left-color: var(--color-green); }
+.notice.synapse-notice--warning,  .notice:has(.synapse-notice--warning)  { border-left-color: var(--color-yellow); }
 /*
  * Error toasts read unmistakably as errors and are click-to-copy/dismiss
  * (see NotificationManager.showErrorNotice): a soft, theme-aware error wash
  * behind the red accent, and a pointer cursor to signal they're clickable.
  */
-.notice.synapse-notice--error {
+.notice.synapse-notice--error,
+.notice:has(.synapse-notice--error) {
   border-left-color: var(--color-red);
   background-color: var(--background-modifier-error);
   cursor: pointer;
@@ -549,7 +555,9 @@
  * confirmation snackbar's Proceed/Cancel pair is unaffected.
  */
 .notice.synapse-notice--success .synapse-notice-actions,
-.notice.synapse-notice--info .synapse-notice-actions {
+.notice.synapse-notice--info .synapse-notice-actions,
+.notice:has(.synapse-notice--success) .synapse-notice-actions,
+.notice:has(.synapse-notice--info) .synapse-notice-actions {
   justify-content: flex-end;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -474,7 +474,16 @@
 .notice.synapse-notice--progress { border-left-color: var(--interactive-accent); }
 .notice.synapse-notice--success  { border-left-color: var(--color-green); }
 .notice.synapse-notice--warning  { border-left-color: var(--color-yellow); }
-.notice.synapse-notice--error    { border-left-color: var(--color-red); }
+/*
+ * Error toasts read unmistakably as errors and are click-to-copy/dismiss
+ * (see NotificationManager.showErrorNotice): a soft, theme-aware error wash
+ * behind the red accent, and a pointer cursor to signal they're clickable.
+ */
+.notice.synapse-notice--error {
+  border-left-color: var(--color-red);
+  background-color: var(--background-modifier-error);
+  cursor: pointer;
+}
 
 /* Running operation layout */
 .synapse-notice-op {


### PR DESCRIPTION
## Summary

Centralizes error-toast behavior in `NotificationManager` so every error toast reads unmistakably as an error, persists until acknowledged, and copies its (redacted) text to the clipboard on dismiss. Non-error toasts (info / success / progress / warning) and the operation progress border are unchanged.

closes #359

## What changed

**Core**
- New private `showErrorNotice(message)` — the single sink for every error path. Soft, theme-aware error wash + red accent + pointer cursor; duration `0` (persists until clicked); **not** `preventDismiss`'d, so it stays click-dismissible.
- The click copies the redacted text to the clipboard, then shows a brief `Error copied to clipboard` info toast; on a rejected write it logs and shows a couldn't-copy notice instead (never blocks dismissal).
- New public `error(message)` wrapper for pre-composed messages (parallel to `info()` / `success()`).
- `OperationHandle.error()` (via `completeOperation`) and `notifyError()` now both route through `showErrorNotice` — so the ~13 existing `notifyError` call sites across modules get the new treatment for free.
- Redaction now uses the canonical `redactSecrets` (`src/shared/redact.ts`) for both the displayed and copied text — closing a latent Google `AIza…` key leak the old inline regex in `notifyError` missed.
- `styles.css`: `.synapse-notice--error` gains `background-color: var(--background-modifier-error)` + `cursor: pointer`.

**Direct `new Notice()` error audit**
- Routed through the new path: the data-migration failure (`main.ts`) and the Accept/Reject All batch failures (`unified-proposal-view.ts`, now constructed with the `NotificationManager`).
- Deleted the redundant, uncalled `api-utils.notifyError` (+ its barrel export) and migrated its redaction assertions to a new `redact.test.ts` that tests `redactSecrets` directly (it had no dedicated tests before).
- Left intentionally as-is: the `fire-and-forget` no-manager fallback (can't route without a manager), and the time-range **validation** notice in `unified-modal.ts`.

## Tests
- New `error toasts (#359)` suite: persistence (duration 0), error styling, click-dismissible (no `--no-dismiss`), click → copy-redacted-text → hide, confirmation toast, and copy-failure fallback. `navigator.clipboard` stubbed via `vi.stubGlobal`; the obsidian `Notice` mock now records `message`.
- Full suite green (**1532 tests**); `tsc`, `eslint`, `check-top-level-requires`, `version-bump --check`, and the production build all pass.

## Verify
Trigger an error (e.g. an invalid API key during enrich): the toast shows a soft red wash + red accent and does **not** auto-dismiss. Click it → it dismisses and a brief "Error copied to clipboard" toast appears; paste → redacted error text (no raw key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
