### PR TITLE
chore: sync package-lock version field to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "synapse",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "synapse",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"license": "AGPL-3.0-only",
 			"devDependencies": {
 				"@emnapi/core": "^1.7.1",


### PR DESCRIPTION
## Summary

`package-lock.json`'s own `version` field was stuck at `1.0.4` while `package.json` is `1.0.5`. npm silently rewrites it to match on every local install, which leaves a perpetually dirty working tree (and the diff keeps reappearing). CI's `version-bump --check` only inspects `package.json` / `manifest.json` / `versions.json`, so it never flagged the drift.

## What changed

Bumps **only** the project's two self-version fields (top-level and `packages[""]`) from `1.0.4` → `1.0.5`. Dependency versions are untouched — e.g. `ast-v8-to-istanbul@1.0.4` stays as-is.

```diff
 {
 	"name": "synapse",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 3,
 		"": {
 			"name": "synapse",
-			"version": "1.0.4",
+			"version": "1.0.5",
```

## Validation

`npx npm@10 ci` — clean install (183 packages, 0 vulnerabilities, no `@emnapi` pruning), so the lockfile stays valid for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
