### PR TITLE
fix: allow & and URL-legal characters in sanitizeUrl (defense-in-depth)

### DIFF
--- a/src/shared/url-classifier.test.ts
+++ b/src/shared/url-classifier.test.ts
@@ -177,6 +177,14 @@ describe('classifyUrl', () => {
 			expect(result.platform).toBe('wikipedia');
 		});
 
+		it('classifies a Wikipedia disambiguation URL with parentheses as article', () => {
+			// sanitizeUrl now allows URL-legal `()`, so a real disambiguation URL
+			// reaches classification instead of being rejected as unknown (#369).
+			const result = classifyUrl('https://en.wikipedia.org/wiki/Obsidian_(software)');
+			expect(result.type).toBe('article');
+			expect(result.platform).toBe('wikipedia');
+		});
+
 		it('classifies any other valid http(s) URL as a generic article', () => {
 			const result = classifyUrl('https://example.com/some/article');
 			expect(result.type).toBe('article');
@@ -233,17 +241,9 @@ describe('classifyUrl', () => {
 		});
 
 		it('classifies a URL with shell metacharacters as unknown (sanitizeUrl rejects)', () => {
+			// Regression guard: `$` (and backtick/`;`/`|`) stay rejected after #369
+			// loosened sanitizeUrl, so a `$(...)` injection attempt is still unknown.
 			expect(classifyUrl('https://example.com/$(rm -rf /)').type).toBe('unknown');
-		});
-
-		it('classifies a URL with parentheses as unknown (known sanitizeUrl limitation)', () => {
-			// Documents current behavior: sanitizeUrl rejects `()`, so even a real
-			// Wikipedia disambiguation URL is unknown until sanitizeUrl is relaxed
-			// for the fetch path (#109). Classification stays in sync with the gate
-			// every downstream fetcher applies.
-			expect(classifyUrl('https://en.wikipedia.org/wiki/Obsidian_(software)').type).toBe(
-				'unknown'
-			);
 		});
 
 		it('classifies a URL containing a null byte as unknown', () => {

--- a/src/shared/url-classifier.ts
+++ b/src/shared/url-classifier.ts
@@ -60,10 +60,12 @@ const URL_IN_TEXT_REGEX = /https?:\/\/[^\s<>"'`]+/gi;
  * would route it to a pipeline guaranteed to throw. Keeping the gate identical
  * means a non-`unknown` classification is always a fetchable URL.
  *
- * KNOWN LIMITATION: sanitizeUrl rejects shell metacharacters including `()`,
- * so disambiguation URLs like `…/wiki/Obsidian_(software)` classify as
- * `unknown` today. Relaxing that safely requires loosening sanitizeUrl for the
- * non-shell (fetch) path, which is out of scope for this module (see #109).
+ * sanitizeUrl now allows the URL-legal characters `()`, `{}`, `!` and `&`
+ * (multi-param query strings), so disambiguation URLs like
+ * `…/wiki/Obsidian_(software)` and multi-param TikTok/YouTube links classify
+ * normally for the fetch path. It still rejects the shell-dangerous `$`,
+ * backtick, `;` and `|` (plus control chars and null bytes) as
+ * defense-in-depth, so a URL like `…/$(rm -rf /)` remains `unknown`.
  */
 function safeParseUrl(url: string): URL | null {
 	if (typeof url !== 'string' || url.trim().length === 0) {

--- a/src/shared/validation.test.ts
+++ b/src/shared/validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
 	blockquoteOriginal, ensureWithinVault, stripCodeFences,
-	parseTimestamp, validateTimeRange, formatTimeRange,
+	parseTimestamp, validateTimeRange, formatTimeRange, sanitizeUrl,
 } from './validation';
 
 describe('blockquoteOriginal', () => {
@@ -59,6 +59,90 @@ describe('blockquoteOriginal', () => {
 		// No valid frontmatter, so the whole thing gets blockquoted
 		expect(result).toContain('> ---');
 		expect(result).toContain('> Not actually frontmatter');
+	});
+});
+
+describe('sanitizeUrl', () => {
+	describe('allows URL-legal characters', () => {
+		it('passes a YouTube watch URL with a second & param', () => {
+			const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s';
+			expect(sanitizeUrl(url)).toBe(url);
+		});
+
+		it('passes a full TikTok URL with multiple tracking params', () => {
+			const url = 'https://www.tiktok.com/@x/video/123?_r=1&_t=ZT-9';
+			expect(sanitizeUrl(url)).toBe(url);
+		});
+
+		it('passes a Wikipedia disambiguation URL with parentheses', () => {
+			const url = 'https://en.wikipedia.org/wiki/Obsidian_(software)';
+			expect(sanitizeUrl(url)).toBe(url);
+		});
+
+		it('passes a URL containing { } and !', () => {
+			const url = 'https://example.com/path/{id}/item!';
+			expect(sanitizeUrl(url)).toBe(url);
+		});
+	});
+
+	describe('still rejects dangerous characters and schemes', () => {
+		it('rejects a URL containing a backtick', () => {
+			expect(() => sanitizeUrl('https://example.com/`whoami`')).toThrow(
+				'URL contains invalid characters'
+			);
+		});
+
+		it('rejects a URL containing $', () => {
+			expect(() => sanitizeUrl('https://example.com/$(x)')).toThrow(
+				'URL contains invalid characters'
+			);
+		});
+
+		it('rejects a URL containing a semicolon', () => {
+			expect(() => sanitizeUrl('https://example.com/a;b')).toThrow(
+				'URL contains invalid characters'
+			);
+		});
+
+		it('rejects a URL containing a pipe', () => {
+			expect(() => sanitizeUrl('https://example.com/a|b')).toThrow(
+				'URL contains invalid characters'
+			);
+		});
+
+		it('rejects a URL containing a newline', () => {
+			expect(() => sanitizeUrl('https://example.com/a\nb')).toThrow(
+				'URL contains invalid characters'
+			);
+		});
+
+		it('rejects a URL containing a carriage return', () => {
+			expect(() => sanitizeUrl('https://example.com/a\rb')).toThrow(
+				'URL contains invalid characters'
+			);
+		});
+
+		it('rejects a URL containing a null byte', () => {
+			expect(() => sanitizeUrl('https://example.com/\0')).toThrow(
+				'contains null bytes'
+			);
+		});
+
+		it('rejects a non-http(s) scheme (ftp)', () => {
+			expect(() => sanitizeUrl('ftp://example.com/file.zip')).toThrow(
+				'Only HTTP and HTTPS URLs are supported'
+			);
+		});
+
+		it('rejects a non-http(s) scheme (file)', () => {
+			expect(() => sanitizeUrl('file:///etc/passwd')).toThrow(
+				'Only HTTP and HTTPS URLs are supported'
+			);
+		});
+
+		it('rejects a structurally invalid URL', () => {
+			expect(() => sanitizeUrl('not a url')).toThrow('Invalid URL format');
+		});
 	});
 });
 

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -25,9 +25,16 @@ export function sanitizeUrl(url: string): string {
 		throw new Error('Only HTTP and HTTPS URLs are supported');
 	}
 
-	// Reject shell metacharacters that could be used for injection
-	// Even with execFile, we want defense-in-depth
-	const shellMeta = /[;|&`$(){}!\n\r]/;
+	// Reject the shell metacharacters most dangerous in a shell context as
+	// defense-in-depth, while allowing URL-legal characters that appear in real
+	// links. `&` (multi-param query strings), `(` `)` `{` `}` `!` are common in
+	// legitimate URLs (TikTok/YouTube tracking params, Wikipedia disambiguation
+	// pages) and are NOT injection vectors here: the URL is passed to execFile as
+	// a single argv element with no shell, and new URL() above guarantees it is
+	// well-formed. We still reject `;` `|` backtick `$` and the control chars
+	// `\n` `\r` because they are rarely legitimate in a URL and stay dangerous if
+	// a value ever reaches a shell. The null-byte check above is also retained.
+	const shellMeta = /[;|`$\n\r]/;
 	if (shellMeta.test(url)) {
 		throw new Error('URL contains invalid characters');
 	}


### PR DESCRIPTION
## Problem
`sanitizeUrl()` rejected **any** URL matching `/[;|&\`$(){}!\n\r]/`, so the `&` separating query params in a full TikTok link (`?_r=1&_t=…`) or a standard YouTube link (`watch?v=…&t=30s`) threw `"URL contains invalid characters"` — *before* normalization could strip the params. This is broader than TikTok: any multi-param URL was rejected.

## Change
Narrow the blocklist regex from `/[;|&\`$(){}!\n\r]/` to **`/[;|\`$\n\r]/`**.

- **Now allowed** (URL-legal, appear in real links): `&` `(` `)` `{` `}` `!`
- **Still rejected** (defense-in-depth): `;` `|` backtick `$`, control chars `\n` `\r`, null bytes (separate check), and any non-http(s) scheme.

`sanitizePath()` is **deliberately untouched** — filesystem paths keep the strict regex.

## Why loosening is safe
- The sanitized URL is passed to `execFile` (`audio-extractor.ts` → `runCommand` → `node.execFile(cmd, args, …)`) as a **single argv element with no shell**, so `&` `(` `)` etc. are never shell-interpreted — they are not injection vectors on this path.
- `new URL()` already guarantees the URL is structurally well-formed before the char check.
- We still reject `$` / backtick / `;` / `|` + control chars + null bytes + non-http(s) schemes as belt-and-suspenders, so a `$(rm -rf /)`-style URL remains blocked.

## Coupled change (url-classifier)
- Updated the "KNOWN LIMITATION" comment in `url-classifier.ts` to reflect the narrower set (`() {} ! &` now allowed for the fetch path; `$` backtick `;` `|` still rejected).
- `url-classifier.test.ts`: the Wikipedia disambiguation URL `…/wiki/Obsidian_(software)` now classifies as `article`/`wikipedia` (was `unknown`). The `…/$(rm -rf /)` test **stays `unknown`** as a regression guard proving `$` is still blocked.

## Tests
Added `describe('sanitizeUrl', …)` to `validation.test.ts`:
- **Passes:** YouTube `&t=30s`, full TikTok multi-param, Wikipedia `(software)`, a URL with `{ } !`.
- **Still rejects:** backtick, `$`, `;`, `|`, `\n`, `\r`, null byte, `ftp://`, `file://`, and a structurally invalid URL.

## Preflight (all pass)
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` — 1553 tests / 116 files
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

closes #369

Co-Authored-By: Claude <bot@wafflenet.io>