### PR TITLE
feat: notify users when a new Synapse version is available

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { CommandRegistrar, auditCommands, listPaletteActions, REGISTRY_BY_ID } f
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
-import { FolderPickerModal, NotificationManager, CheckpointManager, fireAndForget, buildMigratedExclusions } from './shared';
+import { FolderPickerModal, NotificationManager, CheckpointManager, UpdateChecker, fireAndForget, buildMigratedExclusions } from './shared';
 import type { DeferredTask, LegacyModuleExclusions } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
@@ -46,6 +46,7 @@ export default class SynapsePlugin extends Plugin {
 	settings!: SynapseSettings;
 	notifications!: NotificationManager;
 	private checkpointManager!: CheckpointManager;
+	private updateChecker!: UpdateChecker;
 
 	private elaboration!: ElaborationModule;
 	private audio!: AudioModule;
@@ -62,6 +63,12 @@ export default class SynapsePlugin extends Plugin {
 	private audioExtractor: AudioExtractor | undefined;
 	private ffmpegAvailable: boolean | null = null;
 	private startupTimeout: number | null = null;
+	/**
+	 * Separate startup timer for the once-per-day update check (#365). Kept
+	 * distinct from {@link startupTimeout} so neither clobbers the other's
+	 * handle; cleared in {@link onunload}.
+	 */
+	private updateCheckTimeout: number | null = null;
 	/**
 	 * True when `loadData()` returned no persisted settings — i.e. a genuine
 	 * fresh install rather than an existing user upgrading. Drives first-run
@@ -134,6 +141,17 @@ export default class SynapsePlugin extends Plugin {
 		this.deepDive = new DeepDiveModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept['deep-dive']);
 		this.title = new TitleModule(this, getSettings, this.notifications, () => this.settings.autoAccept.title);
 		this.rem = new RemModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept.rem);
+
+		// In-app "newer Synapse available" check (#365). Self-gated on the settings
+		// toggle and rate-limited to once/day inside maybeCheck(); fired from a
+		// delayed startup timer below so it never blocks load.
+		this.updateChecker = new UpdateChecker({
+			currentVersion: this.manifest.version,
+			app: this.app,
+			notifications: this.notifications,
+			getSettings,
+			saveSettings: () => this.saveSettings(),
+		});
 
 		// Register the unified proposal view
 		this.registerView(UNIFIED_VIEW_TYPE, (leaf) => {
@@ -350,6 +368,11 @@ export default class SynapsePlugin extends Plugin {
 		// Startup check for incomplete checkpoints (delayed to avoid blocking load)
 		this.startupTimeout = window.setTimeout(() => { void this.checkForIncompleteCheckpoints(); }, 3000);
 
+		// Startup check for a newer Synapse release (#365). Delayed (and staggered
+		// after the checkpoint check) so it never blocks load; maybeCheck() self-gates
+		// on the toggle and the once/day rate limit.
+		this.updateCheckTimeout = window.setTimeout(() => { void this.updateChecker.maybeCheck(); }, 5000);
+
 		// Unified transcription commands (audio on any platform, video on desktop only, image OCR).
 		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
 		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
@@ -428,6 +451,10 @@ export default class SynapsePlugin extends Plugin {
 		if (this.startupTimeout !== null) {
 			window.clearTimeout(this.startupTimeout);
 			this.startupTimeout = null;
+		}
+		if (this.updateCheckTimeout !== null) {
+			window.clearTimeout(this.updateCheckTimeout);
+			this.updateCheckTimeout = null;
 		}
 		this.elaboration?.onunload();
 		this.audio?.onunload();

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -320,7 +320,7 @@ describe('SynapseSettingTab — General section / auto-fold properties (#381)', 
 		return { view: { containerEl }, isCollapsed: () => classes.has(PROPERTIES_COLLAPSED_CLASS) };
 	}
 
-	/** Render ONLY the General section so the lone toggle is unambiguous. */
+	/** Render ONLY the General section so its toggles are unambiguous. */
 	function renderGeneral(
 		mutate?: (s: SynapseSettings) => void,
 		activeView?: unknown,
@@ -342,7 +342,10 @@ describe('SynapseSettingTab — General section / auto-fold properties (#381)', 
 		return { plugin, settings, saveSettings, containerEl, getActiveViewOfType };
 	}
 
+	// Toggles render in source order: auto-fold (#381) first, then update
+	// notifications (#365).
 	const generalToggle = () => ToggleComponent.instances[0];
+	const updateToggle = () => ToggleComponent.instances[1];
 
 	it('renders a "General" accordion section', () => {
 		const { containerEl } = renderGeneral();
@@ -352,7 +355,8 @@ describe('SynapseSettingTab — General section / auto-fold properties (#381)', 
 
 	it('renders the auto-fold toggle reflecting the stored setting (on)', () => {
 		renderGeneral((s) => { s.ui.autoFoldProperties = true; });
-		expect(ToggleComponent.instances).toHaveLength(1);
+		// Two General toggles now: auto-fold (#381) + update notifications (#365).
+		expect(ToggleComponent.instances).toHaveLength(2);
 		expect(generalToggle().getValue()).toBe(true);
 	});
 
@@ -388,5 +392,19 @@ describe('SynapseSettingTab — General section / auto-fold properties (#381)', 
 		await generalToggle()._trigger(false);
 		expect(isCollapsed()).toBe(false);
 		expect(getActiveViewOfType).not.toHaveBeenCalled();
+	});
+
+	it('renders the update-notifications toggle reflecting the stored setting', () => {
+		renderGeneral((s) => { s.updates.enableUpdateNotifications = false; });
+		expect(updateToggle().getValue()).toBe(false);
+	});
+
+	it('persists the update-notifications flag and saves when the toggle changes', async () => {
+		const { plugin, saveSettings } = renderGeneral(
+			(s) => { s.updates.enableUpdateNotifications = true; },
+		);
+		await updateToggle()._trigger(false);
+		expect(plugin.settings.updates.enableUpdateNotifications).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
 	});
 });

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -604,6 +604,22 @@ export class SynapseSettingTab extends PluginSettingTab {
 						foldActiveNoteProperties(this.app, value);
 					}),
 			);
+
+		// ── Update notifications (#365) ──
+		new Setting(body)
+			.setName('Notify me about Synapse updates')
+			.setDesc(
+				'Show an in-app notice when a newer version of Synapse is available. ' +
+				'Checked at most once a day; the notice links to Community plugins to update.',
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.updates.enableUpdateNotifications)
+					.onChange(async (value) => {
+						this.plugin.settings.updates.enableUpdateNotifications = value;
+						await this.plugin.saveSettings();
+					}),
+			);
 	}
 
 	/**

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -61,6 +61,17 @@ describe('onboarding settings (#89)', () => {
 	});
 });
 
+describe('update settings (#365)', () => {
+	it('enables update notifications by default', () => {
+		expect(DEFAULT_SETTINGS.updates.enableUpdateNotifications).toBe(true);
+	});
+
+	it('starts with no recorded check or dismissed version', () => {
+		expect(DEFAULT_SETTINGS.updates.lastUpdateCheck).toBeUndefined();
+		expect(DEFAULT_SETTINGS.updates.dismissedUpdateVersion).toBeUndefined();
+	});
+});
+
 describe('UI settings — auto-fold properties (#381)', () => {
 	it('defaults autoFoldProperties to false (opt-in)', () => {
 		expect(DEFAULT_SETTINGS.ui.autoFoldProperties).toBe(false);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -260,6 +260,29 @@ export interface UISettings {
 }
 
 /**
+ * Update-notification state (#365). Synapse is a community plugin, so Obsidian
+ * auto-checks for updates — but the only signal is a small badge buried in
+ * Settings → Community plugins. This group drives a louder, in-app, actionable
+ * prompt that points the user at that page when a newer release is published.
+ */
+export interface UpdateSettings {
+	/** Master toggle for the in-app "update available" notice. Default on. */
+	enableUpdateNotifications: boolean;
+	/**
+	 * Epoch ms of the last GitHub release check (success OR failure). Drives the
+	 * once-per-day rate limit so load is never gated on a network round-trip.
+	 * Absent until the first check runs.
+	 */
+	lastUpdateCheck?: number;
+	/**
+	 * The newest version the user has already been notified about. Set right
+	 * after a notice is shown so the same version never nags twice — clearing it
+	 * (or a newer release) re-arms the prompt. Absent until the first notice.
+	 */
+	dismissedUpdateVersion?: string;
+}
+
+/**
  * First-run onboarding state (#89). Persisted so the welcome experience fires
  * exactly once. Nested as its own group (rather than a bare top-level flag) so
  * future onboarding signals can join it without widening the settings root.
@@ -300,6 +323,7 @@ export interface SynapseSettings {
 	ui: UISettings;
 	autoAccept: AutoAcceptSettings;
 	onboarding: OnboardingSettings;
+	updates: UpdateSettings;
 	/**
 	 * Centralized per-path exclusion list (#307). Each rule names a vault-relative
 	 * glob and the features it blocks (or `'all'`). This is the single source of
@@ -471,6 +495,9 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 	},
 	onboarding: {
 		hasSeenWelcome: false,
+	},
+	updates: {
+		enableUpdateNotifications: true,
 	},
 	// Centralized path exclusions (#307). `.synapse` (plugin data) and
 	// `templates` are protected from EVERY flow out of the box; users add their

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -25,6 +25,8 @@ export { decorateCredentialField } from './credential-field';
 export type { CredentialFieldOptions, CredentialFieldHandle } from './credential-field';
 export { NotificationManager, linkLoadError } from './notifications';
 export type { OperationHandle, NoticeAction } from './notifications';
+export { UpdateChecker, isNewerVersion } from './update-checker';
+export type { UpdateCheckerDeps } from './update-checker';
 export { fireAndForget } from './fire-and-forget';
 export type { FireAndForgetOptions } from './fire-and-forget';
 export { FolderPickerModal } from './folder-picker-modal';

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -191,6 +191,35 @@ describe('NotificationManager', () => {
 		});
 	});
 
+	describe('sticky action notice (#365)', () => {
+		it('persists (duration 0) and renders the action button', () => {
+			const onClick = vi.fn();
+			manager.infoSticky('Synapse v1.0.7 is available', { label: 'Update', onClick });
+
+			const notice = lastNotice();
+			// Sticky → Obsidian never auto-hides it.
+			expect(notice.duration).toBe(0);
+			const button = findButton(notice.noticeEl);
+			expect(button?.textContent).toBe('Update');
+		});
+
+		it('stays click-dismissible (no --no-dismiss class) so it can be waved away', () => {
+			manager.infoSticky('Update available', { label: 'Update', onClick: vi.fn() });
+			expect(lastNotice().noticeEl.classList.contains('synapse-notice--no-dismiss')).toBe(false);
+		});
+
+		it('invokes the action exactly once and hides on click', () => {
+			const onClick = vi.fn();
+			manager.infoSticky('Update available', { label: 'Update', onClick });
+
+			const notice = lastNotice();
+			findButton(notice.noticeEl).dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+
+			expect(onClick).toHaveBeenCalledTimes(1);
+			expect(notice.hide).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe('info and notifyError', () => {
 		it('info does not throw', () => {
 			expect(() => manager.info('Test message')).not.toThrow();

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -342,6 +342,17 @@ export class NotificationManager {
 	}
 
 	/**
+	 * Show a STICKY informational notice carrying a single action button (#365).
+	 * Unlike {@link info}/{@link success} with an action — which floor the
+	 * duration (~8s) and then auto-dismiss — this stays up until the user clicks
+	 * the action OR clicks the toast to dismiss it (duration 0, no preventDismiss).
+	 * Used for the "update available" prompt, which must persist until acted on.
+	 */
+	infoSticky(message: string, action: NoticeAction): void {
+		this.showActionNotice(message, 'info', 0, action, { dismissible: true });
+	}
+
+	/**
 	 * Show a one-shot success notice (dismissible). When `action` is supplied the
 	 * toast renders an action button (e.g. "Review") and stays up longer.
 	 */
@@ -371,16 +382,21 @@ export class NotificationManager {
 	 * container holding one `.mod-cta` button. The notice blocks background
 	 * click-to-dismiss, but the button click passes through (preventDismiss
 	 * lets button targets through), runs the action, and hides the toast.
+	 *
+	 * `options.dismissible` (used by {@link infoSticky}) skips preventDismiss so
+	 * a click anywhere on the toast also dismisses it — the right behavior for a
+	 * persistent (duration 0) prompt the user may want to wave away.
 	 */
 	private showActionNotice(
 		message: string,
 		level: NoticeLevel,
 		duration: number,
-		action: NoticeAction
+		action: NoticeAction,
+		options?: { dismissible?: boolean }
 	): void {
 		const notice = new Notice('', duration);
 		styleNotice(notice, level);
-		preventDismiss(notice);
+		if (!options?.dismissible) preventDismiss(notice);
 
 		const el = getNoticeEl(notice);
 		el.empty();

--- a/src/shared/update-checker.test.ts
+++ b/src/shared/update-checker.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Notice, requestUrl } from 'obsidian';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+import { NotificationManager } from './notifications';
+import { UpdateChecker, isNewerVersion } from './update-checker';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Recursively locate the first <button> element in a stub-element tree. */
+function findButton(el: any): any | null {
+	for (const child of el.children ?? []) {
+		if (child.tagName === 'BUTTON') return child;
+		const nested = findButton(child);
+		if (nested) return nested;
+	}
+	return null;
+}
+
+function notices(): any[] {
+	return (Notice as unknown as { instances: any[] }).instances;
+}
+function lastNotice(): any {
+	return notices().at(-1);
+}
+
+/**
+ * Collect a notice's full text. Action notices (#365) put the message in a child
+ * div rather than on `noticeEl.textContent`, so recurse through the stub tree.
+ */
+function noticeText(notice: any): string {
+	const collect = (el: any): string => {
+		let text = el.textContent ?? '';
+		for (const child of el.children ?? []) text += collect(child);
+		return text;
+	};
+	return collect(notice.noticeEl);
+}
+
+/** Build a full settings object with the `updates` group overridden. */
+function settingsWith(updates: Partial<SynapseSettings['updates']>): SynapseSettings {
+	return {
+		...structuredClone(DEFAULT_SETTINGS),
+		updates: { enableUpdateNotifications: true, ...updates },
+	};
+}
+
+interface Harness {
+	checker: UpdateChecker;
+	settings: SynapseSettings;
+	saveSettings: ReturnType<typeof vi.fn>;
+	app: { setting?: { open: ReturnType<typeof vi.fn>; openTabById: ReturnType<typeof vi.fn> } };
+}
+
+function makeChecker(opts?: {
+	currentVersion?: string;
+	updates?: Partial<SynapseSettings['updates']>;
+	app?: unknown;
+}): Harness {
+	const settings = settingsWith(opts?.updates ?? {});
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const app = (opts?.app ?? { setting: { open: vi.fn(), openTabById: vi.fn() } }) as Harness['app'];
+	const checker = new UpdateChecker({
+		currentVersion: opts?.currentVersion ?? '1.0.6',
+		app: app as never,
+		notifications: new NotificationManager(),
+		getSettings: () => settings,
+		saveSettings,
+	});
+	return { checker, settings, saveSettings, app };
+}
+
+/** Stub the next requestUrl resolution as a GitHub "latest release" response. */
+function mockRelease(tag: string | null, status = 200): void {
+	vi.mocked(requestUrl).mockResolvedValue({
+		status,
+		json: tag === null ? {} : { tag_name: tag },
+		text: '',
+		headers: {},
+	} as never);
+}
+
+describe('isNewerVersion', () => {
+	it('returns true when latest is strictly newer (patch/minor/major)', () => {
+		expect(isNewerVersion('1.0.7', '1.0.6')).toBe(true);
+		expect(isNewerVersion('1.1.0', '1.0.6')).toBe(true);
+		expect(isNewerVersion('2.0.0', '1.9.9')).toBe(true);
+	});
+
+	it('returns false when the versions are equal', () => {
+		expect(isNewerVersion('1.0.6', '1.0.6')).toBe(false);
+	});
+
+	it('returns false when latest is older', () => {
+		expect(isNewerVersion('1.0.5', '1.0.6')).toBe(false);
+		expect(isNewerVersion('0.9.9', '1.0.0')).toBe(false);
+	});
+
+	it('ignores a leading v on either side', () => {
+		expect(isNewerVersion('v1.0.7', '1.0.6')).toBe(true);
+		expect(isNewerVersion('1.0.7', 'v1.0.6')).toBe(true);
+		expect(isNewerVersion('v1.0.6', 'v1.0.6')).toBe(false);
+	});
+
+	it('treats a missing trailing component as zero', () => {
+		expect(isNewerVersion('1.1', '1.0.9')).toBe(true);
+		expect(isNewerVersion('1.0', '1.0.0')).toBe(false);
+	});
+
+	it('returns false (fail safe) for malformed input', () => {
+		expect(isNewerVersion('latest', '1.0.6')).toBe(false);
+		expect(isNewerVersion('1.0.7', 'not-a-version')).toBe(false);
+		expect(isNewerVersion('', '1.0.6')).toBe(false);
+		expect(isNewerVersion('1.x', '1.0.6')).toBe(false);
+		expect(isNewerVersion('1.0.0.1', '1.0.0')).toBe(false);
+	});
+});
+
+describe('UpdateChecker.maybeCheck', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		notices().length = 0;
+		vi.mocked(requestUrl).mockReset();
+		mockRelease('1.0.6'); // safe default: equal → no notice
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('shows exactly one sticky notice when a newer release exists', async () => {
+		mockRelease('v1.0.7');
+		const { checker, settings } = makeChecker({ currentVersion: '1.0.6' });
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(notices()).toHaveLength(1);
+		expect(noticeText(lastNotice())).toContain('v1.0.7 is available');
+		// Sticky: persists until clicked/dismissed (duration 0).
+		expect(lastNotice().duration).toBe(0);
+		// The shown version is recorded so it never nags twice.
+		expect(settings.updates.dismissedUpdateVersion).toBe('1.0.7');
+	});
+
+	it('records the attempt timestamp and persists it', async () => {
+		mockRelease('1.0.7');
+		const { checker, settings, saveSettings } = makeChecker();
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(settings.updates.lastUpdateCheck).toBe(DAY_MS * 10);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+
+	it('shows no notice when already on the latest version', async () => {
+		mockRelease('1.0.6');
+		const { checker } = makeChecker({ currentVersion: '1.0.6' });
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(notices()).toHaveLength(0);
+	});
+
+	it('shows no notice when the latest release is older', async () => {
+		mockRelease('1.0.5');
+		const { checker } = makeChecker({ currentVersion: '1.0.6' });
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(notices()).toHaveLength(0);
+	});
+
+	it('shows no notice when this version was already shown', async () => {
+		mockRelease('1.0.7');
+		const { checker } = makeChecker({
+			currentVersion: '1.0.6',
+			updates: { dismissedUpdateVersion: '1.0.7' },
+		});
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(notices()).toHaveLength(0);
+	});
+
+	it('does not check when notifications are disabled', async () => {
+		mockRelease('1.0.7');
+		const { checker, saveSettings } = makeChecker({
+			updates: { enableUpdateNotifications: false },
+		});
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(requestUrl).not.toHaveBeenCalled();
+		expect(saveSettings).not.toHaveBeenCalled();
+		expect(notices()).toHaveLength(0);
+	});
+
+	it('does not check again within the 24h window', async () => {
+		mockRelease('1.0.7');
+		const { checker, saveSettings } = makeChecker({
+			updates: { lastUpdateCheck: 1000 },
+		});
+
+		await checker.maybeCheck(1000 + DAY_MS - 1);
+
+		expect(requestUrl).not.toHaveBeenCalled();
+		expect(saveSettings).not.toHaveBeenCalled();
+		expect(notices()).toHaveLength(0);
+	});
+
+	it('checks again once 24h have elapsed', async () => {
+		mockRelease('1.0.7');
+		const { checker } = makeChecker({
+			currentVersion: '1.0.6',
+			updates: { lastUpdateCheck: 1000 },
+		});
+
+		await checker.maybeCheck(1000 + DAY_MS);
+
+		expect(requestUrl).toHaveBeenCalledTimes(1);
+		expect(notices()).toHaveLength(1);
+	});
+
+	it('fails silently on a network error (no notice, no throw)', async () => {
+		vi.mocked(requestUrl).mockRejectedValue(new Error('boom'));
+		const { checker } = makeChecker();
+
+		await expect(checker.maybeCheck(DAY_MS * 10)).resolves.toBeUndefined();
+
+		expect(notices()).toHaveLength(0);
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it('fails silently on a non-200 response', async () => {
+		mockRelease('1.0.7', 403);
+		const { checker } = makeChecker({ currentVersion: '1.0.6' });
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(notices()).toHaveLength(0);
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it('fails silently when the response has no tag_name', async () => {
+		mockRelease(null, 200);
+		const { checker } = makeChecker();
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		expect(notices()).toHaveLength(0);
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it('clicking Update opens the Community plugins settings tab', async () => {
+		mockRelease('1.0.7');
+		const { checker, app } = makeChecker({ currentVersion: '1.0.6' });
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		const button = findButton(lastNotice().noticeEl);
+		expect(button?.textContent).toBe('Update');
+		button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+
+		expect(app.setting?.open).toHaveBeenCalledTimes(1);
+		expect(app.setting?.openTabById).toHaveBeenCalledWith('community-plugins');
+	});
+
+	it('falls back to a guidance notice when app.setting is unavailable', async () => {
+		mockRelease('1.0.7');
+		// app without the undocumented `setting` API.
+		const { checker } = makeChecker({ currentVersion: '1.0.6', app: {} });
+
+		await checker.maybeCheck(DAY_MS * 10);
+
+		const button = findButton(lastNotice().noticeEl);
+		expect(() =>
+			button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() }),
+		).not.toThrow();
+
+		// The click surfaced a plain guidance notice instead of throwing.
+		expect(lastNotice().noticeEl.textContent).toContain('Community plugins');
+	});
+});

--- a/src/shared/update-checker.ts
+++ b/src/shared/update-checker.ts
@@ -1,0 +1,231 @@
+import { requestUrl } from 'obsidian';
+import type { App, RequestUrlResponse } from 'obsidian';
+import type { SynapseSettings } from '../settings';
+import type { NotificationManager } from './notifications';
+import { withRetry, isTransientNetworkError, describeNetworkError } from './api-utils';
+import { isRecord } from './json-utils';
+
+/**
+ * In-app "a newer Synapse is available" check (#365).
+ *
+ * Synapse ships through the Obsidian community catalog, so the app already
+ * auto-checks for updates — but the only signal is a small badge buried in
+ * Settings → Community plugins. This service adds a louder, actionable prompt:
+ * it polls the plugin's OWN public GitHub Releases API at most once per day,
+ * compares the latest tag to the running version, and, when a newer release
+ * exists, shows a sticky notice whose button jumps the user to the Community
+ * plugins page to update.
+ *
+ * Design guarantees:
+ *   - NEVER blocks load — the only entry point ({@link maybeCheck}) is fired
+ *     from a delayed startup timer and is fully async.
+ *   - FAILS SILENTLY — offline, non-200, or malformed responses are logged and
+ *     swallowed; nothing here ever throws to the caller.
+ *   - NEVER nags twice — a shown version is recorded so the same release does
+ *     not re-prompt, and the whole feature is gated behind a settings toggle.
+ *
+ * Referencing the plugin's own public repo is safe: its GitHub links already
+ * appear in the settings About section.
+ */
+
+/** The plugin's own public "latest release" endpoint. */
+const RELEASES_LATEST_URL =
+	'https://api.github.com/repos/dustinkeeton/obsidian-synapse/releases/latest';
+
+/** Minimum spacing between network checks (24h) — load is never gated on this. */
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Per-attempt request timeout so a hung connection never lingers. */
+const UPDATE_REQUEST_TIMEOUT_MS = 10_000;
+
+/** Retry budget for transient network failures (not HTTP errors). */
+const UPDATE_CHECK_MAX_RETRIES = 2;
+const UPDATE_CHECK_RETRY_DELAY_MS = 1000;
+
+/** The Community plugins settings tab id used by `app.setting.openTabById`. */
+const COMMUNITY_PLUGINS_TAB_ID = 'community-plugins';
+
+/**
+ * Parse a semver string into its `[major, minor, patch]` numeric core, or
+ * `null` when it is malformed. A leading `v` is stripped, missing trailing
+ * components default to 0 (`1.2` → `[1, 2, 0]`), and any prerelease/build
+ * suffix (`-rc.1`, `+build`) is ignored. Anything whose core isn't purely
+ * numeric (e.g. `"latest"`, `""`, `"1.x"`) is rejected so callers can fail safe.
+ */
+function parseSemver(version: string): [number, number, number] | null {
+	const core = version.trim().replace(/^v/i, '').split(/[-+]/)[0];
+	const parts = core.split('.');
+	if (parts.length === 0 || parts.length > 3) return null;
+	const nums: number[] = [];
+	for (const part of parts) {
+		if (!/^\d+$/.test(part)) return null;
+		nums.push(parseInt(part, 10));
+	}
+	while (nums.length < 3) nums.push(0);
+	return [nums[0], nums[1], nums[2]];
+}
+
+/**
+ * Whether `latest` is a strictly newer semver than `current`. Both inputs are
+ * tolerant of a leading `v`. Returns `false` for equal, older, OR malformed
+ * inputs — a parse failure must never trigger a spurious update prompt.
+ */
+export function isNewerVersion(latest: string, current: string): boolean {
+	const l = parseSemver(latest);
+	const c = parseSemver(current);
+	if (!l || !c) return false;
+	for (let i = 0; i < 3; i++) {
+		if (l[i] > c[i]) return true;
+		if (l[i] < c[i]) return false;
+	}
+	return false;
+}
+
+/** Collaborators injected into {@link UpdateChecker} (kept lean for testing). */
+export interface UpdateCheckerDeps {
+	/** The plugin's own manifest version, e.g. "1.0.6". */
+	currentVersion: string;
+	/** Used to feature-detect + open the Community plugins settings tab. */
+	app: App;
+	/** Surfaces the sticky "update available" notice. */
+	notifications: NotificationManager;
+	/** Live settings accessor — read fresh so a toggle change takes effect. */
+	getSettings: () => SynapseSettings;
+	/** Persists `updates.lastUpdateCheck` / `updates.dismissedUpdateVersion`. */
+	saveSettings: () => Promise<void>;
+}
+
+export class UpdateChecker {
+	constructor(private readonly deps: UpdateCheckerDeps) {}
+
+	/**
+	 * Startup entry point. Gated on the feature toggle and rate-limited to once
+	 * per {@link UPDATE_CHECK_INTERVAL_MS}; the attempt timestamp is persisted up
+	 * front so a failed/offline run still counts toward the limit. On finding a
+	 * newer, not-yet-shown release it shows the notice and records the version so
+	 * it never re-prompts. Fully guarded — never throws to the startup timer.
+	 *
+	 * `now` is injectable purely so tests can drive the rate-limit deterministically.
+	 */
+	async maybeCheck(now: number = Date.now()): Promise<void> {
+		try {
+			const settings = this.deps.getSettings();
+			if (!settings.updates.enableUpdateNotifications) return;
+
+			const last = settings.updates.lastUpdateCheck ?? 0;
+			if (now - last < UPDATE_CHECK_INTERVAL_MS) return;
+
+			// Record the attempt before the network round-trip so a failure still
+			// rate-limits (and the timestamp survives a reload).
+			settings.updates.lastUpdateCheck = now;
+			await this.deps.saveSettings();
+
+			const latest = await this.fetchLatestVersion();
+			if (!latest) return; // offline / non-200 / malformed — already logged
+
+			if (!isNewerVersion(latest, this.deps.currentVersion)) return;
+			if (settings.updates.dismissedUpdateVersion === latest) return;
+
+			this.notifyUpdateAvailable(latest);
+
+			// Mark this release shown so it never nags twice, even if ignored.
+			settings.updates.dismissedUpdateVersion = latest;
+			await this.deps.saveSettings();
+		} catch (error) {
+			// Defense in depth: the startup path must never see a throw from here.
+			console.warn('[Synapse] Update check encountered an unexpected error:', error);
+		}
+	}
+
+	/**
+	 * Fetch the latest release's version (tag, `v`-stripped) from GitHub, or
+	 * `null` on any failure. Wraps a timed `requestUrl` in {@link withRetry},
+	 * retrying only transient network errors. Uses `throw: false` so HTTP errors
+	 * (e.g. 403 rate-limit, 404) resolve and degrade to a logged `null` rather
+	 * than churning retries.
+	 */
+	private async fetchLatestVersion(): Promise<string | null> {
+		try {
+			const response = await withRetry(
+				() => this.fetchReleaseResponse(),
+				UPDATE_CHECK_MAX_RETRIES,
+				UPDATE_CHECK_RETRY_DELAY_MS,
+				(error) => isTransientNetworkError(error),
+			);
+			if (response.status !== 200) {
+				console.warn(`[Synapse] Update check: GitHub returned status ${response.status}`);
+				return null;
+			}
+			const body: unknown = response.json;
+			if (!isRecord(body) || typeof body.tag_name !== 'string') {
+				console.warn('[Synapse] Update check: release response missing a tag_name');
+				return null;
+			}
+			return body.tag_name.trim().replace(/^v/i, '');
+		} catch (error) {
+			const detail =
+				describeNetworkError(error, 'GitHub') ??
+				(error instanceof Error ? error.message : String(error));
+			console.warn('[Synapse] Update check failed:', detail);
+			return null;
+		}
+	}
+
+	/** Issue the release request, racing it against a hard timeout. */
+	private fetchReleaseResponse(): Promise<RequestUrlResponse> {
+		const timeout = new Promise<never>((_, reject) =>
+			window.setTimeout(
+				() => reject(new Error('Update check timed out')),
+				UPDATE_REQUEST_TIMEOUT_MS,
+			),
+		);
+		return Promise.race([
+			requestUrl({
+				url: RELEASES_LATEST_URL,
+				method: 'GET',
+				// GitHub's API documents a required User-Agent; Electron's net stack
+				// usually supplies one, but set it explicitly so a UA-less request
+				// can't 403 this check into a silent no-op.
+				headers: {
+					Accept: 'application/vnd.github+json',
+					'User-Agent': 'obsidian-synapse',
+				},
+				throw: false,
+			}),
+			timeout,
+		]);
+	}
+
+	/**
+	 * Show the sticky "update available" notice with an Update action button.
+	 * The message omits a "Synapse" prefix — NotificationManager already prepends
+	 * one, so the toast reads "Synapse: v1.2.3 is available".
+	 */
+	private notifyUpdateAvailable(latest: string): void {
+		this.deps.notifications.infoSticky(`v${latest} is available`, {
+			label: 'Update',
+			onClick: () => this.openCommunityPlugins(),
+		});
+	}
+
+	/**
+	 * Open Settings → Community plugins via the undocumented `app.setting` API.
+	 * Feature-detected and fully guarded: if the API (or either method) is
+	 * absent, fall back to a plain notice telling the user where to go.
+	 */
+	private openCommunityPlugins(): void {
+		const setting = (this.deps.app as unknown as {
+			setting?: { open?: () => void; openTabById?: (id: string) => void };
+		}).setting;
+		if (
+			setting &&
+			typeof setting.open === 'function' &&
+			typeof setting.openTabById === 'function'
+		) {
+			setting.open();
+			setting.openTabById(COMMUNITY_PLUGINS_TAB_ID);
+			return;
+		}
+		this.deps.notifications.info('Open Settings → Community plugins to update Synapse.');
+	}
+}


### PR DESCRIPTION
## Summary
Adds a louder, in-app, actionable update prompt (#365). Synapse ships through the community catalog, so Obsidian already auto-checks for updates — but the only signal is a small badge buried in Settings → Community plugins. This surfaces a sticky notice when a newer release is published; its button takes the user straight to Community plugins to update.

Closes #365

> Stacked PR: base is `feat/issue-381-general-autofold-properties` (the #381 branch), not `main`. It builds on the General settings section and the `MarkdownView` mock stub that branch added.

## What changed
- **UpdateChecker service** (`src/shared/update-checker.ts`): polls the plugin's own public GitHub Releases API via `requestUrl` (timed + `withRetry` on transient network errors), at most once per day. Fully guarded — offline / non-200 / malformed responses are logged and swallowed; never throws, never blocks load. Pure `isNewerVersion(latest, current)` semver helper (strips a leading `v`, fails safe on malformed input).
- **Settings** (`src/settings.ts`): new `updates` group — `enableUpdateNotifications` (default **on**), `lastUpdateCheck`, `dismissedUpdateVersion`.
- **General settings toggle** (`src/settings-tab.ts`): "Notify me about Synapse updates", appended to the existing General section.
- **Startup wiring** (`src/main.ts`): constructs the checker beside the other services and fires `maybeCheck()` from a **separate** delayed timer (`updateCheckTimeout`, staggered after the checkpoint check), cleared in `onunload`. Rate-limit + toggle gating live inside `maybeCheck()`.
- **Sticky notice** (`src/shared/notifications.ts`): new public `infoSticky(message, action)` — a persistent (duration 0), still-dismissible action notice reusing `showActionNotice`'s markup/CSS. The notice button opens Settings → Community plugins via the undocumented `app.setting` API, feature-detected with a graceful guidance-notice fallback. The shown version is recorded so the same release never nags twice.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` (1645 passed)
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

New/updated tests cover: `isNewerVersion` (newer/equal/older/malformed/`v`-prefix); behavior (newer → exactly one notice; same/older/dismissed → none; toggle off → no check; network error / non-200 / missing tag → silent); the action click opening `community-plugins` and the guarded fallback when `app.setting` is absent; `infoSticky` persistence/dismissibility; and the new settings defaults + General toggle.

## Needs live-Obsidian verification
- The `app.setting.open()` → `openTabById('community-plugins')` flow (undocumented API; guarded with a fallback).
- Sticky-notice persistence/dismiss behavior in a running app.
- GitHub Releases request succeeding from Electron's `requestUrl` (a `User-Agent` header is set explicitly as insurance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qLQompTRaCNYs2ZsnLjG4