### PR TITLE
feat: in-app changelog view in settings

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -39,6 +39,9 @@ const context = await esbuild.context({
 	logLevel: "info",
 	sourcemap: prod ? false : "inline",
 	treeShaking: true,
+	// Inline `*.md` imports as strings so CHANGELOG.md ships in the bundle and
+	// can be rendered in the in-app changelog view (#375).
+	loader: { ".md": "text" },
 	outfile: "main.js",
 });
 

--- a/src/changelog-modal.test.ts
+++ b/src/changelog-modal.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the bundled changelog so the test is decoupled from the real CHANGELOG.md
+// (and so Vitest never tries to transform a `.md` file — only esbuild does that
+// at build time). The specifier matches changelog-modal.ts's `'../CHANGELOG.md'`.
+vi.mock('../CHANGELOG.md', () => ({
+	default: `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Something brand new
+
+## [1.0.6] - 2026-06-22
+
+### Changed
+
+- A polished detail
+`,
+}));
+
+import { createEl } from './__mocks__/obsidian';
+import { ChangelogModal } from './changelog-modal';
+
+/** Recursively collect every element in a stub tree. */
+function walkEls(el: any, out: any[] = []): any[] {
+	for (const child of el?.children ?? []) {
+		out.push(child);
+		walkEls(child, out);
+	}
+	return out;
+}
+const elsWithClass = (root: any, cls: string): any[] =>
+	walkEls(root).filter((e) => e.classList?.contains(cls));
+const elsWithTag = (root: any, tag: string): any[] =>
+	walkEls(root).filter((e) => e.tagName === tag);
+
+function openModal(version = '1.0.6') {
+	const plugin = { manifest: { version } } as never;
+	const modal = new ChangelogModal({} as never, plugin);
+	// The mock Modal's contentEl is a bare stub; swap in an introspectable one.
+	(modal as unknown as { contentEl: HTMLElement }).contentEl = createEl();
+	modal.onOpen();
+	return modal;
+}
+
+describe('ChangelogModal', () => {
+	it('renders a title heading', () => {
+		const modal = openModal();
+		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		const headings = elsWithTag(contentEl, 'H2').map((e) => e.textContent);
+		expect(headings).toContain("What's new in Synapse");
+	});
+
+	it('renders the parsed changelog entries (version headings + items)', () => {
+		const modal = openModal();
+		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+
+		const versions = elsWithClass(contentEl, 'synapse-changelog-version').map(
+			(e) => e.textContent,
+		);
+		expect(versions).toContain('Unreleased');
+		expect(versions).toContain('1.0.6 — 2026-06-22');
+
+		const items = elsWithTag(contentEl, 'LI').map((e) => e.textContent);
+		expect(items).toContain('Something brand new');
+		expect(items).toContain('A polished detail');
+	});
+
+	it('highlights the entry matching the installed version', () => {
+		const modal = openModal('1.0.6');
+		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		const highlighted = elsWithClass(contentEl, 'synapse-changelog-entry--current');
+		expect(highlighted).toHaveLength(1);
+		const version = elsWithClass(highlighted[0], 'synapse-changelog-version')[0];
+		expect(version.textContent).toBe('1.0.6 — 2026-06-22');
+	});
+
+	it('adds the synapse-changelog hook class to the content element', () => {
+		const modal = openModal();
+		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		expect(contentEl.classList.contains('synapse-changelog')).toBe(true);
+	});
+});

--- a/src/changelog-modal.ts
+++ b/src/changelog-modal.ts
@@ -1,0 +1,33 @@
+import { App, Modal } from 'obsidian';
+import type SynapsePlugin from './main';
+import { renderChangelog } from './changelog';
+// CHANGELOG.md lives at the repo root and is inlined as a string at build time
+// by esbuild's `.md` text loader (see esbuild.config.mjs + shared/markdown.d.ts).
+import CHANGELOG from '../CHANGELOG.md';
+
+/**
+ * In-app changelog view (#375). A minimal `Modal` that renders the bundled
+ * `CHANGELOG.md` so users can see what changed between versions without leaving
+ * Obsidian. All parsing/rendering lives in the pure `changelog.ts` module; this
+ * class is just the UI shell. Opened from the About section of the settings tab.
+ */
+export class ChangelogModal extends Modal {
+	constructor(app: App, private plugin: SynapsePlugin) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('synapse-changelog');
+
+		contentEl.createEl('h2', { text: "What's new in Synapse" });
+
+		const body = contentEl.createDiv({ cls: 'synapse-changelog-body' });
+		renderChangelog(body, CHANGELOG, this.plugin.manifest.version);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/changelog.test.ts
+++ b/src/changelog.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { createEl } from './__mocks__/obsidian';
+import {
+	parseChangelog,
+	renderChangelog,
+	stripInlineMarkdown,
+} from './changelog';
+
+const SAMPLE = `# Changelog
+
+All notable changes to Synapse will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+### Added
+
+- A brand new **feature** with \`code\`
+
+## [1.0.6] - 2026-06-22
+
+### Added
+
+- Click an [error notice](https://example.com) to copy its message
+
+### Changed
+
+- Softer, less alarming color
+- Clearer, more consistent wording
+`;
+
+/** Recursively collect every element in a stub tree. */
+function walkEls(el: any, out: any[] = []): any[] {
+	for (const child of el?.children ?? []) {
+		out.push(child);
+		walkEls(child, out);
+	}
+	return out;
+}
+const elsWithTag = (root: any, tag: string): any[] =>
+	walkEls(root).filter((e) => e.tagName === tag);
+const elsWithClass = (root: any, cls: string): any[] =>
+	walkEls(root).filter((e) => e.classList?.contains(cls));
+
+describe('stripInlineMarkdown', () => {
+	it('unwraps bold, code, and links to their visible text', () => {
+		expect(stripInlineMarkdown('A **bold** word')).toBe('A bold word');
+		expect(stripInlineMarkdown('Use `code` here')).toBe('Use code here');
+		expect(stripInlineMarkdown('See [the docs](https://x.com)')).toBe('See the docs');
+	});
+
+	it('leaves plain text untouched', () => {
+		expect(stripInlineMarkdown('nothing to strip')).toBe('nothing to strip');
+	});
+});
+
+describe('parseChangelog', () => {
+	it('extracts version entries in document order, ignoring the title/preamble', () => {
+		const entries = parseChangelog(SAMPLE);
+		expect(entries.map((e) => e.version)).toEqual(['Unreleased', '1.0.6']);
+	});
+
+	it('parses the release date when present and null for Unreleased', () => {
+		const [unreleased, released] = parseChangelog(SAMPLE);
+		expect(unreleased.date).toBeNull();
+		expect(released.date).toBe('2026-06-22');
+	});
+
+	it('groups bullets under their section headings', () => {
+		const released = parseChangelog(SAMPLE)[1];
+		expect(released.sections.map((s) => s.title)).toEqual(['Added', 'Changed']);
+		expect(released.sections[1].items).toEqual([
+			'Softer, less alarming color',
+			'Clearer, more consistent wording',
+		]);
+	});
+
+	it('strips inline markdown from bullet text', () => {
+		const unreleased = parseChangelog(SAMPLE)[0];
+		expect(unreleased.sections[0].items).toEqual(['A brand new feature with code']);
+		const released = parseChangelog(SAMPLE)[1];
+		expect(released.sections[0].items[0]).toBe(
+			'Click an error notice to copy its message',
+		);
+	});
+
+	it('returns an empty array for markdown with no version headings', () => {
+		expect(parseChangelog('# Changelog\n\nJust a preamble.\n')).toEqual([]);
+	});
+});
+
+describe('renderChangelog', () => {
+	it('renders a version heading per entry, including the date', () => {
+		const container = createEl();
+		renderChangelog(container, SAMPLE);
+		const versions = elsWithClass(container, 'synapse-changelog-version').map(
+			(e) => e.textContent,
+		);
+		expect(versions).toContain('Unreleased');
+		expect(versions).toContain('1.0.6 — 2026-06-22');
+	});
+
+	it('renders section subheadings and bullet list items', () => {
+		const container = createEl();
+		renderChangelog(container, SAMPLE);
+		const sections = elsWithClass(container, 'synapse-changelog-section').map(
+			(e) => e.textContent,
+		);
+		expect(sections).toContain('Added');
+		expect(sections).toContain('Changed');
+
+		const items = elsWithTag(container, 'LI').map((e) => e.textContent);
+		expect(items).toContain('Softer, less alarming color');
+		expect(items).toContain('Click an error notice to copy its message');
+	});
+
+	it('marks the entry matching the current version with a modifier class', () => {
+		const container = createEl();
+		renderChangelog(container, SAMPLE, '1.0.6');
+		const highlighted = elsWithClass(container, 'synapse-changelog-entry--current');
+		expect(highlighted).toHaveLength(1);
+		// The highlighted entry is the 1.0.6 release, not Unreleased.
+		const version = elsWithClass(highlighted[0], 'synapse-changelog-version')[0];
+		expect(version.textContent).toBe('1.0.6 — 2026-06-22');
+	});
+
+	it('does not highlight any entry when the current version is absent', () => {
+		const container = createEl();
+		renderChangelog(container, SAMPLE, '9.9.9');
+		expect(elsWithClass(container, 'synapse-changelog-entry--current')).toHaveLength(0);
+	});
+
+	it('shows a fallback message when there are no entries', () => {
+		const container = createEl();
+		renderChangelog(container, '# Changelog\n\nNothing yet.\n');
+		const empty = elsWithClass(container, 'synapse-changelog-empty');
+		expect(empty).toHaveLength(1);
+		expect(empty[0].textContent).toBe('No changelog entries found.');
+	});
+});

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure changelog parsing + rendering (#375).
+ *
+ * `CHANGELOG.md` (Keep a Changelog format) is inlined at build time as a string
+ * (esbuild `.md` text loader). This module turns that string into a small data
+ * model and renders it to DOM with `createEl`, so the logic stays synchronous
+ * and unit-testable with the Obsidian mock — no `MarkdownRenderer`, no `.md`
+ * import here (that lives in `changelog-modal.ts`, the thin UI wrapper).
+ */
+
+/** One `### Added` / `### Changed` / … block within a version entry. */
+export interface ChangelogSection {
+	/** Section title, e.g. "Added". Empty for items that precede any heading. */
+	title: string;
+	/** Bullet lines under the section, with inline markdown stripped. */
+	items: string[];
+}
+
+/** One `## [version] - date` release block. */
+export interface ChangelogEntry {
+	/** Version label, e.g. "1.0.6" or "Unreleased". */
+	version: string;
+	/** Release date (e.g. "2026-06-22"), or null when absent (Unreleased). */
+	date: string | null;
+	/** The release's `###` sections, in document order. */
+	sections: ChangelogSection[];
+}
+
+/**
+ * Strip the inline markdown that shows up in changelog bullets so the rendered
+ * text reads cleanly without a full markdown renderer: links → their text,
+ * `**bold**` and `` `code` `` → their inner content.
+ */
+export function stripInlineMarkdown(text: string): string {
+	return text
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) → text
+		.replace(/\*\*([^*]+)\*\*/g, '$1') // **bold** → bold
+		.replace(/`([^`]+)`/g, '$1'); // `code` → code
+}
+
+/** Parse a `## …` heading line into a version label and optional date. */
+function parseVersionHeading(raw: string): { version: string; date: string | null } {
+	const text = raw.trim();
+	// Canonical Keep a Changelog form: `[1.0.6] - 2026-06-22` or `[Unreleased]`.
+	const bracketed = text.match(/^\[([^\]]+)\]\s*(?:[-–—]\s*(.+))?$/);
+	if (bracketed) {
+		return { version: bracketed[1].trim(), date: bracketed[2]?.trim() ?? null };
+	}
+	// Defensive fallback: `1.0.6 - 2026-06-22` (no brackets).
+	const dashed = text.split(/\s+[-–—]\s+/);
+	return { version: dashed[0].trim(), date: dashed[1]?.trim() ?? null };
+}
+
+/**
+ * Parse Keep a Changelog markdown into release entries. Only `## ` version
+ * headings, `### ` section headings, and `- `/`* ` bullets are interpreted; the
+ * file's `# Changelog` title and preamble (everything before the first `## `)
+ * are ignored.
+ */
+export function parseChangelog(markdown: string): ChangelogEntry[] {
+	const entries: ChangelogEntry[] = [];
+	let entry: ChangelogEntry | null = null;
+	let section: ChangelogSection | null = null;
+
+	for (const rawLine of markdown.split('\n')) {
+		const line = rawLine.trimEnd();
+
+		const versionMatch = line.match(/^##\s+(.+)/);
+		if (versionMatch) {
+			const { version, date } = parseVersionHeading(versionMatch[1]);
+			entry = { version, date, sections: [] };
+			section = null;
+			entries.push(entry);
+			continue;
+		}
+
+		// Skip anything before the first version heading (title + preamble).
+		if (!entry) continue;
+
+		const sectionMatch = line.match(/^###\s+(.+)/);
+		if (sectionMatch) {
+			section = { title: sectionMatch[1].trim(), items: [] };
+			entry.sections.push(section);
+			continue;
+		}
+
+		const bulletMatch = line.match(/^[-*]\s+(.+)/);
+		if (bulletMatch) {
+			if (!section) {
+				// Items before any `###` heading: attach to an untitled section.
+				section = { title: '', items: [] };
+				entry.sections.push(section);
+			}
+			section.items.push(stripInlineMarkdown(bulletMatch[1].trim()));
+		}
+	}
+
+	return entries;
+}
+
+/**
+ * Render parsed changelog entries into a container using `createEl`. The entry
+ * whose version equals `currentVersion` is marked with a modifier class so the
+ * installed release can be visually highlighted.
+ */
+export function renderChangelog(
+	container: HTMLElement,
+	markdown: string,
+	currentVersion?: string,
+): void {
+	const entries = parseChangelog(markdown);
+
+	if (entries.length === 0) {
+		container.createEl('p', {
+			text: 'No changelog entries found.',
+			cls: 'synapse-changelog-empty',
+		});
+		return;
+	}
+
+	for (const entry of entries) {
+		const entryEl = container.createDiv({ cls: 'synapse-changelog-entry' });
+		if (currentVersion && entry.version === currentVersion) {
+			entryEl.addClass('synapse-changelog-entry--current');
+		}
+
+		const headingText = entry.date ? `${entry.version} — ${entry.date}` : entry.version;
+		entryEl.createEl('h3', { text: headingText, cls: 'synapse-changelog-version' });
+
+		for (const section of entry.sections) {
+			if (section.title) {
+				entryEl.createEl('h4', {
+					text: section.title,
+					cls: 'synapse-changelog-section',
+				});
+			}
+			if (section.items.length > 0) {
+				const list = entryEl.createEl('ul', { cls: 'synapse-changelog-list' });
+				for (const item of section.items) {
+					list.createEl('li', { text: item });
+				}
+			}
+		}
+	}
+}

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createEl, ToggleComponent, Setting } from './__mocks__/obsidian';
+
+// Mock the changelog modal so this suite never resolves the real CHANGELOG.md
+// import (a build-time `.md` text import that Vitest can't transform), and so
+// the About link's open behavior can be asserted (#375).
+const { changelogOpen } = vi.hoisted(() => ({ changelogOpen: vi.fn() }));
+vi.mock('./changelog-modal', () => ({
+	// A regular function (not an arrow) so it's usable with `new` while staying a
+	// spy for construction assertions.
+	ChangelogModal: vi.fn(function (this: { open: () => void }) {
+		this.open = changelogOpen;
+	}),
+}));
+
+import { ChangelogModal } from './changelog-modal';
 import { SynapseSettingTab } from './settings-tab';
 import { DEFAULT_SETTINGS } from './settings';
 import type { SynapseSettings } from './settings';
@@ -180,6 +194,29 @@ describe('SynapseSettingTab — About support links (#274)', () => {
 		expect(byHref.get('https://www.buymeacoffee.com/dustinkeeton')).toBe(
 			'Buy Me a Coffee',
 		);
+	});
+});
+
+describe('SynapseSettingTab — About "What\'s new" changelog link (#375)', () => {
+	beforeEach(() => {
+		(ChangelogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+		changelogOpen.mockClear();
+	});
+
+	it('renders a "What\'s new" link that opens the changelog modal on click', () => {
+		const { tab } = makeTab();
+		tab.display();
+
+		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+		const link = findAnchors(containerEl).find((a) => a.textContent === "What's new");
+		expect(link).toBeDefined();
+
+		const preventDefault = vi.fn();
+		link!.dispatchEvent({ type: 'click', preventDefault });
+
+		expect(preventDefault).toHaveBeenCalled();
+		expect(ChangelogModal).toHaveBeenCalledTimes(1);
+		expect(changelogOpen).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -34,6 +34,7 @@ import { renderDeepDiveSettings } from './deep-dive';
 import { renderRemSettings } from './rem';
 import { applyApiKeyEmphasis } from './onboarding';
 import { foldActiveNoteProperties } from './properties-fold';
+import { ChangelogModal } from './changelog-modal';
 
 /**
  * Per-kind display copy for the Auto-Accept Proposals section (#228). MUTATING
@@ -642,6 +643,20 @@ export class SynapseSettingTab extends PluginSettingTab {
 		line.createEl('a', {
 			text: 'Buy Me a Coffee',
 			attr: { href: 'https://www.buymeacoffee.com/dustinkeeton' },
+		});
+
+		// "What's new" — opens the in-app changelog view (#375). A modal-opening
+		// link (not navigation), so it preventDefaults the dummy href.
+		const changelogLine = aboutBody.createDiv({ cls: 'setting-item-description' });
+		changelogLine.createSpan({ text: 'See what changed across versions → ' });
+		const changelogLink = changelogLine.createEl('a', {
+			text: "What's new",
+			cls: 'synapse-changelog-link',
+			attr: { href: '#' },
+		});
+		changelogLink.addEventListener('click', (evt) => {
+			evt.preventDefault();
+			new ChangelogModal(this.app, this.plugin).open();
 		});
 	}
 }

--- a/src/shared/markdown.d.ts
+++ b/src/shared/markdown.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Ambient declaration so `tsc` accepts `import X from '*.md'`. The real content
+ * is inlined as a string at build time by esbuild's `.md` text loader (see
+ * esbuild.config.mjs); TypeScript never reads the file, it just types the import
+ * as a string. Used by changelog-modal.ts to bundle CHANGELOG.md (#375).
+ */
+declare module '*.md' {
+	const content: string;
+	export default content;
+}

--- a/styles.css
+++ b/styles.css
@@ -1450,3 +1450,35 @@
 .synapse-install-copy.is-copied {
   color: var(--text-success);
 }
+
+/* ── Changelog view (#375) ──
+ * In-app "What's new" modal: a scrollable, lightly-styled render of CHANGELOG.md.
+ * The entry matching the installed version is accented so users can orient. */
+.synapse-changelog .synapse-changelog-body {
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+.synapse-changelog-entry {
+  margin-bottom: 1.25em;
+}
+.synapse-changelog-version {
+  margin-bottom: 0.25em;
+}
+.synapse-changelog-entry--current {
+  border-left: 2px solid var(--text-accent);
+  padding-left: 0.75em;
+}
+.synapse-changelog-entry--current .synapse-changelog-version {
+  color: var(--text-accent);
+}
+.synapse-changelog-section {
+  margin: 0.5em 0 0.25em;
+  color: var(--text-muted);
+}
+.synapse-changelog-list {
+  margin-top: 0;
+}
+.synapse-changelog-link {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
Adds an in-app way to see what changed between versions. `CHANGELOG.md` is now surfaced inside Obsidian via a "What's new" link in the settings → About section, opening a minimal modal that renders the changelog with the installed version highlighted.

Closes #375

## How it works
- **Build-time inlining** — `esbuild.config.mjs` gains `loader: { '.md': 'text' }`, so `CHANGELOG.md` (repo root) ships in the bundle as a string. `src/shared/markdown.d.ts` is an ambient declaration so `tsc` types `*.md` imports as strings without reading the file.
- **Pure parse/render** — `src/changelog.ts` turns Keep a Changelog markdown into entries and renders them with `createEl` (synchronous, no `MarkdownRenderer`), stripping inline bold/code/link markup. Fully unit-tested.
- **UI shell** — `src/changelog-modal.ts` (`ChangelogModal extends Modal`) renders the bundled changelog and passes `manifest.version` for highlighting.
- **Entry point** — a "What's new" link in `renderAbout`, beside the existing support links.

## Notes
- **No version/CHANGELOG changes.** `CHANGELOG.md` is read-only input here; no `[Unreleased]` entry, no version bump. `version-bump.mjs --check` passes at the current version.
- This is the 3rd PR in a stack; base is `feat/issue-365-update-notification`. Auto-close registers once the base becomes `main` as the stack merges.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` (1662 passed)
- [x] `node scripts/version-bump.mjs --check` (consistent at current version)
- [x] `node esbuild.config.mjs production` (main.js produced; CHANGELOG text inlined)

## Needs live-Obsidian verification
- Modal styling/scroll and the current-version accent in a real theme.

Co-Authored-By: Claude <bot@wafflenet.io>