### PR TITLE
feat: use note title as an elaboration signal

### DIFF
--- a/src/elaboration/proposer.test.ts
+++ b/src/elaboration/proposer.test.ts
@@ -679,3 +679,109 @@ describe('ProposalGenerator -- link-dominated notes (anti-fabrication)', () => {
 		expect(mockComplete).toHaveBeenCalledOnce();
 	});
 });
+
+describe('ProposalGenerator -- note title as elaboration signal (#387)', () => {
+	function makeGenerator(noteContent: string): {
+		generator: ProposalGenerator;
+		notifications: ReturnType<typeof makeNotifications>;
+	} {
+		const mockApp = {
+			vault: {
+				getAbstractFileByPath: vi.fn().mockImplementation((path: string) => new TFile(path)),
+				cachedRead: vi.fn().mockResolvedValue(noteContent),
+				read: vi.fn(),
+				readBinary: vi.fn(),
+			},
+			metadataCache: {
+				getCache: vi.fn().mockReturnValue(null),
+				getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+			},
+		};
+		const settings = makeSettings();
+		settings.elaboration.proposal.includeSourceContext = false;
+		settings.image.enabled = false;
+		const notifications = makeNotifications();
+		return {
+			generator: new ProposalGenerator(mockApp as any, () => settings, notifications),
+			notifications,
+		};
+	}
+
+	beforeEach(() => {
+		mockComplete.mockClear();
+		mockChat.mockClear();
+		mockComplete.mockResolvedValue('Expanded content here.');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('includes the note title as context for a content-bearing note', async () => {
+		// basename derives from the path: notes/Photosynthesis.md -> "Photosynthesis".
+		const { generator } = makeGenerator(
+			'# Photosynthesis\n\nThe process by which plants convert light into chemical energy.'
+		);
+
+		await generator.generate({
+			notePath: 'notes/Photosynthesis.md',
+			reasons: [{ type: 'user-requested' }],
+		});
+
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [prompt] = mockComplete.mock.calls[0];
+		expect(prompt).toContain('Note title: "Photosynthesis"');
+		// The original content is still embedded between the --- markers.
+		expect(prompt).toContain('The process by which plants convert light');
+	});
+
+	it('seeds the prompt from the title when the note body is empty', async () => {
+		// Whitespace-only body, but a meaningful (non-generic) title.
+		const { generator } = makeGenerator('   \n  ');
+
+		const proposal = await generator.generate({
+			notePath: 'notes/Quantum Tunneling.md',
+			reasons: [{ type: 'short-note', wordCount: 0 }],
+		});
+
+		expect(proposal).not.toBeNull();
+		expect(mockComplete).toHaveBeenCalledOnce();
+		const [prompt] = mockComplete.mock.calls[0];
+		// Title-led phrasing, with the title as the seed...
+		expect(prompt).toContain('Note title: "Quantum Tunneling"');
+		expect(prompt).toContain('This note has no body yet');
+		// ...and NO empty `---`/`---` block (the bug this fixes: an empty body must
+		// not be sent as nothing between the markers).
+		expect(prompt).not.toContain('---');
+	});
+
+	it('refuses to fabricate for an empty note with a generic title (no AI call, fires a notice)', async () => {
+		// Empty body + Obsidian "Untitled" default -> nothing to elaborate from.
+		const { generator, notifications } = makeGenerator('');
+
+		const proposal = await generator.generate({
+			notePath: 'notes/Untitled.md',
+			reasons: [{ type: 'short-note', wordCount: 0 }],
+		});
+
+		expect(proposal).toBeNull();
+		expect(mockComplete).not.toHaveBeenCalled();
+		expect(notifications.info).toHaveBeenCalledOnce();
+		const [msg] = notifications.info.mock.calls[0];
+		expect(msg).toContain('Untitled');
+	});
+
+	it('refuses to fabricate for an empty note named after a date', async () => {
+		// Empty body + date-style daily-note name -> also generic.
+		const { generator, notifications } = makeGenerator('');
+
+		const proposal = await generator.generate({
+			notePath: 'daily/2026-06-25.md',
+			reasons: [{ type: 'short-note', wordCount: 0 }],
+		});
+
+		expect(proposal).toBeNull();
+		expect(mockComplete).not.toHaveBeenCalled();
+		expect(notifications.info).toHaveBeenCalledOnce();
+	});
+});

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -1,6 +1,6 @@
 import { App, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, sanitizeAIResponse, stripCodeFences, isTwitterUrl, fetchTweetContent, isRedditUrl, fetchRedditContent, fetchArticleContent, linkLoadError, NotificationManager } from '../shared';
+import { AIClient, sanitizeAIResponse, stripCodeFences, isTwitterUrl, fetchTweetContent, isRedditUrl, fetchRedditContent, fetchArticleContent, linkLoadError, NotificationManager, isGenericTitle } from '../shared';
 import { ImageAnalyzer, ImageAnalysis } from './image-analyzer';
 import { DetectionResult, Proposal } from './types';
 
@@ -35,6 +35,20 @@ export class ProposalGenerator {
 		const content = await this.app.vault.cachedRead(noteFile);
 		const settings = this.getSettings();
 
+		// Anti-fabrication guard (sibling to the link-dominated guard below): a note
+		// with no body offers only its title as signal. When that title is also
+		// generic -- an Obsidian "Untitled" default, a date-style daily-note name,
+		// or a bare URL -- there is nothing meaningful to elaborate from, and asking
+		// the AI would invent content from the filename alone. Refuse instead. A
+		// real title (e.g. "Photosynthesis") is not generic and still seeds a
+		// title-led prompt in buildPrompt().
+		if (content.trim() === '' && isGenericTitle(noteFile.basename)) {
+			this.notifications.info(
+				`"${noteFile.basename}" has no content to elaborate from, and its title isn't specific enough to suggest a topic. Add a few words first, then try again.`
+			);
+			return null;
+		}
+
 		let contextNotes = '';
 		if (settings.elaboration.proposal.includeSourceContext) {
 			contextNotes = await this.gatherContext(detection.notePath);
@@ -63,7 +77,7 @@ export class ProposalGenerator {
 			return null;
 		}
 
-		const prompt = this.buildPrompt(content, detection, contextNotes, imageContext, externalContext, linkDominated);
+		const prompt = this.buildPrompt(noteFile.basename, content, detection, contextNotes, imageContext, externalContext, linkDominated);
 		const systemPrompt = imageContext
 			? 'You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. Image analysis has been provided -- use the descriptions to write contextually aware content that references what the images actually show. Preserve all image embeds in their original format.'
 			: 'You are a note-taking assistant. Your job is to expand placeholder or stub notes into fuller, more useful content. Preserve the original voice and intent. Output only the proposed additions in markdown format. Do not wrap the output in code fences. If the source content contains image URLs, preserve them as markdown image embeds (![alt](url)) rather than describing the image in text. For internal images referenced as [[image.jpg]], embed them as ![[image.jpg]].';
@@ -85,6 +99,7 @@ export class ProposalGenerator {
 	}
 
 	private buildPrompt(
+		noteTitle: string,
 		content: string,
 		detection: DetectionResult,
 		contextNotes: string,
@@ -110,11 +125,21 @@ export class ProposalGenerator {
 		const isUserRequested = detection.reasons.length === 1
 			&& detection.reasons[0].type === 'user-requested';
 
+		// The title is often the clearest statement of a note's topic and intent,
+		// so surface it as context in every prompt. (The empty-body + generic-title
+		// case is already short-circuited in generate(), so any empty body reaching
+		// here has a meaningful title to seed from.)
+		const titleContext = `Note title: "${noteTitle}"`;
+
 		let prompt: string;
-		if (isUserRequested) {
-			prompt = `The user has requested elaboration suggestions for the following note:\n\n---\n${content}\n---\n\nPlease review the entire note and propose additions, expansions, or improvements that would make it more comprehensive and useful. Consider adding detail to existing sections, suggesting new sections, or expanding on key ideas.`;
+		if (content.trim() === '') {
+			// No body yet: seed the proposal from the title rather than emitting an
+			// empty `---`/`---` block, which would give the model no signal at all.
+			prompt = `${titleContext}\n\nThis note has no body yet; it is currently just a title. Propose initial content for a note on this topic, matching the intent the title implies. Write the note as its author plausibly would.`;
+		} else if (isUserRequested) {
+			prompt = `${titleContext}\n\nThe user has requested elaboration suggestions for the following note:\n\n---\n${content}\n---\n\nPlease review the entire note and propose additions, expansions, or improvements that would make it more comprehensive and useful. Consider adding detail to existing sections, suggesting new sections, or expanding on key ideas.`;
 		} else {
-			prompt = `The following note appears to be a placeholder or stub:\n\n---\n${content}\n---\n\nReasons it was flagged:\n${reasonDescriptions.map(r => `- ${r}`).join('\n')}\n\nPlease propose additions that would flesh out this note.`;
+			prompt = `${titleContext}\n\nThe following note appears to be a placeholder or stub:\n\n---\n${content}\n---\n\nReasons it was flagged:\n${reasonDescriptions.map(r => `- ${r}`).join('\n')}\n\nPlease propose additions that would flesh out this note.`;
 		}
 
 		if (contextNotes) {

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -113,6 +113,7 @@ export {
 } from './content-schemas';
 export type { ContentSchema, PipelineStage, SchemaMode } from './content-schemas';
 export { generateId, isValidCheckpointId } from './id-utils';
+export { isUntitled, isGenericTitle } from './title-detector';
 export {
 	loadNodeModules,
 	assertDesktop,

--- a/src/shared/title-detector.test.ts
+++ b/src/shared/title-detector.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { isUntitled, isGenericTitle } from './title-detector';
+
+describe('isUntitled', () => {
+	it('matches Obsidian "Untitled" defaults (case-insensitive, with/without index)', () => {
+		expect(isUntitled('Untitled')).toBe(true);
+		expect(isUntitled('Untitled 1')).toBe(true);
+		expect(isUntitled('Untitled 42')).toBe(true);
+		expect(isUntitled('untitled')).toBe(true);
+		expect(isUntitled('UNTITLED 3')).toBe(true);
+		expect(isUntitled('  Untitled 5  ')).toBe(true);
+	});
+
+	it('rejects real titles and non-numeric suffixes', () => {
+		expect(isUntitled('My Note')).toBe(false);
+		expect(isUntitled('Untitled Ideas')).toBe(false);
+		expect(isUntitled('The Untitled')).toBe(false);
+		expect(isUntitled('Untitled note')).toBe(false);
+		expect(isUntitled('')).toBe(false);
+	});
+});
+
+describe('isGenericTitle', () => {
+	it('treats Obsidian "Untitled" defaults as generic', () => {
+		expect(isGenericTitle('Untitled')).toBe(true);
+		expect(isGenericTitle('Untitled 7')).toBe(true);
+	});
+
+	it('treats date-style daily-note names as generic', () => {
+		// Obsidian default + common separator variants.
+		expect(isGenericTitle('2026-06-25')).toBe(true);
+		expect(isGenericTitle('2026/06/25')).toBe(true);
+		expect(isGenericTitle('2026.06.25')).toBe(true);
+		expect(isGenericTitle('2026_06_25')).toBe(true);
+		// Compact and year-last variants.
+		expect(isGenericTitle('20260625')).toBe(true);
+		expect(isGenericTitle('25-06-2026')).toBe(true);
+		expect(isGenericTitle('06/25/2026')).toBe(true);
+	});
+
+	it('treats bare-URL titles as generic', () => {
+		expect(isGenericTitle('https://example.com/article')).toBe(true);
+		expect(isGenericTitle('http://news.site/post?id=1')).toBe(true);
+		expect(isGenericTitle('www.example.com')).toBe(true);
+	});
+
+	it('does NOT treat real, topical titles as generic', () => {
+		expect(isGenericTitle('Photosynthesis')).toBe(false);
+		expect(isGenericTitle('Project Roadmap')).toBe(false);
+		expect(isGenericTitle('My 2026 Plan')).toBe(false);
+		// Structurally date-like but out of range -> not a date.
+		expect(isGenericTitle('2026-13-40')).toBe(false);
+		// A note that merely starts with a date but has real words is not generic.
+		expect(isGenericTitle('2026-06-25 Standup notes')).toBe(false);
+	});
+});

--- a/src/shared/title-detector.ts
+++ b/src/shared/title-detector.ts
@@ -1,0 +1,71 @@
+/**
+ * Note-title predicates shared across features. These live in `shared/` (not the
+ * `title/` feature module) so that other features -- e.g. elaboration's
+ * anti-fabrication guard -- can reuse them without importing from another feature
+ * module, which the dependency rules forbid. The `title/` module re-exports
+ * `isUntitled` from here to preserve its public surface.
+ */
+
+/**
+ * Checks whether a note title matches Obsidian's "Untitled" default pattern.
+ * Matches "Untitled", "Untitled 1", "Untitled 2", etc. (case-insensitive).
+ */
+export function isUntitled(title: string): boolean {
+	return /^untitled(\s+\d+)?$/i.test(title.trim());
+}
+
+const inMonthRange = (n: number): boolean => n >= 1 && n <= 12;
+const inDayRange = (n: number): boolean => n >= 1 && n <= 31;
+
+/**
+ * True when the whole title is a date-style daily-note name. Obsidian's default
+ * daily-note format is `YYYY-MM-DD`; users commonly swap the separator (`/`, `.`,
+ * `_`), drop it entirely (`YYYYMMDD`), or put the year last (`DD-MM-YYYY` /
+ * `MM-DD-YYYY`). Month and day ranges are validated so a non-date like
+ * "2026-99-99" -- or an ordinary title that merely starts with a year -- is not
+ * mistaken for a date.
+ */
+function isDateStyleTitle(title: string): boolean {
+	const t = title.trim();
+
+	// YYYY<sep>MM<sep>DD with a single, consistent separator (-, /, ., _).
+	const ymd = /^(\d{4})([-/._])(\d{1,2})\2(\d{1,2})$/.exec(t);
+	if (ymd) return inMonthRange(Number(ymd[3])) && inDayRange(Number(ymd[4]));
+
+	// Compact, separator-less YYYYMMDD.
+	const compact = /^(\d{4})(\d{2})(\d{2})$/.exec(t);
+	if (compact) return inMonthRange(Number(compact[2])) && inDayRange(Number(compact[3]));
+
+	// Year-last DD<sep>MM<sep>YYYY or MM<sep>DD<sep>YYYY -- either order accepted,
+	// as long as one field is a valid month and the other a valid day.
+	const yearLast = /^(\d{1,2})([-/._])(\d{1,2})\2(\d{4})$/.exec(t);
+	if (yearLast) {
+		const a = Number(yearLast[1]);
+		const b = Number(yearLast[3]);
+		return (inMonthRange(a) && inDayRange(b)) || (inMonthRange(b) && inDayRange(a));
+	}
+
+	return false;
+}
+
+/**
+ * True when the entire title is just a bare URL (an `http(s)://` link or a `www.`
+ * host). A note whose title is only a link carries no topical signal of its own.
+ */
+function isBareUrlTitle(title: string): boolean {
+	const t = title.trim();
+	return /^https?:\/\/\S+$/i.test(t) || /^www\.\S+\.\S+$/i.test(t);
+}
+
+/**
+ * True when a title carries no topical signal of its own: one of Obsidian's
+ * "Untitled" defaults, a date-style daily-note name, or a bare URL.
+ *
+ * Used by elaboration's anti-fabrication guard: an empty note with a generic
+ * title gives the AI nothing real to work from, so we refuse rather than
+ * fabricate content out of the filename alone. A real title like "Photosynthesis"
+ * is NOT generic and can seed a title-led proposal.
+ */
+export function isGenericTitle(title: string): boolean {
+	return isUntitled(title) || isDateStyleTitle(title) || isBareUrlTitle(title);
+}

--- a/src/title/AGENTS.md
+++ b/src/title/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # title module
@@ -44,7 +44,7 @@ Exported types: `TitleProposal`, `TitleProposalTrigger`, `TitleProposalStatus`
 | `index.ts` | `TitleModule`, re-exports | Module entry point and public API |
 | `title-suggester.ts` | `TitleSuggester` | AI title suggestion and mismatch detection |
 | `title-store.ts` | `TitleProposalStore` | JSON persistence in `settings.title.proposalFolderPath` |
-| `title-detector.ts` | `isUntitled` | Regex check for Obsidian "Untitled" default pattern |
+| `title-detector.ts` | re-exports `isUntitled` | Thin re-export of `isUntitled` from `shared/title-detector` (its canonical home) |
 | `types.ts` | -- | All title types |
 
 ## TitleSuggester (`title-suggester.ts`)
@@ -59,13 +59,15 @@ class TitleSuggester {
 
 Content truncated to 4000 chars before AI call.
 
-## isUntitled (`title-detector.ts`)
+## isUntitled (`shared/title-detector.ts`, re-exported by `title-detector.ts`)
 
 ```ts
 function isUntitled(title: string): boolean
 // Matches "Untitled", "Untitled 1", "Untitled 2", etc. (case-insensitive)
 // Pattern: /^untitled(\s+\d+)?$/i
 ```
+
+Canonical definition lives in `shared/title-detector.ts` (alongside `isGenericTitle`, used by elaboration's anti-fabrication guard) so non-`title/` features can reuse it without importing from this module. `title/title-detector.ts` re-exports it.
 
 ## Data Flow
 

--- a/src/title/title-detector.ts
+++ b/src/title/title-detector.ts
@@ -1,7 +1,6 @@
-/**
- * Checks whether a note title matches Obsidian's "Untitled" default pattern.
- * Matches "Untitled", "Untitled 1", "Untitled 2", etc. (case-insensitive).
- */
-export function isUntitled(title: string): boolean {
-	return /^untitled(\s+\d+)?$/i.test(title.trim());
-}
+// The canonical home for note-title predicates is `shared/title-detector` so
+// that features outside `title/` (e.g. elaboration's generic-title guard) can
+// reuse them without importing from this feature module -- the dependency rules
+// allow features to depend on `shared/` but never on each other. Re-exported
+// here to preserve the title module's public surface (`isUntitled`).
+export { isUntitled } from '../shared/title-detector';


### PR DESCRIPTION
## Summary

Elaboration built its AI prompt from the note **body only** (`buildPrompt()` in `src/elaboration/proposer.ts`), so:
- a note with **no body** (just a title) produced a prompt with nothing between the `---` markers — the AI got no signal and either returned nothing useful or fabricated blindly;
- even content-bearing notes discarded the title, often the clearest statement of the note's topic and intent.

This PR threads the note title (`noteFile.basename`, already in scope in `generate()`) into the prompt and adds an anti-fabrication guard for the empty-body + generic-title case.

## Changes

- **Title as context (both branches):** `buildPrompt()` gains a `noteTitle` parameter and surfaces `Note title: "<title>"` in both the user-requested and stub prompts.
- **Title-led prompt for empty bodies:** when the body is empty/whitespace-only, the prompt is seeded from the title (*"This note has no body yet…"*) instead of emitting an empty `---`/`---` block.
- **Anti-fabrication guard:** when the body is empty **and** the title is generic — an Obsidian `Untitled`/`Untitled N` default, a date-style daily-note name (`YYYY-MM-DD` and common variants), or a bare URL — `generate()` fires an info Notice and returns `null` before any AI call, mirroring the existing link-dominated guard.
- **New helper `isGenericTitle`:** the dependency rules forbid a feature→feature import (elaboration → title), and `shared/` can't depend on `title/` either, so the canonical `isUntitled` was relocated to `src/shared/title-detector.ts` (re-exported by `src/title/title-detector.ts` to preserve the title module's public surface) and `isGenericTitle` delegates to it. `src/title/AGENTS.md` updated to match.

## Tests

- `src/shared/title-detector.test.ts` (new): `isGenericTitle` is true for Untitled / date / bare URL across separator, compact, and year-last date variants; false for real titles like "Photosynthesis" and out-of-range dates.
- `src/elaboration/proposer.test.ts`: (a) the title appears in the prompt for a content-bearing note; (b) an empty-body note seeds a title-led prompt with no empty `---` block; (c) empty body + generic title (Untitled, and a date) ⇒ no AI call **and** an info Notice fires.

## Preflight (full CI parity)

All green: `tsc --noEmit --skipLibCheck`, `eslint src`, `check-top-level-requires.mjs`, `vitest run` (123 files, 1689 tests), `version-bump --check`, `esbuild production`.

closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdCVpgGXyCtp2FaHwoCfKp
