### PR TITLE
feat: make REM inference always-on and down-weight title matches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ SynapseSettings {
   }
   rem: RemSettings {
     enabled: boolean                                // default: true
-    semanticMatching: boolean                       // default: false (AI conceptual matches)
+    titleMatchWeight: number                        // default: 0.6 (weight for literal title/alias matches)
     confidenceThreshold: number                     // default: 0.5 (semantic matches only)
     maxLinksPerNote: number                         // default: 20
     remFolderPath: string                           // default: '.synapse/rem'

--- a/src/rem/AGENTS.md
+++ b/src/rem/AGENTS.md
@@ -58,7 +58,7 @@ interface RemLinkCandidate {
   matchedText: string         // text in source note that was matched
   matchType: RemMatchType
   occurrences: RemOccurrence[]
-  confidence: number          // 1.0 for title/alias; AI-assigned for semantic
+  confidence: number          // title/alias raw 1.0 down-weighted by titleMatchWeight; AI-assigned for semantic
 }
 
 interface RemProposal {
@@ -73,7 +73,7 @@ interface RemProposal {
 
 interface RemSettings {
   enabled: boolean
-  semanticMatching: boolean
+  titleMatchWeight: number      // weight for literal title/alias matches (0-1)
   confidenceThreshold: number   // minimum confidence for semantic matches (0-1)
   maxLinksPerNote: number
   remFolderPath: string
@@ -87,7 +87,7 @@ interface RemSettings {
 | `index.ts` | `RemModule`, type + fn re-exports | Orchestrator, commands, scan + accept/reject/undo |
 | `types.ts` | `RemProposal`, `RemLinkCandidate`, `RemOccurrence`, `RemMatchType`, `RemProposalStatus`, `RemSettings` | Type model |
 | `mention-scanner.ts` | `MentionScanner` | Phase 1: literal title/alias mention scanning |
-| `semantic-matcher.ts` | `SemanticMatcher` | Phase 2: optional AI semantic matching |
+| `semantic-matcher.ts` | `SemanticMatcher` | Phase 2: always-on AI semantic matching |
 | `rem-applier.ts` | `RemApplier` | Inserts `[[wikilinks]]` into note body for accepted candidates |
 | `rem-store.ts` | `RemStore` | Proposal persistence under `rem.remFolderPath` |
 | `settings-section.ts` | `renderRemSettings` | REM settings UI section |
@@ -103,10 +103,10 @@ interface RemSettings {
 ```
 remScanNote(filePath)
   --> isExcluded? (isPathExcluded 'rem' + enrichment.excludeTags)
-  --> MentionScanner.scan(file, content, maxLinksPerNote)   // literal candidates
-  --> if semanticMatching:
-        SemanticMatcher.match(file, content, alreadyMatched, remaining)
-        filter by confidenceThreshold
+  --> gatherCandidates(file, content):
+        MentionScanner.scan(...) literal candidates, down-weighted by titleMatchWeight
+        SemanticMatcher.match(...) always-on, filtered by confidenceThreshold
+        merge + re-rank by confidence desc + cap at maxLinksPerNote
   --> RemProposal { candidates, status: 'pending' } --> RemStore.save
   --> maybeAutoAccept(proposal)   (#228, when shouldAutoAccept())
   --> onOpenProposalView callback offered in Notice (when NOT auto-accepting)
@@ -116,7 +116,7 @@ remScanDirectory(folderPath?, skipConfirmation?, onlyFile?)
   --> getMarkdownFiles filtered by isExcluded
   --> CheckpointManager.create(module: 'rem', items)
   --> addDeferredTask('refresh-sidebar-view')
-  --> for each file: scan literals + semantic, save proposal, maybeAutoAccept(batch=true)
+  --> for each file: gatherCandidates (literal down-weighted + always-on semantic, merged/re-ranked), save proposal, maybeAutoAccept(batch=true)
   --> completeItem() per file
   --> on error: rejectProposalBatch(createdIds) + return 0
   --> on cancel: discard() + rejectProposalBatch()
@@ -155,7 +155,7 @@ WARNING: REM auto-accept REWRITES note body text (inserts `[[wikilinks]]`). This
 
 `remScanDirectory` and `resumeFromCheckpoint` use `CheckpointManager` with module `'rem'`. Items tracked as `rem-{index}-{path}`. On error or cancel, all proposals created in the run are batch-rejected via `rejectProposalBatch()`.
 
-Resume re-checks exclusion rules silently (a path may have been excluded after checkpoint creation).
+Resume re-checks exclusion rules silently (a path may have been excluded after checkpoint creation). Resume runs the same `gatherCandidates` pipeline as a fresh scan (literal + always-on semantic), so resumed items also get content-relevant links (#380).
 
 ## Exclusion Rules
 
@@ -182,7 +182,7 @@ All under `settings.rem` (`RemSettings`):
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
 | `enabled` | `boolean` | — | Module + command activation |
-| `semanticMatching` | `boolean` | — | Enable AI-based conceptual matching |
+| `titleMatchWeight` | `number` | `0.6` | Weight for literal title/alias matches when ranking (0-1) |
 | `confidenceThreshold` | `number` | — | Min confidence for semantic candidates (0-1) |
 | `maxLinksPerNote` | `number` | — | Max link candidates per scanned note |
 | `remFolderPath` | `string` | `.synapse/rem` | Storage folder for proposal JSON files |

--- a/src/rem/index.test.ts
+++ b/src/rem/index.test.ts
@@ -151,7 +151,6 @@ describe('RemModule', () => {
 		});
 
 		it('augments literal candidates with semantic matches above the confidence threshold', async () => {
-			settings.rem.semanticMatching = true;
 			settings.rem.confidenceThreshold = 0.5;
 			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
 			app.vault.read.mockResolvedValue('deep learning content');
@@ -165,6 +164,25 @@ describe('RemModule', () => {
 			const result = await module.remScanNote('notes/A.md');
 			expect(matchSpy).toHaveBeenCalled();
 			expect(result!.candidates.map((c) => c.matchedText)).toEqual(['ML']);
+		});
+
+		it('re-ranks a down-weighted title match below a stronger semantic match (#380)', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('content discussing machine learning');
+			// Literal title hit: scanner emits raw 1.0; gatherCandidates down-weights to 0.6.
+			scanSpy.mockReturnValue([candidate('TitleHit')]);
+			// Semantic hit is more content-relevant than the weighted title match.
+			matchSpy.mockResolvedValue([
+				{ ...candidate('Relevant'), matchType: 'semantic', confidence: 0.8 },
+			]);
+			const module = await loadedModule();
+
+			const result = await module.remScanNote('notes/A.md');
+
+			// 0.8 semantic outranks the 0.6 weighted title -> semantic sorts first.
+			expect(result!.candidates.map((c) => c.matchedText)).toEqual(['Relevant', 'TitleHit']);
+			const title = result!.candidates.find((c) => c.matchedText === 'TitleHit')!;
+			expect(title.confidence).toBeCloseTo(0.6);
 		});
 	});
 
@@ -418,6 +436,47 @@ describe('RemModule', () => {
 			expect(created).toBe(1);
 			expect(saveSpy).toHaveBeenCalledWith(
 				expect.objectContaining({ sourceNotePath: 'notes/B.md' })
+			);
+		});
+	});
+
+	describe('resumeFromCheckpoint', () => {
+		const checkpointWith = (filePaths: string[]): any => ({
+			id: 'cp1',
+			module: 'rem',
+			operationLabel: 'REM scan',
+			status: 'active',
+			createdAt: '2026-06-11T00:00:00.000Z',
+			updatedAt: '2026-06-11T00:00:00.000Z',
+			completedItems: [],
+			remainingItems: filePaths.map((path, i) => ({
+				id: `item-${i}`,
+				label: path,
+				payload: { filePath: path },
+			})),
+			deferredTasks: [],
+			metadata: {},
+		});
+
+		it('runs semantic matching on resumed scans, not just literal (#380)', async () => {
+			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/A.md'));
+			app.vault.read.mockResolvedValue('content about deep learning');
+			scanSpy.mockReturnValue([]); // no literal matches at all
+			matchSpy.mockResolvedValue([
+				{ ...candidate('ML'), matchType: 'semantic', confidence: 0.9 },
+			]);
+			const module = await loadedModule();
+
+			await module.resumeFromCheckpoint(checkpointWith(['notes/A.md']));
+
+			// Resume previously scanned literally only -> a semantic-only note produced
+			// no proposal. Now the semantic candidate is gathered and saved.
+			expect(matchSpy).toHaveBeenCalled();
+			expect(saveSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sourceNotePath: 'notes/A.md',
+					candidates: [expect.objectContaining({ matchedText: 'ML', matchType: 'semantic' })],
+				})
 			);
 		});
 	});

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -85,10 +85,31 @@ export class RemModule {
 	}
 
 	/**
+	 * Gather link candidates for a note: literal title/alias matches (down-weighted
+	 * by `titleMatchWeight`) merged with always-on semantic matches, then re-ranked
+	 * by confidence and capped at `maxLinksPerNote` (#380). Centralizes the scan
+	 * pipeline so single-note, directory, and resumed scans behave identically.
+	 */
+	private async gatherCandidates(file: TFile, content: string): Promise<RemLinkCandidate[]> {
+		const s = this.getSettings().rem;
+		// Phase 1 — literal title/alias matches, down-weighted from their raw 1.0 so a
+		// title coincidence can't automatically outrank a content-relevant link.
+		const literal = this.scanner.scan(file, content, s.maxLinksPerNote)
+			.map(c => ({ ...c, confidence: c.confidence * s.titleMatchWeight }));
+		// Phase 2 — semantic matching, always on, given the full link budget.
+		const already = new Set(literal.map(c => c.targetPath));
+		const semantic = (await this.semanticMatcher.match(file, content, already, s.maxLinksPerNote))
+			.filter(c => c.confidence >= s.confidenceThreshold);
+		// Merge, re-rank by confidence descending, then cap at the per-note budget.
+		return [...literal, ...semantic]
+			.sort((a, b) => b.confidence - a.confidence)
+			.slice(0, s.maxLinksPerNote);
+	}
+
+	/**
 	 * Scan a single note for linkable mentions.
 	 */
 	async remScanNote(filePath: string): Promise<RemProposal | null> {
-		const settings = this.getSettings().rem;
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) {
 			this.notifications.info('File not found');
@@ -108,26 +129,7 @@ export class RemModule {
 
 		const content = await this.plugin.app.vault.read(tFile);
 
-		// Phase 1: literal mention scanning
-		const literalCandidates = this.scanner.scan(tFile, content, settings.maxLinksPerNote);
-
-		// Phase 2: optional semantic matching
-		let semanticCandidates: RemLinkCandidate[] = [];
-		if (settings.semanticMatching) {
-			const alreadyMatched = new Set(literalCandidates.map(c => c.targetPath));
-			const remaining = settings.maxLinksPerNote - literalCandidates.length;
-			if (remaining > 0) {
-				semanticCandidates = await this.semanticMatcher.match(
-					tFile, content, alreadyMatched, remaining
-				);
-				// Filter by confidence threshold
-				semanticCandidates = semanticCandidates.filter(
-					c => c.confidence >= settings.confidenceThreshold
-				);
-			}
-		}
-
-		const allCandidates = [...literalCandidates, ...semanticCandidates];
+		const allCandidates = await this.gatherCandidates(tFile, content);
 
 		if (allCandidates.length === 0) {
 			this.notifications.info('No linkable mentions found');
@@ -162,7 +164,6 @@ export class RemModule {
 	 * Scan all markdown files in a directory (or vault root) with checkpoint support.
 	 */
 	async remScanDirectory(folderPath?: string, _skipConfirmation = false, onlyFile?: TFile): Promise<number> {
-		const settings = this.getSettings().rem;
 		let allFiles = getMarkdownFiles(this.plugin.app, folderPath);
 		// Per-file scoping (#111): narrow to the single requested note.
 		if (onlyFile) allFiles = allFiles.filter(f => f.path === onlyFile.path);
@@ -212,24 +213,7 @@ export class RemModule {
 				op.progress(i + 1, eligible.length, `Scanning ${file.basename}`);
 
 				const content = await this.plugin.app.vault.read(file);
-				const candidates = this.scanner.scan(file, content, settings.maxLinksPerNote);
-
-				// Optional semantic matching
-				let semanticCandidates: RemLinkCandidate[] = [];
-				if (settings.semanticMatching) {
-					const alreadyMatched = new Set(candidates.map(c => c.targetPath));
-					const remaining = settings.maxLinksPerNote - candidates.length;
-					if (remaining > 0) {
-						semanticCandidates = await this.semanticMatcher.match(
-							file, content, alreadyMatched, remaining
-						);
-						semanticCandidates = semanticCandidates.filter(
-							c => c.confidence >= settings.confidenceThreshold
-						);
-					}
-				}
-
-				const allCandidates = [...candidates, ...semanticCandidates];
+				const allCandidates = await this.gatherCandidates(file, content);
 
 				if (allCandidates.length > 0) {
 					const proposal: RemProposal = {
@@ -283,7 +267,6 @@ export class RemModule {
 	 * Resume a REM scan from a checkpoint.
 	 */
 	async resumeFromCheckpoint(checkpoint: import('../shared').Checkpoint): Promise<void> {
-		const settings = this.getSettings().rem;
 		const op = this.notifications.startOperation(
 			'Resuming REM scan',
 			'rem-resume'
@@ -316,7 +299,7 @@ export class RemModule {
 				}
 
 				const content = await this.plugin.app.vault.read(file);
-				const candidates = this.scanner.scan(file, content, settings.maxLinksPerNote);
+				const candidates = await this.gatherCandidates(file, content);
 
 				if (candidates.length > 0) {
 					const proposal: RemProposal = {

--- a/src/rem/settings-section.test.ts
+++ b/src/rem/settings-section.test.ts
@@ -5,7 +5,7 @@ import { renderRemSettings } from './settings-section';
 import { DEFAULT_SETTINGS } from '../settings';
 import type { SynapseSettings } from '../settings';
 
-const FEATURE_TOOLTIP = 'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions';
+const FEATURE_TOOLTIP = 'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions. Link suggestions are ranked by AI content relevance, not just literal title matches.';
 
 function makeCtx(mutate?: (s: SynapseSettings) => void) {
 	const settings = structuredClone(DEFAULT_SETTINGS);

--- a/src/rem/settings-section.ts
+++ b/src/rem/settings-section.ts
@@ -13,20 +13,8 @@ export function renderRemSettings(ctx: SettingsSectionContext): void {
 		'REM (link discovery)',
 		() => plugin.settings.rem.enabled,
 		(v) => { plugin.settings.rem.enabled = v; },
-		'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions',
+		'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions. Link suggestions are ranked by AI content relevance, not just literal title matches.',
 	);
-
-	new Setting(remBody)
-		.setName('Semantic matching')
-		.setDesc('Use AI to find conceptual matches beyond literal title/alias matching')
-		.addToggle((toggle) =>
-			toggle
-				.setValue(plugin.settings.rem.semanticMatching)
-				.onChange(async (value) => {
-					plugin.settings.rem.semanticMatching = value;
-					await plugin.saveSettings();
-				})
-		);
 
 	addEnhancedSlider(
 		new Setting(remBody)

--- a/src/rem/types.ts
+++ b/src/rem/types.ts
@@ -25,7 +25,11 @@ export interface RemLinkCandidate {
 	matchType: RemMatchType;
 	/** All positions where this match appears */
 	occurrences: RemOccurrence[];
-	/** Match confidence (0-1). Always 1.0 for title/alias; AI-assigned for semantic. */
+	/**
+	 * Match confidence (0-1). Literal title/alias matches start at a raw 1.0 and
+	 * are down-weighted by `titleMatchWeight` when ranked; semantic matches are
+	 * AI-assigned.
+	 */
 	confidence: number;
 }
 
@@ -46,8 +50,11 @@ export interface RemProposal {
 
 export interface RemSettings {
 	enabled: boolean;
-	/** Use AI to find conceptual matches beyond literal title/alias matching. */
-	semanticMatching: boolean;
+	/**
+	 * Weight applied to literal title/alias matches (0-1) so a title coincidence
+	 * cannot automatically outrank a genuinely content-relevant semantic link.
+	 */
+	titleMatchWeight: number;
 	/** Minimum confidence for semantic matches (0-1). */
 	confidenceThreshold: number;
 	/** Maximum link candidates per scanned note. */

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -27,7 +27,7 @@ import { METADATA_CONTAINER_SELECTOR, PROPERTIES_COLLAPSED_CLASS } from './prope
  * the REM feature itself.
  */
 const REM_FEATURE_TOOLTIP =
-	'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions';
+	'Scan notes for mentions of other note titles and propose in-place [[wikilink]] insertions. Link suggestions are ranked by AI content relevance, not just literal title matches.';
 
 interface MockPlugin {
 	settings: SynapseSettings;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -194,8 +194,11 @@ export interface DeepDiveSettings {
 
 export interface RemSettings {
 	enabled: boolean;
-	/** Use AI to find conceptual matches beyond literal title/alias matching. */
-	semanticMatching: boolean;
+	/**
+	 * Weight applied to literal title/alias matches (0-1) so a title coincidence
+	 * cannot automatically outrank a genuinely content-relevant semantic link.
+	 */
+	titleMatchWeight: number;
 	/** Minimum confidence for semantic matches (0-1). */
 	confidenceThreshold: number;
 	/** Maximum link candidates per scanned note. */
@@ -467,7 +470,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 	},
 	rem: {
 		enabled: true,
-		semanticMatching: false,
+		titleMatchWeight: 0.6,
 		confidenceThreshold: 0.5,
 		maxLinksPerNote: 20,
 		remFolderPath: '.synapse/rem',


### PR DESCRIPTION
## Summary
Content-based inference is the core of REM, but it shipped behind a second `semanticMatching` toggle that defaulted **off**, and literal title/alias matches were hardcoded to `confidence: 1.0` and consumed the per-note link budget before semantic matching ran — so a title coincidence could outrank a genuinely content-relevant link.

This PR makes inference always-on whenever REM is enabled, and down-weights literal matches so they're ranked fairly against content relevance.

closes #380

## Changes
- **Always-on semantic matching**: removed the `semanticMatching` setting (`RemSettings` in both `src/rem/types.ts` and `src/settings.ts`) and its UI toggle (`src/rem/settings-section.ts`). The section description now notes linking uses content relevance. The global `enabled` toggle, `confidenceThreshold` (0.5), and `maxLinksPerNote` (20) are preserved.
- **Title down-weighting**: added `titleMatchWeight` (default `0.6`) to `RemSettings`. The scanner keeps emitting raw `1.0`; the weight is applied at the combine point so the scanner stays settings-agnostic.
- **Centralized + re-ranked pipeline**: extracted a private `gatherCandidates()` helper that down-weights literal matches, runs semantic matching with the full budget, then merges and **re-ranks all candidates by confidence before capping** at `maxLinksPerNote`. Wired into `remScanNote()`, `remScanDirectory()`, and `resumeFromCheckpoint()` — the last of which previously ran literal-only, so resumed scans now get semantic links too.
- **No migration needed**: `loadSettings()` uses `deepMerge(DEFAULT_SETTINGS, data)`, which recurses into nested groups, so existing users pick up the new `titleMatchWeight` default and a persisted `semanticMatching: false` becomes an inert, unread key.
- Updated module docs (`src/rem/AGENTS.md`, root `AGENTS.md`) to match.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint` (eslint)
- [x] `npm test` — **1681 passed**. Added a re-rank ordering test (weighted title 0.6 sorts below a 0.8 semantic match) and a resume-runs-semantic test; updated existing tests for the removed toggle and the new section tooltip.
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)