### PR TITLE
chore: codebase audit — redaction fix, command casing, docs refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Synapse — Agent Reference
@@ -41,8 +41,12 @@ Output: `main.js` (single bundle, Obsidian loads this)
 | organize | `src/organize/` | AI-powered semantic directory structuring for notes | `OrganizeModule`, types |
 | deep-dive | `src/deep-dive/` | Recursive topic extraction and child note generation | `DeepDiveModule`, types |
 | title | `src/title/` | AI title suggestions for untitled/mismatched notes | `TitleModule`, types |
-| shared | `src/shared/` | AI client (multi-modal), file utils, validation, notifications, callouts, frontmatter, checkpoints, credential metadata + validation | `AIClient`, `NotificationManager`, `CheckpointManager`, `validateCredentials`, `PROVIDER_METADATA`, `decorateCredentialField`, file/validation utils, callout registry, id-utils |
+| shared | `src/shared/` | AI client (multi-modal), file utils, validation, notifications, callouts, frontmatter, checkpoints, credential metadata + validation, secret redaction, update check, title predicates | `AIClient`, `NotificationManager`, `CheckpointManager`, `validateCredentials`, `PROVIDER_METADATA`, `decorateCredentialField`, `redactSecrets`, `UpdateChecker`, `isNewerVersion`, `isUntitled`, `isGenericTitle`, file/validation utils, callout registry, id-utils |
 | views | `src/views/` | Unified proposal/checkpoint sidebar + registry-driven Synapse actions sidebar | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE`, `UnifiedItem`, `SynapseActionsView`, `SYNAPSE_ACTIONS_VIEW_TYPE` |
+| onboarding | `src/onboarding.ts` | First-run welcome gate + required-API-key emphasis (#89) | `needsApiKey`, `planFirstRun`, `applyApiKeyEmphasis`, `FirstRunPlan`, `WELCOME_MESSAGE` |
+| brand-icons | `src/brand-icons.ts` | Registers Synapse SVG icons (S-Signal identity mark + feature glyphs) | `registerSynapseIcons`, `SYNAPSE_ICONS`, `SYNAPSE_ICON_SVG` |
+| changelog | `src/changelog.ts`, `src/changelog-modal.ts` | In-app "What's new" modal; parses build-inlined `CHANGELOG.md` (#375) | `parseChangelog`, `renderChangelog`, `stripInlineMarkdown`, `ChangelogEntry`, `ChangelogSection`, `ChangelogModal` |
+| properties-fold | `src/properties-fold.ts` | Auto-fold a note's Properties panel on open (#381) | `registerPropertiesAutoFold`, `applyPropertiesFold`, `foldActiveNoteProperties`, `foldPropertiesIn` |
 
 ## Dependency Graph
 
@@ -92,23 +96,26 @@ Key constraints:
 ```
 onload()
   |-- loadSettings()  (deepMerge over DEFAULT_SETTINGS; one-time excludeFolders -> exclusions migration, #307)
-  |-- addIcon('synapse', ...)  (brand S-Signal mark; registered before any ribbon use)
+  |-- registerSynapseIcons()  (brand-icons.ts; registers all synapse-* glyphs before any ribbon/setIcon/view use)
   |-- migrateDataFolder()  (.auto-notes -> .synapse, one-time)
   |-- new NotificationManager(); status bar attached on desktop only
   |-- new CheckpointManager(app)  (single instance, injected into all modules)
   |-- new CommandRegistrar(this)
   |-- construct modules (audio before video; video desktop-only); each gets a () => autoAccept[kind] getter
+  |-- new UpdateChecker({ currentVersion, app, notifications, getSettings, saveSettings })  (#365)
   |-- registerView(UNIFIED_VIEW_TYPE), registerView(SYNAPSE_ACTIONS_VIEW_TYPE)
+  |-- registerPropertiesAutoFold(this, () => settings)  (#381; auto-fold note Properties on open)
   |-- wire onViewRefreshNeeded / onOpenProposalView / cross-module callbacks
   |-- await <module>.onload() for each settings.<feature>.enabled module
   |-- addRibbonIcon x3; registrar.register(...) for main commands
   |-- startupTimeout = setTimeout(checkForIncompleteCheckpoints, 3000)
+  |-- updateCheckTimeout = setTimeout(updateChecker.maybeCheck, 5000)  (#365; self-gated, once/day)
   |-- build PipelineModuleMap + SynapseRunner; construct IntakeModule (deps injected)
   |-- auditCommands(registrar.getAttempted())  (logs drift)
   +-- runFirstRunOnboarding()  (#89)
 
 onunload()
-  |-- clearTimeout(startupTimeout)
+  |-- clearTimeout(startupTimeout); clearTimeout(updateCheckTimeout)
   |-- <module>?.onunload() for every module (optional-chained; video may be null)
   +-- notifications.dispose()  (tears down in-flight operation ellipsis intervals + hides notices so a
                                 disable mid-operation never leaks an orphaned 400ms setInterval on a detached toast)
@@ -140,7 +147,7 @@ Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries
 | `synapse:scan-vault-summarize` | Scan folder for notes to summarize | callback | summarize | p, f | active | summarize |
 | `synapse:tidy-current-note` | Tidy current note | editorCallback | tidy | p | active | |
 | `synapse:undo-tidy` | Undo last tidy on current note | editorCallback | tidy | p | disabled | |
-| `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | rem | p | active | |
+| `synapse:rem-current-note` | REM: discover links in current note | editorCallback | rem | p | active | |
 | `synapse:rem-directory` | Scan folder for links | callback | rem | p, f | active | rem |
 | `synapse:check-dependencies` | Check external tool availability | callback | video | p | active | |
 | `synapse:tidy-vault` | Scan folder for notes to tidy | (synthetic) | tidy | f | active | tidy |
@@ -149,11 +156,13 @@ Source of truth: `src/commands/registry.ts` (mirrored here). 23 registry entries
 
 ## Ribbon Icons
 
+All ribbon glyphs are custom Synapse brand icons registered by `registerSynapseIcons()` (`src/brand-icons.ts`).
+
 | Icon | Label | Action |
 |------|-------|--------|
 | `synapse` | Review proposals | Opens unified proposal sidebar |
-| `mic` | Transcribe media | Opens unified transcription modal (desktop only) |
-| `layout-grid` | Synapse actions | Opens registry-driven actions sidebar |
+| `synapse-transcribe` | Transcribe media | Opens unified transcription modal (desktop only) |
+| `synapse-actions` | Synapse actions | Opens registry-driven actions sidebar |
 
 ## View Types
 
@@ -270,6 +279,8 @@ SynapseSettings {
     autoDetectTemplates: boolean                    // default: true
     excludeTags: string[]                           // default: ['no-summarize']
     autoOrganizeOnSummarize: boolean                // default: false
+    includeNoteContent: boolean                     // default: true (summarize the note's own prose as an extra item, #367)
+    combineSummaries: boolean                       // default: true (emit one combined summary instead of a callout per item, #367)
   }
   tidy: TidySettings {
     enabled: boolean                                // default: true
@@ -316,7 +327,8 @@ SynapseSettings {
     captureLogFolder: string                        // default: '_captured'
   }
   ui: UISettings {
-    collapsedSections: Record<string, boolean>      // default: {} (settings accordion state)
+    collapsedSections: Record<string, boolean>      // default: {} (settings accordion state, #235)
+    autoFoldProperties: boolean                     // default: false (fold note Properties panel on open, #381)
   }
   autoAccept: AutoAcceptSettings {                  // Record<ProposalKind, boolean>, all default false
     elaboration: boolean                            // default: false
@@ -328,6 +340,11 @@ SynapseSettings {
   }
   onboarding: OnboardingSettings {
     hasSeenWelcome: boolean                         // default: false (first-run welcome gate, #89)
+  }
+  updates: UpdateSettings {                          // in-app "newer release available" check (#365)
+    enableUpdateNotifications: boolean              // default: true (master toggle)
+    lastUpdateCheck?: number                        // epoch ms of last GitHub check (success or failure); absent until first check
+    dismissedUpdateVersion?: string                 // newest version already notified; absent until first notice
   }
   exclusions: ExclusionRule[]                        // centralized per-path exclusion (#307); default 2 rules (see below)
 }
@@ -491,7 +508,7 @@ Framework: Vitest, globals enabled, node environment.
 - URLs validated via `sanitizeUrl()` before external tool invocation
 - Paths validated via `sanitizePath()` (rejects `..`, null bytes, shell metacharacters)
 - AI output sanitized via `sanitizeAIResponse()` before vault writes
-- Secret redaction centralized in `shared/redact.ts` (`redactSecrets`); both `ai-client.ts` (upstream error bodies) and `api-utils.ts:notifyError` (user/console errors) route through it — single source of truth, re-exported from `ai-client` and the `shared` barrel. Covers `sk-`/`sk-ant-`, `key-`, Deepgram `dg-`, `Bearer `/`Token ` headers, `anthropic-`, and Google `AIza` keys
+- Secret redaction centralized in `shared/redact.ts` (`redactSecrets`); the AI client (`ai-client.ts`, upstream error bodies), the notification manager (`notifications.ts` — every error sink: the operation-error `console.error`, `showErrorNotice`, and the `NotificationManager.notifyError` method), and credential validation (`credential-validator.ts`, probe error bodies) all route through it — single source of truth, re-exported from `ai-client` and the `shared` barrel. Covers `sk-`/`sk-ant-`, `key-`, Deepgram `dg-`, `Bearer `/`Token ` headers, `anthropic-`, and Google `AIza` keys
 - Credential validation (`shared/credential-validator.ts`, `validateCredentials`) probes each provider with a single minimal GET (probe specs in `shared/provider-metadata.ts`); every result message routes through `redactSecrets`, so a key echoed in a 401/400 body cannot reach the status chip. One-shot (no retry), 10s timeout, `throw:false`. Validation state is ephemeral (never persisted to settings)
 - Multipart transcription bodies (`audio/transcriber.ts:buildMultipartBody`) sanitize vault-/settings-derived field names and file names via `sanitizeMultipartHeaderValue` (strips CR/LF, replaces `"`/`\` with `_`) to block `Content-Disposition` header / multipart injection
 - Gemini audio transcription places its instruction in `system_instruction` (not the user turn beside the audio) so speech inside untrusted audio cannot override the prompt (prompt-injection hardening)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,10 +1,10 @@
 # Architecture Overview
 
-**Last updated**: 2026-06-20 · **Version**: 1.0.3
+**Last updated**: 2026-06-25 · **Version**: 1.0.6
 
 Synapse is an Obsidian plugin that layers AI-powered features over a vault: note elaboration (with image analysis), audio transcription, video transcription, image OCR, note enrichment, summarization, note tidying, semantic organization, recursive deep-dive note generation, title proposals, and in-place wikilink discovery (REM). Two coordination layers tie them together — a **Fire Synapse pipeline** that runs the features in a fixed order over a folder or note, and an **intake** watcher that auto-processes notes dropped into an inbox. It runs on both desktop and mobile (video and media-clipping features are desktop-only).
 
-The codebase has **17 modules under `src/`** (audio, commands, deep-dive, elaboration, enrichment, image, intake, organize, pipeline, rem, shared, summarize, tidy, title, transcription, video, views) plus the top-level `main.ts`, `settings.ts`, `settings-tab.ts`, and a small pure `onboarding.ts` (first-run welcome, #89).
+The codebase has **17 modules under `src/`** (audio, commands, deep-dive, elaboration, enrichment, image, intake, organize, pipeline, rem, shared, summarize, tidy, title, transcription, video, views) plus top-level glue: `main.ts`, `settings.ts`, `settings-tab.ts`, a small pure `onboarding.ts` (first-run welcome, #89), `brand-icons.ts` (Synapse SVG icons), `changelog.ts`/`changelog-modal.ts` (in-app "What's new", #375), and `properties-fold.ts` (auto-fold note Properties, #381).
 
 > **Note**: This plugin was previously named "Auto Notes" and was rebranded to "Synapse" in March 2026. The data folder was renamed from `.auto-notes/` to `.synapse/`, with automatic one-time migration on load.
 
@@ -107,6 +107,10 @@ src/
 ├── settings.ts             # Type definitions, defaults, model options (type-only imports of ProposalKind + ExclusionRule)
 ├── settings-tab.ts         # Obsidian settings UI (video section gated behind Platform.isDesktop)
 ├── onboarding.ts           # Pure first-run welcome logic (#89): planFirstRun, needsApiKey
+├── brand-icons.ts          # registerSynapseIcons(): S-Signal mark + per-feature glyphs (before any ribbon/setIcon use)
+├── changelog.ts            # parseChangelog/renderChangelog of the build-inlined CHANGELOG.md (#375)
+├── changelog-modal.ts      # ChangelogModal — in-app "What's new" (#375)
+├── properties-fold.ts      # registerPropertiesAutoFold(): auto-fold note Properties panel on open (#381)
 │
 ├── commands/               # Command registry (base layer; imports nothing in src/)
 │   ├── registry.ts         #   COMMAND_REGISTRY source of truth + flow/status/context gates
@@ -125,8 +129,8 @@ src/
 │   └── index.ts            #   IntakeModule (debounce, idempotency, fireOnFile)
 │
 ├── rem/                    # In-place [[wikilink]] discovery
-│   ├── mention-scanner.ts  #   Literal title/alias matches
-│   ├── semantic-matcher.ts #   Optional AI semantic matches
+│   ├── mention-scanner.ts  #   Literal title/alias matches (down-weighted by titleMatchWeight, #380)
+│   ├── semantic-matcher.ts #   Always-on AI semantic matches (#380)
 │   ├── rem-applier.ts      #   Insert wikilinks into note body
 │   ├── rem-store.ts        #   Proposal persistence
 │   └── index.ts            #   RemModule orchestrator
@@ -220,7 +224,10 @@ src/
 │   ├── checkpoint-manager.ts #  Checkpoint/resume for long-running operations
 │   ├── checkpoint-types.ts #   Checkpoint type definitions
 │   ├── id-utils.ts         #   ID generation and validation
-│   ├── notifications.ts    #   Centralized notification system (+ dispose() teardown on unload)
+│   ├── notifications.ts    #   Centralized notifications: progress, cancellation, action buttons, dispose() teardown
+│   │                       #   every error sink (error/notifyError/operation-error console) routes through redactSecrets
+│   ├── update-checker.ts   #   UpdateChecker/isNewerVersion — once/24h GitHub Releases poll, sticky notice (#365)
+│   ├── title-detector.ts   #   isUntitled/isGenericTitle predicates (shared by title/ and elaboration/)
 │   ├── validation.ts       #   URL, path, AI response sanitization
 │   ├── file-utils.ts       #   Vault file operations
 │   ├── frontmatter-utils.ts#   YAML frontmatter parsing/serialization
@@ -228,7 +235,8 @@ src/
 │   ├── diagram-generator.ts#   Mermaid diagram generation
 │   ├── slider-helper.ts    #   Settings UI helper for range sliders
 │   ├── folder-picker-modal.ts # Modal for folder selection
-│   ├── api-utils.ts        #   Retry logic, error handling (notifyError routes through redactSecrets)
+│   ├── api-utils.ts        #   Retry logic + error handling helpers
+│   ├── markdown.d.ts       #   Ambient `declare module '*.md'` so esbuild can inline CHANGELOG.md (#375)
 │   └── index.ts            #   Barrel export
 │
 └── views/                  # UI components
@@ -393,25 +401,28 @@ sequenceDiagram
 
     O->>M: onload()
     M->>M: loadSettings() (deep-merge + one-time excludeFolders→exclusions migration, #307)
-    M->>M: addIcon('synapse') (brand S-Signal mark, before any ribbon use)
+    M->>M: registerSynapseIcons() (brand S-Signal mark + feature glyphs, before any ribbon/setIcon use)
     M->>M: migrateDataFolder() (.auto-notes -> .synapse)
     M->>M: addSettingTab()
     M->>M: NotificationManager() (status bar on desktop only)
     M->>CK: new CheckpointManager(app)
     M->>Reg: new CommandRegistrar(plugin)
     M->>Mod: Initialize feature modules<br/>(Audio before Video; Video desktop-only; inject CheckpointManager, registrar, shouldAutoAccept getter)
+    M->>M: new UpdateChecker(...) (#365)
     M->>M: registerView(UnifiedProposalView) + registerView(SynapseActionsView)
+    M->>M: registerPropertiesAutoFold(plugin, () => settings) (#381)
     M->>M: Wire view refresh + onOpenProposalView + cross-module callbacks<br/>(enrichment, title, organize)
     M->>Mod: Conditional module.onload()<br/>(registers commands via registrar if enabled)
-    M->>M: addRibbonIcon x3 (synapse; mic [desktop]; layout-grid)
+    M->>M: addRibbonIcon x3 (synapse; synapse-transcribe [desktop]; synapse-actions)
     M->>Reg: registrar.register(main commands)
     M->>CK: startupTimeout = checkForIncompleteCheckpoints() (delayed 3s)
+    M->>M: updateCheckTimeout = updateChecker.maybeCheck() (delayed 5s, self-gated once/day, #365)
     M->>Coord: Build SynapseRunner (inject PipelineModuleMap)<br/>+ IntakeModule (inject IntakeDeps.fireOnFile)
     M->>Reg: auditCommands(attempted) — warn on drift
     M->>M: runFirstRunOnboarding() (#89, fresh installs only)
 
     O->>M: onunload()
-    M->>M: clearTimeout(startupTimeout)
+    M->>M: clearTimeout(startupTimeout); clearTimeout(updateCheckTimeout)
     M->>Mod: module?.onunload() for every module (video may be null)
     M->>M: notifications.dispose() (tear down ellipsis timers + hide notices)
 ```
@@ -833,20 +844,24 @@ SynapseSettings
 |   +-- tagVocabulary   -> TagVocabularyEntry[] (category, tags, description)
 |   +-- weights         -> Same/sibling/cousin/distant folder, decay, minimum
 +-- summarize       -> Style (bullets/paragraph/key-points), max length, templates,
-|                     exclude tags, auto-organize on summarize
+|                     exclude tags, auto-organize on summarize,
+|                     include note content + combine summaries (#367, both default on)
 +-- tidy            -> Snapshot folder path
 +-- organize        -> Proposal/snapshot folder paths, confidence threshold, exclude tags
 +-- deepDive        -> Max depth, quality threshold, max notes, output folder,
 |                     nesting mode, auto-enrich/organize on accept, exclude tags
 +-- title           -> Enabled, proposal folder path, check after operations
-+-- rem             -> Enabled, semantic matching, confidence threshold,
-|                     max links per note, proposal folder path
++-- rem             -> Enabled, title-match weight (#380, no UI), semantic confidence
+|                     threshold, max links per note, proposal folder path
 +-- intake          -> Enabled, watched folder, mark-processed, move-when-done,
 |                     settle seconds, capture log + capture-log folder
-+-- ui              -> collapsedSections (settings accordion state)
++-- ui              -> collapsedSections (settings accordion state),
+|                     autoFoldProperties (#381, default off)
 +-- autoAccept      -> Per-kind booleans (elaboration, enrichment, organize,
 |                     deep-dive, title, rem) — all default false (#228)
 +-- onboarding      -> hasSeenWelcome (first-run welcome gate, #89)
++-- updates         -> enableUpdateNotifications, lastUpdateCheck,
+|                     dismissedUpdateVersion (in-app update check, #365)
 +-- exclusions      -> ExclusionRule[] — centralized per-path exclusion (#307);
                       replaces all former per-module excludeFolders fields
 ```
@@ -865,7 +880,7 @@ Path exclusion is centralized (#307): the per-module `excludeFolders` fields wer
 | Desktop gating | `assertDesktop()`/`loadNodeModules()` — Node builtins resolve only on desktop, behind one guarded site; keeps `isDesktopOnly: false` mobile-safe | `shared/node-loader.ts` |
 | Temp-path hardening | Vault-derived basenames sanitized before composing temp paths (2026-06-08) | `transcription/duration-detector.ts` |
 | Multipart header hardening | Vault-/settings-derived field + file names sanitized (`sanitizeMultipartHeaderValue`: strip CR/LF, replace `"`/`\`) before `Content-Disposition` lines — blocks multipart/header injection (2026-06-11) | `audio/transcriber.ts` |
-| API key protection | `redactSecrets()` — **single source of truth** scrubbing keys from error messages/console; covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Gemini `AIza`. Password-masked inputs; keys live only in gitignored `data.json` | `shared/redact.ts` (used by `ai-client.ts` + `api-utils.ts`) |
+| API key protection | `redactSecrets()` — **single source of truth** scrubbing keys from error messages/console on **every error path**; covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Gemini `AIza`. Password-masked inputs; keys live only in gitignored `data.json` | `shared/redact.ts` (used by `ai-client.ts`, `credential-validator.ts`, and all of `notifications.ts` — `error`/`notifyError`/operation-error `console.error`) |
 | Frontmatter safety | Key validation regex + forbidden keys blocklist | `enrichment/enrichment-applier.ts` |
 | Network security | Ollama HTTPS required (HTTP for localhost only), 2min timeouts | `shared/ai-client.ts` |
 | Credential validation | Live key probe is one minimal authenticated GET; result is **ephemeral** (never persisted) and routed through `redactSecrets` so an echoed key can't reach the status chip | `shared/credential-validator.ts`, `shared/provider-metadata.ts` |
@@ -873,7 +888,7 @@ Path exclusion is centralized (#307): the per-module `excludeFolders` fields wer
 | Prototype pollution | `deepMerge` skips `__proto__`, `constructor`, `prototype` keys | `main.ts` |
 | Lifecycle hygiene | `NotificationManager.dispose()` tears down in-flight ellipsis timers + hides notices on unload (no orphaned `setInterval`) | `shared/notifications.ts`, `main.ts:onunload()` |
 
-**Audit status:** The full audit (2026-06-08) found no critical or high vulnerabilities. The 2026-06-11 re-audit added two defense-in-depth hardenings — canonical secret redaction (now covering Gemini `AIza` keys everywhere) and multipart header-injection hardening. The 2026-06-20 audit pass re-verified architecture, security, and Obsidian-guideline compliance as clean; its one fix was a lifecycle leak (in-flight notification ellipsis timers now torn down on unload). `data.json` (live API keys) is gitignored and never committed.
+**Audit status:** The full audit (2026-06-08) found no critical or high vulnerabilities. The 2026-06-11 re-audit added two defense-in-depth hardenings — canonical secret redaction (now covering Gemini `AIza` keys everywhere) and multipart header-injection hardening. The 2026-06-20 audit pass re-verified architecture, security, and Obsidian-guideline compliance as clean; its one fix was a lifecycle leak (in-flight notification ellipsis timers now torn down on unload). The 2026-06-25 audit pass (v1.0.6) brought the per-operation error `console.error` under `redactSecrets`, so the single redaction source now guards **every** error sink in `notifications.ts`. `data.json` (live API keys) is gitignored and never committed.
 
 **Known posture / not-yet-enforced:**
 - `ensureWithinVault()` exists in `shared/validation.ts` but is **not yet wired into write paths** — there is no active vault-boundary enforcement on writes today.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,155 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-06-25: Audit pass (1.0.6) — redaction now guards the operation-error console sink; command-name normalization
+
+**Context**: A periodic codebase audit reviewed the plugin at version 1.0.6. The module graph is still acyclic and the code security-mature, but two small gaps surfaced. (1) `NotificationManager` routed three error sinks through `redactSecrets` — the `error()` toast, `notifyError`, and `showErrorNotice` — but the per-*operation* failure path still did a raw `console.error(message)`. That was the one remaining spot where an API key echoed into an operation error could reach the console unredacted. (2) One command name broke the all-lowercase palette convention ("REM: **D**iscover links in current note").
+
+**Decision**: Route the operation-error `console.error` through `redactSecrets` too, so *every* error sink in `notifications.ts` shares the single redaction source. Normalize the command to "REM: discover links in current note". Refresh all 18 machine-readable `AGENTS.md` files and these human docs against the live code.
+
+**Alternatives considered**:
+- **Leave the console log raw ("it's just a log")** — rejected; logs get copied into bug reports, so a redacted toast beside a raw console line defeats the purpose.
+- **Tolerate the mixed-case command name** — rejected; the palette reads as inconsistent, and the registry is the place to keep names uniform.
+
+**Rationale**: `redact.ts` is the single source of truth only if it actually covers every path; the operation-error console was the last hole. The wording fix is cosmetic but keeps the registry authoritative.
+
+**Impact**: `shared/notifications.ts` (+ `notifications.test.ts`), `commands/registry.ts`. No behavior change beyond redaction coverage and palette wording. `data.json` (live keys) remains gitignored; the audit otherwise found no critical/high security issues.
+
+---
+
+## 2026-06-25: REM semantic matching is always-on; literal title/alias matches are down-weighted (#380)
+
+**Context**: REM gated AI semantic matching behind a toggle most users never enabled, so the feature mostly produced only literal title/alias matches — and those literal matches (raw confidence 1.0) out-ranked everything, crowding out the content-relevant links semantic matching is *for*.
+
+**Decision**: Make semantic matching **always run** (drop the enable toggle) and add `titleMatchWeight` (default `0.6`) that multiplies the raw confidence of literal title/alias matches so they no longer automatically dominate the ranking. Candidates from both phases merge, re-rank by confidence, and cap at `maxLinksPerNote`; `confidenceThreshold` now filters *semantic* matches only. Resume re-runs the same gather pipeline, so resumed items also get semantic links.
+
+**Alternatives considered**:
+- **Keep the toggle but default it on** — rejected; a setting people never find isn't a real default, and the literal-match ranking problem would remain.
+- **Surface `titleMatchWeight` in the settings UI** — deferred; left as a `data.json`-only knob rather than ship an obscure slider most users won't tune.
+
+**Rationale**: REM's value is the non-obvious links. Gating that behind a toggle and then out-ranking it with literal matches buried the whole feature.
+
+**Impact**: `rem/` (`SemanticMatcher` always invoked; weight applied during gather/re-rank); new `rem.titleMatchWeight` setting (no UI). REM auto-accept still **rewrites the note body** — the long-standing caution is unchanged.
+
+---
+
+## 2026-06-25: Note title as an elaboration signal + anti-fabrication guards (#387, #380)
+
+**Context**: Elaboration generated from body text alone. A near-empty note with a meaningful title ("Photosynthesis") produced weak proposals, while a note that is essentially just a URL or a date-named daily note risked the AI fabricating content from a slug.
+
+**Decision**: Surface the note title in every elaboration prompt (`Note title: "<basename>"`) and seed a title-only proposal when the body is empty. Add two **anti-fabrication guards** that return `null` (skip the note, create no proposal) rather than invent content:
+- **Guard A** — empty body **and** a generic title (Obsidian "Untitled", date-style daily-note names, bare URLs), detected via the shared `isGenericTitle` predicate.
+- **Guard B** — a link-dominated note where **every** external fetch returned nothing.
+
+**Alternatives considered**:
+- **Always generate something** — rejected; fabricated elaboration on a date-named note is worse than no proposal.
+- **Re-implement "generic title" detection inside elaboration** — rejected; it reuses the shared `isGenericTitle`/`isUntitled` predicate (`shared/title-detector.ts`) so elaboration and the title module agree, honoring the no-feature-to-feature-import rule.
+
+**Rationale**: The title is the single most reliable topic hint for a stub note; the guards keep that signal from becoming a fabrication vector.
+
+**Impact**: `elaboration/proposer.ts` (title context + Guards A/B), shared `isGenericTitle`. `generate()` returning `null` is a normal skip, not an error — callers complete the checkpoint item and move on.
+
+---
+
+## 2026-06-25: In-app update check against the plugin's GitHub Releases (#365)
+
+**Context**: Synapse isn't in the Obsidian community browser yet, so there is no auto-update channel and users had no signal when a newer build shipped.
+
+**Decision**: Add a `shared/UpdateChecker` that — gated on `settings.updates.enableUpdateNotifications` (default on) — polls the plugin's own public GitHub Releases API **at most once per 24h**, compares the latest tag to the running version (`isNewerVersion`, pure semver), and shows a sticky, dismissible notice whose button opens Settings → Community plugins. It **fails silently** (offline / non-200 / malformed → logged `null`) and records the version it surfaced so it never nags twice for the same release.
+
+**Alternatives considered**:
+- **Check on every load** — rejected; network spam and rate-limit risk. The 24h gate plus dismissed-version memory keep it quiet.
+- **Wait for community-store distribution to provide updates** — rejected as the *only* answer; this is the stop-gap until that lands.
+
+**Rationale**: A once-a-day, self-silencing nudge is the least-annoying way to close the "no auto-update channel" gap.
+
+**Impact**: `shared/update-checker.ts`; new `settings.updates` block (`enableUpdateNotifications`, `lastUpdateCheck`, `dismissedUpdateVersion`); a delayed (5 s) startup timer in `main.ts`.
+
+---
+
+## 2026-06-25: In-app "What's new" via build-inlined CHANGELOG.md (#375)
+
+**Context**: Release notes lived only in `CHANGELOG.md` on GitHub; users never saw them in-app.
+
+**Decision**: Inline `CHANGELOG.md` into the bundle at build time (esbuild text loader + a `*.md` ambient type in `shared/markdown.d.ts`) and parse/render it in a `ChangelogModal` reachable from settings. One source file, no network fetch, no drift between the shipped changelog and what's displayed.
+
+**Alternatives considered**:
+- **Fetch the changelog from GitHub at runtime** — rejected; offline-fragile and redundant with a file already in the repo.
+- **Maintain a separate in-app copy of the notes** — rejected; guarantees drift.
+
+**Rationale**: The changelog is already the source of truth; inlining it at build time shows exactly what shipped with zero extra maintenance.
+
+**Impact**: `changelog.ts`, `changelog-modal.ts`, `shared/markdown.d.ts`; esbuild config. Purely additive UX.
+
+---
+
+## 2026-06-25: Auto-fold the Properties panel on note open (#381)
+
+**Context**: Synapse writes a lot of frontmatter (tags, links, references), so the Obsidian Properties panel can grow tall and push content down on every note.
+
+**Decision**: Add an opt-in `ui.autoFoldProperties` (default **off**) that folds a note's Properties panel — and its heading chevron — when the note opens, via `registerPropertiesAutoFold`. It lives in a new "General" settings section.
+
+**Alternatives considered**:
+- **Default it on** — rejected; folding is a personal preference, and silently hiding metadata the plugin just wrote would surprise users.
+
+**Rationale**: The feature exists *because* Synapse-heavy vaults accumulate properties; making it opt-in respects users who want metadata visible.
+
+**Impact**: `properties-fold.ts`; new `ui.autoFoldProperties` setting; new "General" settings section.
+
+---
+
+## 2026-06-25: Actionable video-dependency onboarding notice (#382)
+
+**Context**: When yt-dlp/ffmpeg were missing, video and URL-transcription paths failed with a generic error and no guidance on how to fix it.
+
+**Decision**: Detect the `DependencyMissingError` through the error `cause` chain and show an actionable notice with an "Open settings" button that reveals the Video settings section (where the tool paths live). Path fields also gained tooltips.
+
+**Rationale**: A missing external tool is a setup problem, not a bug; the notice should route the user straight to the fix instead of surfacing a dead-end error.
+
+**Impact**: `summarize/` (dependency-error detection + notice), settings-tab tooltips. No schema change.
+
+---
+
+## 2026-06-23: Summarize the note's own prose + combined-summary mode (#367)
+
+**Context**: Summarize only touched the URLs, transcriptions, and audio a note *referenced* — never the note's own writing — and emitted a separate callout per item, cluttering notes with many references.
+
+**Decision**: Add two toggles, **both default on**. `includeNoteContent` adds the note's own prose (frontmatter and previously-generated Synapse blocks stripped, so it never re-summarizes its own output) as an extra summarize target. `combineSummaries` folds all summarizable items into ONE "Combined summary (N items)" callout instead of one callout each. Both are honored by single-note summarize, the 2+-target selection modal, and vault/folder scans. Enrichment-reference targets stay per-item (they create notes + rewrite links).
+
+**Alternatives considered**:
+- **Always combine** — rejected; some users want a per-source callout, so it's a toggle.
+- **Summarize whatever's in the note, including prior summaries** — rejected; `extractNoteProse` strips Synapse-generated blocks to avoid a feedback loop where the AI re-summarizes its own output.
+
+**Rationale**: Summarizing a note's own content is the common ask, and one combined block reads far better on reference-heavy notes.
+
+**Impact**: `summarize/` (`extractNoteProse`, combined path, modal defaults); new `summarize.includeNoteContent` and `summarize.combineSummaries` settings.
+
+---
+
+## 2026-06-22: Error notices persist, copy-on-dismiss, softer color (1.0.6)
+
+**Context**: Error toasts auto-dismissed on the standard timer, so a user could miss the message, and the full (often long) error text wasn't recoverable. The error color also read as alarming for routine, recoverable failures.
+
+**Decision**: Error notices now **stay up until dismissed**; clicking one **copies its full (redacted) message to the clipboard** before it closes; and they use a **softer, less-alarming color**. Implemented in `NotificationManager.error()`/`notifyError()`.
+
+**Rationale**: A persistent, copyable error is far easier to act on or paste into a bug report; the softer color matches that these failures are usually recoverable.
+
+**Impact**: `shared/notifications.ts`, `styles.css`. The copied text routes through `redactSecrets`, so keys never reach the clipboard.
+
+---
+
+## 2026-06-20: On-brand icon system (1.0.5)
+
+**Context**: Synapse reused generic Obsidian/Lucide glyphs for its ribbon icons and actions, which diluted the brand and left the actions sidebar visually flat.
+
+**Decision**: Register a set of bespoke Synapse SVG icons (`brand-icons.ts`, `registerSynapseIcons()`) — an S-Signal identity mark plus per-feature glyphs — **before** any ribbon/`setIcon`/view use, and use them for all three ribbon icons, the Synapse Actions sidebar buttons, and per-action command-palette icons.
+
+**Rationale**: Custom marks make the plugin recognizable and give the actions sidebar a scannable, per-feature visual language.
+
+**Impact**: `brand-icons.ts` (`SYNAPSE_ICONS`, `SYNAPSE_ICON_SVG`); ribbon + actions-sidebar + palette icon wiring. No behavior change.
+
+---
+
 ## 2026-06-20: Notification timers torn down on unload; audit reaffirms the layering
 
 **Context**: A periodic codebase audit (architecture, security, and Obsidian-guideline compliance) reviewed the plugin at version 1.0.3. It found the code security-mature and the module graph acyclic, but surfaced one lifecycle leak: `NotificationManager` starts a 400 ms `setInterval` to animate the "…" ellipsis on every in-flight operation toast. If the plugin was disabled (or reloaded) while an operation was still running, that interval kept firing against a detached toast — an orphaned timer, exactly the class of leak Obsidian's reviewer guidelines call out.
@@ -205,6 +354,8 @@ This is the single sanctioned `no-var-requires` site; audio, video, and transcri
 **Rationale**: One function, one regex, one place to extend when a new provider key shape appears — and one set of regression tests instead of two partial ones. The drift that exposed Gemini keys becomes structurally impossible once both callers share the module.
 
 **Impact**: New `src/shared/redact.ts`. Redaction is now consistent across both surfaces and covers Gemini `AIza` keys everywhere. Behavior-preserving except that `notifyError` now also redacts Gemini keys. Regression tests added (`ai-client.test.ts`, `api-utils.test.ts`).
+
+> _Later (2026-06-25): `notifyError` moved into `notifications.ts`, and the per-operation error `console.error` sink was brought under the same redactor — so `redactSecrets` now covers **every** error path, not just the two original surfaces. See the 2026-06-25 audit entry at the top of this log._
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,9 @@
 # Project Status
 
-**Last updated**: 2026-06-20
-**Version**: 1.0.3
-**Branch**: `main`
-**Health**: Green — `tsc` clean, **1511/1511 tests passing (114 files)**, dependency graph acyclic, no critical/high security findings.
+**Last updated**: 2026-06-25
+**Version**: 1.0.6
+**Branch**: `chore/codebase-audit-2026-06-25`
+**Health**: Green — `tsc` clean, **1692/1692 tests passing (123 files)**, dependency graph acyclic, no critical/high security findings.
 
 > Snapshot only. Decision history lives in `DECISIONS.md`; architecture in `ARCHITECTURE.md`.
 
@@ -11,12 +11,13 @@
 
 ## At a Glance
 
-- **17 modules** under `src/` plus top-level `main.ts`, `settings.ts`, `settings-tab.ts`, and `onboarding.ts`.
+- **17 modules** under `src/` plus top-level `main.ts`, `settings.ts`, `settings-tab.ts`, `onboarding.ts`, `brand-icons.ts`, `changelog.ts`/`changelog-modal.ts`, and `properties-fold.ts`.
 - **Fire Synapse pipeline** runs features in order: elaboration → summarize → enrichment → REM → tidy → organize.
 - **Intake folder** auto-processes dropped notes/URLs through that same pipeline.
-- All AI output is reviewed in one **unified proposal sidebar**; per-feature **auto-accept** (#228) is available and defaults off.
-- A second **Synapse actions sidebar** (#289) gives mobile users touch-friendly buttons for every enabled command.
-- **Path exclusions** are centralized in one `exclusions` list (#307); **first-run onboarding** (#89) and **guided key validation** (#335) ease setup.
+- All AI output is reviewed in one **unified proposal sidebar**; per-feature **auto-accept** (#228) is available and defaults off. A second **Synapse actions sidebar** (#289) gives touch-friendly buttons for every enabled command.
+- **REM** now runs semantic matching **always-on**, down-weighting literal title matches (#380); **elaboration** uses the note title as a signal with anti-fabrication guards (#387).
+- **Summarize** can include a note's own prose and emit one combined summary (#367, both default on).
+- An **in-app update check** (#365) and a **"What's new" changelog modal** (#375) keep users current; **on-brand icons** appear throughout (1.0.5).
 
 ---
 
@@ -24,32 +25,32 @@
 
 | Module | Path | Role | Status |
 |--------|------|------|--------|
-| elaboration | `src/elaboration/` | Detect stub notes, propose content (image-aware) | Working |
+| elaboration | `src/elaboration/` | Detect stubs, propose content (image-aware); title signal + anti-fabrication guards (#387) | Working |
 | audio | `src/audio/` | Transcribe audio (Whisper / Deepgram / Gemini); auto-lyrics (#234) | Working (local-whisper not impl.) |
-| video | `src/video/` | Download + transcribe YouTube/TikTok/Instagram | Working (desktop only; local file + frames not impl.) |
+| video | `src/video/` | Download + transcribe YouTube/TikTok/Instagram; dependency onboarding notice (#382) | Working (desktop only; local file + frames not impl.) |
 | image | `src/image/` | OCR via vision models, auto-downscale, batch + checkpoints | Working |
 | transcription | `src/transcription/` | Unified transcription/OCR UI + time-range clipping | Working (desktop-only clipping) |
 | enrichment | `src/enrichment/` | Tags, links, refs, frontmatter | Working |
-| summarize | `src/summarize/` | URL + transcription summaries, content templates | Working |
+| summarize | `src/summarize/` | URL/transcription/audio + note prose; per-item or combined (#367) | Working |
 | tidy | `src/tidy/` | Spelling/formatting fixes (+ undo) | Working |
 | organize | `src/organize/` | AI directory structuring, folder coalescing (#172) | Working |
 | deep-dive | `src/deep-dive/` | Recursive topic extraction + child notes | Working |
 | title | `src/title/` | Untitled/mismatch detection → rename | Working |
-| rem | `src/rem/` | In-place `[[wikilink]]` discovery | Working |
+| rem | `src/rem/` | In-place `[[wikilink]]` discovery; always-on semantic matching (#380) | Working |
 | intake | `src/intake/` | Watch folder, auto-process notes (#111) | Working (media branch stubbed, #112) |
 | pipeline | `src/pipeline/` | Fire Synapse ordered multi-phase runner | Working |
 | commands | `src/commands/` | Command registry + registrar + drift audit | Working |
-| shared | `src/shared/` | AIClient, validation, checkpoints, callouts, URL detection, exclusions, node-loader, credential validation | Working (base layer) |
+| shared | `src/shared/` | AIClient, validation, checkpoints, callouts, URL detection, exclusions, node-loader, credential validation, secret redaction, update checker | Working (base layer) |
 | views | `src/views/` | Unified proposal sidebar + Synapse actions sidebar | Working |
 
-Top-level `onboarding.ts` is a small pure module powering the first-run welcome (#89).
+Top-level helpers: `onboarding.ts` (first-run welcome, #89), `brand-icons.ts` (Synapse SVG icons), `changelog.ts`/`changelog-modal.ts` ("What's new" modal, #375), `properties-fold.ts` (auto-fold Properties, #381).
 
 ---
 
 ## Current Focus
 
-- **Codebase audit (2026-06-20)** — architecture, security, and Obsidian-guideline compliance verified clean. The graph is acyclic and the code is security-mature; the one fix was a lifecycle leak: in-flight notification ellipsis timers are now torn down on unload via `NotificationManager.dispose()`. Companion hygiene: barrel-import normalization, `.gitignore` credential hardening, and a refresh of the machine-readable `AGENTS.md` docs.
-- **Recent feature work (1.0.x)**: centralized path exclusions + migration (#307); guarded desktop-only Node loader (#299); Synapse actions sidebar for mobile (#289); first-run onboarding (#89); guided API-key validation, OAuth deferred (#335); transcription credentials hoisted to AI Configuration (#332); content-type registry + lyrics auto-format (#233/#234); "Review" action on proposal toasts (#340); semantic theme color tokens (#342).
+- **Codebase audit (2026-06-25)** — refreshed all 18 `AGENTS.md` files and these human docs against the live code. Two small fixes: secret redaction now also guards the per-operation error `console.error` sink (so the single redaction source covers *every* error path in `notifications.ts`), and one command name was normalized for palette consistency. `tsc` clean, 1692 tests green, graph acyclic, no critical/high security findings.
+- **Recent feature work (1.0.4–1.0.6 and since)**: combined / note-content summaries (#367); in-app update check (#365); "What's new" changelog modal (#375); auto-fold Properties (#381); video-dependency onboarding notice (#382); always-on REM semantic matching (#380); elaboration title signal + anti-fabrication guards (#387); persistent copy-on-dismiss error notices + softer color (1.0.6); on-brand icon system (1.0.5).
 
 ---
 
@@ -58,12 +59,11 @@ Top-level `onboarding.ts` is a small pure module powering the first-run welcome 
 - The full audit found **no critical or high vulnerabilities**; the codebase is security-mature.
 - API keys live in `data.json`, which is **gitignored and never committed** — no secrets in the repo.
 - Subprocess calls use `execFile` with argument arrays (no shell); API auth is header-based and HTTPS-only; AI responses are sanitized before being written to notes.
-- Secret redaction has a single source of truth (`shared/redact.ts`), used by the AI client and `api-utils:notifyError` — covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Google `AIza` keys.
+- Secret redaction has a single source of truth (`shared/redact.ts`), now used on **every error path** — the AI client, credential validation, and all of `notifications.ts` (the error toast, `notifyError`, and the per-operation error `console.error`). Covers OpenAI/Anthropic `sk-`, `key-`, Deepgram `dg-`, `Bearer`/`Token`, `anthropic-`, and Google `AIza` keys.
 - Credential validation (#335) probes each provider with one minimal GET; results route through redaction and are **ephemeral** (never persisted).
-- Multipart Whisper upload bodies sanitize vault-derived field/file names (`sanitizeMultipartHeaderValue`) to block header/multipart injection; Gemini audio places its instruction in `system_instruction` (prompt-injection hardening).
-- Desktop-only Node access is gated behind `assertDesktop()`/`loadNodeModules()` (`shared/node-loader.ts`), keeping `isDesktopOnly: false` mobile-safe.
-- Notification ellipsis timers are now torn down on unload (no orphaned `setInterval` after disable/reload).
-- **Accepted risk**: `sanitizeUrl` permits arbitrary hosts (an SSRF surface on user-supplied URLs) — accepted because URLs are author-supplied within the user's own vault.
+- Multipart Whisper bodies sanitize vault-derived field/file names (`sanitizeMultipartHeaderValue`); Gemini audio places its instruction in `system_instruction` (prompt-injection hardening).
+- Desktop-only Node access is gated behind `assertDesktop()`/`loadNodeModules()` (`shared/node-loader.ts`), keeping `isDesktopOnly: false` mobile-safe. Notification ellipsis timers are torn down on unload.
+- **Accepted risk**: `sanitizeUrl` permits arbitrary hosts (an SSRF surface) — accepted because URLs are author-supplied within the user's own vault.
 - **Not yet wired**: an `ensureWithinVault` helper exists but is **not** yet enforced on write paths.
 
 ---
@@ -80,6 +80,7 @@ Top-level `onboarding.ts` is a small pure module powering the first-run welcome 
 | Ribbon icons always visible | Low | Obsidian has no `removeRibbonIcon` API |
 | Image checkpoint resume is a no-op | Low | Discards + asks user to re-run (same as deep-dive) |
 | `audio → video` type-only back-edge | Low | No runtime cycle; cleanup = move `AudioExtractor` into `shared/` |
+| `rem.titleMatchWeight` has no UI | Low | Edit `data.json` to change (#380) |
 
 ---
 
@@ -104,5 +105,5 @@ No npm runtime dependencies.
 |---------|---------|
 | `npm run dev` | esbuild watch (development) |
 | `npm run build` | `tsc -noEmit -skipLibCheck` + esbuild production bundle |
-| `npm test` | Vitest — **1511/1511 passing** (114 files) |
+| `npm test` | Vitest — **1692/1692 passing** (123 files) |
 | `npm run test:coverage` | Vitest with coverage |

--- a/src/audio/AGENTS.md
+++ b/src/audio/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Audio Module
@@ -8,7 +8,7 @@ Transcribes audio files from the vault using configurable providers (Whisper API
 
 ## Public API
 
-Barrel (`index.ts`) re-exports: `AudioModule`, `findAudioEmbeds`, `AUDIO_EXTENSIONS`, `AUDIO_EMBED_REGEX`, and types `AudioEmbed`, `TranscribeOptions`, `TranscriptionResult`, `TimestampEntry`. `transcriber.ts` symbols below are module-internal (reached via `audio/transcriber`, not the barrel) and consumed by tests + `transcription-credentials.ts`.
+Barrel (`index.ts`) re-exports: `AudioModule`, `renderAudioSettings`, `findAudioEmbeds`, `AUDIO_EXTENSIONS`, `AUDIO_EMBED_REGEX`, and types `AudioEmbed`, `TranscribeOptions`, `TranscriptionResult`, `TimestampEntry`. `transcriber.ts` symbols below are module-internal (reached via `audio/transcriber`, not the barrel) and consumed by tests + `transcription-credentials.ts`.
 
 ```ts
 class AudioModule {
@@ -19,11 +19,11 @@ class AudioModule {
   transcribe(audioData: ArrayBuffer, fileName: string, options?: TranscribeOptions): Promise<TranscriptionResult>
   transcribeFileToActiveNote(file: TFile, timeRange?: TimeRange): Promise<void>
   transcribeAndInsert(noteFile: TFile, embeds: AudioEmbed[]): Promise<void>
-  transcribeAndInsertCombined(noteFile: TFile, embeds: AudioEmbed[]): Promise<void>   // #214; <2 embeds falls back to transcribeAndInsert
-  transcribeAudioCombined(files: TFile[]): Promise<string>                            // #214; concat (ffmpeg) or sequential fallback -> combined text
+  transcribeAndInsertCombined(noteFile: TFile, embeds: AudioEmbed[]): Promise<void>   // #214; <2 embeds falls back to transcribeAndInsert; ffmpeg concat (desktop) or per-file text merge (mobile) -> one combined callout
   onTranscriptionComplete: ((filePath: string) => void) | null
 }
 
+function renderAudioSettings(ctx: SettingsSectionContext): void   // settings UI; from settings-section.ts
 function findAudioEmbeds(content: string, sourcePath: string, metadataCache: MetadataCache): AudioEmbed[]
 
 // transcriber.ts (module-internal: imported directly, NOT via the barrel)
@@ -47,6 +47,8 @@ interface TranscriptionResult {
   duration?: number
   sourceName: string
   timestamps?: TimestampEntry[]
+  reformatted?: boolean   // #234; true when a content schema (e.g. lyrics) reformatted the transcript
+  schemaId?: string       // #234; id of the schema that reformatted (e.g. 'lyrics')
 }
 
 interface TimestampEntry { start: number; end: number; text: string }
@@ -105,26 +107,38 @@ interface AudioEmbed { fileName: string; file: TFile; line: number }
 
 ## Note Scanning
 
-`findAudioEmbeds(content, sourcePath, metadataCache)` in `note-scanner.ts`:
-- Regex: `![[*.mp3|wav|m4a|ogg|flac|webm|aac]]`
-- Resolves files via `metadataCache.getFirstLinkpathDest()`
-- Skips embeds with existing transcription callout below (checks 3 lines)
+`findAudioEmbeds(content, sourcePath, metadataCache)` in `note-scanner.ts:L8`:
+- Regex `AUDIO_EMBED_REGEX`: `![[*.mp3|wav|m4a|ogg|flac|webm|aac]]`
+- Resolves files via `metadataCache.getFirstLinkpathDest()`; only `TFile` matches passing `AUDIO_EXTENSIONS` are kept
+- Skips embeds already transcribed via `hasTranscriptionBelow` (`note-scanner.ts:L38`): scans lines `embedLine+1..+3` for the legacy `**Transcription of X**`, the `[!synapse-transcription]` callout, or the `[!...lyrics]` callout `Lyrics of X` (#234)
 - Returns `AudioEmbed[]` with file references and line numbers
 
 ## Settings Keys
 
-All under `settings.audio`:
+All under `settings.audio` (interface `AudioSettings`, `settings.ts:L79`; defaults `settings.ts:L367`):
 
-| Key | Controls |
-|-----|----------|
-| `transcriptionProvider` | Backend: `whisper-api` \| `deepgram` \| `gemini` \| `local-whisper` |
-| `whisperApiKey` | Dedicated OpenAI key (fallback: `ai.apiKey`) |
-| `deepgramApiKey` | Deepgram API key |
-| `geminiApiKey` | Dedicated Gemini key (fallback: `ai.apiKey`) |
-| `whisperModel` | Whisper model name |
-| `language` | Language hint |
-| `autoFormatLyrics` | Auto-detect song transcripts and reformat as structured lyrics (#234); default `true` |
-| `postProcessing.*` | AI cleanup flags |
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `enabled` | boolean | `true` | Feature toggle for the audio module |
+| `transcriptionProvider` | `'whisper-api' \| 'deepgram' \| 'gemini' \| 'local-whisper'` | `'whisper-api'` | Transcription backend (routed in `transcriber.ts:L270`) |
+| `whisperApiKey` | string | `''` | Dedicated OpenAI key (fallback: `ai.apiKey`, `transcriber.ts:L287`) |
+| `deepgramApiKey` | string | `''` | Deepgram API key (no fallback) |
+| `geminiApiKey` | string | `''` | Dedicated Gemini key (fallback: `ai.apiKey`, `transcriber.ts:L392`) |
+| `whisperModel` | string | `'whisper-1'` | Whisper model name (multipart `model` field) |
+| `localWhisperPath` | string | `''` | Reserved for `local-whisper` CLI path (provider not implemented) |
+| `language` | string | `''` | Language hint; empty = auto-detect |
+| `autoFormatLyrics` | boolean | `true` | Auto-detect song transcripts and reformat as structured lyrics (#234) |
+| `postProcessing` | `PostProcessingSettings` | see below | AI transcript cleanup block (`settings.ts:L71`) |
+
+`postProcessing` (`PostProcessingSettings`, `settings.ts:L71`), consumed by `post-processor.ts`:
+
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `postProcessing.enabled` | boolean | `true` | Master switch; off returns the raw transcript unchanged |
+| `postProcessing.removeFiller` | boolean | `true` | Strip filler words / false starts |
+| `postProcessing.addStructure` | boolean | `true` | Add punctuation, paragraph breaks, headers |
+| `postProcessing.extractKeyPoints` | boolean | `false` | Prepend a "Key Points" summary section |
+| `postProcessing.customPrompt` | string | `''` | Extra instruction appended to the cleanup prompt |
 
 Path exclusion: write paths gate on the centralized `settings.exclusions` (#307) via `isPathExcluded(path, 'audio', settings)` (batch insert = silent skip; single-file = `findMatchingRule` Notice). No per-module `excludeFolders`/`excludeTags`.
 

--- a/src/commands/AGENTS.md
+++ b/src/commands/AGENTS.md
@@ -1,53 +1,60 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Commands Module
 
-Declarative command registry: the developer-facing source of truth for every user-invocable Synapse command, plus the registrar that gates and wires handlers to Obsidian and a drift auditor. Depends on nothing else in `src/` — never participates in an import cycle.
+Declarative command registry: the developer-facing source of truth for every user-invocable Synapse command, plus the registrar that gates and wires handlers to Obsidian, an icon-name contract, and a drift auditor. Depends on nothing else in `src/` — never participates in an import cycle.
 
 ## Public API
 
-Exported from `index.ts`:
+Barrel re-exports from `index.ts` (`index.ts:L14`). Note: `buildPipelineKeyMap` is exported from `registry.ts` but NOT re-exported through the barrel (test-only).
 
 ```ts
 // types.ts
-type CommandStatus = 'active' | 'deprecated' | 'disabled'   // only 'active' registers/runs
-type CommandFlow = 'palette' | 'fire-synapse' | 'startup'
-type CommandContext = 'note' | 'vault' | 'global'           // runtime env; drives per-note gating in actions sidebar
+type CommandStatus = 'active' | 'deprecated' | 'disabled'   // only 'active' registers/runs   (types.ts:L11)
+type CommandFlow = 'palette' | 'fire-synapse' | 'startup'                                       // (types.ts:L14)
+type CommandContext = 'note' | 'vault' | 'global'           // runtime env; drives sidebar gating (types.ts:L25)
 type FeatureKey = 'main' | 'elaboration' | 'enrichment' | 'organize' | 'deep-dive'
-                | 'summarize' | 'tidy' | 'rem' | 'video'
-interface CommandDefinition {
-  id: string                       // command id WITHOUT plugin prefix, e.g. 'scan-vault' (Obsidian prepends -> 'synapse:scan-vault')
-  name: string                     // palette display name
+               | 'summarize' | 'tidy' | 'rem' | 'video'                                          // (types.ts:L28)
+
+interface CommandDefinition {                                                                   // (types.ts:L40)
+  id: string                       // command id WITHOUT plugin prefix, e.g. 'scan-vault' (Obsidian -> 'synapse:scan-vault')
+  name: string                     // command-palette display name
   feature: FeatureKey
   status: CommandStatus
   flows: readonly CommandFlow[]
   context: CommandContext          // required: 'note' | 'vault' | 'global'
+  icon?: string                    // addIcon glyph name overriding FEATURE_ICONS[feature]; main entries set it
   pipelineKey?: string             // links to a PipelineModuleKey; typed string to avoid pipeline import cycle
-  note?: string
+  note?: string                    // free-form developer note
 }
 
-// actions.ts
-function listPaletteActions(registered: ReadonlySet<string>): CommandDefinition[]   // registry entries whose id passed the full register() gate, in registry order
-
 // registry.ts
-const COMMAND_REGISTRY: readonly CommandDefinition[]
-const REGISTRY_BY_ID: ReadonlyMap<string, CommandDefinition>
-const REGISTRY_BY_PIPELINE_KEY: ReadonlyMap<string, CommandDefinition>   // 1:1, throws on dup pipelineKey
-function isInFlow(id: string, flow: CommandFlow): boolean                // exists && active && in flow
-function isPipelineKeyInFlow(pipelineKey: string, flow: CommandFlow): boolean  // fail-OPEN on unmapped key
+const COMMAND_REGISTRY: readonly CommandDefinition[]                                             // (registry.ts:L15)
+const REGISTRY_BY_ID: ReadonlyMap<string, CommandDefinition>                                     // (registry.ts:L70)
+function buildPipelineKeyMap(commands: readonly CommandDefinition[]): Map<string, CommandDefinition>  // throws on dup pipelineKey (registry.ts:L78)
+const REGISTRY_BY_PIPELINE_KEY: ReadonlyMap<string, CommandDefinition>   // 1:1, built via buildPipelineKeyMap (registry.ts:L93)
+function isInFlow(id: string, flow: CommandFlow): boolean                // exists && active && in flow (registry.ts:L97)
+function isPipelineKeyInFlow(pipelineKey: string, flow: CommandFlow): boolean  // fail-OPEN on unmapped key (registry.ts:L107)
+
+// icons.ts
+const FEATURE_ICONS: Record<FeatureKey, string>     // default glyph name per feature; build fails if a key is missing (icons.ts:L26)
+function resolveActionIcon(def: CommandDefinition): string   // def.icon ?? FEATURE_ICONS[def.feature] (icons.ts:L44)
+
+// actions.ts
+function listPaletteActions(registered: ReadonlySet<string>): CommandDefinition[]   // registry entries that passed register()'s gate, in registry order (actions.ts:L22)
 
 // registrar.ts
-class CommandRegistrar {
+class CommandRegistrar {                                                                         // (registrar.ts:L22)
   constructor(host: { addCommand: (command: Command) => unknown })
-  register(id: string, userEnabled: boolean, spec: Omit<Command, 'id' | 'name'>): void
-  getAttempted(): ReadonlySet<string>
-  getRegistered(): ReadonlySet<string>
+  register(id: string, userEnabled: boolean, spec: Omit<Command, 'id' | 'name'>): void   // (registrar.ts:L38)
+  getAttempted(): ReadonlySet<string>                                                     // (registrar.ts:L61)
+  getRegistered(): ReadonlySet<string>                                                    // (registrar.ts:L66)
 }
 
 // audit.ts
-function auditCommands(attempted: ReadonlySet<string>): string[]   // drift warnings; empty when consistent
+function auditCommands(attempted: ReadonlySet<string>): string[]   // drift warnings; empty when consistent (audit.ts:L27)
 ```
 
 ## File Inventory
@@ -56,21 +63,26 @@ function auditCommands(attempted: ReadonlySet<string>): string[]   // drift warn
 |------|---------|---------|
 | `types.ts` | `CommandStatus`, `CommandFlow`, `CommandContext`, `FeatureKey`, `CommandDefinition` | Registry type model |
 | `registry.ts` | `COMMAND_REGISTRY`, `REGISTRY_BY_ID`, `REGISTRY_BY_PIPELINE_KEY`, `isInFlow`, `isPipelineKeyInFlow`, `buildPipelineKeyMap` | Source-of-truth registry + flow gates |
+| `icons.ts` | `FEATURE_ICONS`, `resolveActionIcon` | Icon-name contract; default feature glyph + per-action override resolution (no `addIcon` here) |
 | `registrar.ts` | `CommandRegistrar` | Single wiring point to `plugin.addCommand`; gates by status + palette flow + userEnabled |
-| `actions.ts` | `listPaletteActions` | Derives the Synapse actions sidebar's button list from the registry + `getRegistered()` (no hand-maintained list) |
+| `actions.ts` | `listPaletteActions` | Derives the Synapse actions sidebar button list from the registry + `getRegistered()` |
 | `audit.ts` | `auditCommands` | Drift detection between registry and wired handlers |
+| `index.ts` | re-exports | Barrel (omits `buildPipelineKeyMap`) |
 | `registry.test.ts`, `registrar.test.ts`, `actions.test.ts`, `audit.test.ts` | Tests | |
-| `index.ts` | re-exports | Barrel |
 
 ## Registration Gate
 
 ```
-CommandRegistrar.register(id, userEnabled, spec)
+CommandRegistrar.register(id, userEnabled, spec)              // registrar.ts:L38
   --> records id in `attempted`
-  --> entry = REGISTRY_BY_ID.get(id)
-  --> active   = entry ? entry.status === 'active' : true   (fail-open on unknown id)
-  --> inPalette= entry ? entry.flows.includes('palette') : true
-  --> if (active && inPalette && userEnabled) plugin.addCommand({id, name: entry?.name ?? id, ...spec}); record in `registered`
+  --> entry    = REGISTRY_BY_ID.get(id)
+  --> active   = entry ? entry.status === 'active'        : true   (fail-open on unknown id)
+  --> inPalette= entry ? entry.flows.includes('palette')  : true
+  --> if (active && inPalette && userEnabled):
+        name = entry ? entry.name : id                     // label sourced from registry, not the spec
+        icon = entry ? resolveActionIcon(entry) : undefined
+        host.addCommand({ id, name, ...(icon ? {icon} : {}), ...spec })   // caller-supplied spec.icon still wins
+        record id in `registered`
 ```
 
 Precedence (all ANDed, registry authoritative):
@@ -86,11 +98,44 @@ Precedence (all ANDed, registry authoritative):
 
 ## Drift Audit
 
-`auditCommands(attempted)` returns warnings for:
+`auditCommands(attempted)` (`audit.ts:L27`) returns warnings for:
 - (a) an `active` palette entry whose feature loaded (>=1 attempt) but was never registered — handler missing.
 - (b) a registered id with no `COMMAND_REGISTRY` entry — command in code, missing from registry.
 
-Run once at the end of `main.ts` `onload()` and reused by `registry`/`audit` tests so CI fails on drift.
+A fully disabled feature (onload never runs) produces zero attempts and so cannot be drift-checked. Run once at the end of `main.ts` `onload()` and reused by `registry`/`audit` tests so CI fails on drift.
+
+## Command Registry
+
+24 entries: 23 real (registered via `register()`) + 1 synthetic pipeline-only (`tidy-vault`, never registered). 6 ship `status: 'disabled'` as a developer master switch and are gated out of registration. Source: `registry.ts:L15`. All palette entries omit an explicit `icon` and inherit `FEATURE_ICONS[feature]` except the 5 `main` entries (icons: `review-proposals`=synapse, `manage-checkpoints`=synapse-checkpoints, `transcribe-media`=synapse-transcribe, `transcribe-note-media`=synapse-transcribe, `fire`=synapse-fire).
+
+| id | name | feature | status | flows | context | pipelineKey |
+|----|------|---------|--------|-------|---------|-------------|
+| `review-proposals` | Open proposal review sidebar | main | active | palette | global | — |
+| `manage-checkpoints` | Manage interrupted operations | main | active | palette | global | — |
+| `transcribe-media` | Transcribe media | main | disabled | palette | global | — |
+| `transcribe-note-media` | Transcribe current note | main | active | palette | note | — |
+| `fire` | Run all features on a folder | main | active | palette | vault | — |
+| `scan-vault` | Scan folder for stub notes | elaboration | active | palette, fire-synapse, startup | vault | elaboration |
+| `scan-current-note` | Elaborate current note | elaboration | active | palette | note | — |
+| `clear-proposals` | Clear all pending proposals | elaboration | disabled | palette | global | — |
+| `enrich-current-note` | Enrich current note | enrichment | active | palette | note | — |
+| `scan-vault-enrichment` | Scan folder for enrichment | enrichment | active | palette, fire-synapse | vault | enrichment |
+| `undo-enrichment` | Undo last enrichment on current note | enrichment | disabled | palette | note | — |
+| `organize-current-note` | Organize current note | organize | active | palette | note | — |
+| `scan-directory-organize` | Scan folder for organization | organize | active | palette, fire-synapse | vault | organize |
+| `undo-organize` | Undo last organize on current note | organize | disabled | palette | note | — |
+| `deep-dive` | Deep dive current note | deep-dive | active | palette | note | — |
+| `clear-deep-dive` | Clear deep dive proposals | deep-dive | disabled | palette | global | — |
+| `summarize-current-note` | Summarize current note | summarize | active | palette | note | — |
+| `scan-vault-summarize` | Scan folder for notes to summarize | summarize | active | palette, fire-synapse | vault | summarize |
+| `tidy-current-note` | Tidy current note | tidy | active | palette | note | — |
+| `undo-tidy` | Undo last tidy on current note | tidy | disabled | palette | note | — |
+| `rem-current-note` | REM: discover links in current note | rem | active | palette | note | — |
+| `rem-directory` | Scan folder for links | rem | active | palette, fire-synapse | vault | rem |
+| `check-dependencies` | Check external tool availability | video | active | palette | global | — |
+| `tidy-vault` | Scan folder for notes to tidy | tidy | active | fire-synapse | vault | tidy |
+
+`tidy-vault` is synthetic: pipeline-only, never passed to `register()`. The pipeline runs `tidy.scanVault()` (vault-wide) under `pipelineKey: 'tidy'`, distinct from the `tidy-current-note` palette command which runs `tidy()` on one note. See `registry.ts:L60`.
 
 ## Consumers
 
@@ -100,12 +145,6 @@ Run once at the end of `main.ts` `onload()` and reused by `registry`/`audit` tes
 | `isPipelineKeyInFlow` | `pipeline/synapse-runner.ts` |
 | `isInFlow` | `elaboration/index.ts` (startup flow gating) |
 | `auditCommands` | `main.ts` (end of onload) |
-| `listPaletteActions` | `main.ts` (Synapse actions sidebar factory) -> rendered by `views/synapse-actions-view.ts` |
+| `listPaletteActions` | `main.ts` (Synapse actions sidebar factory) -> `views/synapse-actions-view.ts` |
+| `resolveActionIcon` / `FEATURE_ICONS` | `registrar.ts` (palette command icons); Synapse actions sidebar |
 | `context` field | `views/synapse-actions-view.ts` (disables `note` buttons when no markdown note is active); `main.runCommand` re-activates the note leaf for `context: 'note'` commands |
-
-## Command Registry (active palette + pipeline)
-
-See root `AGENTS.md` Command Registry for the full table. `status: 'disabled'` entries
-(`transcribe-media`, `clear-proposals`, `undo-enrichment`, `undo-organize`, `clear-deep-dive`, `undo-tidy`)
-exist in the registry but are gated out of registration. `synapse:tidy-vault` is synthetic
-(pipeline-only, `pipelineKey: tidy`, flow `fire-synapse`) and never passed to `register()`.

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -51,7 +51,7 @@ export const COMMAND_REGISTRY: readonly CommandDefinition[] = [
 	{ id: 'undo-tidy', name: 'Undo last tidy on current note', feature: 'tidy', status: 'disabled', flows: ['palette'], context: 'note' },
 
 	// --- rem (src/rem/index.ts) ---
-	{ id: 'rem-current-note', name: 'REM: Discover links in current note', feature: 'rem', status: 'active', flows: ['palette'], context: 'note' },
+	{ id: 'rem-current-note', name: 'REM: discover links in current note', feature: 'rem', status: 'active', flows: ['palette'], context: 'note' },
 	{ id: 'rem-directory', name: 'Scan folder for links', feature: 'rem', status: 'active', flows: ['palette', 'fire-synapse'], context: 'vault', pipelineKey: 'rem' },
 
 	// --- video (src/video/index.ts) ---

--- a/src/deep-dive/AGENTS.md
+++ b/src/deep-dive/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # deep-dive module
 
-Recursively explores a note by extracting topics and generating child notes via AI. Uses quality scoring to control recursion depth. Generates a syllabus index and inter-note navigation. Supports checkpointed generation for resumability.
+Recursively explores a note by AI-extracting sub-topics and generating child notes, using a local quality score to bound recursion depth, and emitting a syllabus index plus inter-note navigation under a resumable checkpoint.
 
 ## Public API (`index.ts`)
 
@@ -47,9 +47,9 @@ function computeTraversalOrder(proposals: DeepDiveProposal[], run: DeepDiveRun):
 function buildNavigationContext(proposalId: string, nodes: TraversalNode[], run: DeepDiveRun, syllabusPath: string): NavigationContext | null
 function renderNavigationBlock(ctx: NavigationContext): string
 function renderSyllabusContent(nodes: TraversalNode[], run: DeepDiveRun): string
-function buildTreeFromNodes(nodes: TraversalNode[]): TreeNode[]
+function buildTreeFromNodes(nodes: TraversalNode[], rootTitle: string): TreeNode
 function syllabusTitle(rootNotePath: string): string
-function syllabusPath(rootNotePath: string, outputFolder: string): string
+function syllabusPath(rootNotePath: string, noteOutputFolder: string): string
 function injectNavigationBlock(content: string, navBlock: string): string
 ```
 
@@ -61,15 +61,17 @@ Re-exported settings renderer: `renderDeepDiveSettings` (from `./settings-sectio
 
 | File | Class/Function | Role |
 |------|---------------|------|
-| `index.ts` | `DeepDiveModule`, `buildDeepDivePath` | Module entry point and public API |
-| `topic-analyzer.ts` | `TopicAnalyzer` | AI topic extraction; checks vault for existing notes |
-| `note-generator.ts` | `NoteGenerator` | AI content generation for a topic given parent context |
-| `quality-scorer.ts` | `scoreQuality` | Local heuristic scoring: word count, child topics, overlap, genericity |
-| `syllabus-navigator.ts` | Navigation utilities | Traversal ordering, syllabus index, prev/next navigation blocks |
-| `deep-dive-store.ts` | `DeepDiveStore` | JSON persistence for proposals and runs |
-| `depth-selector-modal.ts` | `DepthSelectorModal`, `selectDepth`, `MIN_DEPTH`, `MAX_DEPTH` | Modal for user to select recursion depth (1-6) |
-| `settings-section.ts` | `renderDeepDiveSettings` | Settings UI renderer |
+| `index.ts` | `DeepDiveModule` (L51), `buildDeepDivePath` (L681) | Module entry point and public API |
+| `topic-analyzer.ts` | `TopicAnalyzer` (L10) | AI topic extraction; matches titles against included vault notes |
+| `note-generator.ts` | `NoteGenerator` (L8) | AI content generation for a topic given parent title+content |
+| `quality-scorer.ts` | `scoreQuality` (L30) | Local heuristic scoring: topic count, word count, genericity, overlap, depth decay |
+| `syllabus-navigator.ts` | navigation utilities (L50+) | Traversal ordering, syllabus index, prev/next navigation blocks |
+| `deep-dive-store.ts` | `DeepDiveStore` (L36) | JSON persistence for proposals and runs |
+| `depth-selector-modal.ts` | `DepthSelectorModal`, `selectDepth`, `MIN_DEPTH`, `MAX_DEPTH` (L4-5) | Modal for user to select recursion depth (1-6) |
+| `settings-section.ts` | `renderDeepDiveSettings` (L12) | Settings UI renderer (accordion key `deepDive`) |
 | `types.ts` | -- | All deep-dive types |
+
+`syllabus-navigator.ts` also exports `wikiLink` (L107) and `buildBreadcrumbs` (L115); these are internal helpers and are NOT re-exported through `index.ts`.
 
 ## Dependency on `organize` module
 
@@ -182,10 +184,19 @@ interface DeepDiveRun {
 
 ## Commands Registered
 
-| Command ID | Enabled When | Description |
-|------------|-------------|-------------|
-| `deep-dive` | `settings.deepDive.enabled` | Deep dive current note |
-| `clear-deep-dive` | `settings.deepDive.enabled` | Clear all deep dive proposals |
+Registered at runtime in `index.ts:92` and `index.ts:100` via `registrar.register(id, deepDive.enabled, ...)`. Declared with metadata in `commands/registry.ts:42-43`. Gate order: registry `status` (dev) -> flow membership (dev) -> `settings.deepDive.enabled` (user).
+
+| Command ID | Name (registry.ts) | Callback | Context | Registry status | Runtime gate |
+|------------|--------------------|----------|---------|-----------------|--------------|
+| `deep-dive` | Deep dive current note | editorCallback | note | active | `settings.deepDive.enabled` |
+| `clear-deep-dive` | Clear deep dive proposals | callback | global | disabled (dev kill switch) | `settings.deepDive.enabled` |
+
+## Callouts
+
+| Callout | Defined / used | Emitted by |
+|---------|----------------|-----------|
+| `synapse-nav` | `syllabus-navigator.ts:205` | `renderNavigationBlock`; injected at the top of each accepted note body and replaced on every nav refresh |
+| `synapse-deep-dive` | `shared/callouts.ts:17` (`CALLOUT_TYPES.deepDive`), command icon `commands/icons.ts:31` | registered callout type + command/brand icon; not written into note bodies by this module |
 
 ## Settings Keys
 
@@ -211,6 +222,23 @@ Path exclusion is centralized (#307): `settings.exclusions: ExclusionRule[]` con
 In: `shared/` (NotificationManager, readNote, writeNote, wordCount, CheckpointManager, generateId, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule, Checkpoint, CheckpointWorkItem, DeferredTask), `organize/` (ContentAnalyzer, DirectoryMatcher — auto-organize mode only), `settings.ts` (SynapseSettings, DeepDiveNestingMode), `commands.ts` (CommandRegistrar)
 
 Out: Nothing consumed by other feature modules.
+
+## Error States
+
+| Condition | Handling (index.ts) |
+|-----------|---------------------|
+| Note excluded by rule or excludeTag | `isExcluded` true -> info Notice naming the matched rule pattern; abort before any AI call (L233) |
+| Empty/unreadable note | info Notice "Could not read note content"; abort (L245) |
+| Topic extraction throws (Phase 1) | `scanOp.error(...)`; abort, no run created (L261) |
+| Zero topics found / all already in vault | `scanOp.finish('No topics found')` or info Notice; abort (L266, L277) |
+| Depth modal dismissed / user declines confirm | info Notice "Deep dive cancelled"; abort (L283, L294) |
+| Child topic extraction throws (per-node) | caught; `childTopics = []`, score from content alone, recursion stops for that branch (L409) |
+| User cancels mid-generation (`genOp.cancelled`) | run.status='cancelled', `checkpointManager.discard`, info Notice; partial proposals stay saved (L482) |
+| Generation loop throws | run.status='cancelled', `checkpointManager.discard`, `genOp.error(...)` (L509) |
+| `acceptProposal` on missing proposal | info Notice "Proposal not found"; no-op (L139) |
+| `acceptProposal` on non-pending proposal | silent no-op (double-accept guard) (L145) |
+| `acceptProposal` write failure | `notifyError`, then rethrows `Accept proposal failed: <msg>` (L173) |
+| auto-organize AI failure or top score < 0.6 | caught; falls back to `buildDeepDivePath` (nested) (L632, L637) |
 
 ## Invariants / Gotchas
 

--- a/src/elaboration/AGENTS.md
+++ b/src/elaboration/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Elaboration Module
 
-Detects stub/placeholder notes in the vault and generates AI-powered elaboration proposals for non-destructive review. Includes image analysis to enrich proposals with context from embedded images.
+Detects stub/placeholder notes, treats the note title as a topic signal, and generates AI-powered elaboration proposals for non-destructive review; includes image analysis and external-link context to enrich proposals.
 
 ## Public API
 
@@ -22,12 +22,12 @@ class ElaborationModule {
   )
   onload(): Promise<void>
   onunload(): void
+  getPendingProposals(): Promise<Proposal[]>
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
   scanNote(file: TFile, userInvoked?: boolean): Promise<void>
   acceptProposal(id: string, editedContent?: string, options?: { silent?: boolean }): Promise<void>
   rejectProposal(id: string): Promise<void>
-  getPendingProposals(): Promise<Proposal[]>
   onProposalAccepted: ((filePath: string) => void) | null
   onViewRefreshNeeded: (() => Promise<void>) | null
   onOpenProposalView: (() => void) | null
@@ -58,82 +58,108 @@ interface Proposal {
   imageAnalysis?: ImageAnalysis[]
 }
 
-// settings-section.ts (also exported from index.ts)
+// settings-section.ts (also re-exported from index.ts)
 function renderElaborationSettings(ctx: SettingsSectionContext): void
 ```
 
-`ImageAnalysis` and `ImageAnalyzer` are internal to `image-analyzer.ts` (not re-exported from `index.ts`).
+`DetectionReason`, `DetectionResult`, `Proposal` are re-exported from `index.ts` via `export type` (index.ts:L15). `ImageAnalysis` and `ImageAnalyzer` stay internal to `image-analyzer.ts` (not re-exported from `index.ts`). Proposals only ever set `insertionPoint: 'append'`; the other variants and `insertionTarget` exist on the type but are unused.
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
 | `types.ts` | `DetectionReason`, `DetectionResult`, `Proposal` | Type definitions |
-| `detector.ts` | `PlaceholderDetector` | Scans notes for stub signals; applies centralized path exclusions + per-module tag exclusion |
-| `proposer.ts` | `ProposalGenerator` | AI proposal generation; gathers linked-note context, image context, and external URL context |
-| `proposal-store.ts` | `ProposalStore` | CRUD for proposal JSON files in `.synapse/` storage |
-| `proposal-view.ts` | `ProposalReviewView`, `PROPOSAL_VIEW_TYPE` | Legacy sidebar view (not registered by `main.ts`) |
-| `proposal-modal.ts` | `ProposalDetailModal` | Legacy modal for editing proposals |
-| `image-analyzer.ts` | `ImageAnalyzer`, `ImageAnalysis`, `MAX_IMAGES_PER_NOTE` | Multi-modal AI image analysis for enriching elaboration proposals |
+| `index.ts` | `ElaborationModule`, type re-exports, `renderElaborationSettings` | Orchestrator: commands, scan flows, accept/reject, checkpoints, auto-accept |
+| `detector.ts` | `PlaceholderDetector` | Local stub detection; path + tag exclusions |
+| `proposer.ts` | `ProposalGenerator` | AI proposal generation; title/link/image/external context + anti-fabrication guards |
+| `proposal-store.ts` | `ProposalStore` | CRUD for proposal JSON in `elaboration.proposalFolderPath` (default `.synapse/proposals`) |
+| `image-analyzer.ts` | `ImageAnalyzer`, `ImageAnalysis`, `MAX_IMAGES_PER_NOTE` | Multi-modal image analysis for proposal context |
 | `settings-section.ts` | `renderElaborationSettings` | Settings accordion renderer |
-| `auto-accept.test.ts` | Tests | Auto-accept elaboration proposal tests |
-| `scan-note.test.ts` | Tests | `scanNote` integration tests |
-| `startup-flow.test.ts` | Tests | Startup scan + interval timer tests |
-| `proposer.test.ts` | Tests | `ProposalGenerator` tests |
-| `proposal-store.test.ts` | Tests | `ProposalStore` tests |
-| `settings-section.test.ts` | Tests | Settings section rendering tests |
-| `index.ts` | `ElaborationModule`, re-exports | Orchestrator, commands, scan intervals |
+| `proposal-view.ts` | `ProposalReviewView`, `PROPOSAL_VIEW_TYPE` | Legacy sidebar view (not registered by `main.ts`) |
+| `proposal-modal.ts` | `ProposalDetailModal` | Legacy proposal-edit modal |
+| `auto-accept.test.ts` | Tests | Auto-accept behavior |
+| `scan-note.test.ts` | Tests | `scanNote` integration |
+| `startup-flow.test.ts` | Tests | Startup scan + interval timer |
+| `proposer.test.ts` | Tests | `ProposalGenerator` (incl. title-guard) |
+| `image-analyzer.test.ts` | Tests | `ImageAnalyzer` |
+| `proposal-store.test.ts` | Tests | `ProposalStore` |
+| `settings-section.test.ts` | Tests | Settings rendering |
 
 ## Data Flow
 
 ```
-1. scanVault() / scanNote()
+1. scanVault(folderPath?, skipConfirmation?, onlyFile?) / scanNote(file, userInvoked=true)
    |
-2. PlaceholderDetector.detect(file)
-   |  Checks: word count, TODO markers, empty sections, sparse links
-   |  Filters: isPathExcluded('elaboration', settings), matchesExcludeTag(excludeTags)
+2. PlaceholderDetector.detect(file)  (detector.ts:L12)
+   |  Checks: TODO markers, empty sections, word count, sparse links
+   |  Excludes: isPathExcluded(path,'elaboration',settings), matchesExcludeTag(...)
    |  Returns: DetectionResult | null
+   |  scanNote(userInvoked) with no reasons -> synthetic { type:'user-requested' }
    |
-3. Two-phase confirmation (vault scan only):
-   |  Phase 1: lightweight detection (no API calls)
-   |  Phase 2: NotificationManager.confirm() snackbar
-   |  Phase 3: cancellable proposal generation
+3. Vault scan only -- two-phase confirm + checkpoint:
+   |  Phase 1: lightweight detection (no API)
+   |  Phase 2: notifications.confirm() snackbar (skipped when skipConfirmation)
+   |  Phase 3: checkpointed, cancellable generation
    |
-4. ProposalGenerator.generate(detection)
-   |  Gathers context from up to 5 linked notes (500 chars each)
-   |  Gathers image context via ImageAnalyzer (if image.enabled)
-   |  Gathers external URL context (Twitter/article fetching, up to 3 URLs)
-   |  AIClient.complete() with system prompt
-   |  stripCodeFences(sanitizeAIResponse()) on output
-   |  Returns: Proposal (status: 'pending')
+4. ProposalGenerator.generate(detection)  (proposer.ts:L27)
+   |  Guard A: empty body + isGenericTitle(basename) -> notify + return null (proposer.ts:L45)
+   |  Context: up to 5 linked notes (500 chars each) if proposal.includeSourceContext
+   |  Context: ImageAnalyzer if settings.image.enabled
+   |  Context: external URLs (<=3) -- tweet(500) / Reddit(2000) / article(2000); video hosts skipped
+   |  Guard B: attempted>0 && externalContext='' && isLinkDominated -> return null (proposer.ts:L76)
+   |  buildPrompt() always prepends `Note title: "<basename>"` (proposer.ts:L132)
+   |  AIClient.complete(prompt, systemPrompt)
+   |  proposedAdditions = stripCodeFences(sanitizeAIResponse(raw))
+   |  Returns: Proposal (status:'pending', insertionPoint:'append') | null
    |
-5. ProposalStore.save(proposal)
+5. ProposalStore.save(proposal) -> JSON file in proposalFolderPath
    |
-6. maybeAutoAccept(proposal) if shouldAutoAccept() === true
+6. maybeAutoAccept(proposal) when shouldAutoAccept() === true
    |
-7. onViewRefreshNeeded() --> main.refreshUnifiedView()
+7. onViewRefreshNeeded() -> main refreshes unified view
    |
-8. User action via UnifiedProposalView:
-   Accept --> sanitizeAIResponse(additions), buildCallout(CALLOUT_TYPES.elaboration), append
-   Reject --> status = 'rejected'
+8. User action (unified view / legacy modal):
+   Accept -> stripCodeFences(sanitizeAIResponse(additions)),
+             buildCallout(CALLOUT_TYPES.elaboration,'Elaboration',...),
+             vault.process(file, d => d.trimEnd()+'\n'+callout)  (index.ts:L410)
+   Reject -> status = 'rejected'
 ```
 
 ## Detection Rules
 
-| Rule | Setting | Logic |
-|------|---------|-------|
-| Short note | `elaboration.detection.minWordThreshold` | `wordCount(body) < threshold` |
-| TODO markers | `elaboration.detection.detectTodoMarkers` | Regex: `\bTODO\b`, `\bTBD\b`, `\bFIXME\b`, `\bPLACEHOLDER\b` |
-| Empty sections | `elaboration.detection.detectEmptySections` | Heading with no content before next same-or-higher heading |
-| Sparse links | `elaboration.detection.detectSparseLinks` | Inbound links AND word count below threshold |
+| Rule | Setting | Logic | Ref |
+|------|---------|-------|-----|
+| TODO markers | `detection.detectTodoMarkers` | Regex `\bTODO\b`, `\bTBD\b`, `\bFIXME\b`, `\bPLACEHOLDER\b` (last case-insensitive) | detector.ts:L66 |
+| Empty sections | `detection.detectEmptySections` | Heading with no body before next same/higher heading | detector.ts:L78 |
+| Short note | `detection.minWordThreshold` | `wordCount(body) < threshold` | detector.ts:L36 |
+| Sparse links | `detection.detectSparseLinks` | Inbound links exist AND `wordCount < threshold` | detector.ts:L41 |
+
+Body is analyzed with frontmatter stripped (detector.ts:L61). Inbound links resolved via `getIncludedMarkdownFiles(app,'elaboration',settings)`, which already honors path exclusions (detector.ts:L104).
+
+## Title Signal and Anti-Fabrication Guards (#380, #387)
+
+The note title is surfaced as context in every prompt (`Note title: "<basename>"`, proposer.ts:L132); an empty body seeds the proposal from the title alone rather than an empty block (proposer.ts:L135).
+
+Guard A (empty-body + generic title), proposer.ts:L45:
+
+```ts
+if (content.trim() === '' && isGenericTitle(noteFile.basename)) {
+  this.notifications.info(/* "<title>" has no content ... not specific enough ... */);
+  return null;
+}
+```
+
+`isGenericTitle` is imported from the `../shared` barrel (shared/index.ts:L116), which re-exports it from `shared/title-detector.ts:L69` -- not a local copy, and not from the `title/` feature module (dependency rules forbid feature-to-feature imports; `title/` re-exports `isUntitled` from the same shared source). `isGenericTitle(t) === isUntitled(t) || isDateStyleTitle(t) || isBareUrlTitle(t)` (title-detector.ts:L69-71). It returns true for Obsidian "Untitled" defaults, date-style daily-note names (e.g. `2026-06-25`, `YYYYMMDD`, `DD-MM-YYYY`), and bare URLs. A real title like "Photosynthesis" is not generic, so the title-led prompt still runs.
+
+Guard B (link-dominated note, all fetches failed), proposer.ts:L76: when the note is essentially just link(s) and every external fetch returned nothing, `generate()` returns null rather than fabricating from a URL slug. `isLinkDominated` strips URLs/markdown/wikilinks to visible text and checks `length < 10` (proposer.ts:L223). Both guards return `null`; callers skip the file without creating a proposal.
 
 ## Accept Behavior
 
-On accept, additions are sanitized via `stripCodeFences(sanitizeAIResponse())`, then wrapped in a `synapse-elaboration` callout via `buildCallout(CALLOUT_TYPES.elaboration, 'Elaboration', additions)` and appended to the note.
+On accept (index.ts:L389): no-op if `proposal.status !== 'pending'` (double-accept guard); additions sanitized via `stripCodeFences(sanitizeAIResponse(...))`, wrapped in a `synapse-elaboration` callout via `buildCallout(CALLOUT_TYPES.elaboration, 'Elaboration', ...)`, and appended with `vault.process(file, d => d.trimEnd() + '\n' + callout)`. Then `store.updateStatus(id,'accepted')` and `onProposalAccepted?.(sourceNotePath)`. `options.silent` suppresses the per-proposal Notice + refresh (used by batch auto-accept).
 
 ## Image Analysis
 
-`ImageAnalyzer` (`image-analyzer.ts`) uses multi-modal `AIClient.chat()` with `ContentBlock[]` to analyze images embedded in notes during proposal generation. Internal; not exported from `index.ts`.
+`ImageAnalyzer` (image-analyzer.ts) uses multi-modal `AIClient.chat()` with `ContentBlock[]`; internal, not exported from `index.ts`.
 
 ```ts
 class ImageAnalyzer {
@@ -144,66 +170,74 @@ class ImageAnalyzer {
 }
 
 interface ImageAnalysis {
-  reference: string       // Original embed reference
-  description: string     // AI-generated image description
-  locationHints: string   // Location clues from visual content
-  metadata: string        // Observable metadata clues
+  reference: string     // original embed reference
+  description: string   // AI-generated description
+  locationHints: string // location clues from visual content
+  metadata: string      // observable metadata clues
 }
 
 const MAX_IMAGES_PER_NOTE = 5
 ```
 
-- Finds both wiki-link (`![[image.png]]`) and markdown (`![alt](path)`) image references
-- Skips external URLs (vault images only)
-- Caps at 5 images per note (`MAX_IMAGES_PER_NOTE`)
-- Applies `settings.image.visionModel` override (same pattern as `ImageExtractor`)
-- Graceful degradation: logs warning, skips individual image failures
-- Imports `AIClient`, `arrayBufferToBase64` from the `shared` barrel; reuses `image/preprocessImage` (via the `image` barrel) for downscaling — no duplicate encoding logic
-- Uses `settings.image.maxImageSizeMb` (default 5) as the downscale threshold
+- Finds wiki-link (`![[image.png]]`) and markdown (`![alt](path)`) refs; skips external `http(s)` markdown URLs (vault images only).
+- Caps at `MAX_IMAGES_PER_NOTE` (5).
+- Resolves via `metadataCache.getFirstLinkpathDest`; reads binary; downscales over `settings.image.maxImageSizeMb` (default 5) MB via `preprocessImage` from the `../image` barrel (Notice on downscale).
+- Applies `settings.image.visionModel` override (falls back to `settings.ai.model`), restored in `finally`.
+- Graceful degradation: warns and skips individual image failures; `gatherImageContext` swallows analyzer errors (proposer.ts:L259).
 
-## Settings Keys
+## Configuration
 
-All under `settings.elaboration`:
+All under `settings.elaboration` unless noted.
 
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
-| `enabled` | boolean | false | Module activation |
-| `scanOnStartup` | boolean | false | Trigger vault scan 5 s after load |
+| `enabled` | boolean | true | Module activation / command gating |
+| `proposalFolderPath` | string | `.synapse/proposals` | Proposal JSON storage (ProposalStore) |
+| `scanOnStartup` | boolean | false | Vault scan 5 s after load (if in startup flow) |
 | `autoScanInterval` | number | 0 | Periodic scan interval (minutes; 0 = off) |
 | `detection.minWordThreshold` | number | 50 | Notes below this word count are stubs |
-| `detection.detectTodoMarkers` | boolean | true | Flag TODO/TBD/FIXME/PLACEHOLDER markers |
-| `detection.detectEmptySections` | boolean | true | Flag headings with no body content |
-| `detection.detectSparseLinks` | boolean | true | Flag notes with inbound links but sparse content |
+| `detection.detectTodoMarkers` | boolean | true | Flag TODO/TBD/FIXME/PLACEHOLDER |
+| `detection.detectEmptySections` | boolean | true | Flag headings with no body |
+| `detection.detectSparseLinks` | boolean | true | Flag inbound-linked but sparse notes |
 | `detection.excludeTags` | string[] | `['no-elaborate']` | Per-note opt-out via frontmatter tags |
 | `proposal.includeSourceContext` | boolean | true | Gather up to 5 linked notes as context |
+| `proposal.maxProposalsPerNote` | number | 3 | Defined in settings; not referenced by module code |
+| `proposal.preserveFrontmatter` | boolean | true | Defined in settings; not referenced by module code |
 
-Path-based exclusions use centralized `settings.exclusions: ExclusionRule[]` (#307) via `isPathExcluded('elaboration', settings)` from the `shared` barrel. There is no per-module `excludeFolders` field.
-
-Auto-accept is controlled by `settings.autoAccept.elaboration: boolean` (default `false`), wired into the module at construction via `shouldAutoAccept: () => boolean`.
+Path exclusions use centralized `settings.exclusions: ExclusionRule[]` via `isPathExcluded(path,'elaboration',settings)`; there is no per-module `excludeFolders`. Auto-accept is `settings.autoAccept.elaboration` (default false), passed in via `shouldAutoAccept: () => boolean`; module code never mutates settings. Image analysis reads `settings.image.enabled`, `settings.image.visionModel`, `settings.image.maxImageSizeMb`, `settings.ai.model`.
 
 ## Commands Registered
 
-All registered via `CommandRegistrar` in `onload()`:
+Via `CommandRegistrar.register(...)` in `onload()`; all gated on `elaboration.enabled` at registration time.
 
-| Command suffix | Name | Condition |
-|---------------|------|-----------|
-| `scan-vault` | Scan folder for stub notes | `elaboration.enabled` |
-| `scan-current-note` | Elaborate current note | `elaboration.enabled` |
-| `clear-proposals` | Clear all pending proposals | `elaboration.enabled` |
+| Command suffix | Name | Callback type | Action |
+|---------------|------|---------------|--------|
+| `scan-vault` | Scan folder for stub notes | `callback` | `FolderPickerModal` -> `scanVault(folder?)` |
+| `scan-current-note` | Elaborate current note | `editorCallback` | `scanNote(ctx.file)` |
+| `clear-proposals` | Clear all pending proposals | `callback` | delete all pending proposals |
 
 ## Dependencies
 
-| Import | From |
-|--------|------|
-| `buildCallout`, `CALLOUT_TYPES`, `NotificationManager`, `sanitizeAIResponse`, `stripCodeFences`, `CheckpointManager`, `generateId`, `fireAndForget`, `FolderPickerModal`, `getMarkdownFiles`, `isPathExcluded`, `matchesExcludeTag`, `getIncludedMarkdownFiles`, `wordCount`, `AIClient`, `arrayBufferToBase64`, `isTwitterUrl`, `fetchTweetContent`, `fetchArticleContent` | `../shared` |
-| `CommandRegistrar`, `isInFlow` | `../commands` |
-| `preprocessImage` | `../image` (barrel) |
+| Symbols | From | Used in |
+|---------|------|---------|
+| `buildCallout`, `CALLOUT_TYPES`, `FolderPickerModal`, `getMarkdownFiles`, `NotificationManager`, `sanitizeAIResponse`, `stripCodeFences`, `CheckpointManager`, `generateId`, `fireAndForget` (+ types `Checkpoint`, `CheckpointWorkItem`, `DeferredTask`) | `../shared` | index.ts |
+| `wordCount`, `isPathExcluded`, `matchesExcludeTag`, `getIncludedMarkdownFiles` | `../shared` | detector.ts |
+| `AIClient`, `sanitizeAIResponse`, `stripCodeFences`, `isTwitterUrl`, `fetchTweetContent`, `isRedditUrl`, `fetchRedditContent`, `fetchArticleContent`, `linkLoadError`, `NotificationManager`, `isGenericTitle` | `../shared` | proposer.ts |
+| `AIClient`, `arrayBufferToBase64` (+ type `ContentBlock`) | `../shared` | image-analyzer.ts |
+| `ensureFolder`, `isRecord`, `readJsonFile` | `../shared` | proposal-store.ts |
+| `fireAndForget` | `../shared` | proposal-view.ts |
+| type `SettingsSectionContext` | `../shared` | settings-section.ts |
+| `preprocessImage` | `../image` (barrel) | image-analyzer.ts |
+| `CommandRegistrar`, `isInFlow` | `../commands` | index.ts |
+
+No feature-to-feature imports (architecture rule); `proposer.ts` keeps a tiny local `VIDEO_HOST_PATTERN` instead of importing `video/url-detector` (proposer.ts:L302).
 
 ## Invariants / Gotchas
 
-- `scanVault` creates a checkpoint before the generation phase; cancellation or error auto-rejects all proposals created in that run and discards the checkpoint.
-- `acceptProposal` guards against double-acceptance: no-ops if `proposal.status !== 'pending'`.
-- `scanNote` with `userInvoked=true` bypasses the stub gate — always generates a proposal even if detection finds no reasons.
-- `ProposalGenerator` imports `preprocessImage` from the `image` barrel (`../image`), not directly from `image/preprocess.ts` — respects the "import from module index" architecture rule.
-- `detector.ts` uses `getIncludedMarkdownFiles` (which already respects path exclusions) for inbound link resolution.
-- `onOpenProposalView` callback (#340) was added after the original AGENTS.md; it is a third wired callback alongside `onProposalAccepted` and `onViewRefreshNeeded`.
+- `scanVault` and `resumeFromCheckpoint` create/advance a checkpoint; cancellation or error auto-rejects all proposals created in the run (`rejectProposalBatch`) and discards the checkpoint.
+- `generate()` returning `null` (either anti-fabrication guard) is not an error: callers complete the checkpoint item and skip without saving a proposal (index.ts:L150, index.ts:L277, index.ts:L355).
+- `acceptProposal` no-ops when `proposal.status !== 'pending'` (cascade-safe double-accept guard).
+- `scanNote(userInvoked=true)` bypasses the stub gate: a synthetic `user-requested` reason is created so the proposer always runs, except where the anti-fabrication guards apply.
+- `ProposalGenerator` imports `preprocessImage` from the `../image` barrel, never `image/preprocess.ts` directly (import-from-index rule).
+- `onOpenProposalView` is the third wired callback (#340) alongside `onProposalAccepted` and `onViewRefreshNeeded`; the operation toast's "Review" action only appears when a proposal stays pending after any auto-accept.
+- `ImageAnalyzer.analyzeImage` temporarily reassigns `settings.ai.model` to the vision model and restores it in `finally`; concurrent callers could observe the override.

--- a/src/enrichment/AGENTS.md
+++ b/src/enrichment/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Enrichment Module
@@ -37,13 +37,14 @@ class EnrichmentModule {
   acceptSelectedFromView(id: string, accepted: AcceptedItems, options?: { silent?: boolean }): Promise<void>
   rejectFromView(id: string): Promise<void>
 }
+
+function renderEnrichmentSettings(ctx: SettingsSectionContext): void  // re-exported (index.ts:684)
 ```
 
-Re-exported types from `types.ts`:
+Types re-exported from the `index.ts` barrel (`index.ts:19-28`):
 
 ```ts
 type EnrichmentTrigger = 'elaboration' | 'transcription' | 'summarization' | 'deep-dive' | 'manual'
-type EnrichmentStatus = 'pending' | 'accepted' | 'partially-accepted' | 'rejected'
 
 interface EnrichmentProposal {
   id: string
@@ -70,8 +71,8 @@ interface AcceptedItems {
 }
 
 interface TagCandidate {
-  tag: string
-  category: string       // vocabulary category, e.g. "Status", "Type"
+  tag: string            // normalized, '#'-prefixed (metadata-classifier.ts:L54)
+  category: string       // vocabulary category, e.g. "Status", "Type", "Source"
   confidence: number     // AI classification confidence (0–1)
   rawScore: number       // always 0 for classifier-produced candidates
   weightedScore: number  // equals confidence for classifier-produced candidates
@@ -80,41 +81,37 @@ interface TagCandidate {
 
 interface InternalLinkCandidate { targetPath: string; displayText: string; relevanceScore: number; reason: string }
 interface ExternalLinkCandidate { url: string; title: string; reason: string }
-interface FrontmatterEnrichment { key: string; value: string | string[]; action: 'add' | 'merge' }
 interface WeightConfig { sameFolder: number; siblingFolder: number; cousinFolder: number; distantFolder: number; decayPerLevel: number; minWeight: number }
+```
 
-// Vault topology snapshots (types.ts)
+Defined in `types.ts` but NOT re-exported via `index.ts` (import from `./types`):
+
+```ts
+type EnrichmentStatus = 'pending' | 'accepted' | 'partially-accepted' | 'rejected'
+interface FrontmatterEnrichment { key: string; value: string | string[]; action: 'add' | 'merge' }
 interface TagIndex { tags: Map<string, { count: number; files: string[] }> }
 interface LinkGraph { outgoing: Map<string, Set<string>>; incoming: Map<string, Set<string>> }
 ```
 
-Note: `TagVocabularyEntry` and `EnrichmentWeightSettings` are defined in `src/settings.ts`, not in `types.ts`.
+Note: `TagVocabularyEntry`, `EnrichmentSettings`, and `EnrichmentWeightSettings` are defined in `src/settings.ts`, not in `types.ts`.
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `types.ts` | All interfaces and types | `TagCandidate`, `InternalLinkCandidate`, `ExternalLinkCandidate`, `FrontmatterEnrichment`, `EnrichmentResult`, `EnrichmentProposal`, `AcceptedItems`, `TagIndex`, `LinkGraph`, `WeightConfig` |
-| `index.ts` | `EnrichmentModule`, re-exports | Orchestrator; registers commands; exclusion checks; vault scan; checkpoint resume |
+| `types.ts` | All interfaces and types | `TagCandidate`, `InternalLinkCandidate`, `ExternalLinkCandidate`, `FrontmatterEnrichment`, `EnrichmentResult`, `EnrichmentProposal`, `EnrichmentTrigger`, `EnrichmentStatus`, `AcceptedItems`, `TagIndex`, `LinkGraph`, `WeightConfig` |
+| `index.ts` | `EnrichmentModule`, type re-exports, `renderEnrichmentSettings` re-export | Orchestrator; registers commands; exclusion checks; vault scan; checkpoint resume; auto-accept |
 | `vault-analyzer.ts` | `VaultAnalyzer` | Cached vault-wide `TagIndex` and `LinkGraph` from `MetadataCache`; invalidated on `'resolved'` event |
 | `weight-calculator.ts` | `computeProximityWeight` | Pure function: folder-proximity scoring |
-| `metadata-classifier.ts` | `MetadataClassifier` | AI-powered tag classification against user-defined vocabulary; replaces former `TagScorer` |
+| `metadata-classifier.ts` | `MetadataClassifier` | AI tag classification against user-defined vocabulary; rejects hallucinated tags |
 | `topic-extractor.ts` | `TopicExtractor` | AI topic extraction; matched topics → `InternalLinkCandidate`; unmatched topics accumulated for multi-note resolution |
 | `link-resolver.ts` | `LinkResolver` | Graph-based internal link candidates (link hops, shared tags, folder proximity); merges with topic candidates |
 | `prompt-builder.ts` | `PromptBuilder` | AI prompts for external link and frontmatter suggestions |
-| `enrichment-store.ts` | `EnrichmentStore` | CRUD for enrichment proposal JSON files in `.synapse/enrichments/` |
-| `enrichment-applier.ts` | `EnrichmentApplier` | Applies/undoes accepted enrichments to note content non-destructively |
+| `enrichment-store.ts` | `EnrichmentStore` | CRUD for enrichment proposal JSON files in the enrichment folder |
+| `enrichment-applier.ts` | `EnrichmentApplier` | Applies/undoes accepted enrichments to note content non-destructively via `vault.process` |
 | `enrichment-modal.ts` | `EnrichmentDetailModal` | Per-item toggle modal for reviewing a single proposal |
 | `settings-section.ts` | `renderEnrichmentSettings` | Settings UI accordion for the enrichment feature (#243) |
-| `vault-analyzer.test.ts` | Tests | `VaultAnalyzer` |
-| `weight-calculator.test.ts` | Tests | `computeProximityWeight` |
-| `metadata-classifier.test.ts` | Tests | `MetadataClassifier` |
-| `topic-extractor.test.ts` | Tests | `TopicExtractor` |
-| `link-resolver.test.ts` | Tests | `LinkResolver` |
-| `enrichment-store.test.ts` | Tests | `EnrichmentStore` |
-| `enrichment-applier.test.ts` | Tests | `EnrichmentApplier` |
-| `settings-section.test.ts` | Tests | `renderEnrichmentSettings` |
-| `auto-accept.test.ts` | Tests | Auto-accept behavior (#228) |
+| `*.test.ts` | Co-located Vitest suites | `vault-analyzer`, `weight-calculator`, `metadata-classifier`, `topic-extractor`, `link-resolver`, `prompt-builder`, `enrichment-store`, `enrichment-applier`, `settings-section`, `auto-accept` (#228) |
 
 ## Internal Class Signatures
 
@@ -126,19 +123,16 @@ class VaultAnalyzer {
   buildTagIndex(): TagIndex
   buildLinkGraph(): LinkGraph
   getFileTags(file: TFile): string[]
-  getOutgoingLinks(filePath: string): Set<string>
-  getIncomingLinks(filePath: string): Set<string>
+  getOutgoingLinks(filePath: string): string[]
+  getIncomingLinks(filePath: string): string[]
 }
-
 // weight-calculator.ts
 function computeProximityWeight(sourcePath: string, targetPath: string, config: WeightConfig): number
-
 // metadata-classifier.ts
 class MetadataClassifier {
   constructor(getSettings: () => SynapseSettings)
   classify(noteContent: string, existingTags: string[]): Promise<TagCandidate[]>
 }
-
 // topic-extractor.ts
 class TopicExtractor {
   constructor(app: App, analyzer: VaultAnalyzer, getSettings: () => SynapseSettings)
@@ -146,21 +140,18 @@ class TopicExtractor {
   resolveNewNoteCandidates(): Map<string, InternalLinkCandidate[]>  // notePath → candidates
   clearPending(): void
 }
-
 // link-resolver.ts
 class LinkResolver {
   constructor(app: App, analyzer: VaultAnalyzer, getSettings: () => SynapseSettings)
   findInternalLinks(file: TFile, existingLinkPaths: string[]): InternalLinkCandidate[]
   mergeTopicCandidates(topicCandidates: InternalLinkCandidate[], graphCandidates: InternalLinkCandidate[]): InternalLinkCandidate[]
 }
-
 // prompt-builder.ts
 class PromptBuilder {
   constructor(getSettings: () => SynapseSettings)
-  suggestExternalLinks(noteContent: string, existingUrls: string[]): Promise<ExternalLinkCandidate[]>
+  suggestExternalLinks(noteContent: string, existingLinks: string[]): Promise<ExternalLinkCandidate[]>
   suggestFrontmatter(noteContent: string, existingFrontmatter: Record<string, unknown>): Promise<FrontmatterEnrichment[]>
 }
-
 // enrichment-store.ts
 class EnrichmentStore {
   constructor(app: App, getSettings: () => SynapseSettings)
@@ -173,80 +164,88 @@ class EnrichmentStore {
   updateStatus(id: string, status: EnrichmentStatus, acceptedItems?: AcceptedItems): Promise<void>
   delete(id: string): Promise<void>
 }
-
 // enrichment-applier.ts
 class EnrichmentApplier {
   constructor(app: App, getSettings: () => SynapseSettings)
   apply(proposal: EnrichmentProposal, accepted: AcceptedItems): Promise<void>
   undo(proposal: EnrichmentProposal): Promise<void>
 }
-
+// enrichment-modal.ts
+class EnrichmentDetailModal extends Modal {
+  constructor(app: App, proposal: EnrichmentProposal, callbacks: { onAccept: (accepted: AcceptedItems) => void; onReject: () => void })
+}
 // settings-section.ts
 function renderEnrichmentSettings(ctx: SettingsSectionContext): void
 ```
 
 ## Registered Commands
 
-| Command ID | Name | Condition |
-|-----------|------|-----------|
-| `enrich-current-note` | Enrich current note | `settings.enrichment.enabled` |
-| `scan-vault-enrichment` | Scan folder for enrichment | `settings.enrichment.enabled` |
-| `undo-enrichment` | Undo last enrichment on current note | `settings.enrichment.enabled` |
+Registered in `EnrichmentModule.onload` via `registrar.register(id, condition, callbacks)`; all gated on `settings.enrichment.enabled`.
+
+| Command ID | Name | Callback type | Action |
+|-----------|------|--------------|--------|
+| `enrich-current-note` | Enrich current note | `editorCallback` | `enrich(ctx.file.path, 'manual')` |
+| `scan-vault-enrichment` | Scan folder for enrichment | `callback` | `FolderPickerModal` → `scanVault(folder)` |
+| `undo-enrichment` | Undo last enrichment on current note | `editorCallback` | `undoLastEnrichment(ctx.file.path)` (registry status: disabled) |
 
 ## Dependencies
 
 In (consumed by this module):
-- `src/shared`: `isPathExcluded`, `matchesExcludeTag`, `findMatchingRule`, `getIncludedMarkdownFiles`, `NotificationManager`, `CheckpointManager`, `CommandRegistrar`, `AIClient`, `parseFrontmatter`, `serializeFrontmatter`, `mergeTags`, `buildCallout`, `ENRICHMENT_START`, `ENRICHMENT_END`, `sanitizeAIResponse`, `parseJson`, `generateId`, `isTwitterUrl`, `fetchTweetContent`, `fireAndForget`, `getMarkdownFiles`, `ensureFolder`, `readJsonFile`, `isRecord`
+- `src/shared`: `isPathExcluded`, `matchesExcludeTag`, `findMatchingRule`, `getIncludedMarkdownFiles`, `getMarkdownFiles`, `NotificationManager`, `CheckpointManager`, `FolderPickerModal`, `AIClient`, `parseFrontmatter`, `serializeFrontmatter`, `mergeTags`, `asStringArray`, `buildCallout`, `CALLOUT_TYPES`, `ENRICHMENT_START`, `ENRICHMENT_END`, `sanitizeAIResponse`, `parseJson`, `isRecord`, `generateId`, `isTwitterUrl`, `fetchTweetContent`, `fireAndForget`, `ensureFolder`, `readJsonFile`, `addEnhancedSlider`; types `Checkpoint`, `CheckpointWorkItem`, `DeferredTask`, `SettingsSectionContext`
+- `src/commands`: `CommandRegistrar`
 - `src/settings`: `SynapseSettings`, `TagVocabularyEntry`, `EnrichmentWeightSettings`
 
 Out (consumed by other modules):
 - `src/main.ts`: imports `EnrichmentModule`, wires `onViewRefreshNeeded`, `onOpenProposalView`, `shouldAutoAccept`; calls `enrich()`, `scanVault()`, `getPendingProposals()`, `acceptSelectedFromView()`, `rejectFromView()`, `resumeFromCheckpoint()`
 
-No feature module dependencies (enrichment does not import from elaboration, transcription, etc.).
+No feature-module dependencies (enrichment does not import from elaboration, transcription, etc.).
 
 ## Data Flow
 
 ```
 enrich(filePath, trigger)
-  └─ isExcluded(file)  ← isPathExcluded('enrichment', settings) + matchesExcludeTag
-  └─ enrichFile(file, trigger) [private]
-       ├─ MetadataClassifier.classify()        → TagCandidate[]
-       ├─ LinkResolver.findInternalLinks()      → InternalLinkCandidate[] (graph)
-       ├─ TopicExtractor.extractTopics()        → InternalLinkCandidate[] (topics)
-       ├─ PromptBuilder.suggestExternalLinks()  → ExternalLinkCandidate[]
-       └─ PromptBuilder.suggestFrontmatter()    → FrontmatterEnrichment[]
-       └─ LinkResolver.mergeTopicCandidates(topicLinks, graphLinks)
-       └─ EnrichmentStore.save(proposal)
-  └─ maybeAutoAccept(id)  [if shouldAutoAccept()]
-  └─ onViewRefreshNeeded()
+  └─ getAbstractFileByPath → TFile guard
+  └─ isExcluded(file)  ← isPathExcluded('enrichment', settings) || matchesExcludeTag
+  │    └─ if trigger === 'manual' && excluded → Notice naming findMatchingRule(); else silent (#307)
+  └─ enrichFile(file, trigger) [private]  (fetchTwitterContext prepends tweet text to classifier body)
+       ├─ MetadataClassifier.classify()             → TagCandidate[]
+       ├─ LinkResolver.findInternalLinks()          → InternalLinkCandidate[] (graph)
+       ├─ TopicExtractor.extractTopics()            → InternalLinkCandidate[] (topics)
+       ├─ PromptBuilder.suggestExternalLinks()      → ExternalLinkCandidate[]
+       ├─ PromptBuilder.suggestFrontmatter()        → FrontmatterEnrichment[]
+       ├─ LinkResolver.mergeTopicCandidates(topicLinks, graphLinks)
+       └─ EnrichmentStore.save(proposal)  [skipped when totalItems === 0 → returns null]
+  └─ topicExtractor.clearPending(); maybeAutoAccept(id)  [if shouldAutoAccept()]
+  └─ refreshView() → onViewRefreshNeeded()
 ```
 
 ```
 scanVault(folderPath?, skipConfirmation?, onlyFile?)
-  Phase 1: collect eligible files; warm VaultAnalyzer caches
-  Phase 2: user confirmation via NotificationManager.confirm() [skipped if skipConfirmation]
-  Phase 3: cancellable per-file enrichFile(); CheckpointManager tracks progress
+  Phase 1: collect eligible (non-excluded) files; warm buildTagIndex()/buildLinkGraph() caches
+  Phase 2: NotificationManager.confirm()  [skipped if skipConfirmation]
+  Phase 3: CheckpointManager.create(); cancellable per-file enrichFile(); completeItem() per file
   Phase 4: TopicExtractor.resolveNewNoteCandidates()
            → topics cited by 2+ notes → new-note InternalLinkCandidates
-           → injected into existing proposals via LinkResolver.mergeTopicCandidates()
-  On cancel/error: discard checkpoint, rejectProposalBatch(), clearPending()
+           → merged into existing proposals via LinkResolver.mergeTopicCandidates()
+  Auto-accept (#228): runs AFTER Phase 4 so merged candidates are included; batch mode (one summary Notice)
+  On cancel/error: discard checkpoint, clearPending(), rejectProposalBatch()
 ```
 
 ```
-User review (UnifiedProposalView):
+User review (UnifiedProposalView / EnrichmentDetailModal):
   Accept Selected → acceptSelectedFromView(id, accepted)
                     → EnrichmentApplier.apply(proposal, accepted)
-                    → EnrichmentStore.updateStatus(id, 'accepted'|'partially-accepted')
+                    → EnrichmentStore.updateStatus(id, 'accepted' | 'partially-accepted')
   Reject          → rejectFromView(id)
                     → EnrichmentStore.updateStatus(id, 'rejected')
 ```
 
 ## Exclusion Handling (#307)
 
-Exclusion uses the centralized `src/shared/exclusions.ts` API. `excludeFolders` per module was removed; path exclusions are stored in `settings.exclusions: ExclusionRule[]` at the top level and scoped by feature name.
+Exclusion uses the centralized `src/shared/exclusions.ts` API. Per-module `excludeFolders` was removed; path exclusions live in `settings.exclusions: ExclusionRule[]` at the top level, scoped by feature name.
 
 ```ts
-// index.ts:639-644
+// index.ts:636-642
 private isExcluded(file: TFile): boolean {
   const settings = this.getSettings();
   return (
@@ -256,38 +255,45 @@ private isExcluded(file: TFile): boolean {
 }
 ```
 
-`findMatchingRule(file.path, 'enrichment', settings)` is called on the manual-trigger path to surface the matching rule name in the user-facing notice.
+`findMatchingRule(file.path, 'enrichment', settings)` is called only on the manual-trigger path to surface the matching rule pattern in the user-facing notice (`index.ts:393-403`).
 
 ## Settings Keys
 
-All under `settings.enrichment` unless noted:
+All under `settings.enrichment` (interface `EnrichmentSettings`, `settings.ts:133-148`) unless noted. Defaults from `DEFAULT_SETTINGS.enrichment` (`settings.ts:405-431`).
 
-| Key | Type | Controls |
-|-----|------|----------|
-| `enabled` | `boolean` | Module activation; gates command registration |
-| `autoEnrich` | `boolean` | Auto-trigger after elaboration/transcription/summarization |
-| `maxTags` | `number` | Max tags to suggest (default: 5) |
-| `maxInternalLinks` | `number` | Max related-note link suggestions |
-| `maxExternalLinks` | `number` | Max external references (0 = disable) |
-| `maxTopicLinks` | `number` | Max topic-extracted link candidates per note (default: 10) |
-| `suggestNewNotes` | `boolean` | Enable new-note suggestions for unmatched topics (default: true) |
-| `tagVocabulary` | `TagVocabularyEntry[]` | Classification categories and valid tags for `MetadataClassifier` |
-| `internalLinkThreshold` | `number` | Min relevance score to include a link candidate |
-| `weights` | `EnrichmentWeightSettings` | Proximity weight tiers for `computeProximityWeight` |
-| `enrichmentFolderPath` | `string` | Path to proposal JSON storage (default: `.synapse/enrichments`) |
-| `excludeTags` | `string[]` | Tags that suppress enrichment for a note |
-| `relatedNotesHeading` | `string` | Heading for the internal-links section |
-| `referencesHeading` | `string` | Heading for the external-links section |
-| `settings.exclusions` (top-level) | `ExclusionRule[]` | Path/glob exclusions scoped by feature `'enrichment'`; replaces removed per-module `excludeFolders` |
-| `settings.autoAccept.enrichment` (top-level) | `boolean` | Wired to `shouldAutoAccept` constructor param (#228) |
+| Key | Type | Default | Controls |
+|-----|------|---------|----------|
+| `enabled` | `boolean` | `true` | Module activation; gates command registration |
+| `autoEnrich` | `boolean` | `true` | Auto-trigger after elaboration/transcription/summarization |
+| `maxTags` | `number` | `5` | Max metadata tags suggested per note |
+| `maxInternalLinks` | `number` | `15` | Max related-note link suggestions |
+| `maxExternalLinks` | `number` | `3` | Max external references (`0` = disable; `suggestExternalLinks` early-returns) |
+| `maxTopicLinks` | `number` | `10` | Max topic-extracted link candidates per note |
+| `suggestNewNotes` | `boolean` | `true` | Accumulate unmatched topics as new-note suggestions |
+| `tagVocabulary` | `TagVocabularyEntry[]` | 3 entries: Status, Type, Source | Classification categories + valid tags for `MetadataClassifier` |
+| `internalLinkThreshold` | `number` | `0.3` | Min relevance score to include a link candidate |
+| `weights` | `EnrichmentWeightSettings` | see below | Proximity weight tiers for `computeProximityWeight` |
+| `enrichmentFolderPath` | `string` | `'.synapse/enrichments'` | Path to proposal JSON storage |
+| `excludeTags` | `string[]` | `['no-enrich']` | Tags that suppress enrichment for a note |
+| `relatedNotesHeading` | `string` | `'Related Notes'` | Heading for the internal-links callout |
+| `referencesHeading` | `string` | `'References'` | Heading for the external-links callout |
+| `settings.exclusions` (top-level) | `ExclusionRule[]` | — | Path/glob exclusions scoped by feature `'enrichment'`; replaces removed `excludeFolders` |
+| `settings.autoAccept.enrichment` (top-level) | `boolean` | — | Wired to the `shouldAutoAccept` constructor param (#228) |
+
+`TagVocabularyEntry` = `{ category: string; tags: string[]; description: string }` (`settings.ts:127-131`). Default vocabulary: `Status` (draft, todo, reference, unfinished, needs-review, archived), `Type` (meeting, idea, project, log, guide, brainstorm), `Source` (source/video, source/audio, source/transcript, source/article, source/book).
+`EnrichmentWeightSettings` defaults (`settings.ts:419-426`): `sameFolder 1.0`, `siblingFolder 0.8`, `cousinFolder 0.5`, `distantFolder 0.2`, `decayPerLevel 0.15`, `minWeight 0.1`.
 
 ## Invariants
 
-- Idempotency markers: `%% synapse-enrichment-start %%` / `%% synapse-enrichment-end %%` (constants `ENRICHMENT_START` / `ENRICHMENT_END` from `src/shared`). Applier strips existing marker sections before re-writing; undo deletes them. `enrichment-applier.ts:L36`
-- Frontmatter keys: never overwritten; `action: 'add'` skips if key exists; `action: 'merge'` appends to arrays
-- Frontmatter key allowlist: `^[a-z][a-z0-9_-]{0,49}$`; forbidden keys (`__proto__`, `constructor`, `prototype`, etc.) blocked (`prompt-builder.ts:L9-16`)
-- Tag format: `^[a-zA-Z0-9][a-zA-Z0-9_/-]{0,49}$` (`metadata-classifier.ts:L5`)
-- External URL validation: HTTP/HTTPS only (`prompt-builder.ts:L19-24`)
-- New-note topic threshold: topic must appear in 2+ notes during a vault scan to become a suggestion (`topic-extractor.ts:L118`)
-- Double-acceptance guard: `acceptSelected` and `maybeAutoAccept` bail immediately if `proposal.status !== 'pending'`
-- Auto-accept (#228) runs after Phase 4 in `scanVault` so merged cross-note candidates are included before acceptance
+- Applied sections are Obsidian callouts `> [!synapse-enrichment]` (`CALLOUT_TYPES.enrichment`, `src/shared/callouts.ts:L15`), written via `buildCallout` (`enrichment-applier.ts:L180,L208`).
+- Idempotent re-write / undo: `removeEnrichmentSections` strips both callout sections AND legacy comment markers `%% synapse-enrichment-start %%` / `%% synapse-enrichment-end %%` (`ENRICHMENT_START` / `ENRICHMENT_END`, `src/shared/callouts.ts:L46-47`) before re-writing (`enrichment-applier.ts:L215-240`).
+- Writes are atomic: `apply` and `undo` re-derive content inside `vault.process` callbacks (`enrichment-applier.ts:L36,L129`).
+- Frontmatter keys never overwritten: `action: 'add'` skips if key exists; `action: 'merge'` appends new array values (dedup via `asStringArray`).
+- Frontmatter key allowlist `^[a-z][a-z0-9_-]{0,49}$` (`prompt-builder.ts:L6`); forbidden keys (`__proto__`, `constructor`, `prototype`, `toString`, `valueOf`, `hasOwnProperty`) blocked (`prompt-builder.ts:L9-16`); `tags` key also rejected.
+- Tag format `^[a-zA-Z0-9][a-zA-Z0-9_/-]{0,49}$`; only vocabulary tags accepted, hallucinated tags dropped (`metadata-classifier.ts:L5,L48-51`).
+- External URL validation: HTTP/HTTPS only, in both proposal generation (`prompt-builder.ts:L19-26`) and write-out (`enrichment-applier.ts:L196-205`).
+- New-note topic threshold: a topic must be surfaced by 2+ notes during a vault scan to become a suggestion; new-note candidate `relevanceScore` = `0.5` (`topic-extractor.ts:L122,L127`).
+- Double-acceptance guard: `acceptSelected` and `maybeAutoAccept` bail if `proposal.status !== 'pending'` (`index.ts:L546,L570`).
+- Empty proposals skipped: `enrichFile` returns `null` when no items are produced (`index.ts:L497`).
+- Proposal JSON filename: `<sanitized-path>-enrich-<8charId>.json`; null bytes and `..` stripped (`enrichment-store.ts:L113-122`).
+- `VaultAnalyzer` caches invalidate on the `metadataCache 'resolved'` event (`index.ts:L75-79`).

--- a/src/image/AGENTS.md
+++ b/src/image/AGENTS.md
@@ -1,16 +1,15 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Image Module
 
-OCR text extraction from vault images using multi-modal AI (vision models). Supports single-file extraction, batch extraction with checkpoints, and note scanning for image embeds.
+OCR text extraction from vault images via multi-modal AI vision models: single-file extraction to the active note, checkpoint-based batch extraction from note scans, and note scanning for image embeds.
 
-## Public API
-
-Exported from `index.ts`:
+## Public API (barrel exports from index.ts)
 
 ```ts
+// index.ts:15
 class ImageModule {
   constructor(
     plugin: Plugin,
@@ -18,168 +17,175 @@ class ImageModule {
     notifications: NotificationManager,
     checkpointManager: CheckpointManager
   )
-  onload(): Promise<void>
-  onunload(): void
-  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
-  extractFromFile(file: TFile): Promise<void>
-  extractAndInsert(noteFile: TFile, embeds: ImageEmbed[]): Promise<void>
-  onExtractionComplete: ((filePath: string) => void) | null
+  onExtractionComplete: ((filePath: string) => void) | null  // wired by main.ts
+  onload(): Promise<void>            // no-op (no commands/views registered)
+  onunload(): void                   // no-op
+  extractFromFile(file: TFile): Promise<void>                 // OCR one image into active note
+  extractAndInsert(noteFile: TFile, embeds: ImageEmbed[]): Promise<void>  // batch OCR
+  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void> // notify + discard (no mid-batch resume)
 }
 
-// note-scanner.ts (also exported from index.ts)
+// re-exported from ./note-scanner (index.ts:11)
 function findImageEmbeds(content: string, sourcePath: string, metadataCache: MetadataCache): ImageEmbed[]
-function hasExtractionBelow(lines: string[], embedLine: number, fileName: string): boolean
-const IMAGE_EXTENSIONS: RegExp  // /\.(png|jpg|jpeg|gif|webp|bmp|tiff)$/i
+const IMAGE_EXTENSIONS: RegExp   // /\.(png|jpg|jpeg|gif|webp|bmp|tiff)$/i
 const IMAGE_EMBED_REGEX: RegExp  // /!\[\[([^\]]+\.(?:png|jpg|jpeg|gif|webp|bmp|tiff))\]\]/gi
 
-// preprocess.ts (also exported from index.ts)
+// re-exported from ./preprocess (index.ts:12)
+function arrayBufferToBase64(buffer: ArrayBuffer): string   // canonical home: shared/encoding.ts
 function preprocessImage(data: ArrayBuffer, mediaType: string, maxBytes: number): Promise<PreprocessResult>
-// re-exported from shared/encoding.ts for back-compat (canonical home is shared):
-function arrayBufferToBase64(buffer: ArrayBuffer): string
-function base64EncodedLength(byteLength: number): number
 
-interface PreprocessResult {
-  data: ArrayBuffer
-  mediaType: string
-  downscaled: boolean
-}
-
-interface ImageEmbed {
-  fileName: string
-  file: TFile
-  line: number
-}
-
-interface OCRResult {
-  text: string
-  sourceName?: string
-}
-
-// settings-section.ts (also exported from index.ts)
+// re-exported from ./settings-section (index.ts:205)
 function renderImageSettings(ctx: SettingsSectionContext): void
+
+// re-exported types from ./types (index.ts:13)
+interface ImageEmbed { fileName: string; file: TFile; line: number }
+interface OCRResult  { text: string; sourceName?: string }
+```
+
+## File-level exports (NOT in the index.ts barrel)
+
+```ts
+// extractor.ts:8 — internal class, constructed by ImageModule
+class ImageExtractor {
+  constructor(getSettings: () => SynapseSettings)
+  extract(imageData: ArrayBuffer, fileName: string): Promise<OCRResult>
+}
+
+// preprocess.ts:25 / :17 — exported from preprocess.ts only
+interface PreprocessResult { data: ArrayBuffer; mediaType: string; downscaled: boolean }
+function base64EncodedLength(byteLength: number): number   // re-exported from shared for back-compat
+
+// note-scanner.ts:38 — exported from note-scanner.ts only
+function hasExtractionBelow(lines: string[], embedLine: number, fileName: string): boolean
 ```
 
 ## File Inventory
 
-| File | Class/Export | Purpose |
-|------|-------------|---------|
+| File | Export | Purpose |
+|------|--------|---------|
 | `types.ts` | `ImageEmbed`, `OCRResult` | Type definitions |
-| `extractor.ts` | `ImageExtractor` | Multi-modal AI OCR via `AIClient.chat()` with `ContentBlock[]`; applies vision model override |
-| `preprocess.ts` | `preprocessImage`, re-exports `arrayBufferToBase64`, `base64EncodedLength` | Auto-downscale/re-encode when payload exceeds `maxImageSizeMb`. Base64 helpers live in `shared/encoding.ts` and are re-exported here for back-compat |
-| `note-scanner.ts` | `findImageEmbeds`, `hasExtractionBelow`, `IMAGE_EXTENSIONS`, `IMAGE_EMBED_REGEX` | Scan note content for image embeds; skip embeds with existing OCR callouts |
-| `settings-section.ts` | `renderImageSettings` | Settings accordion renderer |
-| `index.ts` | `ImageModule`, re-exports | Orchestrator, public extraction methods, checkpoint management |
-| `extractor.test.ts` | Tests | `ImageExtractor` tests |
-| `note-scanner.test.ts` | Tests | `findImageEmbeds` tests |
-| `preprocess.test.ts` | Tests | `preprocessImage` tests |
-| `index.test.ts` | Tests | `ImageModule` integration tests |
-| `settings-section.test.ts` | Tests | Settings section rendering tests |
+| `extractor.ts` | `ImageExtractor` | Multi-modal OCR via `AIClient.chat()` with `ContentBlock[]`; applies vision-model override |
+| `preprocess.ts` | `preprocessImage`, `PreprocessResult`; re-exports `arrayBufferToBase64`, `base64EncodedLength` | Auto-downscale/re-encode oversized payloads; base64 helpers re-exported from `shared/encoding.ts` |
+| `note-scanner.ts` | `findImageEmbeds`, `hasExtractionBelow`, `IMAGE_EXTENSIONS`, `IMAGE_EMBED_REGEX` | Scan note text for image embeds; skip embeds already OCR'd |
+| `settings-section.ts` | `renderImageSettings` | Settings accordion renderer (registered in `settings-tab.ts:105`) |
+| `index.ts` | `ImageModule` + barrel re-exports | Orchestrator, public extraction methods, checkpoint management |
+| `extractor.test.ts`, `note-scanner.test.ts`, `preprocess.test.ts`, `index.test.ts`, `settings-section.test.ts` | Tests | Co-located unit tests |
 
 ## Data Flow
 
 ```
-1. User triggers via NoteMediaModal (in transcription/) or direct API call
-   |
-2a. extractFromFile(file) -- single image file to active note
-   |  findMatchingRule(activeFile.path, 'image', settings) -- skip if excluded (with Notice)
-   |  Reads binary, calls ImageExtractor.extract(), sanitizeAIResponse()
-   |  buildCallout(CALLOUT_TYPES.ocr, 'OCR of filename', text, true)
-   |  Appends to active note
-   |
-2b. extractAndInsert(noteFile, embeds) -- batch from note scan
-   |  isPathExcluded(noteFile.path, 'image', settings) -- silent skip
-   |  Creates checkpoint (module: 'image')
-   |  Processes embeds in reverse line order, 2 s delay between API calls
-   |  All inserts applied atomically to fresh content
-   |  Cancellable via NotificationManager operation handle
-   |
-3. ImageExtractor.extract(imageData, fileName)
-   |  preprocessImage(data, sourceMediaType, maxBytes) -- downscale if needed
-   |  arrayBufferToBase64(processed.data)
-   |  Builds ContentBlock[]: image block + text prompt
-   |  Overrides settings.ai.model with image.visionModel if set (restores in finally)
-   |  AIClient.chat() with system prompt "You are an OCR assistant"
-   |  Returns: OCRResult { text, sourceName }
-   |
-4. sanitizeAIResponse(result.text)
-   |
-5. Result wrapped in callout block (collapsed):
+1. extractFromFile(file)  -- index.ts:33  (single image -> active note)
+   findMatchingRule(activeFile.path, 'image', settings) -> excluded: info Notice, return
+   vault.readBinary(file) -> ImageExtractor.extract(data, file.name)
+   sanitizeAIResponse(result.text)
+   buildCallout(CALLOUT_TYPES.ocr, `OCR of ${file.name}`, text, collapsed=true)
+   vault.process(activeFile, append) -> onExtractionComplete?.(activeFile.path)
+
+2. extractAndInsert(noteFile, embeds)  -- index.ts:86  (batch from note scan)
+   isPathExcluded(noteFile.path, 'image', settings) -> excluded: silent return
+   checkpointManager.create({ module: 'image', items }) + addDeferredTask('refresh-sidebar-view')
+   sort embeds by descending line; for each: 2000ms delay (i>0), extract, sanitize, buildCallout
+   completeItem per embed; if op.cancelled -> break
+   vault.process(noteFile, splice all inserts at line+1) -> onExtractionComplete
+   cancelled -> checkpointManager.discard ; else complete + dispatchDeferredTasks + op.finish
+
+3. ImageExtractor.extract(imageData, fileName)  -- extractor.ts:15
+   getMediaType(fileName) -> MIME from extension (default image/png)
+   maxBytes = (image.maxImageSizeMb || 5) * 1024 * 1024
+   preprocessImage(data, mediaType, maxBytes); downscaled -> Notice (auto-downscaled)
+   arrayBufferToBase64(processed.data)
+   ContentBlock[] = [ { type:'image', data, mediaType }, { type:'text', text: OCR prompt } ]
+   visionModel = image.visionModel || ai.model; override ai.model if differs; restore in finally
+   AIClient.chat([{role:'system', content:'You are an OCR assistant...'}, {role:'user', content: blocks}])
+   -> OCRResult { text, sourceName: fileName }
+
+Output callout (collapsed):
    > [!synapse-ocr]- OCR of filename.png
    > ...extracted text...
 ```
 
 ## Note Scanning
 
-`findImageEmbeds(content, sourcePath, metadataCache)` in `note-scanner.ts`:
-- Regex: `![[*.png|jpg|jpeg|gif|webp|bmp|tiff]]`
-- Resolves files via `metadataCache.getFirstLinkpathDest()`
-- Skips embeds with an existing OCR callout in the 3 lines below (`hasExtractionBelow`)
-- Returns `ImageEmbed[]` with file references and line numbers
+`findImageEmbeds(content, sourcePath, metadataCache)` (note-scanner.ts:8):
+- Matches `IMAGE_EMBED_REGEX` per line; resolves files via `metadataCache.getFirstLinkpathDest()`.
+- Includes only `TFile` results whose name passes `IMAGE_EXTENSIONS`.
+- Skips embeds with an existing OCR marker in the 3 lines below (`hasExtractionBelow`), matching both the legacy `**OCR of <name>**` and the `[!synapse-ocr]` callout forms.
+- Returns `ImageEmbed[]` with `fileName`, `file`, and zero-based `line`.
 
 ## Vision Model Override
 
-`ImageExtractor.extract()` temporarily mutates `settings.ai.model` to `settings.image.visionModel` for the duration of the API call. Restored in a `finally` block. If `visionModel` is empty, falls back to `ai.model`.
+`ImageExtractor.extract()` (extractor.ts:41) computes `visionModel = image.visionModel || ai.model`. It mutates `settings.ai.model` only when `visionModel !== ai.model`, and restores the original in a `finally` block. Empty `visionModel` means no override (uses `ai.model`).
 
 ## Exclusion Behavior
 
-Path-based exclusions use centralized `settings.exclusions: ExclusionRule[]` (#307):
-- `extractFromFile`: uses `findMatchingRule(path, 'image', settings)` — emits a Notice naming the matched rule.
-- `extractAndInsert`: uses `isPathExcluded(path, 'image', settings)` — silent skip.
-- No per-module `excludeFolders` field exists.
-
-The image module has no `excludeTags` setting.
+Path exclusions use the centralized `settings.exclusions: ExclusionRule[]`:
+- `extractFromFile`: `findMatchingRule(activeFile.path, 'image', settings)` — emits an info Notice naming the matched rule pattern (OCR lands in the active note).
+- `extractAndInsert`: `isPathExcluded(noteFile.path, 'image', settings)` — silent skip, checked once per note (not per embed).
+- No per-module `excludeFolders` or `excludeTags` field exists.
 
 ## Checkpoint Behavior
 
-- `extractAndInsert()` creates a checkpoint with `module: 'image'`
-- Items tracked per embed (`id: 'image-{index}-{fileName}'`)
-- `resumeFromCheckpoint()` cannot resume mid-batch: discards the checkpoint and notifies the user to re-run
+- `extractAndInsert()` creates a checkpoint with `module: 'image'`, one item per embed (`id: image-{index}-{fileName}`), plus a `refresh-sidebar-view` deferred task.
+- Items are marked complete as each embed finishes; cancellation discards the checkpoint.
+- `resumeFromCheckpoint()` cannot resume mid-batch: it notifies the user (completed items already saved) and discards the checkpoint.
 
-## Settings Keys
+## Settings
 
-All under `settings.image`:
+`ImageSettings` (settings.ts:110); defaults at settings.ts:399. All under `settings.image`:
 
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
-| `enabled` | boolean | true | Module activation; also gates image analysis in elaboration proposer |
+| `enabled` | boolean | true | Module activation; also gates image analysis in the elaboration proposer |
 | `visionModel` | string | `''` | Override AI model for vision calls (empty = use `ai.model`) |
-| `language` | string | `''` | Language hint (reserved, not yet consumed) |
+| `language` | string | `''` | Language hint; reserved, not consumed anywhere |
 | `maxImageSizeMb` | number | 5 | Max base64 payload (MB) before `preprocessImage` auto-downscales |
+
+Settings UI (`renderImageSettings`, settings-section.ts:7) surfaces only the `enabled` toggle (via `featureSection`) and a `Max image size (MB)` text field. `visionModel` and `language` are not exposed in the accordion.
 
 ## Commands Registered
 
-No commands registered directly by `ImageModule.onload()`. Image OCR is accessible via:
-- Command `synapse:transcribe-note-media` (registered by `transcription` module) calls `ImageModule.extractAndInsert(file, embeds)`
-- Direct API: `ImageModule.extractFromFile(file)`
+`ImageModule.onload()` registers no commands. OCR is reached via:
+- `synapse:transcribe-note-media` (registered by the transcription module) -> `extractAndInsert(file, embeds)`.
+- Direct API: `extractFromFile(file)`.
 
 ## Dependencies
 
-All imports resolve through the `shared` barrel (`../shared`), never an internal `shared/*` file directly.
+All cross-module imports resolve through the `../shared` barrel, never an internal `shared/*` file.
 
 | Import | From |
 |--------|------|
-| `AIClient`, `ContentBlock` | `shared` |
-| `NotificationManager` | `shared` |
-| `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `shared` |
-| `buildCallout`, `CALLOUT_TYPES` | `shared` |
-| `sanitizeAIResponse` | `shared` |
-| `generateId` | `shared` |
-| `isPathExcluded`, `findMatchingRule` | `shared` |
-| `base64EncodedLength` (in `preprocess.ts`) | `shared` (canonical: `shared/encoding`) |
+| `AIClient`, `ContentBlock` | `shared` (extractor.ts) |
+| `NotificationManager`, `buildCallout`, `CALLOUT_TYPES`, `sanitizeAIResponse`, `generateId` | `shared` (index.ts) |
+| `CheckpointManager`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `shared` (index.ts) |
+| `isPathExcluded`, `findMatchingRule` | `shared` (index.ts) |
+| `arrayBufferToBase64`, `base64EncodedLength` | `shared` (preprocess.ts) |
+| `SettingsSectionContext` | `shared` (settings-section.ts) |
 
 Consumed by:
-- `elaboration/image-analyzer.ts` imports `preprocessImage` and `arrayBufferToBase64` from the `image` barrel
-- `transcription/` module invokes `ImageModule.extractAndInsert()`
+- `elaboration/image-analyzer.ts` imports `preprocessImage` from `../image` (barrel) and `arrayBufferToBase64` from `../shared`.
+- transcription module invokes `ImageModule.extractAndInsert()`.
 
 ## Supported Image Formats
 
-`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `tiff`
+`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `tiff`.
 
-GIF payloads that exceed `maxImageSizeMb` are passed through untouched (non-rasterizable; no downscale attempted).
+Downscale path re-encodes to JPEG. Lossless sources (`image/png`, `image/bmp`, `image/tiff`) benefit most. Animated GIF (`image/gif`) is non-rasterizable and passed through untouched even when oversized.
+
+## Error States
+
+| Site | Condition | Behavior |
+|------|-----------|----------|
+| `extractFromFile` | no active file | info Notice "Open a note first to insert the OCR result"; return |
+| `extractFromFile` | path excluded | info Notice naming the rule; return |
+| `extractFromFile` | extract throws | `op.error("OCR extraction failed -- <msg>")` |
+| `extractAndInsert` | per-embed extract throws | `notifications.notifyError(...)`; continue to next embed |
+| `extractAndInsert` | user cancels | write partial inserts, discard checkpoint |
+| `extract` | payload downscaled | Notice "Synapse: large image auto-downscaled to fit the API limit" |
+| `preprocessImage` | canvas/DOM unavailable or downscale throws | console.warn; return original bytes, `downscaled: false` |
 
 ## Invariants / Gotchas
 
-- `extractAndInsert` processes embeds in **reverse line order** so that inserts at higher line numbers do not shift lower line numbers. All inserts are applied atomically via `vault.process()`.
-- A 2 s delay (`window.setTimeout`) is inserted between successive API calls to respect rate limits.
-- `preprocessImage` is only available in Obsidian's Electron renderer (needs `createEl` + `createImageBitmap` or `Image`). In unit tests without DOM mocks it degrades gracefully (returns original bytes, `downscaled: false`).
-- `arrayBufferToBase64` and `base64EncodedLength` canonical home is `shared/encoding.ts`; `preprocess.ts` re-exports them for back-compat so callers that previously imported from `image` continue to work.
+- `extractAndInsert` sorts embeds by descending line and applies all inserts atomically in one `vault.process()` so earlier splices never shift later lines.
+- A 2000ms `window.setTimeout` delay separates successive API calls to respect rate limits.
+- `preprocessImage` needs Obsidian's Electron renderer (`createEl` + `createImageBitmap`/`Image`); in non-DOM test envs it passes original bytes through (`downscaled: false`).
+- `arrayBufferToBase64`/`base64EncodedLength` canonical home is `shared/encoding.ts`; `preprocess.ts` re-exports them for back-compat (only `arrayBufferToBase64` is also forwarded through the `index.ts` barrel).

--- a/src/intake/AGENTS.md
+++ b/src/intake/AGENTS.md
@@ -1,43 +1,50 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Intake Module
 
-Watches a configurable intake folder and auto-processes newly added/settled notes (#111): routes each note (article URL / media URL / general), runs the full Synapse pipeline on it, stamps a processed flag, and optionally relocates it. Imports only `obsidian` and `src/shared/*`; all cross-module work goes through injected `IntakeDeps`.
+Watches a configurable intake folder and auto-processes newly added/settled notes (#111): routes each note (transcription URL / article URL / general), runs the full Synapse pipeline on it, stamps a processed flag, and optionally relocates it. Imports only `obsidian`, `src/shared/*`, and the `SynapseSettings` type; all cross-module work goes through injected `IntakeDeps`.
 
 ## Public API
 
 Exported from `index.ts`:
 
 ```ts
-// index.ts
+// index.ts:58 — class IntakeModule
 class IntakeModule {
-  constructor(plugin: Plugin, getSettings: () => SynapseSettings, notifications: NotificationManager, deps: IntakeDeps)
-  onload(): Promise<void>    // registers vault create+modify listeners when intake.enabled
-  onunload(): void           // clears all pending debounce timers
+  constructor(
+    plugin: Plugin,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+    deps: IntakeDeps,
+  )
+  onload(): Promise<void>    // index.ts:78 — registers vault create+modify listeners when intake.enabled
+  onunload(): void           // index.ts:93 — clears all debounce timers + pending/inFlight sets
 }
 
-// types.ts
+// types.ts:9 / types.ts:12
 const SYNAPSE_PROCESSED_FLAG = 'synapse-processed'        // frontmatter idempotency flag
 const SYNAPSE_PROCESSED_AT_FLAG = 'synapse-processed-at'  // ISO timestamp companion
 
+// types.ts:19
 type IntakeRoute =
   | { kind: 'transcription'; url: string; mediaType: 'video' | 'audio' }   // STUB (#112)
   | { kind: 'article'; url: string }                                        // fetch + append + pipeline
   | { kind: 'general' }                                                     // pipeline on note as-is
 
+// types.ts:46
 interface IntakeDeps {
   fireOnFile(file: TFile): Promise<void>                                    // run whole pipeline on ONE note
   transcribeUrlToNote(url: string, mediaType: 'video' | 'audio', file: TFile): Promise<void>  // STUB (#112)
 }
 
-// intake-dispatcher.ts
+// intake-dispatcher.ts:18
 class IntakeDispatcher {
-  route(file: TFile, parsed: ParsedNote): IntakeRoute   // classifies note into a route
+  route(file: TFile, parsed: ParsedNote): IntakeRoute   // intake-dispatcher.ts:25 — classify note into a route
 }
 
-// settings-section.ts
+// settings-section.ts:7
 function renderIntakeSettings(ctx: SettingsSectionContext): void
 ```
 
@@ -46,70 +53,93 @@ function renderIntakeSettings(ctx: SettingsSectionContext): void
 | File | Exports | Purpose |
 |------|---------|---------|
 | `index.ts` | `IntakeModule`, `IntakeDispatcher`, `IntakeDeps`, `IntakeRoute`, `SYNAPSE_PROCESSED_FLAG`, `SYNAPSE_PROCESSED_AT_FLAG`, `renderIntakeSettings` | Barrel + folder watcher |
-| `intake-dispatcher.ts` | `IntakeDispatcher` | Routes a parsed note to an `IntakeRoute` |
+| `intake-dispatcher.ts` | `IntakeDispatcher` | Pure routing of a parsed note to an `IntakeRoute` |
 | `types.ts` | `IntakeRoute`, `IntakeDeps`, `SYNAPSE_PROCESSED_FLAG`, `SYNAPSE_PROCESSED_AT_FLAG` | Type model |
 | `settings-section.ts` | `renderIntakeSettings` | Settings UI accordion (#243) |
 | `intake-module.test.ts`, `intake-dispatcher.test.ts`, `intake-organize-e2e.test.ts`, `settings-section.test.ts` | Tests | |
+
+Note: `index.ts` re-exports `IntakeDispatcher`, `IntakeDeps`, `IntakeRoute`, and both flags from their source files; `IntakeModule` is the module's primary public class.
+
+## Routing Table
+
+`IntakeDispatcher.route` (intake-dispatcher.ts:25) maps a note to a branch. A note is "bare URL" only when the body contains exactly one URL and nothing but whitespace remains after removing it (`bareUrl`, intake-dispatcher.ts:55). The URL is then classified via `classifyUrl`.
+
+| Body shape | `classifyUrl` type | Route `kind` | Branch (execute, index.ts:277) |
+|------------|--------------------|--------------|--------------------------------|
+| Not a bare URL (prose / 0 / multiple URLs) | — | `general` | `deps.fireOnFile` |
+| Bare URL | `video` or `audio` | `transcription` | `deps.transcribeUrlToNote` (STUB no-op) |
+| Bare URL | `article` | `article` | `fetchArticleContent` → append → `deps.fireOnFile` |
+| Bare URL | `unknown` (or default) | `general` | `deps.fireOnFile` |
 
 ## Data Flow
 
 ```
 vault create/modify event
-  --> handleEvent: cheap sync guards (is .md, intake.enabled, in intake folder,
-                   not capture-log subfolder, not path-excluded, not in-flight)
-  --> scheduleFlush(path): per-path debounce, resets timer on every event (settle window)
-        settleWindowMs = intake.settleSeconds * 1000 (fallback 5000ms if missing/invalid)
-  --> flush(path) after the note is quiet for the full window:
+  --> handleEvent (index.ts:107): cheap sync guards, cheapest-first:
+        is TFile && .md  -->  intake.enabled  -->  isInIntakeFolder
+        (excludes capture-log subfolder)  -->  not isPathExcluded(...,'intake',...)
+        -->  not inFlight
+  --> scheduleFlush(path) (index.ts:189): per-path debounce, resets timer on every event
+        settleWindowMs (index.ts:212) = intake.settleSeconds * 1000
+        (fallback DEBOUNCE_MS=5000ms when missing/not a positive number, index.ts:37)
+  --> flush(path) (index.ts:225) after the note is quiet for the full window:
         read + parseFrontmatter
-        idempotency guard: skip if SYNAPSE_PROCESSED_FLAG is truthy
+        idempotency guard (isProcessed, index.ts:260): skip if SYNAPSE_PROCESSED_FLAG truthy
         dispatcher.route(file, parsed) --> execute(file, route)
-  --> execute:
+  --> execute (index.ts:277):
         snapshot originalPath (organize mutates file.path on rename)
         transcription: deps.transcribeUrlToNote (STUB no-op)
         article:       fetchArticleContent(url) --> appendArticleContent --> deps.fireOnFile
         general:       deps.fireOnFile
-        markProcessedAndMaybeMove --> optional writeCaptureBreadcrumb
+        markProcessedAndMaybeMove (index.ts:355) --> optional writeCaptureBreadcrumb (index.ts:449)
 ```
 
 ## Processing Semantics
 
 - Idempotency: a note carrying `synapse-processed` (boolean `true` or string `'true'`) is never reprocessed; this also suppresses the modify echo from the flag-stamp write.
-- In-flight guard: paths being flushed are tracked so the stamp/move rename echo does not re-enter `flush`.
+- In-flight guard: paths being flushed are tracked in `inFlight` (keyed on originalPath) so the stamp/move rename echo does not re-enter `flush`.
 - Path exclusion: `isPathExcluded(file.path, 'intake', settings)` is checked before scheduling; excluded notes are silently skipped (#307).
-- Primary mover is organize (last pipeline phase). `moveWhenDone` is a FALLBACK mover, applied only when organize left the note inside the intake folder (low-confidence / no-op).
-- Stamp-before-move: the processed flag is written before any relocation so idempotency survives the move's rename echo.
-- Failure leaves the note un-stamped (retriable); errors surface via `notifications.notifyError`.
+- Primary mover is organize (last pipeline phase inside `fireOnFile`). `moveWhenDone` is a FALLBACK mover (index.ts:355), applied only when organize left the note inside the intake folder (low confidence / no-op).
+- Stamp-before-move: the processed flag is written before any relocation (`stampProcessed`, index.ts:401) so idempotency survives the move's rename echo.
+- `moveNote` (index.ts:414) uses `fileManager.renameFile` so inbound links stay intact and `ensureFolder` to create the destination.
 
 ## Capture Log (#224)
 
-When `intake.captureLog` is true and a processed note actually left the intake folder, a dated breadcrumb
-is written to `<intakeFolder>/<captureLogFolder>/<YYYY-MM-DD> — <title>.md` (default subfolder `_captured`).
-The capture-log subfolder is excluded from the watcher and breadcrumbs are stamped `synapse-processed: true`
-(defense-in-depth) so they are never re-ingested — preventing an infinite ingest loop.
+When `intake.captureLog` is true and a processed note actually left the intake folder (`movedOutOfIntake`, index.ts:392), a dated breadcrumb is written to `<intakeFolder>/<captureLogFolder>/<YYYY-MM-DD> — <title>.md` (default subfolder `_captured`). The capture-log subfolder is excluded from the watcher (`isInIntakeFolder`, index.ts:148) and breadcrumbs are stamped `synapse-processed: true` (defense-in-depth) so they are never re-ingested — preventing an infinite ingest loop.
 
-Collision policy (#227): two distinct notes that sanitize to the same dated title get a uniqueness suffix
-(` (2)`, ` (3)`, ...). Re-processing the same note overwrites its own breadcrumb idempotently.
+Collision policy (#227, `resolveBreadcrumbPath`, index.ts:495): two distinct notes that sanitize to the same dated title get a uniqueness suffix (` (2)`, ` (3)`, ...). Re-processing the same note overwrites its own breadcrumb idempotently (`breadcrumbTargets`, index.ts:527).
 
-## Settings Keys
+## Configuration
 
-All under `settings.intake` (`IntakeSettings`):
+All under `settings.intake` (`IntakeSettings`, settings.ts:216; defaults `DEFAULT_SETTINGS.intake`, settings.ts:478):
 
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
-| `enabled` | boolean | true | Module activation (watcher registration) |
+| `enabled` | boolean | `true` | Module activation (watcher registration) |
 | `intakeFolder` | string | `'Inbox'` | Folder watched; empty/whitespace watches nothing |
-| `markProcessed` | boolean | true | Stamp `synapse-processed` after processing |
-| `moveWhenDone` | string? | `''` | Fallback destination when organize did not relocate the note |
-| `settleSeconds` | number | 5 | Debounce settle window (seconds) before processing |
-| `captureLog` | boolean | true | Write breadcrumb when a note is organized out of the intake folder |
+| `markProcessed` | boolean | `true` | Stamp `synapse-processed` after processing |
+| `moveWhenDone` | string \| undefined | `''` | Fallback destination when organize did not relocate the note |
+| `settleSeconds` | number | `5` | Debounce settle window (seconds) before processing |
+| `captureLog` | boolean | `true` | Write breadcrumb when a note is organized out of the intake folder |
 | `captureLogFolder` | string | `'_captured'` | Breadcrumb subfolder (excluded from watcher) |
+
+## Error States
+
+| Condition | Handling |
+|-----------|----------|
+| File vanished before flush | `flush` returns silently (index.ts:226) |
+| Note already processed | `flush` returns before routing (idempotency, index.ts:237) |
+| Processing throws (fetch/pipeline) | Caught in `flush`; note left un-stamped (retriable); surfaced via `notifications.notifyError` (index.ts:243) |
+| Breadcrumb read fails during collision check | Treated as "not ours" → falls through to a suffix rather than clobbering (`breadcrumbTargets`, index.ts:531) |
+| Empty/whitespace `intakeFolder` | Watches nothing; `isInIntakeFolder` returns false (index.ts:149) |
 
 ## Dependencies
 
 | Import | From |
 |--------|------|
+| `Plugin`, `TFile`, `TAbstractFile`, `normalizePath`, `Setting` | `obsidian` |
 | `NotificationManager`, `ensureFolder`, `fetchArticleContent`, `isPathExcluded`, `parseFrontmatter`, `serializeFrontmatter`, `writeNote`, `classifyUrl`, `extractUrls`, `ParsedNote`, `SettingsSectionContext` | `../shared` |
+| `SynapseSettings` (type) | `../settings` |
 | `fireOnFile`, `transcribeUrlToNote` | injected via `IntakeDeps` (wired in `main.ts`) |
 
-Architecture rule: intake imports no feature module. `fireOnFile` is `SynapseRunner.fireOnFile` injected by `main.ts`.
-The transcription branch (`transcribeUrlToNote`) is a STUB (#112) and currently no-ops with a notice.
+Architecture rule: intake imports no feature module — only `obsidian`, `src/shared/*`, and the `SynapseSettings` type. `fireOnFile` is `SynapseRunner.fireOnFile` injected by `main.ts`. The transcription branch (`transcribeUrlToNote`) is a STUB (#112) and currently no-ops with a notice.

--- a/src/organize/AGENTS.md
+++ b/src/organize/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # organize module
 
-AI-powered semantic directory structuring. Analyzes note content to determine the best directory, moves directly to existing directories or creates proposals for new ones. Supports checkpointed vault scans for resumability.
+AI-powered semantic directory structuring: analyzes note content to pick the best directory, moves directly into existing directories or proposes new ones, runs resumable checkpointed vault scans, and writes Mermaid move-diagram summaries.
 
 ## Public API (`index.ts`)
 
@@ -104,7 +104,7 @@ acceptProposal(id, options?)
   --> OrganizeStore.saveSnapshot()
   --> vault.rename(file, newPath)
   --> OrganizeStore.updateProposalStatus('accepted')
-  --> writeOrganizeSummary(moveRecords)  [.synapse/organize/summaries/]
+  --> writeOrganizeSummary(moveRecords)  [Mermaid move diagram -> .synapse/organize/summaries/]
 
 rejectProposal(id)
   --> OrganizeStore.updateProposalStatus('rejected')
@@ -202,7 +202,7 @@ Out: `ContentAnalyzer` and `DirectoryMatcher` are re-exported for use by `deep-d
 - Move skips if a file already exists at the destination (returns null, does not overwrite).
 - Batch scan coalesces near-identical proposed directories via `batchProposedDirs` map — variants like "model"/"models" resolve to a single folder (#172).
 - `organizeConfidenceThreshold` gates new-directory proposals; `minScoreThreshold` (0.6, hardcoded in `determineAction` call site) gates existing-directory moves.
-- Summary notes written to `.synapse/organize/summaries/{YYYY-MM-DD}-organize-summary.md`.
+- Summary notes (Mermaid `graph LR` move diagram via `generateOrganizeSummary`) written to `.synapse/organize/summaries/{YYYY-MM-DD}-organize-summary.md` by `writeOrganizeSummary` / `buildSummaryPath`.
 - `deep-dive` calls `onOrganizeRequested` which invokes `organizeNote` on accepted deep-dive notes (when `deepDive.autoOrganizeOnAccept` is true).
 
 ## Tests

--- a/src/pipeline/AGENTS.md
+++ b/src/pipeline/AGENTS.md
@@ -1,38 +1,53 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Pipeline Module
 
-Fire Synapse orchestration: runs the ordered multi-phase pipeline (elaboration → summarize → enrichment → REM → tidy → organize) over a folder or a single note. Each phase is one feature module's scan function, gated by settings and the command registry.
+Fire Synapse orchestration: runs the ordered multi-phase pipeline (elaboration -> summarize -> enrichment -> rem -> tidy -> organize) over a folder or a single note, where each phase is one feature module's scan function gated by settings and the command registry.
 
 ## Public API
 
-Exported from `index.ts`:
+Re-exported from `index.ts`:
 
 ```ts
 // types.ts
-type PipelineModuleKey = 'elaboration' | 'summarize' | 'enrichment' | 'rem' | 'tidy' | 'organize'
+type PipelineModuleKey =
+  | 'elaboration'
+  | 'summarize'
+  | 'enrichment'
+  | 'rem'
+  | 'tidy'
+  | 'organize';
 
 // Scan-fn contract every pipeline module must satisfy.
-// folderPath scopes the scan; skipConfirmation bypasses the confirm dialog (always true from Fire Synapse);
-// onlyFile narrows a folder scan to a single note (filtered right after getMarkdownFiles).
+// folderPath scopes the scan; skipConfirmation bypasses the confirm dialog
+// (always true from Fire Synapse); onlyFile narrows a folder scan to a single
+// note (filtered right after getMarkdownFiles). Returns a processed count or void.
 type PipelineScanFn = (
   folderPath?: string,
   skipConfirmation?: boolean,
   onlyFile?: TFile,
-) => Promise<number | void>
+) => Promise<number | void>;
 
-interface PipelinePhase { key: PipelineModuleKey; label: string }
-type PipelineModuleMap = Record<PipelineModuleKey, PipelineScanFn>
+interface PipelinePhase {
+  key: PipelineModuleKey;
+  label: string;
+}
 
-const SYNAPSE_PIPELINE: PipelinePhase[]   // ordered phases (see below)
+type PipelineModuleMap = Record<PipelineModuleKey, PipelineScanFn>;
+
+const SYNAPSE_PIPELINE: PipelinePhase[]; // ordered phases (see table below)
 
 // synapse-runner.ts
 class SynapseRunner {
-  constructor(modules: PipelineModuleMap, getSettings: () => SynapseSettings, notifications: NotificationManager)
-  fire(folderPath?: string): Promise<void>        // folder-scoped, all active phases
-  fireOnFile(file: TFile): Promise<void>          // single-note scoped (used by intake #111)
+  constructor(
+    modules: PipelineModuleMap,
+    getSettings: () => SynapseSettings,
+    notifications: NotificationManager,
+  );
+  fire(folderPath?: string): Promise<void>; // folder-scoped, all active phases
+  fireOnFile(file: TFile): Promise<void>;   // single-note scoped (intake #111)
 }
 ```
 
@@ -40,12 +55,15 @@ class SynapseRunner {
 
 | File | Exports | Purpose |
 |------|---------|---------|
-| `types.ts` | `PipelineModuleKey`, `PipelineModuleMap`, `PipelinePhase`, `PipelineScanFn`, `SYNAPSE_PIPELINE` | Phase model + ordered phase list |
+| `types.ts` | `PipelineModuleKey`, `PipelineModuleMap`, `PipelinePhase`, `PipelineScanFn`, `SYNAPSE_PIPELINE` | Phase model + ordered phase list + scan-fn contract |
 | `synapse-runner.ts` | `SynapseRunner` | Sequential phase executor with per-phase progress + error isolation |
-| `index.ts` | re-exports all of the above | Barrel |
-| `synapse-runner.test.ts`, `fire-flow-gate.test.ts` | Tests | |
+| `index.ts` | re-exports `SynapseRunner`, `SYNAPSE_PIPELINE`, and the four types | Barrel (public API) |
+| `synapse-runner.test.ts` | tests | Runner behaviour (filtering, progress, error isolation, fireOnFile) |
+| `fire-flow-gate.test.ts` | tests | Flow-gate filtering via `isPipelineKeyInFlow` |
 
 ## Ordered Phases (`SYNAPSE_PIPELINE`)
+
+Source: types.ts:L41-L48. Order is load-bearing — the runner executes phases in array order.
 
 | Order | key | label |
 |-------|-----|-------|
@@ -58,31 +76,48 @@ class SynapseRunner {
 
 Organize is intentionally last: it is the content-aware mover that relocates notes to their proper folder.
 
-## Execution
+## Data Flow
 
 ```
-fire(folderPath?) / fireOnFile(file)
+fire(folderPath?)  /  fireOnFile(file)
   --> activePhases = SYNAPSE_PIPELINE.filter(p =>
         settings[p.key].enabled && isPipelineKeyInFlow(p.key, 'fire-synapse'))
-  --> if none active: notify "No features are enabled", return
-  --> startOperation with N-phase progress
-  --> for each phase (sequential, ordered):
-        modules[phase.key](folderPath, true[, file])   // skipConfirmation=true; onlyFile for fireOnFile
-        per-phase try/catch — a thrown phase is logged (console.warn) and the run continues
-  --> finish unless cancelled
+  --> if activePhases.length === 0: notifications.info('No features are enabled'); return
+  --> op = notifications.startOperation('Fire Synapse (0/N)' | 'Fire Synapse on <basename> (0/N)')
+  --> for each phase (sequential, in order):
+        if op.cancelled: break
+        op.progress(completed, N, 'Phase i/N: <label>')
+        try { await modules[phase.key](folderPath, true[, file]) }  // skipConfirmation=true
+        catch { console.warn('[Synapse] Phase <label> failed: <msg>') }  // isolated; run continues
+  --> if !op.cancelled: op.finish('Fire Synapse complete — <completed> phases run')
 ```
 
-`fireOnFile` scopes each phase to the note's parent folder (so `getMarkdownFiles` includes it) and passes
-the note as `onlyFile`; every module's scan fn filters to that single path. The folder-scoped `fire` path
-never passes `onlyFile`.
+- `fire` (synapse-runner.ts:L14): folder-scoped; never passes `onlyFile`.
+- `fireOnFile` (synapse-runner.ts:L70): scopes `folderPath` to the note's parent folder so `getMarkdownFiles` returns a superset that includes it, then passes the note as `onlyFile` (3rd arg) so each module filters to that single path. A root-level note (parent is root/undefined) passes `folderPath = undefined`. Uses operation id `synapse-fire-file`; `fire` uses `synapse-fire`.
+
+## Configuration
+
+| Settings access | Source | Effect |
+|-----------------|--------|--------|
+| `settings[phase.key].enabled` | per-feature settings section keyed by `PipelineModuleKey` | Phase included only when its feature is enabled |
+| `getSettings()` | injected accessor | Read-only; runner never mutates settings |
+
+## Error States
+
+| Condition | Handling |
+|-----------|----------|
+| No phases enabled / in flow | `notifications.info('No features are enabled')`, early return, no operation started |
+| A phase throws | Caught per-phase, logged via `console.warn('[Synapse] Phase <label> failed: ...')`; remaining phases still run (error isolation) |
+| Operation cancelled | `op.cancelled` checked at top of each iteration; loop breaks and `op.finish` is skipped |
 
 ## Dependencies
 
 | Import | From |
 |--------|------|
-| `isPipelineKeyInFlow` | `../commands` |
-| `NotificationManager`, `SynapseSettings` (type) | `../shared`, `../settings` |
-| `PipelineModuleMap` | wired in `main.ts` from each module's scan fn |
+| `isPipelineKeyInFlow(pipelineKey: string, flow: CommandFlow): boolean` | `../commands` (registry.ts:L107; fail-open on unmapped key) |
+| `NotificationManager` (type) | `../shared` |
+| `SynapseSettings` (type) | `../settings` |
+| `TFile` (type) | `obsidian` |
+| `PipelineModuleMap` instances | injected by `main.ts` from each feature module's scan fn |
 
-Pipeline imports `commands` but NOT the feature modules directly — `main.ts` injects the `PipelineModuleMap`,
-keeping the runner decoupled from concrete feature implementations.
+Pipeline imports `commands` (for the `fire-synapse` flow gate) but NOT the feature modules directly — `main.ts` injects the `PipelineModuleMap`, keeping the runner decoupled from concrete feature implementations.

--- a/src/rem/AGENTS.md
+++ b/src/rem/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # REM Module
 
-REM (Re-link & Enrich Mappings): discovers linkable references in note text (literal title/alias matches plus optional AI semantic matches) and proposes in-place `[[wikilink]]` insertions. Accepting a proposal rewrites the note body. Participates in the Fire Synapse pipeline (phase 4) and the unified proposal view.
+REM (Re-link & Enrich Mappings): discovers linkable references in note text (literal title/alias matches plus always-on AI semantic matches) and proposes in-place `[[wikilink]]` insertions. Accepting a proposal rewrites the note body. Participates in the Fire Synapse pipeline (`pipelineKey: rem`) and the unified proposal view.
 
 ## Public API (`index.ts`)
 
@@ -24,7 +24,7 @@ class RemModule {
   onload(): Promise<void>
   onunload(): void
   remScanNote(filePath: string): Promise<RemProposal | null>
-  remScanDirectory(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
+  remScanDirectory(folderPath?: string, _skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>  // _skipConfirmation currently unused
   resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
   acceptProposal(id: string, acceptedMatchTexts: string[], options?: { silent?: boolean }): Promise<void>
   rejectProposal(id: string): Promise<void>
@@ -140,7 +140,7 @@ Registered in `onload()` (both gated by `rem.enabled`):
 
 | ID | Name | Type | Pipeline |
 |----|------|------|---------|
-| `synapse:rem-current-note` | REM: Discover links in current note | editorCallback | palette |
+| `synapse:rem-current-note` | REM: discover links in current note | editorCallback | palette |
 | `synapse:rem-directory` | Scan folder for links | callback (FolderPickerModal) | palette, fire-synapse (`pipelineKey: rem`) |
 
 ## Auto-Accept (#228)
@@ -160,7 +160,7 @@ Resume re-checks exclusion rules silently (a path may have been excluded after c
 ## Exclusion Rules
 
 ```ts
-// index.ts:L495-500
+// index.ts:L476-482
 private isExcluded(file: TFile): boolean {
   const settings = this.getSettings();
   return (
@@ -179,20 +179,24 @@ Single-note command (`rem-current-note`) names the matched rule in the Notice. D
 
 All under `settings.rem` (`RemSettings`):
 
+Defaults from `settings.ts:L471-477`.
+
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
-| `enabled` | `boolean` | — | Module + command activation |
+| `enabled` | `boolean` | `true` | Module + command activation |
 | `titleMatchWeight` | `number` | `0.6` | Weight for literal title/alias matches when ranking (0-1) |
-| `confidenceThreshold` | `number` | — | Min confidence for semantic candidates (0-1) |
-| `maxLinksPerNote` | `number` | — | Max link candidates per scanned note |
+| `confidenceThreshold` | `number` | `0.5` | Min confidence for semantic candidates only (0-1) |
+| `maxLinksPerNote` | `number` | `20` | Max link candidates per scanned note |
 | `remFolderPath` | `string` | `.synapse/rem` | Storage folder for proposal JSON files |
+
+Settings UI (`settings-section.ts`) renders only the `enabled` toggle, `confidenceThreshold` slider, and `maxLinksPerNote` text input. `titleMatchWeight` has no UI control (#380) — edit `data.json` directly to change it.
 
 ## Dependencies
 
 | Import | From |
 |--------|------|
-| `generateId`, `getMarkdownFiles`, `FolderPickerModal`, `fireAndForget`, `isPathExcluded`, `matchesExcludeTag`, `findMatchingRule`, `NotificationManager`, `CheckpointManager` | `../shared` |
-| `DeferredTask`, `CheckpointWorkItem`, `Checkpoint` | `../shared` (type-only) |
+| `generateId`, `getMarkdownFiles`, `FolderPickerModal`, `fireAndForget`, `isPathExcluded`, `matchesExcludeTag`, `findMatchingRule` | `../shared` |
+| `NotificationManager`, `CheckpointManager`, `DeferredTask`, `CheckpointWorkItem`, `Checkpoint` | `../shared` (type-only) |
 | `CommandRegistrar` | `../commands` (type-only) |
 | `SynapseSettings`, `RemSettings` | `../settings` (type-only) |
 | `MentionScanner` | `./mention-scanner` |

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -1,15 +1,16 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Shared Module
 
-Cross-cutting base layer used by all feature modules: AI client, secret redaction, file operations, base64 encoding, notifications, validation, frontmatter parsing, checkpoint management, ID generation, URL platform detection / classification, web content fetching, credential validation, JSON utilities, and Node.js desktop-only loader. Depends on NO feature module — this is the bottom of the dependency graph.
+Cross-cutting base layer used by all feature modules: AI client, secret redaction, file operations, base64 encoding, notifications, in-app update checking, validation, frontmatter parsing, checkpoint management, ID generation, note-title predicates, URL platform detection / classification, web / Reddit / tweet content fetching, credential validation, JSON utilities, and Node.js desktop-only loader. Depends on NO feature module — this is the bottom of the dependency graph.
 
 Canonical homes (re-exported elsewhere for back-compat — import from the `shared` barrel, never an internal file):
 - `url-detector.ts` (`detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult`) — moved here from `src/video/` to break the former shared⇄video import cycle; `video` re-exports for back-compat.
-- `redact.ts` (`redactSecrets`) — single source of truth for API-key/token redaction; `ai-client.ts` re-exports it. Previously `ai-client` and `notifyError` each kept inline copies that drifted (the `notifyError` copy lacked the Google `AIza` pattern).
+- `redact.ts` (`redactSecrets`) — single source of truth for API-key/token redaction; `ai-client.ts` re-exports it. Consumed by `ai-client.ts`, `credential-validator.ts`, and `notifications.ts` (operation-error + notifyError paths). Previously `ai-client` and the former `api-utils.notifyError` each kept inline copies that drifted (the `notifyError` copy lacked the Google `AIza` pattern).
 - `encoding.ts` (`arrayBufferToBase64`, `base64EncodedLength`) — base64 helpers; `image/preprocess.ts` re-exports them so audio + image + elaboration share one implementation.
+- `title-detector.ts` (`isUntitled`, `isGenericTitle`) — note-title predicates; lives here (not in `title/`) so non-title features can reuse them without a cross-feature import. `title/title-detector.ts` re-exports `isUntitled`.
 
 ## Public API
 
@@ -22,7 +23,7 @@ class AIClient {
   complete(prompt: string, systemPrompt?: string): Promise<string>
   chat(messages: ChatMessage[]): Promise<string>   // providers: openai | anthropic | gemini | ollama
 }
-function extractGeminiResponseText(json: GeminiResponseJson): string  // throws on blocked/empty 200 shapes
+function extractGeminiResponseText(json: unknown): string  // throws on blocked/empty 200 shapes
 export { redactSecrets }                              // re-export of redact.ts (back-compat)
 
 // redact.ts (single source of truth for secret redaction)
@@ -39,7 +40,8 @@ type ContentBlock = TextContentBlock | ImageContentBlock
 interface ChatMessage { role: 'system' | 'user' | 'assistant'; content: string | ContentBlock[] }
 
 // notifications.ts
-type NoticeLevel = 'info' | 'progress' | 'success' | 'warning' | 'error'
+function linkLoadError(source: string, reason: string): string   // standardized "Could not load content from {source}: {reason}" message
+type NoticeLevel = 'info' | 'progress' | 'success' | 'warning' | 'error'   // NOT re-exported via the barrel; module-local, used by signatures below
 interface NoticeAction {
   label: string
   onClick: () => void
@@ -57,9 +59,25 @@ class NotificationManager {
   confirm(message: string, options?: { proceedLabel?: string; cancelLabel?: string; level?: NoticeLevel }): Promise<boolean>
   cancelOperation(id: string): void
   info(message: string, duration?: number, action?: NoticeAction): void
+  infoSticky(message: string, action: NoticeAction): void   // duration 0, dismissible; used by UpdateChecker
   success(message: string, duration?: number, action?: NoticeAction): void
-  notifyError(context: string, error: unknown): void
+  error(message: string): void   // persistent, copy-on-dismiss; redacts via redactSecrets
+  notifyError(context: string, error: unknown): void   // error object + context label; routes through error()/redactSecrets
   dispose(): void
+}
+
+// update-checker.ts
+function isNewerVersion(latest: string, current: string): boolean   // strict semver gt; tolerant of leading 'v'; false on equal/older/malformed
+interface UpdateCheckerDeps {
+  currentVersion: string
+  app: App
+  notifications: NotificationManager
+  getSettings: () => SynapseSettings
+  saveSettings: () => Promise<void>
+}
+class UpdateChecker {
+  constructor(deps: UpdateCheckerDeps)
+  maybeCheck(now?: number): Promise<void>   // gated on settings.updates.enableUpdateNotifications; polls GitHub Releases at most 1/24h; fails silently; never nags twice
 }
 
 // file-utils.ts
@@ -70,10 +88,9 @@ function getMarkdownFiles(app: App, folder?: string): TFile[]
 function getIncludedMarkdownFiles(app: App, feature: FeatureId, settings: ExclusionSettings, folder?: string): TFile[]
 function wordCount(text: string): number
 
-// api-utils.ts
-function withRetry<T>(fn: () => Promise<T>, maxRetries?: number, delayMs?: number, shouldRetry?: (error: unknown) => boolean): Promise<T>
+// api-utils.ts (notifyError now lives on NotificationManager, not here)
+function withRetry<T>(fn: () => Promise<T>, maxRetries?: number, delayMs?: number, shouldRetry?: (error: unknown) => boolean): Promise<T>   // defaults: maxRetries 3, delayMs 1000, shouldRetry () => true; exponential backoff
 function sleep(ms: number): Promise<void>
-function notifyError(context: string, error: unknown): void   // redacts secrets via redactSecrets() before Notice/console
 function classifyNetworkError(error: unknown): NetworkErrorKind   // 'connection-refused' | 'dns' | 'timeout' | 'offline' | null
 function isTransientNetworkError(error: unknown): boolean
 function describeNetworkError(error: unknown, resource: string): string | null   // user-facing explanation, null for non-network
@@ -126,6 +143,12 @@ function fetchTweetContent(url: string, maxLength: number): Promise<string>
 function isTwitterUrl(url: string): boolean
 interface TweetContent { author: string; text: string; url: string }
 
+// reddit-fetcher.ts
+function fetchRedditContent(url: string, maxLength: number): Promise<string>   // resolves share/short links, reads per-post .rss Atom feed, formats post + top comments
+function isRedditUrl(url: string): boolean                       // reddit.com / *.reddit.com / redd.it hostnames
+function extractCanonicalPostUrl(html: string): string          // derive /comments/ permalink from share-page HTML; '' if none (exported mainly for tests)
+interface RedditContent { author: string; title: string; selftext: string; comments: string[]; url: string }
+
 // callouts.ts
 const CALLOUT_TYPES: {
   summary: 'synapse-summary'
@@ -159,6 +182,10 @@ class FolderPickerModal extends SuggestModal<TFolder> { ... }
 // id-utils.ts
 function generateId(): string                    // timestamp(base36) + random(base36)
 function isValidCheckpointId(id: string): boolean // /^[a-z0-9]+$/
+
+// title-detector.ts
+function isUntitled(title: string): boolean       // matches Obsidian 'Untitled' / 'Untitled N' default (case-insensitive)
+function isGenericTitle(title: string): boolean   // generic = Untitled default | date-style daily-note name | bare URL
 
 // checkpoint-manager.ts
 class CheckpointManager {
@@ -310,14 +337,17 @@ function scoreLyricsContent(content: string): number
 | File | Exports | Purpose |
 |------|---------|---------|
 | `ai-client.ts` | `AIClient`, `extractGeminiResponseText`, re-export `redactSecrets` | Multi-provider AI completion (openai/anthropic/gemini/ollama) with multi-modal support; `safeRequest`, `resolveModelId`, `toOpenAIContent`, `toAnthropicContent`, `toGeminiContent`, `toOllamaMessage` (internal). Imports `redactSecrets` from `redact.ts` |
-| `redact.ts` | `redactSecrets` | Single source of truth for API-key/token redaction (sk-/key-/dg-/Bearer/Token/anthropic-/AIza). Consumed by `ai-client.ts` + `api-utils.ts`; redaction behavior covered by `ai-client.test.ts` + `api-utils.test.ts` |
+| `redact.ts` | `redactSecrets` | Single source of truth for API-key/token redaction (sk-/key-/dg-/Bearer/Token/anthropic-/AIza). Consumed by `ai-client.ts`, `credential-validator.ts`, `notifications.ts`; redaction behavior covered by `redact.test.ts` |
+| `redact.test.ts` | Tests | Redaction pattern tests |
 | `encoding.ts` | `arrayBufferToBase64`, `base64EncodedLength` | Base64 encode + exact encoded-length calc; canonical home reused by audio/image/elaboration |
 | `encoding.test.ts` | Tests | Encoding tests |
 | `types.ts` | `ChatMessage`, `ContentBlock`, `TextContentBlock`, `ImageContentBlock` | Shared types including multi-modal content blocks |
-| `notifications.ts` | `NotificationManager`, `OperationHandle`, `NoticeLevel`, `NoticeAction` | Centralized notifications with cancellation, progress, confirmation snackbars, and action buttons. `dispose()` tears down all in-flight operations (called from `main.ts` `onunload()`). `info()` and `success()` accept optional `action?: NoticeAction`. `OperationHandle.finish()` accepts optional `action?: NoticeAction`. |
+| `notifications.ts` | `NotificationManager`, `linkLoadError`, `OperationHandle`, `NoticeAction` (barrel); `NoticeLevel` (module-local, not re-exported) | Centralized notifications with cancellation, progress, confirmation snackbars, and action buttons. `dispose()` tears down all in-flight operations (called from `main.ts` `onunload()`). `info()`/`success()` accept optional `action?: NoticeAction`; `infoSticky()` shows a duration-0 dismissible action toast; `error()`/`notifyError()`/operation-error `console.error` all route through `redactSecrets` (single redaction source). `linkLoadError(source, reason)` builds the shared external-link failure message used by Elaborate + Summarize |
 | `notifications.test.ts` | Tests | NotificationManager tests |
+| `update-checker.ts` | `UpdateChecker`, `isNewerVersion`, `UpdateCheckerDeps` | In-app "newer Synapse available" check (#365). Polls the plugin's own public GitHub Releases API at most once/24h (gated on `settings.updates.enableUpdateNotifications`), compares the latest tag to the running version, and shows a sticky notice via `notifications.infoSticky` whose button opens Settings → Community plugins. Fails silently (offline/non-200/malformed → logged `null`); records the shown version so it never nags twice. `isNewerVersion` is pure semver gt |
+| `update-checker.test.ts` | Tests | UpdateChecker + isNewerVersion tests |
 | `file-utils.ts` | `ensureFolder`, `readNote`, `writeNote`, `getMarkdownFiles`, `getIncludedMarkdownFiles`, `wordCount` | Vault file operations. `getIncludedMarkdownFiles` drops notes excluded by centralized exclusion rules for a given `FeatureId` |
-| `api-utils.ts` | `withRetry`, `sleep`, `notifyError`, `classifyNetworkError`, `isTransientNetworkError`, `describeNetworkError` | Retry with exponential backoff, network-error classification/disclosure, redacted error display (via `redactSecrets`) |
+| `api-utils.ts` | `withRetry`, `sleep`, `classifyNetworkError`, `isTransientNetworkError`, `describeNetworkError` | Retry with exponential backoff + per-error `shouldRetry` gate, network-error classification/disclosure. `notifyError` no longer lives here — error display moved to `NotificationManager` |
 | `validation.ts` | `sanitizeUrl`, `sanitizePath`, `ensureWithinVault`, `sanitizeAIResponse`, `stripCodeFences`, `blockquoteOriginal`, `parseTimestamp`, `validateTimeRange`, `formatTimeRange`, `TimeRange` | Input validation, output sanitization, time-range parsing |
 | `validation.test.ts` | Tests | Validation tests |
 | `url-detector.ts` | `detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult` | Regex platform detection (moved here from video/) |
@@ -343,6 +373,10 @@ function scoreLyricsContent(content: string): number
 | `checkpoint-manager.test.ts` | Tests | CheckpointManager tests |
 | `tweet-fetcher.ts` | `fetchTweetContent`, `isTwitterUrl`, `TweetContent` | Twitter/X.com tweet fetching with oEmbed → fxtwitter → vxtwitter fallback chain |
 | `tweet-fetcher.test.ts` | Tests | Tweet fetcher tests |
+| `reddit-fetcher.ts` | `fetchRedditContent`, `isRedditUrl`, `extractCanonicalPostUrl`, `RedditContent` | Reddit post fetching via the per-post `.rss` Atom feed (the `.json` API now 403s unauthenticated clients). Resolves `/s/` share + `redd.it` short links to canonical `/comments/` permalinks from share-page HTML, retries 429/503 with backoff, formats post body + top `MAX_COMMENTS` comments. Uses Obsidian `requestUrl` (never native fetch) for mobile CSP (#88) |
+| `reddit-fetcher.test.ts` | Tests | Reddit fetcher + canonical-URL + Atom-parsing tests |
+| `title-detector.ts` | `isUntitled`, `isGenericTitle` | Note-title predicates shared across features (canonical home; `title/title-detector.ts` re-exports `isUntitled`). `isGenericTitle` = Untitled default OR date-style daily-note name (validated month/day ranges) OR bare URL; used by elaboration's anti-fabrication guard so a generic-titled empty note is refused rather than fabricated from the filename |
+| `title-detector.test.ts` | Tests | Title-predicate tests |
 | `exclusions.ts` | `FeatureId`, `ExclusionRule`, `ExclusionSettings`, `LegacyModuleExclusions`, `ALL_FEATURE_IDS`, `findMatchingRule`, `isPathExcluded`, `matchesExcludeTag`, `buildMigratedExclusions` | Centralized per-path exclusion (#307): case-sensitive glob→regex matcher (`/**`, `/*`, exact, bare-token recursive; escapes metacharacters), shared tag-exclusion check, and the legacy `excludeFolders`→`exclusions` migration builder |
 | `exclusions.test.ts` | Tests | Exclusion matcher + migration tests |
 | `content-schemas.ts` | `ContentSchema`, `PipelineStage`, `SchemaMode`, `CONTENT_SCHEMAS`, `detectSchemaFor`, `isRecipeContent`, `scoreRecipeContent`, `isReceiptContent`, `scoreReceiptContent`, `isLyricsContent`, `scoreLyricsContent` | Content-aware formatting registry (#233): recipe/receipt/lyrics detection heuristics + prompts, stage-gated via `appliesTo` and `mode`. `isLyricsContent`/`scoreLyricsContent` added for audio transcription lyric reformatting (#234) |
@@ -355,6 +389,7 @@ function scoreLyricsContent(content: string): number
 | `json-utils.ts` | `parseJson`, `isRecord`, `asStringArray`, `readJsonFile` | Type-safe JSON helpers. `parseJson` returns `unknown` (not `any`). `readJsonFile` reads via `DataAdapter`, validates with a type guard, returns `null` on any failure |
 | `node-loader.ts` | `loadNodeModules`, `assertDesktop`, `shellEnv`, `DesktopOnlyError`, `NodeModules` | Single sanctioned entry point for desktop-only Node.js builtins (os/path/fs/child_process). Lazy-loads inside function body so importing never triggers a module load on mobile. `shellEnv()` builds a narrowed subprocess environment with PATH augmented for common tool install locations |
 | `settings-section.ts` | `createSettingsSectionContext`, `isSectionCollapsed`, `persistCollapse`, `SettingsSectionContext`, `SettingsSectionContextOptions` | Shared accordion plumbing for the settings tab (#243). Feature renderers receive a `SettingsSectionContext` and call `featureSection()`/`configSection()` to build accordions without importing `settings-tab.ts` |
+| `markdown.d.ts` | ambient `declare module '*.md'` | Types `import X from '*.md'` as a string (esbuild inlines the file at build time); used by `changelog-modal.ts` to bundle CHANGELOG.md (#375). Not part of the barrel |
 | `index.ts` | re-exports | Barrel file |
 
 ## AIClient Provider Routing
@@ -416,11 +451,13 @@ Write concurrency: per-checkpoint mutex via `withLock()` prevents concurrent rea
 - Non-dismissible notices for running operations
 - Confirmation snackbars (Proceed/Cancel) returning `Promise<boolean>`
 - Status bar integration (shows active operation count)
-- CSS injection for styled notices
-- API key redaction in error messages
-- `info()` and `success()` accept optional `action?: NoticeAction` 3rd param — renders an action button on the toast (8s auto-dismiss)
+- Styling via `styles.css` classes (prefix `synapse-notice`), loaded/unloaded with the plugin
+- Secret redaction on every error path via `redactSecrets` — `error()`, `notifyError()`, and the operation `error()` `console.error` all route through `showErrorNotice`/`redactSecrets`. Source ref: `notifications.ts:L275`, `notifications.ts:L433`
+- `info()` and `success()` accept optional `action?: NoticeAction` 3rd param — renders an action button on the toast (floors duration to 8s, then auto-dismiss)
+- `infoSticky(message, action)` — duration-0 dismissible action toast that stays up until the user clicks the action or clicks the toast; used by `UpdateChecker` for the "update available" prompt. Source ref: `notifications.ts:L355`
+- `error(message)` — persistent (until clicked) error toast; clicking copies the redacted text to the clipboard. `notifyError(context, error)` wraps an error object + context label through the same sink
 - `OperationHandle.finish(message?, action?)` accepts optional `action?: NoticeAction` — completion toast includes a button that runs `action.onClick()` then hides the toast
-- `dispose()` — tears down every in-flight tracked operation (stops its `setInterval` + hides its notice, clears the map). Called from `main.ts` `onunload()` so disabling the plugin mid-operation never leaves an orphaned 400ms timer firing against a detached toast. Source ref: `notifications.ts:L139`
+- `dispose()` — tears down every in-flight tracked operation (stops its `setInterval` + hides its notice, clears the map). Called from `main.ts` `onunload()` so disabling the plugin mid-operation never leaves an orphaned 400ms timer firing against a detached toast. Source ref: `notifications.ts:L153`
 
 ## Validation Rules
 
@@ -457,7 +494,7 @@ Mid-segment wildcards (e.g. `dir/*.md`) are out of scope for v1 and fall through
 | Utility | Used By |
 |---------|---------|
 | `AIClient` | elaboration/proposer, elaboration/image-analyzer, audio/post-processor, image/extractor, enrichment/metadata-classifier, enrichment/topic-extractor, enrichment/prompt-builder, tidy/index |
-| `redactSecrets` | ai-client (safeRequest error bodies), api-utils/notifyError (user/console errors) |
+| `redactSecrets` | ai-client (safeRequest error bodies + API-error wrap), credential-validator (probe error messages), notifications (`error`/`notifyError`/operation-error toast + console paths) |
 | `extractGeminiResponseText` | ai-client (callGemini), audio/transcriber (Gemini provider) |
 | `arrayBufferToBase64` / `base64EncodedLength` | image/preprocess (re-exports), audio/transcriber (Gemini inline audio), elaboration/image-analyzer |
 | `classifyNetworkError` / `describeNetworkError` | audio/transcriber (retry gating + failure disclosure) |
@@ -483,7 +520,11 @@ Mid-segment wildcards (e.g. `dir/*.md`) are out of scope for v1 and fall through
 | `blockquoteOriginal` | elaboration/index |
 | `withRetry` | tidy/index |
 | `generateId` | elaboration, enrichment, summarize, organize, deep-dive (proposal/run IDs) |
-| `notifyError` | (legacy, replaced by NotificationManager in most modules) |
+| `UpdateChecker` / `isNewerVersion` | main (instantiated with `UpdateCheckerDeps`; `maybeCheck()` fired from a delayed startup timer) |
+| `linkLoadError` | summarize/index, elaboration/proposer (shared external-link fetch-failure message) |
+| `fetchRedditContent` / `isRedditUrl` | summarize/index, elaboration/proposer (Reddit URL routing + fetch) |
+| `isGenericTitle` | elaboration/proposer (anti-fabrication guard) |
+| `isUntitled` | title/index, title/title-detector (re-export); elaboration/proposer |
 | `PROVIDER_METADATA` / `aiProviderToCredential` | credential-field, credential-validator, settings-tab |
 | `validateCredentials` | credential-field (injected; default impl used by Test button) |
 | `decorateCredentialField` | settings-tab (per provider credential row) |

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -111,6 +111,21 @@ describe('NotificationManager', () => {
 			handle.finish('Should not show');
 			consoleSpy.mockRestore();
 		});
+
+		it('redacts API keys from the console log', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const handle = manager.startOperation('Transcribe', 'error-redact');
+			handle.error('Failed with sk-1234567890abcdef');
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('[Synapse]'),
+				expect.stringContaining('[REDACTED]')
+			);
+			expect(consoleSpy).not.toHaveBeenCalledWith(
+				expect.anything(),
+				expect.stringContaining('sk-1234567890abcdef')
+			);
+			consoleSpy.mockRestore();
+		});
 	});
 
 	describe('status bar', () => {

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -268,7 +268,11 @@ export class NotificationManager {
 				// Duration is ignored for errors (showErrorNotice forces persist);
 				// pass 0 to document the persist-until-dismissed intent.
 				this.completeOperation(opId, 'error', message, 'error', 0);
-				console.error(`[Synapse] ${op.label}:`, message);
+				// Redact before the console sink too: the toast (via showErrorNotice)
+				// is already redacted, so logging the SAME message raw here would be
+				// the one spot a key echoed into an operation error could still leak.
+				// Matches notifyError below — redact.ts is the single source of truth.
+				console.error(`[Synapse] ${op.label}:`, redactSecrets(message));
 			},
 		};
 

--- a/src/summarize/AGENTS.md
+++ b/src/summarize/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Summarize Module
 
-Summarizes URLs, transcription blocks, and audio embeds found in notes. Creates inline summary callouts or standalone summary notes for enrichment-section links. Auto-transcribes video URLs and audio embeds via injected callbacks.
+Summarizes a note's own prose plus the URLs, transcription blocks, and audio embeds it references, emitting either per-item summary callouts or one combined summary, and creating standalone notes for enrichment-section links. Video URLs and audio embeds are transcribed via injected callbacks (no static `video/` import).
 
 ## Public API (`index.ts`)
 
@@ -20,8 +20,7 @@ class SummarizeModule {
     checkpointManager: CheckpointManager,
     registrar: CommandRegistrar,
     transcribeUrl?: TranscribeUrlFn,
-    transcribeAudio?: TranscribeAudioFn,
-    transcribeAudioCombined?: TranscribeAudioCombinedFn
+    transcribeAudio?: TranscribeAudioFn
   )
   onload(): Promise<void>
   onunload(): void
@@ -29,22 +28,18 @@ class SummarizeModule {
   scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<void>
 }
 
-// Injected callback: transcribes a video URL (from VideoModule)
+// Injected callback: transcribes a video URL (from VideoModule).
 type TranscribeUrlFn = (
   url: string,
   parentOp?: { update: (msg: string) => void }
 ) => Promise<string>
 
-// Injected callback: transcribes a single audio TFile (from AudioModule)
+// Injected callback: transcribes a single audio TFile (from AudioModule).
 type TranscribeAudioFn = (file: TFile) => Promise<string>
-
-// Injected callback: transcribes multiple audio TFiles as one combined recording (#214)
-type TranscribeAudioCombinedFn = (files: TFile[]) => Promise<string>
 ```
 
-Exported types: `SummarizeTarget`, `TranscribeUrlFn`, `TranscribeAudioFn`, `TranscribeAudioCombinedFn`
-
-Exported functions: `renderSummarizeSettings(ctx: SettingsSectionContext): void`
+Exported types: `SummarizeTarget` (re-export of `./types`), `TranscribeUrlFn`, `TranscribeAudioFn`.
+Exported functions: `renderSummarizeSettings(ctx: SettingsSectionContext): void` (re-export of `./settings-section`).
 
 ## Internal File Map
 
@@ -53,24 +48,27 @@ Exported functions: `renderSummarizeSettings(ctx: SettingsSectionContext): void`
 | `index.ts` | `SummarizeModule`, type + fn re-exports | Orchestrator, commands, scan + summarize flows |
 | `types.ts` | `SummarizeTarget` | Target type model |
 | `summarizer.ts` | `Summarizer` | AI summarization with style (bullets/paragraph/key-points) |
-| `note-scanner.ts` | `findSummarizeTargets`, `hasSummaryBelow` | Finds URLs, transcription blocks in note content |
-| `summarize-modal.ts` | `SummarizeSelectionModal` | Selection modal when multiple targets found; offers combine option for 2+ audio targets |
-| `settings-section.ts` | `renderSummarizeSettings` | Summarize settings UI section |
-| `summarizer.test.ts` | Tests | Summarizer tests |
-| `note-scanner.test.ts` | Tests | Note scanner tests |
+| `note-scanner.ts` | `findSummarizeTargets`, `hasSummaryBelow`, `extractNoteProse`, `extractTranscriptionContent` | Pure-string scan for URLs / transcription blocks; note-prose extraction |
+| `summarize-modal.ts` | `SummarizeSelectionModal`, `SummarizeModalDefaults` | Selection modal for 2+ targets; include-note + combine toggles (#367) |
+| `settings-section.ts` | `renderSummarizeSettings` | Summarize settings UI section (#243) |
+| `summarizer.test.ts` | Tests | Summarizer style/prompt tests |
+| `note-scanner.test.ts` | Tests | Scanner + prose-extraction tests |
 | `summarize-module.test.ts` | Tests | SummarizeModule integration tests |
 | `audio-summarize.test.ts` | Tests | Audio-embed summarization tests |
-| `combine-summarize.test.ts` | Tests | Combined-audio summarization tests (#214) |
+| `combine-summarize.test.ts` | Tests | Combined-summary tests (#367) |
+| `summarize-modal.test.ts` | Tests | Selection-modal tests |
+| `settings-section.test.ts` | Tests | Settings-section render tests |
+| `video-dependency-notice.test.ts` | Tests | yt-dlp/ffmpeg onboarding-notice tests (#382) |
 
 ## Target Types (`types.ts`)
 
 ```ts
 interface SummarizeTarget {
-  type: 'url' | 'transcription' | 'audio'
-  source: string          // URL or audio filename or transcription source label
-  line: number            // zero-based line number in note
-  endLine: number         // end of target block (for transcriptions)
-  content?: string        // pre-extracted content (for transcription blocks)
+  type: 'url' | 'transcription' | 'audio' | 'note-content'
+  source: string          // URL / transcription source label, or note basename for note-content
+  line: number            // line in note (last line for note-content, so its callout appends)
+  endLine: number         // end of target block (transcriptions / note-content)
+  content?: string        // pre-extracted content (transcriptions and note-content prose)
   inEnrichmentSection?: boolean  // found inside enrichment markers
   linkTitle?: string      // display text from markdown link (enrichment refs)
 }
@@ -79,140 +77,153 @@ interface SummarizeTarget {
 ## Data Flow
 
 ```
-summarizeNote(file)
-  --> collectTargets(content, sourcePath)
+summarizeNote(file)                                   index.ts:L230
+  --> collectTargets(content, sourcePath)             index.ts:L453
         findSummarizeTargets(content)    [URLs, transcription blocks]
-        findAudioEmbeds(content, ...)    [audio embeds without existing summary below]
-  --> if 1 target: processTargets(file, targets, content)
-  --> if 2+ targets: SummarizeSelectionModal
-        if combine + 2+ audio: processTargetsCombined(file, selected, content)
-        else: processTargets(file, selected, content)
+        findAudioEmbeds(...)             [audio embeds w/o summary below]
+        extractNoteProse(content)        [appends 'note-content' if includeNoteContent]
+  --> 1 target:  processTargets(file, targets, content)            [per-item, no modal]
+  --> 2+ targets: SummarizeSelectionModal(defaults={includeNoteContent, combineSummaries})
+        callback(selected, combine):
+          combine  -> processTargetsCombined(file, selected, content)   index.ts:L270
+          !combine -> processTargets(file, selected, content)           index.ts:L502
 
-processFileTargets(file, targets, op, content)
-  For each target (reverse line order):
-    if inEnrichmentSection + linkTitle:
-      --> fetchContentForUrl(url)  [video transcription or HTTP fetch]
-      --> Summarizer.summarize(content, url, style, COMPREHENSIVE_SUMMARY_PROMPT)
-      --> pendingNotes.push(path, content)
-      --> replace external link with [[internal link]] in lines[]
-    elif target.type === 'audio':
-      --> fetchContentForAudio(fileName, sourceFile)  [transcribeAudio callback]
-      --> Summarizer.summarize(transcript, source, style, effectivePrompt)
-      --> lines.splice(endLine+1, callout)
-    else (inline URL / transcription):
-      --> fetchContentForUrl(url) or use target.content
-      --> effectivePrompt: customPrompt > detectSchemaFor('summary', content) > style default
-      --> Summarizer.summarize(content, url, style, effectivePrompt)
-      --> lines.splice(endLine+1, callout)
-  --> vault.process(file, () => lines.join('\n'))   [source written FIRST]
-  --> vault.create() for each pendingNote            [new notes AFTER source]
-  --> onSummaryComplete?.(filePath)
-  --> onOrganizeRequested?.(file)  [if autoOrganizeOnSummarize]
+processTargetsForFile(file, targets, op, content, combine)            index.ts:L301
+  combine == false:
+    --> processFileTargets(file, targets, op, content)
+  combine == true:
+    --> enrichment refs first (per-item):  processFileTargets(enrichmentTargets)
+    --> everything else folded into ONE summary: combineSelectedTargets(summarizable)
 
-processTargetsCombined(file, targets, content)   [#214]
-  --> otherTargets processed via processFileTargets first
-  --> transcribeAudioCombined(audioFiles) --> combined transcript
-  --> Summarizer.summarize(transcript, ..., COMPREHENSIVE_SUMMARY_PROMPT)
-  --> vault.process(file, insert combined callout after last audio embed)
-  --> onSummaryComplete?.(file.path)
+combineSelectedTargets(file, targets, op, content)                    index.ts:L356
+  per target: reuse note-content/transcript content, else fetch URL / transcribe audio
+  --> join sections w/ '## <label>' + '---' separators, slice(maxContentLength)
+  --> Summarizer.summarize(combinedText, labels, style, prompt)
+        prompt = customPrompt > schema('summary') > COMPREHENSIVE_SUMMARY_PROMPT
+  --> vault.process(file): append ONE 'Combined summary (N items)' callout at end
+
+processFileTargets(file, targets, op, content)                        index.ts:L560
+  for each target (reverse line order):
+    enrichment ref (inEnrichmentSection + linkTitle):
+      --> if note exists: rewrite link only (linksUpdated++)
+      --> else fetch + summarize(COMPREHENSIVE_SUMMARY_PROMPT) -> pendingNote + link rewrite
+    audio:        fetchContentForAudio() -> summarize -> splice inline callout
+    transcription: reuse target.content -> summarize -> splice inline callout
+    note-content:  reuse target.content -> summarize -> splice inline callout
+    inline URL:    fetchUrlContentOrNotify() -> summarize -> splice inline callout
+                   prompt = customPrompt > schema('summary') > style default
+  --> vault.process(file, finalContent)   [source written FIRST]
+  --> vault.create() per pendingNote      [new notes AFTER source]
+  returns { inlineCompleted, enrichmentCompleted, linksUpdated, newNotePaths }
+
+fireEnrichmentCallbacks(path, result)                                 index.ts:L543
+  --> onSummaryComplete?.(path)  [only if inlineCompleted>0 and enrichmentCompleted==0]
+  --> onSummaryComplete?.(newNotePath)  per created note
+  caller separately: onOrganizeRequested?.(file) if autoOrganizeOnSummarize
 ```
 
 ## Vault Scan (checkpointed)
 
 ```
-scanVault(folderPath?, skipConfirmation?, onlyFile?)
-  Phase 1: collect files with targets (cancellable scan)
-  Phase 2: user confirmation (skipped when skipConfirmation=true)
+scanVault(folderPath?, skipConfirmation?, onlyFile?)                  index.ts:L900
+  Phase 1: collect files with targets (cancellable scan; onlyFile narrows scope, #111)
+  Phase 2: user confirmation (skipped when skipConfirmation=true / Fire Synapse)
   Phase 3: checkpointed processing
-    --> checkpointManager.create(module: 'summarize', items)
+    --> checkpointManager.create({ module: 'summarize', items })
     --> addDeferredTask('refresh-sidebar-view')
-    --> for each file: re-read + re-scan + processFileTargets(), completeItem()
-    --> on cancel: checkpointManager.discard()
-    --> on success: checkpointManager.complete(), dispatchDeferredTasks
+    --> per file: re-read + collectTargets + processTargetsForFile(..., combineSummaries)
+    --> completeItem() after each file
+    --> on cancel: discard(); on success: complete() + dispatchDeferredTasks
 
-resumeFromCheckpoint(checkpoint)
-  --> re-processes remaining items from saved checkpoint
-  --> completeItem() after each file
-  --> on cancel: discard()
-  --> on success: complete(), dispatchDeferredTasks
+resumeFromCheckpoint(checkpoint)                                      index.ts:L169
+  --> re-process remaining items via processTargetsForFile(..., combineSummaries)
+  --> completeItem() per file; on cancel discard(); on success complete()
 ```
 
 ## Commands
 
-Registered in `onload()` (both gated by `summarize.enabled`):
+Registered in `onload()`, both gated by `settings.summarize.enabled` (`commands/registry.ts:L46`):
 
 | ID | Name | Type |
 |----|------|------|
 | `synapse:summarize-current-note` | Summarize current note | editorCallback |
 | `synapse:scan-vault-summarize` | Scan folder for notes to summarize | callback (FolderPickerModal) |
 
-## Video URL Auto-Transcription
+## URL Fetch / Video Auto-Transcription (`fetchContentForUrl`, index.ts:L738)
 
-`transcribeUrl` is injected by `main.ts` from `VideoModule.transcribeUrl`. When set:
-- `fetchContentForUrl()` calls `isSupportedUrl(url)` (from `shared`) before deciding
-- If supported video URL: calls injected `transcribeUrl` callback
-- Falls back to `fetchTweetContent()` for Twitter URLs, then `fetchPageContent()` for others
+Routing order for a target URL:
+1. `transcribeUrl` injected AND `isSupportedUrl(url)` -> call `transcribeUrl(url, op)` (video transcript).
+2. `detectPlatform(url)?.platform === 'twitter'` -> `fetchTweetContent(url, max)`.
+3. `isRedditUrl(url)` -> `fetchRedditContent(url, max)` (Reddit is generic 'article'; routed explicitly to the RSS fetcher).
+4. else -> `fetchPageContent(url, max)`.
 
-`isSupportedUrl` and `detectPlatform` both resolve from `shared` barrel. There is NO static import of `video/` anywhere in this module.
+`transcribeUrl`/`transcribeAudio` are injected by `main.ts:L128`. On mobile (no VideoModule) `transcribeUrl` throws "Video transcription is not available on mobile". `isSupportedUrl`, `detectPlatform`, `isRedditUrl` all resolve from the `shared` barrel; there is NO static import of `video/`.
 
-## Combined Audio (#214)
+## Combined Summaries (#367)
 
-When `transcribeAudioCombined` is injected and 2+ audio targets are selected via the modal:
-- `processTargetsCombined()` resolves all audio `TFile` objects via `MetadataCache`
-- Calls `transcribeAudioCombined(files)` for one transcript spanning all files
-- Inserts a single `Combined summary (N files)` callout after the last audio embed
-- Insert line is re-derived from fresh content inside `vault.process()` callback (safe against phase-1 line shifts)
+When `combineSummaries` (or the modal's "Combine into one summary" toggle) is set:
+- Enrichment refs are processed per-item first (they create notes + rewrite links).
+- All remaining summarizable items (note prose, URLs, transcriptions, audio) are concatenated with `## <label>` sections and summarized in ONE `summarize()` call.
+- Output is a single `Combined summary (N items)` callout appended at the end of the note via `vault.process()` (re-read after the enrichment pass when links were rewritten).
+- A single item falls back to the per-item path for a cleaner callout title.
 
-Injected in `main.ts`:
-```ts
-this.summarize = new SummarizeModule(
-  this, getSettings, this.notifications, this.checkpointManager, this.registrar,
-  (url, parentOp) => this.video.transcribeUrl(url, parentOp),
-  async (audioFile) => {
-    const data = await this.app.vault.readBinary(audioFile);
-    const result = await this.audio.transcribe(data, audioFile.name);
-    return result.processed || result.raw;
-  },
-  (files) => this.audio.transcribeCombined(files)
-);
-```
+## Note Content (#367)
+
+`extractNoteProse(content)` (`note-scanner.ts:L226`) strips YAML frontmatter and every Synapse-generated summary / transcription / lyrics block (callout and legacy formats) so the AI never re-summarizes its own output. `collectTargets` appends a `note-content` target (when `includeNoteContent`) at the note's last line so a per-item prose callout lands at the end.
 
 ## Settings Keys
 
-All under `settings.summarize` (`SummarizeSettings`):
+All under `settings.summarize` (`SummarizeSettings`, `settings.ts:L150`):
 
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
 | `enabled` | `boolean` | `true` | Module + command activation |
-| `maxContentLength` | `number` | — | Truncation limit for fetched content |
-| `summaryStyle` | `'bullets' \| 'paragraph' \| 'key-points'` | — | AI output style |
-| `customPrompt` | `string` | `''` | Overrides style-based prompt (highest priority) |
+| `maxContentLength` | `number` | `4000` | Truncation limit for fetched/combined content (UI slider 1000-10000) |
+| `summaryStyle` | `'bullets' \| 'paragraph' \| 'key-points'` | `'bullets'` | AI output style |
+| `customPrompt` | `string` | `''` | Overrides style/schema prompt (highest priority) |
 | `autoDetectTemplates` | `boolean` | `true` | Enable content-schema detection |
 | `excludeTags` | `string[]` | `['no-summarize']` | Skip notes with these tags |
-| `autoOrganizeOnSummarize` | `boolean` | — | Trigger organize after single-note summarize |
+| `autoOrganizeOnSummarize` | `boolean` | `false` | Trigger single-note organize after summarize |
+| `includeNoteContent` | `boolean` | `true` | Summarize the note's own prose as an additional item (#367) |
+| `combineSummaries` | `boolean` | `true` | Emit ONE combined summary instead of a callout per item (#367) |
 
-Path exclusion: centralized `settings.exclusions: ExclusionRule[]` (#307). No per-module `excludeFolders` field. Checked via `isPathExcluded(path, 'summarize', settings)` from `shared`.
+Path exclusion: centralized `settings.exclusions: ExclusionRule[]`; no per-module `excludeFolders`. Checked via `isPathExcluded(path, 'summarize', settings)`; tag exclusion via `matchesExcludeTag(file, excludeTags, metadataCache)` (both in `isExcluded`, `index.ts:L1031`).
 
 ## Content-Aware Schemas
 
-Registry: `shared/content-schemas.ts`. Called via `detectSchemaFor('summary', content)`.
+Registry: `shared/content-schemas.ts`. Consulted via `detectSchemaFor('summary', content)`.
 
-Priority chain for inline targets: `customPrompt` > schema match > style default.
-Enrichment targets always use `COMPREHENSIVE_SUMMARY_PROMPT` regardless.
+Inline / combined prompt priority: `customPrompt` > schema match (when `autoDetectTemplates`) > style default.
+Enrichment-ref targets always use `COMPREHENSIVE_SUMMARY_PROMPT`.
 
-| ID | Detection | Stage |
-|----|-----------|-------|
-| `recipe` | Keyword scoring >= 5 (headers, cooking verbs, measurements) | `'summary'` |
-| `receipt` | Keyword scoring >= 5 (currency, totals, payment terms) | `'summary'` |
+| ID | appliesTo | Mode |
+|----|-----------|------|
+| `recipe` | `'summary'` | summarize |
+| `receipt` | `'summary'` | summarize |
+
+(`lyrics` exists but applies to `'transcription'`, not summarize.)
+
+## Error States
+
+| Condition | Handling |
+|-----------|----------|
+| Missing video dep (yt-dlp/ffmpeg) | `DependencyMissingError` matched by `name` through the `cause` chain (`findDependencyMissingError`, index.ts:L98); shows an actionable "Open settings" notice that reveals the Video section (#382) |
+| URL fetch throws | `notifyTargetError` -> `linkLoadError(source, reason)` persistent notice; target skipped |
+| Fetch returns empty text | `linkLoadError(source, 'page returned no readable text')`; target skipped |
+| Audio file not found in vault | throws `Audio file not found in vault: <name>` |
+| No targets in note | info notice "No note content, URLs, transcriptions, or audio to summarize in this note" |
+| Scan / resume exception | `op.error(...)`; checkpoint left intact |
+| User cancels | checkpoint `discard()`; partial work preserved |
 
 ## Dependencies
 
 | Import | From |
 |--------|------|
-| `FolderPickerModal`, `getMarkdownFiles`, `NotificationManager`, `OperationHandle`, `buildCallout`, `CALLOUT_TYPES`, `CheckpointManager`, `generateId`, `fireAndForget`, `isPathExcluded`, `matchesExcludeTag`, `detectSchemaFor`, `isSupportedUrl`, `detectPlatform`, `fetchPageContent`, `fetchTweetContent` | `../shared` |
+| `FolderPickerModal`, `getMarkdownFiles`, `NotificationManager`, `buildCallout`, `CALLOUT_TYPES`, `CheckpointManager`, `generateId`, `fireAndForget`, `isPathExcluded`, `matchesExcludeTag`, `detectSchemaFor`, `OperationHandle`, `isSupportedUrl`, `detectPlatform`, `fetchPageContent`, `fetchTweetContent`, `isRedditUrl`, `fetchRedditContent`, `linkLoadError` | `../shared` |
 | `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` | `../shared` (type-only) |
 | `findAudioEmbeds` | `../audio` |
 | `CommandRegistrar` | `../commands` |
-| `SynapseSettings`, `SummarizeSettings` | `../settings` |
+| `SynapseSettings` | `../settings` |
+| `findSummarizeTargets`, `extractNoteProse`, `hasSummaryBelow`, `SummarizeTarget`, `SummarizeSelectionModal`, `Summarizer` | local (`./note-scanner`, `./types`, `./summarize-modal`, `./summarizer`) |
 
 NO static import of `../video`. Video transcription is callback-only (`TranscribeUrlFn`).

--- a/src/tidy/AGENTS.md
+++ b/src/tidy/AGENTS.md
@@ -1,10 +1,10 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Tidy Module
 
-Spelling correction and markdown formatting for notes via AI. No content changes — only fixes typos and applies structural formatting. Supports undo via pre-tidy snapshots.
+AI spelling correction and markdown formatting for notes with no content changes, plus single-snapshot undo.
 
 ## Public API (`index.ts`)
 
@@ -18,117 +18,159 @@ class TidyModule {
   )
   onload(): Promise<void>
   onunload(): void
-  tidy(file: TFile): Promise<void>
   scanVault(folderPath?: string, skipConfirmation?: boolean, onlyFile?: TFile): Promise<number>
+  tidy(file: TFile): Promise<void>
+  // private undoTidy(file: TFile): Promise<void>
 }
 
 interface TidySnapshot {
-  id: string
-  filePath: string
+  id: string            // generateId()
+  filePath: string      // source note path
   originalContent: string
-  createdAt: string
+  createdAt: string     // ISO timestamp
 }
+
+function renderTidySettings(ctx: SettingsSectionContext): void
 ```
 
-Exported types: `TidySnapshot`
-
-Exported functions: `renderTidySettings(ctx: SettingsSectionContext): void`
+Re-exports from `index.ts`: type `TidySnapshot` (index.ts:L8), `renderTidySettings` (index.ts:L192).
 
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `index.ts` | `TidyModule`, type + fn re-exports | Orchestrator, commands, AI interaction, undo |
-| `types.ts` | `TidySnapshot` | Snapshot type for undo |
-| `tidy-store.ts` | `TidyStore` | Stores pre-tidy snapshots (one per file path) |
-| `settings-section.ts` | `renderTidySettings` | Tidy settings UI section (no configurable options; placeholder only) |
+| `index.ts` | `TidyModule`, `TidySnapshot` (re-export), `renderTidySettings` (re-export) | Orchestrator: commands, AI call, undo, vault scan |
+| `types.ts` | `TidySnapshot` | Snapshot type for undo (types.ts:L2) |
+| `tidy-store.ts` | `TidyStore` | One pre-tidy snapshot per file path |
+| `settings-section.ts` | `renderTidySettings` | Tidy settings accordion (toggle only, no options) |
 | `tidy-store.test.ts` | Tests | TidyStore tests |
 | `tidy-module.test.ts` | Tests | TidyModule tests |
 | `settings-section.test.ts` | Tests | Settings section tests |
 
-## Data Flow
+## TidyStore (`tidy-store.ts`, internal)
 
-```
-tidy(file)
-  1. vault.read(file) --> content
-  2. TidyStore.save(snapshot)        -- saves original for undo
-  3. parseFrontmatter(content)       -- separate frontmatter from body
-  4. withRetry(3, 2000ms):
-       AIClient.complete(body, SYSTEM_PROMPT)
-     System prompt constrains AI to:
-       - Spelling correction only (no grammar/word choice/meaning changes)
-       - Markdown formatting (lists, headers, code blocks, emphasis)
-       - No content addition/removal/rephrasing
-       - Preserve all links, tags, embeds, Obsidian syntax
-  5. sanitizeAIResponse() --> stripCodeFences()
-  6. vault.process(file, (data) => {
-       fm = parseFrontmatter(data).frontmatter
-       return fm ? serializeFrontmatter(fm, cleaned) : cleaned
-     })                              -- atomic write; frontmatter re-parsed from fresh content
+```ts
+class TidyStore {
+  constructor(app: App, getSettings: () => SynapseSettings)
+  init(): Promise<void>                                  // ensureFolder(folderPath)
+  save(snapshot: TidySnapshot): Promise<void>            // adapter.write (overwrite)
+  load(filePath: string): Promise<TidySnapshot | null>   // null if path is folder/missing
+  remove(filePath: string): Promise<void>                // fileManager.trashFile (recoverable)
+  // private folderPath(): string                        // settings.tidy.snapshotFolderPath
+  // private snapshotPath(filePath: string): string
+}
 ```
 
-## Undo Flow
+- Storage folder: `settings.tidy.snapshotFolderPath` (default `.synapse/tidy-snapshots`).
+- One snapshot per file path; re-tidy overwrites the previous one.
+- Filename (tidy-store.ts:L53): `filePath` with `/` and `\` → `__`, trailing `.md` stripped, `.json` appended.
+- Write via `vault.adapter.write()` (overwrites regardless of prior existence).
+- Delete via `app.fileManager.trashFile()` (respects user "Deleted files" preference; recoverable).
+
+## Data Flow — tidy(file) (index.ts:L125)
 
 ```
-undoTidy(file)   [triggered by synapse:undo-tidy command]
-  1. TidyStore.load(file.path) --> snapshot | null
-  2. vault.process(file, () => snapshot.originalContent)
-  3. TidyStore.remove(file.path)   -- trashes snapshot file (recoverable)
+startOperation("Tidying <basename>", "tidy-<path>")
+1. vault.read(file) -> content
+2. snapshot { id: generateId(), filePath, originalContent: content, createdAt: ISO }
+   store.save(snapshot)                       -- snapshot taken before any write
+3. parseFrontmatter(content) -> { frontmatter, body }
+4. if !body.trim(): op.finish("Nothing to tidy — note is empty"); return
+5. withRetry(() => aiClient.complete(body, SYSTEM_PROMPT), 3, 2000)
+     SYSTEM_PROMPT (index.ts:L10) constrains AI to:
+       - spelling correction only (no grammar/word-choice/meaning changes)
+       - markdown formatting (lists, quotes, headers, code blocks, emphasis)
+       - no content add/remove/rephrase; preserve frontmatter/links/tags/embeds
+       - return raw markdown, no code fence, no commentary
+6. sanitizeAIResponse(tidiedBody) -> stripCodeFences() -> cleaned
+7. vault.process(file, data => {
+     fm = parseFrontmatter(data).frontmatter
+     return fm ? serializeFrontmatter(fm, cleaned) : cleaned
+   })                                         -- atomic; frontmatter re-parsed from fresh content
+8. op.finish("Note tidied")
+catch: op.error("Tidy failed — <msg>")
 ```
 
-## Vault Scan
+## Data Flow — undoTidy(file) (index.ts:L176, private)
 
 ```
-scanVault(folderPath?, skipConfirmation?, onlyFile?)
-  --> getMarkdownFiles(app, folderPath)
-  --> if onlyFile: narrow to single file
-  --> optional confirmation prompt
-  --> for each file:
-        isPathExcluded(path, 'tidy', settings) --> skip silently (batch)
-        findMatchingRule(path, 'tidy', settings) --> named in Notice (single-note command)
-        tidy(file)
-  --> returns count of tidied files
+1. store.load(file.path) -> snapshot | null
+2. if !snapshot: notifications.info("No tidy to undo for this note"); return
+3. vault.process(file, () => snapshot.originalContent)
+4. store.remove(file.path)                    -- trashes snapshot (recoverable)
+5. notifications.success("Tidy undone")
 ```
 
-Note: `tidy` module does NOT use `CheckpointManager`. Vault scan has no resume capability.
+Reachable in code only via the `undo-tidy` command, which is gated off (registry status `disabled`); not invokable from the palette today.
 
-## TidyStore
+## Data Flow — scanVault(folderPath?, skipConfirmation?, onlyFile?) (index.ts:L76)
 
-- Storage path: `settings.tidy.snapshotFolderPath` (default: `.synapse/tidy-snapshots`)
-- One snapshot per file path (overwrites previous on re-tidy)
-- Filename: `{path-with-double-underscores}.json` (deterministic, no collisions)
-- Write: `vault.adapter.write()` (atomic overwrite)
-- Delete: `app.fileManager.trashFile()` (respects user's "Deleted files" preference; recoverable)
+```
+1. getMarkdownFiles(app, folderPath) -> allFiles
+2. if onlyFile: filter to f.path === onlyFile.path        (per-file scoping, #111)
+3. if allFiles.length === 0: return 0
+4. if !skipConfirmation: confirm("Found N notes to tidy. Proceed?",
+     { proceedLabel: "Tidy", cancelLabel: "Cancel" })
+     if declined: info("Tidy scan skipped"); return 0
+5. startOperation("Tidying notes", "tidy-vault")
+6. for each file:
+     if op.cancelled: break
+     op.progress(i+1, total, "Tidying notes")
+     if isPathExcluded(path, "tidy", settings): continue   (silent skip, #307)
+     try { tidy(file); tidied++ } catch { console.warn(...) }
+7. if !op.cancelled: op.finish("Tidied N notes")
+8. return tidied
+```
+
+Note: tidy does NOT use `CheckpointManager`. The vault scan has no resume/checkpoint capability.
 
 ## Commands
 
-Registered in `onload()` (both gated by `tidy.enabled`):
+Registry entries live in `src/commands/registry.ts`. Source ids are bare; Obsidian namespaces the runtime id as `synapse:<id>`. `TidyModule.onload()` calls `registrar.register(...)` for the two palette ids; the registrar only reaches `addCommand` when the registry status is `active`, the flow includes `palette`, and `tidy.enabled` is true.
 
-| ID | Name | Type |
-|----|------|------|
-| `synapse:tidy-current-note` | Tidy current note | editorCallback |
-| `synapse:undo-tidy` | Undo last tidy on current note | editorCallback |
+| Id | Name | Status | Flow | Context | Handler | Registered when |
+|----|------|--------|------|---------|---------|-----------------|
+| `tidy-current-note` | Tidy current note | active | palette | note | editorCallback → `tidy(file)` | `tidy.enabled` true |
+| `undo-tidy` | Undo last tidy on current note | disabled | palette | note | editorCallback → `undoTidy(file)` | never (gated off by status) |
+| `tidy-vault` | Scan folder for notes to tidy | active | fire-synapse | vault | pipeline → `scanVault()` | synthetic; never passed to `register()` |
 
-Single-note command shows an exclusion Notice naming the matched rule. Batch scan silently skips.
+- `tidy-current-note` editorCallback (index.ts:L49): if `findMatchingRule(path, "tidy", settings)` matches, shows a Notice naming the rule pattern and skips; otherwise runs `tidy(file)`.
+- `undo-tidy` is attempted in `onload()` (index.ts:L65) but its registry status is `disabled`, so `addCommand` is never called.
+- `tidy-vault` (registry.ts:L66) is pipeline-only with `pipelineKey: 'tidy'`; Fire Synapse runs `scanVault()` vault-wide. It has no matching palette command (the palette `tidy-current-note` runs `tidy()` on one note — a different operation).
 
-## Settings Keys
+## Configuration
 
-All under `settings.tidy` (`TidySettings`):
+`TidySettings` (settings.ts:L164), under `settings.tidy`:
 
 | Key | Type | Default | Controls |
 |-----|------|---------|----------|
-| `enabled` | `boolean` | — | Module + command activation |
-| `snapshotFolderPath` | `string` | `.synapse/tidy-snapshots` | Snapshot storage location |
+| `enabled` | `boolean` | `true` | Module + palette command activation |
+| `snapshotFolderPath` | `string` | `.synapse/tidy-snapshots` | Snapshot storage folder |
 
-Path exclusion: centralized `settings.exclusions: ExclusionRule[]` (#307). No per-module `excludeFolders` field and no `excludeTags` field. Checked via `isPathExcluded(path, 'tidy', settings)` and `findMatchingRule(path, 'tidy', settings)` from `shared`.
+Path exclusion is centralized in `settings.exclusions: ExclusionRule[]` (#307). Tidy has no per-module `excludeFolders`/`excludeTags` field. Checked via `isPathExcluded(path, 'tidy', settings)` (batch, silent skip) and `findMatchingRule(path, 'tidy', settings)` (single-note, Notice) from `../shared`.
+
+Settings UI: `renderTidySettings` (settings-section.ts:L7) renders an accordion with the enable toggle and a static empty-note placeholder — no configurable options.
+
+## Error States
+
+| Condition | Handling |
+|-----------|----------|
+| Empty note body | `op.finish("Nothing to tidy — note is empty")`; snapshot still saved, no write |
+| AI call failure | `withRetry` 3 attempts / 2000ms backoff; on final failure `op.error("Tidy failed — <msg>")` |
+| Per-file tidy failure in scan | caught; `console.warn`; scan continues to next file |
+| `undoTidy` with no snapshot | `notifications.info("No tidy to undo for this note")` |
+| Excluded single note | Notice naming the matched rule pattern; `tidy()` skipped |
+| Excluded note in batch scan | silently skipped (`isPathExcluded`) |
 
 ## Dependencies
 
-| Import | From |
-|--------|------|
-| `AIClient`, `NotificationManager`, `getMarkdownFiles`, `parseFrontmatter`, `sanitizeAIResponse`, `stripCodeFences`, `serializeFrontmatter`, `withRetry`, `generateId`, `isPathExcluded`, `findMatchingRule` | `../shared` |
+| Imports | From |
+|---------|------|
+| `Plugin`, `TFile`, `App` | `obsidian` |
+| `AIClient`, `NotificationManager`, `getMarkdownFiles`, `parseFrontmatter`, `sanitizeAIResponse`, `stripCodeFences`, `serializeFrontmatter`, `withRetry`, `generateId`, `isPathExcluded`, `findMatchingRule`, `ensureFolder`, `SettingsSectionContext` | `../shared` |
 | `CommandRegistrar` | `../commands` |
-| `SynapseSettings`, `TidySettings` | `../settings` |
+| `SynapseSettings` | `../settings` |
 | `TidyStore` | `./tidy-store` |
+| `TidySnapshot` | `./types` |
 
-No `CheckpointManager` dependency. No `excludeTags` per-module field.
+No `CheckpointManager` dependency. No `TidySettings` import (only `SynapseSettings`). No per-module exclusion fields.

--- a/src/title/AGENTS.md
+++ b/src/title/AGENTS.md
@@ -30,7 +30,7 @@ class TitleModule {
   rejectProposal(id: string): Promise<void>
 }
 
-function isUntitled(basename: string): boolean
+function isUntitled(title: string): boolean
 ```
 
 Note: `TitleModule` does NOT take a `CheckpointManager`. Title proposals are single-note operations; no checkpoint support.
@@ -78,32 +78,42 @@ checkTitle(filePath)  [called by main.ts after enrichment/elaboration/transcript
   --> else: checkMismatch(filePath)
 
 checkUntitled(filePath)
+  --> return if not a TFile, or if !isUntitled(basename)
   --> skip if existing pending proposal for this note
+  --> return if note content empty/whitespace
   --> TitleSuggester.suggestTitle(content, basename)  [AI]
-  --> TitleProposalStore.save(proposal)
-  --> maybeAutoAccept(proposal)  [if shouldAutoAccept(): acceptProposal(id, {silent:true})]
+  --> return if suggested title empty or itself isUntitled()
+  --> TitleProposalStore.save(proposal)  [trigger 'untitled']
+  --> maybeAutoAccept(proposal)  [if shouldAutoAccept(): acceptProposal(id, {silent:true}) + info notice]
   --> if not auto-accepted: notifications.success('Title proposal ready', ..., Review toast)
-  --> onViewRefreshNeeded?()
+  --> refreshView() --> onViewRefreshNeeded?()
 
 checkMismatch(filePath)
-  --> skip if isUntitled (handled by checkUntitled)
+  --> return if not a TFile, or if isUntitled (handled by checkUntitled)
   --> skip if existing pending proposal for this note
+  --> return if note content empty/whitespace
   --> TitleSuggester.checkTitleMismatch(content, basename)  [AI]
-  --> if mismatch: TitleProposalStore.save(proposal)
+  --> return unless result.isMismatch && result.suggestedTitle
+  --> TitleProposalStore.save(proposal)  [trigger 'content-mismatch']
   --> maybeAutoAccept(proposal)
   --> if not auto-accepted: notifications.success('Title proposal ready', ..., Review toast)
-  --> onViewRefreshNeeded?()
+  --> refreshView() --> onViewRefreshNeeded?()
 
 acceptProposal(id, options?)
+  --> store.load(id); no-op if not found
   --> guard: no-op if proposal.status !== 'pending'
-  --> check no file exists at target path (in-folder rename collision)
+  --> if source note no longer a TFile: info notice, updateStatus(id,'rejected'), refreshView, return
+  --> compute newPath = <parentFolder>/<proposedTitle>.md (normalizePath)
+  --> if file already exists at newPath: info notice, abort (no rename)
   --> vault.rename(file, newPath)
-  --> TitleProposalStore.updateStatus(id, 'accepted')
-  --> if !silent: notifications.success, onViewRefreshNeeded?()
+  --> store.updateStatus(id, 'accepted')
+  --> if !silent: notifications.success('Renamed to ...'), refreshView()
+  --> on rename throw: notifyError, rethrow Error('Rename failed: ...')
 
 rejectProposal(id)
-  --> TitleProposalStore.updateStatus(id, 'rejected')
-  --> onViewRefreshNeeded?()
+  --> store.updateStatus(id, 'rejected')
+  --> notifications.info('Title proposal rejected')
+  --> refreshView() --> onViewRefreshNeeded?()
 ```
 
 ## Key Types
@@ -156,6 +166,18 @@ Out: Nothing. No other feature module imports from `title/`.
 - The Review toast fires via `notifications.success('Title proposal ready', undefined, { label: 'Review', onClick: ... })` — only when a proposal remains pending after generation.
 - `checkMismatch` skips notes that are already untitled (let `checkUntitled` handle those).
 - Both check methods skip if any pending proposal already exists for the note (prevents duplicate proposals).
+
+## Error States
+
+| Condition | Handling |
+|-----------|----------|
+| AI call fails in `checkUntitled`/`checkMismatch` | Caught; `console.warn('[Synapse] Title suggestion failed ...' / 'Title mismatch check failed ...')`; no user notice (flow is silent) |
+| Note content empty/whitespace | Silent return; no proposal generated |
+| Suggested title empty or itself `isUntitled()` | Silent return; no proposal saved (`checkUntitled`) |
+| `acceptProposal`: source note missing | `notifications.info('Source note no longer exists')`; proposal marked `rejected` |
+| `acceptProposal`: file exists at target path | `notifications.info('Cannot rename -- a file already exists at <path>')`; rename aborted |
+| `acceptProposal`: `vault.rename` throws | `notifications.notifyError('Failed to rename note', error)`; rethrows `Error('Rename failed: <msg>')` |
+| Persisted proposal JSON fails `isTitleProposal` guard | File skipped during load (`title-store.ts:L7`) |
 
 ## Tests
 

--- a/src/transcription/AGENTS.md
+++ b/src/transcription/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Transcription Module
@@ -8,7 +8,9 @@ UI-only module providing unified transcription modals with duration-aware time-r
 
 ## Public API
 
-Exported from `index.ts`:
+Re-exported from the `index.ts` barrel (`index.ts:L1`). `NodeDeps` is the one
+exception: it is a module-level export of `duration-detector.ts` (`duration-detector.ts:L46`),
+not re-exported by the barrel; it is only the type of the optional `deps?` param.
 
 ```ts
 class UnifiedTranscriptionModal extends Modal {
@@ -81,7 +83,7 @@ interface DurationResult {
   title: string
 }
 
-type NodeDeps = NodeModules  // injection seam for tests; alias of shared NodeModules
+type NodeDeps = NodeModules  // injection seam for tests; alias of shared NodeModules (not barrel-exported)
 ```
 
 ## File Inventory
@@ -100,17 +102,18 @@ type NodeDeps = NodeModules  // injection seam for tests; alias of shared NodeMo
 ## UnifiedTranscriptionModal
 
 Single modal combining audio file selection and video URL input (`unified-modal.ts`):
-- Dropdown lists all audio files in vault (filtered by `AUDIO_EXTENSIONS`, honors audio path exclusions from settings #323)
-- URL text field with platform detection badge (YouTube/TikTok/Instagram etc.)
-- URL section shown only on `Platform.isDesktop`
-- File selection and URL input are mutually exclusive
-- On submit: attempts duration detection (ffprobe for files, yt-dlp for URLs)
+- Local-file section rendered only when `enabledModules.audio || enabledModules.video` (`unified-modal.ts:L37`)
+- Dropdown lists all audio files in vault (filtered by `AUDIO_EXTENSIONS`, honors audio path exclusions via `isPathExcluded(path, 'audio', settings)`, #323)
+- URL section rendered only when `enabledModules.video && Platform.isDesktop` (`unified-modal.ts:L74`)
+- URL text field with platform detection badge (`detectPlatform`); unknown non-empty input shows "Unsupported URL"
+- File selection and URL input are mutually exclusive (setting one clears the other)
+- On submit (`handleTranscribe`, `unified-modal.ts:L118`): on mobile, transcribes full file/URL (no duration step); on desktop attempts duration detection (ffprobe for files, yt-dlp for URLs)
   - Duration >= `MIN_SLIDER_DURATION` (10s): shows `showTimeRangeToast`
-  - Duration < 10s: transcribes full file (no slider)
-  - Duration unknown: shows fallback text-input toast (MM:SS/HH:MM:SS manual entry)
+  - Duration defined but < 10s: transcribes full file (no slider)
+  - Duration unknown: shows fallback text-input toast (`showFallbackTextInputToast`, MM:SS/HH:MM:SS manual entry via `validateTimeRange`)
 - Callbacks receive `timeRange?: TimeRange` (undefined = full file)
 
-Opened via ribbon icon (`mic`) and command `synapse:transcribe-media`.
+Opened by `main.ts`: ribbon icon `synapse-transcribe` (desktop only) and command `synapse:transcribe-media` (plain `callback`; registration gated on a transcription module being enabled).
 
 ## NoteMediaModal
 
@@ -120,20 +123,21 @@ Selection modal for media embedded in the current note (`note-media-modal.ts`):
 - "Select all" / "Select none" buttons
 - "Combine audio" toggle (#214): shown for 2+ audio embeds; with ffmpeg concatenates audio before transcribing (single API call); without ffmpeg merges text transcriptions
   - `ffmpegAvailable` param controls the toggle description text only; actual concat logic is in `AudioModule`
+  - `combine` is passed true only when the toggle is on AND 2+ audio files are actually selected (`combine = this.combineAudio && chosenAudio.length >= 2`, `note-media-modal.ts:L109`)
   - `onTranscribeAudio` receives `combine: boolean` as second arg; caller decides behavior
 - "Process selected" dispatches to separate audio/video/image callbacks
 
-Opened via command `synapse:transcribe-note-media`.
+Opened by `main.ts` (`transcribeMediaFromNote`) via command `synapse:transcribe-note-media` (`editorCallback`; scans the active note's embeds, no-ops with a notice when none found).
 
 ## Duration Detection
 
 `duration-detector.ts` — both functions return early with `{ durationSeconds: undefined }` on mobile (`!Platform.isDesktop`).
 
 Local files (`detectLocalFileDuration`):
-1. Writes audio binary to OS temp dir (`synapse-probe-<ts>-<safeName>`)
-2. Runs ffprobe (derived from `video.ffmpegPath` by replacing `ffmpeg` with `ffprobe`)
+1. Writes audio binary to OS temp dir (`synapse-probe-<ts>-<safeName>`); `safeName` strips path-unsafe chars via `/[^A-Za-z0-9._-]/g`
+2. Runs ffprobe (derived from `video.ffmpegPath` via `replace(/ffmpeg$/, 'ffprobe')`), `env: shellEnv()`, `timeout: 15_000`ms
 3. Parses `-show_entries format=duration -of csv=p=0` output
-4. Cleans up temp file in `execFile` callback (fire-and-forget)
+4. Cleans up temp file in `execFile` callback (fire-and-forget `fs.promises.unlink`)
 
 URLs (`detectUrlDuration`):
 1. Validates URL via `sanitizeUrl`
@@ -163,16 +167,22 @@ URLs (`detectUrlDuration`):
 ## Data Flow
 
 ```
-main.ts constructs modals and wires callbacks:
+main.ts constructs modals and wires callbacks (main.ts:L539, main.ts:L576):
 
-UnifiedTranscriptionModal
+UnifiedTranscriptionModal (openUnifiedModal)
+  enabledModules = { audio: settings.audio.enabled,
+                     video: settings.video.enabled && this.video !== null }
   onTranscribeFile(file, timeRange?) --> AudioModule.transcribeFileToActiveNote(file, timeRange)
   onTranscribeUrl(url, timeRange?)   --> VideoModule.transcribeUrlToActiveNote(url, timeRange)
+                                         (no-op when video module absent)
 
-NoteMediaModal
-  onTranscribeAudio(embeds, combine) --> AudioModule.transcribeAndInsert(file, embeds, combine)
+NoteMediaModal (transcribeMediaFromNote; embeds from findAudioEmbeds/findVideoUrls/findImageEmbeds)
+  onTranscribeAudio(embeds, combine) --> combine
+                                           ? AudioModule.transcribeAndInsertCombined(file, embeds)
+                                           : AudioModule.transcribeAndInsert(file, embeds)
   onTranscribeVideo(embeds)          --> VideoModule.transcribeAndInsert(file, embeds)
   onExtractImages(embeds)            --> ImageModule.extractAndInsert(file, embeds)
+  ffmpegAvailable                    <-- await main.isFfmpegAvailable()
 ```
 
 ## Module Dependencies

--- a/src/video/AGENTS.md
+++ b/src/video/AGENTS.md
@@ -1,20 +1,20 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Video Module
 
-Downloads videos from YouTube/TikTok/Instagram/Twitter via yt-dlp, extracts audio, delegates transcription to AudioModule, optionally saves video to vault. Exposes public methods consumed by the unified transcription UI. Desktop-only: VideoModule is only constructed when `Platform.isDesktop`.
+Downloads videos from YouTube/TikTok/Instagram via yt-dlp, extracts audio with ffmpeg, delegates transcription to AudioModule, and optionally saves the video file into the vault. Desktop-only: VideoModule is constructed only when `Platform.isDesktop` (it may be null off-desktop).
 
-URL platform detection lives in `src/shared/url-detector.ts` (moved out of this module to break the shared-video cycle). Video re-exports `detectPlatform`, `isSupportedUrl`, `Platform`, and `UrlDetectionResult` from `../shared` for back-compat; new code should import them directly from `shared`.
+URL platform detection lives in `src/shared/url-detector.ts` (moved out of this module to break the shared/video cycle). Video re-exports `detectPlatform`, `isSupportedUrl`, `Platform`, and `UrlDetectionResult` for back-compat; new code should import them directly from `shared`.
 
 ## Public API
 
-Exported from `index.ts`:
+Re-exported from `index.ts` (the module barrel):
 
 ```ts
 class VideoModule {
-  onTranscriptionComplete: ((filePath: string) => void) | null
+  onTranscriptionComplete: ((filePath: string) => void) | null  // index.ts:L31
   constructor(
     plugin: Plugin,
     getSettings: () => SynapseSettings,
@@ -22,17 +22,17 @@ class VideoModule {
     notifications: NotificationManager,
     checkpointManager: CheckpointManager,
     registrar: CommandRegistrar
-  )
-  onload(): Promise<void>
-  onunload(): void
-  transcribeUrl(url: string, parentOp?: { update: (msg: string) => void }): Promise<string>
-  processUrl(url: string, options?: VideoProcessOptions, parentOp?: { update: (msg: string) => void }): Promise<TranscriptionResult & { videoVaultPath?: string }>
-  transcribeUrlToActiveNote(url: string, timeRange?: TimeRange): Promise<void>
-  transcribeAndInsert(noteFile: TFile, embeds: VideoUrlEmbed[]): Promise<void>
-  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>
+  )                                                              // index.ts:L33
+  onload(): Promise<void>                                        // index.ts:L44
+  onunload(): void                                               // index.ts:L55
+  transcribeUrl(url: string, parentOp?: { update: (msg: string) => void }): Promise<string>  // index.ts:L62
+  processUrl(url: string, options?: VideoProcessOptions, parentOp?: { update: (msg: string) => void }): Promise<TranscriptionResult & { videoVaultPath?: string }>  // index.ts:L70
+  transcribeUrlToActiveNote(url: string, timeRange?: TimeRange): Promise<void>  // index.ts:L149
+  resumeFromCheckpoint(checkpoint: Checkpoint): Promise<void>    // index.ts:L208
+  transcribeAndInsert(noteFile: TFile, embeds: VideoUrlEmbed[]): Promise<void>  // index.ts:L216
 }
 
-class AudioExtractor {
+class AudioExtractor {                                           // audio-extractor.ts:L152
   constructor(getSettings: () => SynapseSettings)
   extractFromUrl(url: string): Promise<ExtractionResult>
   extractFromFile(filePath: string): Promise<ExtractionResult>
@@ -44,18 +44,15 @@ class AudioExtractor {
 
 // Re-exported from ../shared (canonical home: shared/url-detector.ts)
 function detectPlatform(url: string): UrlDetectionResult | null
-function isSupportedUrl(url: string): boolean
+function isSupportedUrl(url: string): boolean   // true for detected platforms EXCEPT twitter
 type Platform = 'youtube' | 'tiktok' | 'instagram' | 'twitter' | 'unknown'
 interface UrlDetectionResult { platform: Platform; videoId: string; url: string }
 
 // Owned by this module
-function findVideoUrls(content: string): VideoUrlEmbed[]
-function hasTranscriptionBelow(lines: string[], embedLine: number, url: string): boolean
+function findVideoUrls(content: string): VideoUrlEmbed[]   // re-exported via index.ts:L25
+function renderVideoSettings(ctx: SettingsSectionContext): void  // re-exported via index.ts:L432
 
-// Settings renderer (#243)
-function renderVideoSettings(ctx: SettingsSectionContext): void
-
-// Types
+// Types (re-exported index.ts:L15-L22)
 interface VideoProcessOptions {
   postProcess?: boolean
   extractFrames?: boolean
@@ -85,16 +82,29 @@ interface VideoSource {
 }
 ```
 
+Exported by source files but NOT re-exported through `index.ts`:
+
+```ts
+class DependencyMissingError extends Error {   // audio-extractor.ts:L45
+  readonly tool: 'yt-dlp' | 'ffmpeg'
+}
+function hasTranscriptionBelow(lines: string[], embedLine: number, url: string): boolean  // note-scanner.ts:L36
+class FrameExtractor {                          // frame-extractor.ts:L6 — placeholder, throws on use
+  constructor(getSettings: () => SynapseSettings)
+  extractFrames(videoPath: string): Promise<string[]>
+}
+```
+
 ## File Inventory
 
 | File | Class/Export | Purpose |
 |------|-------------|---------|
-| `types.ts` | `VideoProcessOptions`, `ExtractionResult`, `VideoMetadata`, `VideoUrlEmbed`, `VideoSource` | Type definitions |
+| `types.ts` | `VideoProcessOptions`, `ExtractionResult`, `VideoMetadata`, `VideoUrlEmbed`, `VideoSource`, re-export `Platform` | Type definitions |
 | `note-scanner.ts` | `findVideoUrls`, `hasTranscriptionBelow` | Scan note content for video URLs |
 | `note-scanner.test.ts` | Tests | Note scanner unit tests |
-| `audio-extractor.ts` | `AudioExtractor` | yt-dlp/ffmpeg via `execFile` (no shell); URL download, file extract, clip, concat, dependency check |
+| `audio-extractor.ts` | `AudioExtractor`, `DependencyMissingError` | yt-dlp/ffmpeg via `execFile` (no shell); URL download, file extract, clip, concat, dependency check, no-audio detection |
 | `audio-extractor.test.ts` | Tests | AudioExtractor unit tests |
-| `frame-extractor.ts` | `FrameExtractor` | Placeholder; throws on use (unimplemented) |
+| `frame-extractor.ts` | `FrameExtractor` | Placeholder; `extractFrames` throws unless disabled (unimplemented) |
 | `settings-section.ts` | `renderVideoSettings` | Video settings accordion renderer for settings-tab.ts |
 | `settings-section.test.ts` | Tests | Settings section tests |
 | `mobile-safety.test.ts` | Tests | Desktop-only guard tests |
@@ -104,106 +114,135 @@ interface VideoSource {
 ## Data Flow
 
 ```
-1. User triggers via UnifiedTranscriptionModal or NoteMediaModal (in transcription/)
+1. User triggers via UnifiedTranscriptionModal or NoteMediaModal (src/transcription/)
    |
 2a. transcribeUrlToActiveNote(url, timeRange?) -- single URL to active note
-   |  Checks path exclusion (#307); calls processUrl; builds callout; appends to note
+   |  Checks path exclusion via findMatchingRule (#307); calls processUrl;
+   |  builds callout; appends via vault.process; fires onTranscriptionComplete
    |
 2b. transcribeAndInsert(noteFile, embeds) -- batch from note scan
-   |  Creates checkpoint; processes embeds in reverse line order; 2s delay between
-   |  API calls; atomic splice via vault.process; cancellable via NotificationManager
+   |  isPathExcluded silent skip (#307); creates checkpoint; processes embeds in
+   |  reverse line order; 2s delay between API calls; atomic splice via
+   |  vault.process; cancellable via NotificationManager operation
    |
 2c. transcribeUrl(url, parentOp) -- returns transcript text only
-   |  Used by SummarizeModule to auto-transcribe video URLs before summarizing
+   |  processUrl({ insertMode:false }); used by SummarizeModule
    |
-3. sanitizeUrl(url) -- validates HTTP(S), rejects shell chars
+3. sanitizeUrl(url) -- validates HTTP(S), rejects shell chars (processUrl + extractFromUrl)
    |
-4. detectPlatform(url) [from shared/url-detector.ts]
+4. detectPlatform(url) [shared/url-detector.ts]; platform defaults to 'unknown'
    |  YouTube: youtube.com/watch, youtu.be, youtube.com/shorts|embed|live
    |  TikTok: tiktok.com/@user/video/id, tiktok.com/t/..., vm/vt.tiktok.com
    |  Instagram: instagram.com/reel|reels|p/CODE
-   |  Twitter/X: (mobile.)twitter.com|x.com/.../status/id
-   |  isSupportedUrl() returns true for all detected platforms EXCEPT twitter
+   |  Twitter/X: (mobile.)twitter.com|x.com/.../status/id (NOT supported)
    |
 5. AudioExtractor.extractFromUrl(url)
-   |  getMetadata() --> yt-dlp --dump-json --no-download
-   |  Download audio --> yt-dlp -x --audio-format mp3
-   |  Tool paths via sanitizePath(), env via shellEnv()
+   |  dumpJson() --> yt-dlp --dump-json --no-download (never throws; null on failure)
+   |  toMetadata() builds VideoMetadata (fallback title 'Untitled')
+   |  isNoAudioPost() proactive slideshow check --> throws NoAudioError
+   |  yt-dlp -x --audio-format mp3 (retry once with -f bestaudio/best on soft failure)
+   |  Tool paths via sanitizePath(); env via shellEnv(); --ffmpeg-location only when concrete path
    |
 5a. [if timeRange] AudioExtractor.clipAudio(audioPath, startSeconds, endSeconds)
-   |  ffmpeg -ss/-to; cleans up original unclipped audio
+   |  ffmpeg -ss/-to -vn -acodec libmp3lame; deletes original unclipped audio;
+   |  endSeconds > metadata.duration throws before clipping
    |
-6. downloadVideoToVault() [if video.downloadFolder configured]
-   |  AudioExtractor.downloadVideo() --> yt-dlp -f mp4/best to tmp
-   |  vault.createBinary() with collision-safe path; cleans up temp file
+6. downloadVideoToVault() [if video.downloadFolder set]
+   |  AudioExtractor.downloadVideo() --> yt-dlp -f mp4/best to OS tmp
+   |  vault.createBinary() with collision-safe path; deletes temp file
    |
-7. AudioModule.transcribe(audioData, fileName, { sourceName })
+7. AudioModule.transcribe(audioData.buffer, title + '.mp3', { sourceName: title })
+   |  temp audio file deleted afterward
    |
-8. Result wrapped in callout block + optional video embed (![[file.mp4]])
+8. Result wrapped in callout (calloutForTranscriptionResult + buildCallout);
+   optional ![[file.mp4]] embed when video.embedInNote and a video was saved
 ```
 
 ## Note Scanning
 
-`findVideoUrls(content)` in `note-scanner.ts` (index.ts:L25):
+`findVideoUrls(content)` in `note-scanner.ts:L7`:
 - Regex: `/https?:\/\/[^\s)\]>]+/g`
-- Skips blockquote lines (transcription output, `>` prefix)
-- Skips Twitter/X URLs (`detected.platform === 'twitter'`)
-- Skips URLs with existing transcription callout within 3 lines below
+- Skips blockquote lines (`>` prefix — transcription output, not user content)
+- Skips undetected URLs and `detected.platform === 'twitter'`
+- Skips URLs with an existing transcription callout within 3 lines below
 - Returns `VideoUrlEmbed[]` with line numbers
 
-`hasTranscriptionBelow(lines, embedLine, url)` checks legacy `**Transcription of ...**` and callout formats.
+`hasTranscriptionBelow(lines, embedLine, url)` (`note-scanner.ts:L36`) matches the legacy `**Transcription of ...**` and the `[!<CALLOUT_TYPES.transcription>]` callout formats.
 
 ## Commands Registered
 
-| Command ID | Enabled condition | Description |
-|-----------|------------------|-------------|
-| `synapse:check-dependencies` | `video.enabled` | Check yt-dlp and ffmpeg availability |
+| Command ID | Enabled condition | Registry name |
+|-----------|------------------|---------------|
+| `synapse:check-dependencies` | `video.enabled` | Check external tool availability |
 
-Transcription commands are registered in `main.ts` (not here):
-- `synapse:transcribe-media` -> `VideoModule.transcribeUrlToActiveNote` via `UnifiedTranscriptionModal`
-- `synapse:transcribe-note-media` -> `VideoModule.transcribeAndInsert` via `NoteMediaModal`
+Registered via `registrar.register('check-dependencies', ...)` (index.ts:L50); Obsidian prefixes the manifest id with `synapse:`. The handler reports yt-dlp/ffmpeg presence and brew install hints. Transcription palette commands (`transcribe-media`, `transcribe-note-media`) are wired in `main.ts`, not here.
 
-## Settings Keys
+## Settings Keys (VideoSettings, settings.ts:L100)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `video.enabled` | `boolean` | `false` | Feature gate |
-| `video.ytDlpPath` | `string` | `'yt-dlp'` | yt-dlp binary path |
-| `video.ffmpegPath` | `string` | `'ffmpeg'` | ffmpeg binary path |
-| `video.tempFolder` | `string` | - | Vault folder for temp audio extraction |
-| `video.downloadFolder` | `string` | `''` | Vault folder to save downloaded videos (empty = do not save) |
-| `video.embedInNote` | `boolean` | `false` | Add `![[video.mp4]]` embed to note when saving video |
+| `video.enabled` | `boolean` | `true` | Feature gate |
+| `video.ytDlpPath` | `string` | `'yt-dlp'` | yt-dlp binary path (bare name = PATH lookup) |
+| `video.ffmpegPath` | `string` | `'ffmpeg'` | ffmpeg binary path (bare name = PATH lookup) |
+| `video.tempFolder` | `string` | `'.synapse/temp'` | Vault folder ensured on load for temp work |
+| `video.downloadFolder` | `string` | `'Media'` | Vault folder to save downloaded videos (empty = do not save) |
+| `video.embedInNote` | `boolean` | `true` | Add `![[video.mp4]]` embed to note when a video is saved |
+| `video.frameExtraction.enabled` | `boolean` | `false` | Frame extraction gate (unimplemented) |
+| `video.frameExtraction.intervalSeconds` | `number` | `30` | Seconds between extracted frames |
+| `video.frameExtraction.visionModel` | `string` | `'gpt-4o'` | Vision model for frame analysis |
+| `video.frameExtraction.maxFrames` | `number` | `20` | Max frames to extract |
+
+Settings UI: `renderVideoSettings` (`settings-section.ts:L144`) renders the accordion; `addPathSetting` attaches per-OS install-help panels (#382/#383) to the yt-dlp and ffmpeg path fields. Invoked only on desktop by `settings-tab.ts`.
 
 ## External Runtime Dependencies
 
 | Tool | Setting key | Default | Purpose |
 |------|-------------|---------|---------|
-| yt-dlp | `video.ytDlpPath` | `'yt-dlp'` | Video download and metadata |
-| ffmpeg | `video.ffmpegPath` | `'ffmpeg'` | Audio extraction, clipping, concatenation |
+| yt-dlp | `video.ytDlpPath` | `'yt-dlp'` | Video download and `--dump-json` metadata |
+| ffmpeg (incl. ffprobe) | `video.ffmpegPath` | `'ffmpeg'` | Audio extraction, clipping, concatenation |
 
-`shellEnv()` appends `/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin` to PATH.
-`execFile` timeout: 300s; maxBuffer: 10MB.
+`shellEnv()` prepends `/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin` ahead of the existing PATH. `execFile` timeout: 300s; maxBuffer: 10MB (audio-extractor.ts:L438). No shell is invoked (explicit argument arrays).
 
 ## Module Dependencies
 
 In:
-- `../audio` — `AudioModule`, `TranscriptionResult`
-- `../shared` — `CheckpointManager`, `NotificationManager`, `CommandRegistrar`, `sanitizeUrl`, `sanitizePath`, `buildCallout`, `calloutForTranscriptionResult`, `ensureFolder`, `formatTimeRange`, `detectPlatform`, `isSupportedUrl`, `loadNodeModules`, `shellEnv`, `isPathExcluded`, `findMatchingRule`, `generateId`, `TimeRange`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask`
+- `../audio` — `AudioModule` (runtime value edge: reuses the transcription pipeline), `TranscriptionResult` (type)
+- `../commands` — `CommandRegistrar`
+- `../shared` — `ensureFolder`, `NotificationManager`, `sanitizeUrl`, `buildCallout`, `calloutForTranscriptionResult`, `CheckpointManager`, `generateId`, `formatTimeRange`, `detectPlatform`, `loadNodeModules`, `isPathExcluded`, `findMatchingRule`, `TimeRange`, `Checkpoint`, `CheckpointWorkItem`, `DeferredTask` (index.ts); `sanitizePath`, `describeNetworkError`, `isRecord`, `parseJson`, `shellEnv`, `NodeModules` (audio-extractor.ts); `CALLOUT_TYPES` (note-scanner.ts); `SettingsSectionContext` (settings-section.ts)
+- `../settings` — `SynapseSettings`, `VideoSettings`, `FrameExtractionSettings` (types)
 
 Out (consumed by):
-- `src/transcription/` — `UnifiedTranscriptionModal`, `NoteMediaModal` import `VideoUrlEmbed`, `detectPlatform` from here
-- `src/summarize/` — imports `transcribeUrl` behavior via `VideoModule` instance
+- `src/transcription/note-media-modal.ts` — imports `VideoUrlEmbed`
+- `src/transcription/unified-modal.ts` — imports `detectPlatform`
+- `src/audio/index.ts` — imports `type AudioExtractor` (type-only; no runtime cycle)
 
-## Security
+VideoModule → AudioModule is the one documented cross-feature runtime dependency; the reverse edge is type-only.
 
-- URLs validated via `sanitizeUrl()` (called in both `VideoModule.processUrl` and `AudioExtractor.extractFromUrl`)
-- Tool paths validated via `sanitizePath()`
-- All subprocess calls use `execFile` with explicit argument arrays (no shell interpolation)
+## Error States
+
+| Condition | Behavior |
+|-----------|----------|
+| Missing yt-dlp/ffmpeg (ENOENT, or ffmpeg/ffprobe stderr signature) | `DependencyMissingError` (carries `tool`); rethrown untouched through processUrl/summarize so callers can show an "Open settings" notice (#382) |
+| TikTok photo slideshow / no audio stream | `NoAudioError` (internal); proactive from `--dump-json` (`isNoAudioPost`) and reactive from ffprobe `unable to obtain file audio codec` stderr |
+| Network failure | `describeNetworkError`-classified message; not retried |
+| Subprocess timeout (>5 min, SIGTERM) | `Error('<tool> timed out after 5 minutes')` |
+| Other download/extract failure | Wrapped `Error('Download/audio extraction failed: ...')` after one looser-format retry |
+| `endSeconds > metadata.duration` | Throws before clipping |
+| Transcription failure | Wrapped `Error('Transcription failed: ...')` |
+| No active file (transcribeUrlToActiveNote) | Info notice; returns without error |
+| Path excluded (#307) | transcribeUrlToActiveNote: named notice; transcribeAndInsert: silent skip |
 
 ## Invariants / Gotchas
 
-- Desktop-only: `loadNodeModules()` throws `DesktopOnlyError` off-desktop; VideoModule is only constructed after `Platform.isDesktop` check in `main.ts`
-- `FrameExtractor` in `frame-extractor.ts` is a placeholder and throws on use
-- `AudioExtractor.concatAudio` re-encodes via ffmpeg filter (handles mixed formats: mp3/wav/m4a/ogg/flac/webm/aac)
-- `downloadVideoToVault` uses `vault.createBinary()` (not adapter API) for first-class vault citizenship; collision-safe naming appends `-1`, `-2`, etc.
-- Back-compat re-exports: `detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult` are re-exported from `../shared`; direct `shared` imports preferred in new code
+- Desktop-only: `loadNodeModules()` throws `DesktopOnlyError` off-desktop; VideoModule is constructed only after `Platform.isDesktop` in `main.ts` and may be null. AudioExtractor also asserts desktop at first fs/subprocess access.
+- `FrameExtractor` (`frame-extractor.ts`) is a placeholder: `extractFrames` returns `[]` when disabled, otherwise throws "not yet implemented".
+- `AudioExtractor.concatAudio` re-encodes via the ffmpeg concat filter (handles mixed mp3/wav/m4a/ogg/flac/webm/aac).
+- `--ffmpeg-location` is emitted only when `ffmpegPath` is a concrete path (contains `/` or `\`); a bare name relies on PATH discovery.
+- `downloadVideoToVault` uses `vault.createBinary()` (not the adapter API); collision-safe naming appends `-1`, `-2`, ... before the extension.
+- Back-compat re-exports (`detectPlatform`, `isSupportedUrl`, `Platform`, `UrlDetectionResult`) come from `../shared`; prefer direct `shared` imports in new code.
+
+## Security
+
+- URLs validated via `sanitizeUrl()` in both `VideoModule.processUrl` and `AudioExtractor` entry points.
+- Tool and file paths validated via `sanitizePath()`.
+- All subprocess calls use `execFile` with explicit argument arrays — no shell interpolation.

--- a/src/views/AGENTS.md
+++ b/src/views/AGENTS.md
@@ -1,42 +1,46 @@
 ---
-last-updated: 2026-06-19
+last-updated: 2026-06-25
 ---
 
 # Views Module
 
-Two Obsidian sidebar views: `UnifiedProposalView` (proposal review with checkpoint recovery) and `SynapseActionsView` (touch-friendly command palette). Also exports the semantic color token system and BEM class helpers used by both views.
+Two Obsidian sidebar `ItemView`s — `UnifiedProposalView` (proposal review with checkpoint recovery and bulk accept/reject) and `SynapseActionsView` (registry-driven touch-friendly command palette) — plus the semantic color-token system and BEM class helpers shared by both.
 
 ## Public API
 
-Exported from `index.ts`:
+Exported from `index.ts` (re-export barrel; see `index.ts:L1-L23`).
 
 ```ts
 // unified-proposal-view.ts
 const UNIFIED_VIEW_TYPE = 'synapse-proposals'
 
 class UnifiedProposalView extends ItemView {
-  constructor(leaf: WorkspaceLeaf, callbacks: UnifiedViewCallbacks)
-  setItems(items: UnifiedItem[]): void
-  setCheckpoints(checkpoints: Checkpoint[]): void
+  constructor(
+    leaf: WorkspaceLeaf,
+    callbacks: UnifiedViewCallbacks,
+    notifications: NotificationManager,   // required 3rd arg; surfaces bulk-op errors
+  )
+  setItems(items: UnifiedItem[]): void           // replace list; exits stale review mode
+  setCheckpoints(checkpoints: Checkpoint[]): void // banner data for interrupted ops
   getViewType(): string    // 'synapse-proposals'
   getDisplayText(): string // 'Synapse Proposals'
-  getIcon(): string        // 'synapse'  (brand S-Signal mark, not 'sparkles')
+  getIcon(): string        // 'synapse'  (brand S-Signal mark; not 'sparkles')
 }
 
 // synapse-actions-view.ts
 const SYNAPSE_ACTIONS_VIEW_TYPE = 'synapse-actions'
 
 interface SynapseActionsCallbacks {
-  getActions: () => CommandDefinition[]
-  runAction: (id: string) => void
-  isNoteActive: () => boolean
+  getActions: () => CommandDefinition[]   // palette commands in registry order
+  runAction: (id: string) => void         // invoke command by registry id
+  isNoteActive: () => boolean             // gates context:'note' buttons
 }
 
 class SynapseActionsView extends ItemView {
   constructor(leaf: WorkspaceLeaf, callbacks: SynapseActionsCallbacks)
   getViewType(): string    // 'synapse-actions'
   getDisplayText(): string // 'Synapse actions'
-  getIcon(): string        // 'layout-grid'
+  getIcon(): string        // 'synapse-actions'  (bespoke launcher mark; addIcon)
   refresh(): void          // re-render; called by main.ts on active-leaf-change
 }
 
@@ -49,11 +53,11 @@ type ProposalKind = (typeof PROPOSAL_KINDS)[number]
 
 type UnifiedItem =
   | { kind: 'elaboration'; data: Proposal }
-  | { kind: 'enrichment'; data: EnrichmentProposal }
-  | { kind: 'organize'; data: OrganizeProposal }
-  | { kind: 'deep-dive'; data: DeepDiveProposal }
-  | { kind: 'title'; data: TitleProposal }
-  | { kind: 'rem'; data: RemProposal }
+  | { kind: 'enrichment';  data: EnrichmentProposal }
+  | { kind: 'organize';    data: OrganizeProposal }
+  | { kind: 'deep-dive';   data: DeepDiveProposal }
+  | { kind: 'title';       data: TitleProposal }
+  | { kind: 'rem';         data: RemProposal }
 
 interface UnifiedViewCallbacks {
   onElaborationAccept: (id: string, editedContent: string) => Promise<void>
@@ -73,8 +77,8 @@ interface UnifiedViewCallbacks {
 }
 
 // proposal-styles.ts
-const SYNAPSE_COLOR_TOKENS: Record<ProposalKind, string>   // e.g. 'elaboration' -> '--synapse-color-elaboration'
-const FEATURE_COLOR_TOKENS: Record<FeatureKey, string>     // superset; covers main/summarize/tidy/video too
+const SYNAPSE_COLOR_TOKENS: Record<ProposalKind, string>  // 'elaboration' -> '--synapse-color-elaboration'
+const FEATURE_COLOR_TOKENS: Record<FeatureKey, string>    // superset minus 'title'; adds main/summarize/tidy/video
 
 function cardClass(kind: ProposalKind): string             // 'synapse-card--<kind>'
 function badgeClass(kind: ProposalKind): string            // 'synapse-badge--<kind>'
@@ -86,99 +90,125 @@ function actionsGroupClass(feature: FeatureKey): string    // 'synapse-actions-g
 
 | File | Exports | Purpose |
 |------|---------|---------|
-| `unified-proposal-view.ts` | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE` | Combined proposal sidebar with checkpoint banner |
-| `synapse-actions-view.ts` | `SynapseActionsView`, `SYNAPSE_ACTIONS_VIEW_TYPE`, `SynapseActionsCallbacks` | Touch-friendly command palette sidebar |
-| `types.ts` | `UnifiedItem`, `UnifiedViewCallbacks`, `ProposalKind`, `PROPOSAL_KINDS` | View type definitions; compile-time guard asserts `PROPOSAL_KINDS` matches `UnifiedItem['kind']` |
-| `proposal-styles.ts` | `SYNAPSE_COLOR_TOKENS`, `FEATURE_COLOR_TOKENS`, `cardClass`, `badgeClass`, `reviewPaneLabelClass`, `actionsGroupClass` | Semantic color tokens + BEM class helpers (#342) |
-| `index.ts` | re-exports all of the above | Barrel |
-| `unified-proposal-view.test.ts`, `synapse-actions-view.test.ts`, `proposal-styles.test.ts` | Tests | |
+| `unified-proposal-view.ts` | `UnifiedProposalView`, `UNIFIED_VIEW_TYPE` (re-exports `UnifiedItem`, `UnifiedViewCallbacks` types) | Combined proposal sidebar: checkpoint banner, list, per-kind review, bulk ops |
+| `synapse-actions-view.ts` | `SynapseActionsView`, `SYNAPSE_ACTIONS_VIEW_TYPE`, `SynapseActionsCallbacks` | Registry-driven touch-friendly command palette sidebar |
+| `types.ts` | `PROPOSAL_KINDS`, `ProposalKind`, `UnifiedItem`, `UnifiedViewCallbacks` | View type defs; compile-time guard binds `PROPOSAL_KINDS` to `UnifiedItem['kind']` |
+| `proposal-styles.ts` | `SYNAPSE_COLOR_TOKENS`, `FEATURE_COLOR_TOKENS`, `cardClass`, `badgeClass`, `reviewPaneLabelClass`, `actionsGroupClass` | Semantic color tokens + BEM class helpers |
+| `index.ts` | barrel re-export of all the above | Public surface |
+| `*.test.ts` (3 files) | tests | `unified-proposal-view`, `synapse-actions-view`, `proposal-styles` |
+
+No legacy views exist in this directory; only the two registered `ItemView`s above. A legacy `ProposalReviewView` still lives in `src/elaboration/proposal-view.ts` (outside this module) and is not registered.
+
+## View Registry
+
+| View type id | Class | getIcon | getDisplayText | Source |
+|--------------|-------|---------|----------------|--------|
+| `synapse-proposals` | `UnifiedProposalView` | `synapse` | `Synapse Proposals` | `unified-proposal-view.ts:L15` |
+| `synapse-actions` | `SynapseActionsView` | `synapse-actions` | `Synapse actions` | `synapse-actions-view.ts:L6` |
 
 ## Compile-Time Guards
 
-`types.ts:L43-L46` asserts `PROPOSAL_KINDS` exactly covers `UnifiedItem['kind']` in both directions via two
-typed `const` assertions. Build fails if a new proposal kind is added to only one.
+`types.ts:L43-L48` asserts `PROPOSAL_KINDS` equals `UnifiedItem['kind']` in both directions via two distinct `const _x: true` assertions (`_AssertKindsCoverUnion`, `_AssertUnionCoversKinds`). Adding a kind to only one side fails the build.
 
-`proposal-styles.ts:L15` types `SYNAPSE_COLOR_TOKENS` as `Record<ProposalKind, string>` — build fails if a
-kind lacks a CSS token. `FEATURE_COLOR_TOKENS` does the same for `FeatureKey`.
+`proposal-styles.ts:L15` types `SYNAPSE_COLOR_TOKENS` as `Record<ProposalKind, string>`; `proposal-styles.ts:L34` types `FEATURE_COLOR_TOKENS` as `Record<FeatureKey, string>`. Build fails if a kind/feature lacks a `--synapse-color-*` token. CSS custom properties are authoritative in `styles.css`; these maps are only the exhaustiveness guard, not the color values.
+
+## Color Tokens
+
+| Proposal kind | CSS token | Feature-only keys (no proposal kind) | CSS token |
+|---------------|-----------|--------------------------------------|-----------|
+| elaboration | `--synapse-color-elaboration` | main | `--synapse-color-main` |
+| enrichment | `--synapse-color-enrichment` | summarize | `--synapse-color-summarize` |
+| organize | `--synapse-color-organize` | tidy | `--synapse-color-tidy` |
+| deep-dive | `--synapse-color-deep-dive` | video | `--synapse-color-video` |
+| title | `--synapse-color-title` | | |
+| rem | `--synapse-color-rem` | | |
+
+`FEATURE_COLOR_TOKENS` covers all `FeatureKey` values (the proposal kinds minus `title`, plus `main`/`summarize`/`tidy`/`video`) for the actions sidebar, which groups by `FeatureKey` rather than `ProposalKind`.
 
 ## Rendering Modes (UnifiedProposalView)
 
-1. Checkpoint banner: incomplete checkpoints → banner per checkpoint with module label, progress (done/total), Resume/Discard buttons.
-2. List mode: all pending proposals grouped by source note path. Accept All button when 2+ proposals. Each card shows badge, reasons/summary, preview, and action buttons (Review/Accept/Reject).
-3. Elaboration review: editable textarea for proposed additions; Accept sends edited content.
-4. Enrichment review: per-item checkboxes for tags/links/refs/frontmatter; Accept Selected/All/None/Reject.
-5. Organize review: proposed directory path + AI reasoning; Accept/Reject.
-6. Deep-dive review: topic title, depth badge, quality score, proposed path, read-only content preview, child count warning; Accept/Reject.
-7. Title review: current vs proposed title, trigger reason, AI reasoning; Accept (rename)/Reject.
-8. REM review: per-match checkboxes for link suggestions; Accept Selected/Reject.
+`render()` (`unified-proposal-view.ts:L129`) dispatches on whichever `reviewing*` field is set, else list mode.
 
-## Card Types
+1. Checkpoint banner: one card per incomplete checkpoint with operation label, done/total progress bar, Resume/Discard.
+2. List mode: pending proposals grouped by `data.sourceNotePath`; Accept all / Reject all bar shown when 2+ pending; each card has a badge, summary, preview, and Review/Accept/Reject.
+3. Elaboration review: editable textarea; Accept sends edited content.
+4. Enrichment review: per-item checkboxes (tags / internalLinks / externalLinks / frontmatter); Accept selected / All / None / Reject.
+5. Organize review: proposed directory + reasoning; Accept/Reject.
+6. Deep-dive review: title, depth + quality badges, proposed path, read-only content preview, cascade warning when `childProposalIds.length > 0`; Accept/Reject.
+7. Title review: current vs proposed title, trigger (`untitled` | `mismatch`), reasoning; Accept (rename)/Reject.
+8. REM review: per-candidate checkboxes with match-type badge (`title`/`alias`/`semantic`, semantic shows confidence %); Accept selected / All / None / Reject.
 
-| Kind | CSS token |
-|------|-----------|
-| elaboration | `--synapse-color-elaboration` |
-| enrichment | `--synapse-color-enrichment` |
-| organize | `--synapse-color-organize` |
-| deep-dive | `--synapse-color-deep-dive` |
-| title | `--synapse-color-title` |
-| rem | `--synapse-color-rem` |
+## Bulk Operations (UnifiedProposalView)
 
-CSS custom properties declared in `styles.css` (`.theme-light, .theme-dark` block). TypeScript tokens in
-`proposal-styles.ts` are the exhaustiveness guard — they are NOT the authoritative color values.
+| Op | Method | Trigger | Behavior |
+|----|--------|---------|----------|
+| Accept all | `acceptAll()` `:L190` | "Accept all" button, 2+ pending | Sequential over snapshot; per-kind accept-all; stops on first error |
+| Reject all | `rejectAll()` `:L296` | "Reject all" button, 2+ pending | Sequential over snapshot; stops on first error |
 
-## Accept All (UnifiedProposalView)
+Sequential because organize accepts may move files. Mutually exclusive via `acceptAllInProgress` / `rejectAllInProgress`; buttons disabled while either runs. Enrichment accept-all selects all tags/links/refs/frontmatter; REM accept-all selects all `candidates[].matchedText`.
 
-- Available when 2+ proposals pending.
-- Processes sequentially (organize proposals may affect file paths).
-- Shows progress bar during batch; stops on first failure.
-- Enrichment: accepts all suggested items (tags + links + refs + frontmatter).
-- REM: accepts all suggested match texts.
+## Data Flow
 
-## Wiring (in main.ts)
+Input: `main.refreshUnifiedView()` gathers pending proposals from the six feature modules into `UnifiedItem[]` and incomplete checkpoints, then calls `setItems()` / `setCheckpoints()`.
+
+Processing: view stores items, re-renders. User clicks invoke `UnifiedViewCallbacks` (proposal accept/reject) or `SynapseActionsCallbacks.runAction` (command dispatch). The view holds no proposal store and never touches `app`/vault for state — only `openNote()` opens files in the editor.
+
+Output: callbacks return `Promise<void>`; modules mutate the vault/proposal store and re-trigger `refreshUnifiedView()`. `SynapseActionsView.refresh()` re-renders on `active-leaf-change` to enable/disable `context:'note'` buttons.
+
+## Wiring (main.ts)
+
+`main.ts:L157-L174` registers `UNIFIED_VIEW_TYPE` with the third `notifications` arg:
 
 ```ts
-this.registerView(UNIFIED_VIEW_TYPE, (leaf) =>
-  new UnifiedProposalView(leaf, {
-    onElaborationAccept: (id, content) => this.elaboration.acceptProposal(id, content),
-    onElaborationReject: (id) => this.elaboration.rejectProposal(id),
-    onEnrichmentAcceptSelected: (id, accepted) => this.enrichment.acceptSelectedFromView(id, accepted),
-    onEnrichmentReject: (id) => this.enrichment.rejectFromView(id),
-    onOrganizeAccept: (id) => this.organize.acceptProposal(id),
-    onOrganizeReject: (id) => this.organize.rejectProposal(id),
-    onDeepDiveAccept: (id) => this.deepDive.acceptProposal(id),
-    onDeepDiveReject: (id) => this.deepDive.rejectProposal(id),
-    onTitleAccept: (id) => this.title.acceptProposal(id),
-    onTitleReject: (id) => this.title.rejectProposal(id),
-    onRemAcceptSelected: (id, texts) => this.rem.acceptSelectedFromView(id, texts),
-    onRemReject: (id) => this.rem.rejectFromView(id),
-    onCheckpointDiscard: (id) => this.discardCheckpoint(id),
-    onCheckpointResume: (id) => this.resumeCheckpoint(id),
-  })
-);
-
-this.registerView(SYNAPSE_ACTIONS_VIEW_TYPE, (leaf) =>
-  new SynapseActionsView(leaf, {
-    getActions: () => this.commands.listPaletteActions(),
-    runAction: (id) => (this.app as any).commands.executeCommandById(id),
-    isNoteActive: () => this.app.workspace.getActiveViewOfType(MarkdownView) !== null,
-  })
-);
+new UnifiedProposalView(leaf, {
+  onElaborationAccept: (id, content) => this.elaboration.acceptProposal(id, content),
+  onElaborationReject: (id) => this.elaboration.rejectProposal(id),
+  onEnrichmentAcceptSelected: (id, accepted) => this.enrichment.acceptSelectedFromView(id, accepted),
+  onEnrichmentReject: (id) => this.enrichment.rejectFromView(id),
+  onOrganizeAccept: (id) => this.organize.acceptProposal(id),
+  onOrganizeReject: (id) => this.organize.rejectProposal(id),
+  onDeepDiveAccept: (id) => this.deepDive.acceptProposal(id),
+  onDeepDiveReject: (id) => this.deepDive.rejectProposal(id),
+  onTitleAccept: (id) => this.title.acceptProposal(id),
+  onTitleReject: (id) => this.title.rejectProposal(id),
+  onRemAcceptSelected: (id, texts) => this.rem.acceptProposal(id, texts),
+  onRemReject: (id) => this.rem.rejectProposal(id),
+  onCheckpointDiscard: (id) => this.discardCheckpoint(id),
+  onCheckpointResume: (id) => this.resumeCheckpoint(id),
+}, this.notifications);
 ```
 
-Refreshed via `main.refreshUnifiedView()` which gathers items from all six modules plus incomplete checkpoints.
-`SynapseActionsView.refresh()` called on `active-leaf-change` to enable/disable per-note buttons.
+`main.ts:L182-L186` registers `SYNAPSE_ACTIONS_VIEW_TYPE`:
+
+```ts
+new SynapseActionsView(leaf, {
+  getActions: () => listPaletteActions(registrar.getRegistered()),
+  runAction: (id) => this.runCommand(id),
+  isNoteActive: () => this.activeMarkdownFile() !== null,
+});
+```
 
 ## Dependencies
 
-| Import | From |
-|--------|------|
-| `Proposal` | `../elaboration` (type only) |
-| `AcceptedItems`, `EnrichmentProposal` | `../enrichment` (type only) |
-| `OrganizeProposal` | `../organize` (type only) |
-| `DeepDiveProposal` | `../deep-dive` (type only) |
-| `TitleProposal` | `../title` (type only) |
-| `RemProposal` | `../rem` (type only) |
-| `Checkpoint`, `fireAndForget` | `../shared` |
-| `CommandDefinition`, `FeatureKey` | `../commands` (type only, in synapse-actions-view.ts) |
+| Import | From | Kind |
+|--------|------|------|
+| `Proposal` | `../elaboration` | type only |
+| `AcceptedItems`, `EnrichmentProposal` | `../enrichment` | type only |
+| `OrganizeProposal` | `../organize` | type only |
+| `DeepDiveProposal` | `../deep-dive` | type only |
+| `TitleProposal` | `../title` | type only |
+| `RemProposal` | `../rem` | type only |
+| `Checkpoint`, `NotificationManager` | `../shared` | type only |
+| `fireAndForget` | `../shared` | runtime value |
+| `CommandDefinition`, `FeatureKey` | `../commands` | type only |
+| `FEATURE_ICONS` | `../commands` | runtime value (`synapse-actions-view.ts`) |
 
-`unified-proposal-view.ts` imports TYPES ONLY from feature modules (no runtime feature-module code in the view layer).
+The six proposal feature modules are imported as TYPES ONLY (no runtime feature-module code in the view layer). Runtime imports are limited to `fireAndForget` (shared) and `FEATURE_ICONS` (commands).
+
+## Error States
+
+- Individual Accept/Reject: handlers run via `onClick()`/`fireAndForget` (`:L158`), so a rejected promise is surfaced to the user instead of failing silently.
+- Bulk Accept all / Reject all: on first failure the loop stops, sets the in-progress flag false, and calls `notifications.error(...)` with the failing item label, the error message, and a `X/total accepted, N remaining` summary (`:L207-L217`, `:L313-L323`). Already-applied items are not rolled back.
+- `setItems()` exits any active review mode whose proposal id is no longer pending (`:L90-L125`).
+- `openNote()` no-ops when the path resolves to no file (`:L165-L171`).
+- `SynapseActionsView`: empty `getActions()` renders an "enable features in settings" message (`:L88-L94`); `context:'note'` buttons are `disabled` with `aria-disabled` and no click handler when no note is active (`:L114-L126`).


### PR DESCRIPTION
## Codebase audit (`/audit`)

Ran the full six-stage audit chain over the codebase. Each specialist audited the tree and implemented fixes before the next started; the lead verified the build green between every stage and ran the complete CI guard set as a final gate.

| # | Stage | Findings | Result |
|---|-------|----------|--------|
| 1 | **Architect** | 5 low/info flagged (intentional or defensible co-location) | **0 changes** — conforms to documented architecture |
| 2 | **Security (pass 1)** | 1 low (key-leak to console, defense-in-depth) | **1 fix** — redact the operation-error `console.error` sink + regression test |
| 3 | **Obsidian compliance** | 1 low (command-name casing) + several flagged-intentional | **1 fix** — sentence-case the REM discover-links command |
| 4 | **Docs-agent** | n/a | **18 files** — root `AGENTS.md` + 17 per-feature `AGENTS.md` regrounded |
| 5 | **Docs-human** | n/a | **3 files** — `STATUS.md`, `DECISIONS.md`, `ARCHITECTURE.md` refreshed to v1.0.6 |
| 6 | **Security (pass 2)** | none | **clean** — no secrets/cross-project refs in docs; prior fixes intact |

### Code changes (2)
- **`src/shared/notifications.ts`** — the operation-handle `error()` showed a redacted toast but logged the same message **raw** to `console.error`. Now wrapped in `redactSecrets()`, matching the sibling `notifyError` path and `redact.ts`'s single-source-of-truth contract. Adds a regression test.
- **`src/commands/registry.ts`** — `"REM: Discover links in current note"` → `"REM: discover links in current note"` for Obsidian's sentence-case command convention.

### Documentation changes (21)
Root + all 17 per-feature `AGENTS.md`, plus `ARCHITECTURE.md` / `DECISIONS.md` / `STATUS.md`, regenerated and grounded against current source (module registry, dependency graph, public API signatures, command + settings schema, decision log).

### Deliberately left as-is (flagged, not changed)
Type-only audio→video back-edge, desktop-gated `loadNodeModules`, `sanitizeUrl` allowing URL-legal chars passed safely to `execFile` argv, `isDesktopOnly: false` mobile stance, and 8 self-clearing `Promise.race` timeouts.

### Verification
`tsc` · `lint` · top-level-require guard · version check · **1692/1692 tests** · production build — all green. No version bump, no `CHANGELOG.md` edits, build artifact (`main.js`) not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqCNfQ3REzK2y7VbUWnvKK
