### PR TITLE
docs: add command-pipeline Mermaid diagram (#388)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -351,9 +351,11 @@ Key constraints:
 
 "Fire Synapse" runs the AI features over a folder (or a single note) in a fixed, deliberate order. The `pipeline/` module owns a `SynapseRunner` that executes each phase sequentially, isolating failures so one bad phase doesn't abort the run.
 
+> This diagram expands subgraph **c (Fire Synapse)** of the master command-pipeline overview in [`README.md` → How it all fits together](README.md#how-it-all-fits-together), which is the canonical birds-eye view.
+
 ```mermaid
 graph LR
-    Elab["1. Elaboration"] --> Summ["2. Summarize"] --> Enrich["3. Enrichment"] --> Rem["4. REM"] --> Tidy["5. Tidy"] --> Org["6. Organize"]
+    Elab["1 · Elaboration"] --> Summ["2 · Summarize"] --> Enrich["3 · Enrichment"] --> Rem["4 · REM"] --> Tidy["5 · Tidy"] --> Org["6 · Organize"]
     style Org fill:#e8f5e9,stroke:#333
 ```
 
@@ -368,14 +370,22 @@ graph LR
 
 The `intake/` module turns a watched folder into a hands-off inbox. Drop a note — or a note containing an article/media URL — and Synapse processes it automatically.
 
+> This diagram expands subgraph **d (Intake)** of the master command-pipeline overview in [`README.md` → How it all fits together](README.md#how-it-all-fits-together), which is the canonical birds-eye view.
+
 ```mermaid
 graph TB
     Event["Vault create/modify in intake folder"] --> Guard["Cheap guards:<br/>is .md? enabled? in folder? not in-flight?"]
     Guard --> Debounce["Per-path debounce<br/>(wait for note to settle)"]
     Debounce --> Idem{"Already has<br/>synapse-processed flag?"}
     Idem -->|Yes| Skip["Skip (idempotent)"]
-    Idem -->|No| Route["Route: article URL / media URL / general"]
-    Route --> Fire["deps.fireOnFile(note)<br/>(full pipeline on one note)"]
+    Idem -->|No| Bare{"Body is essentially<br/>one bare URL?"}
+    Bare -->|"no — general / mixed / text"| Fire["deps.fireOnFile(note)<br/>(full pipeline on one note)"]
+    Bare -->|yes| Classify{"Classify URL"}
+    Classify -->|article| Article["Fetch article content<br/>+ deps.fireOnFile(note)"]
+    Classify -->|"video / audio"| Stub["Transcribe (stub — no-op today, #112)"]
+    Classify -->|unknown| Fire
+    Article --> Stamp
+    Stub --> Stamp
     Fire --> Stamp["Stamp synapse-processed<br/>(before any move)"]
     Stamp --> Move["Organize moved it?<br/>else optional fallback move"]
     Move --> Log["If it left the inbox:<br/>write dated capture-log breadcrumb (#224)"]
@@ -573,6 +583,8 @@ URL detection (`shared/url-detector.ts`) recognizes:
 
 All inter-module communication flows through `main.ts` via nullable callback assignments. No event bus, no pub-sub.
 
+> This diagram is the wiring-level detail behind the per-note cascade — subgraph **a** of the master command-pipeline overview in [`README.md` → How it all fits together](README.md#how-it-all-fits-together), which is the canonical birds-eye view. The setting names and defaults on the edges below match that diagram.
+
 ```mermaid
 graph LR
     subgraph Triggers["Enrichment + Title Triggers"]
@@ -584,15 +596,15 @@ graph LR
         DDa["Deep Dive<br/>onNoteAccepted"]
     end
 
-    Enrich["Enrichment.enrich()"]
-    TitleChk["Title.checkTitle()"]
+    Enrich["Enrichment.enrich()<br/>gated by enrichment.autoEnrich (default ON)"]
+    TitleChk["Title.checkTitle()<br/>gated by title.checkAfterOperations (default ON)"]
 
     Elab -->|"'elaboration'"| Enrich
     Audio -->|"'transcription'"| Enrich
     Video -->|"'transcription'"| Enrich
     Img -->|"'transcription'"| Enrich
     Summ -->|"'summarization'"| Enrich
-    DDa -->|"'deep-dive'"| Enrich
+    DDa -->|"'deep-dive' · deepDive.autoEnrichOnAccept (default ON)"| Enrich
 
     Elab --> TitleChk
     Audio --> TitleChk
@@ -601,11 +613,13 @@ graph LR
     Summ --> TitleChk
     DDa --> TitleChk
 
-    DD2["Deep Dive<br/>onOrganizeRequested"] -->|"when autoOrganize"| Org["Organize.organizeNote()"]
-    Summ2["Summarize<br/>onOrganizeRequested"] -->|"when autoOrganize"| Org
+    DD2["Deep Dive<br/>onOrganizeRequested"] -->|"deepDive.autoOrganizeOnAccept (default OFF)"| Org["Organize.organizeNote()"]
+    Summ2["Summarize<br/>onOrganizeRequested"] -->|"summarize.autoOrganizeOnSummarize (default OFF)"| Org
 
     ElabR["Elaboration"] & EnrichR["Enrichment"] & OrgR["Organize"] & DDR["Deep Dive"] & TitleR["Title"] -->|onViewRefreshNeeded| Refresh["main.refreshUnifiedView()"]
 ```
+
+> **Deep Dive caveat.** When global enrichment is on (`enrichment.autoEnrich` ON) but `deepDive.autoEnrichOnAccept` is OFF, accepting a deep-dive note wires *neither* the enrich nor the title callback — so the title check is effectively gated behind `deepDive.autoEnrichOnAccept` too. The standalone title-only fallback (each trigger → `Title.checkTitle()` with no enrich) is wired only when `enrichment.autoEnrich` is OFF.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,79 @@ Recursively explores a note's topics into a tree of interlinked child notes. Use
 - **Checkpoint/Undo System** -- every vault-wide operation creates checkpoints so you can resume interrupted operations or roll back changes.
 - **Notification Manager** -- centralized notifications with status bar integration on desktop.
 
+## How it all fits together
+
+Synapse has many commands, and several of them quietly trigger *other* steps once they finish. This master diagram is the **canonical birds-eye view** of every chain: what cascades after a single-note command, what runs standalone, what **Fire Synapse** runs over a folder, and how the **intake** folder auto-routes new notes.
+
+**How to read it**
+
+- **Solid labeled edge** = a follow-on step that is **on by default**.
+- **Dotted labeled edge** = a follow-on step that is **off by default**.
+- Every conditional edge names the exact setting that gates it and its default, so you can answer "does this *also* fire X?" at a glance.
+- Diamonds are routing decisions.
+
+```mermaid
+flowchart TD
+    subgraph perNote["a · Per-note commands — cascade after accept / complete"]
+        EL["Elaborate<br/>(on accept)"]
+        TR["Transcribe<br/>audio · video · image"]
+        SU["Summarize"]
+        DD["Deep Dive<br/>(on accept)"]
+    end
+
+    EL --> OP
+    TR --> OP
+    SU --> OP
+    DD -->|"deepDive.autoEnrichOnAccept · default ON"| OP
+    OP(["Operation completes / proposal accepted"])
+
+    OP -->|"enrichment.autoEnrich · default ON"| ENp["Enrichment proposals<br/>tags · links · references"]
+    OP -->|"title.checkAfterOperations · default ON"| TTp["Title → rename proposal"]
+
+    SU -.->|"summarize.autoOrganizeOnSummarize · default OFF"| ORGp["Organize proposal<br/>(single note)"]
+    DD -.->|"deepDive.autoOrganizeOnAccept · default OFF"| ORGp
+
+    subgraph standalone["b · Standalone commands — no cascade"]
+        SA1["Enrich"]
+        SA2["Tidy"]
+        SA3["REM — wikilink discovery"]
+        SA4["Organize"]
+        SA5["Title (manual check)"]
+    end
+    standalone --> SAp["Proposal only — nothing else fires"]
+
+    subgraph fire["c · Fire Synapse — run all on a folder/note, fixed order, serial"]
+        F1["1 · Elaboration"] --> F2["2 · Summarize"] --> F3["3 · Enrichment"] --> F4["4 · REM"] --> F5["5 · Tidy"] --> F6["6 · Organize"]
+    end
+
+    subgraph intake["d · Intake folder — auto-routes new notes"]
+        IN["New note in intake folder"] --> IG["Debounce + idempotency guard"]
+        IG --> IU{"Body is essentially<br/>one bare URL?"}
+        IU -->|"no — general / mixed / text"| FT["Fire pipeline on note"]
+        IU -->|yes| IC{"Classify URL"}
+        IC -->|article| FA["Fetch article + Fire pipeline"]
+        IC -->|"video / audio"| VS["Transcribe — stub, no-op today"]
+        IC -->|unknown| FT
+    end
+
+    FA -.->|fireOnFile| fire
+    FT -.->|fireOnFile| fire
+```
+
+**Per-note cascade defaults at a glance**
+
+| When you… | Also fires by default | Gated by | Default |
+|---|---|---|---|
+| Elaborate, Transcribe, Summarize, or accept a Deep Dive note | Enrichment proposals | `enrichment.autoEnrich` | On |
+| …any of the above | Title → rename proposal | `title.checkAfterOperations` | On |
+| Accept a Deep Dive note | Its enrich + title cascade | `deepDive.autoEnrichOnAccept` | On |
+| Summarize | Organize the note | `summarize.autoOrganizeOnSummarize` | Off |
+| Accept a Deep Dive note | Organize the note | `deepDive.autoOrganizeOnAccept` | Off |
+
+**Standalone commands** — Enrich, Tidy, REM, Organize, and a manual Title check — produce their own proposals and trigger nothing else.
+
+> This overview is the **single source of truth** for the command flow. For module-level detail — the exact callback wiring, the fallback path when enrichment is disabled but title checks stay on, and intake internals — see [`ARCHITECTURE.md`](ARCHITECTURE.md), whose **Fire Synapse Pipeline**, **Intake** and **Cross-Module Communication** diagrams expand the subgraphs above.
+
 ## Privacy and network use
 
 Synapse runs inside your vault. It contacts a remote service only when you configure one and then trigger a feature that needs it. Every request goes through Obsidian's `requestUrl` API, and every request is one you set up (your provider and API key) or started yourself (running a command).


### PR DESCRIPTION
## Summary

Adds ONE master Mermaid flowchart to the README giving a birds-eye view of how every command fires down its chain — including which cascades are conditional and on what setting/default — and reconciles the three related `ARCHITECTURE.md` diagrams to match it (single source of truth), with cross-links both ways.

closes #388

## README — new `## How it all fits together` section (after `## Features`)

One master `flowchart TD` with four subgraphs:

- **(a) Per-note commands** — Elaborate, Transcribe (audio · video · image), Summarize, Deep Dive cascade after accept/complete. Every conditional edge is labeled with its gating setting **and** default:
  - `enrichment.autoEnrich` → Enrichment proposals (default **ON**)
  - `title.checkAfterOperations` → Title rename proposal (default **ON**)
  - `deepDive.autoEnrichOnAccept` gates the Deep Dive cascade entry (default **ON**)
  - `summarize.autoOrganizeOnSummarize` and `deepDive.autoOrganizeOnAccept` → Organize (dotted, default **OFF**)
- **(b) Standalone commands** — Enrich, Tidy, REM, Organize, manual Title (no cascade)
- **(c) Fire Synapse** — serial Elaboration → Summarize → Enrichment → REM → Tidy → Organize
- **(d) Intake folder** — bare-URL routing → article (fetch + Fire) / video·audio (transcribe stub) / general·unknown (Fire)

Plus a defaults-at-a-glance table and a legend (solid = on by default, dotted = off by default).

## ARCHITECTURE.md — reconciled to match (single source of truth)

- **Fire Synapse Pipeline** — aligned phase labels; added cross-link to the README master.
- **Intake: Auto-Processing Inbox** — replaced the single `Route → Fire` box with the real 3-way branch (bare-URL? → classify → article / video·audio stub / general·unknown), all converging on the processed-stamp; matches subgraph (d).
- **Cross-Module Communication** — added the gating setting names + defaults onto the enrich/title/organize edges so it matches the README cascade, plus a note on the Deep Dive enrich/title coupling and the enrichment-disabled title-only fallback.

Each ARCHITECTURE diagram now cross-links back to the README master as the canonical birds-eye view.

## Verification

- All settings/defaults re-verified against `src/main.ts:254–335`, `src/settings.ts`, `src/pipeline/types.ts:41–48`, and `src/intake/intake-dispatcher.ts` / `src/intake/index.ts`.
- No Mermaid CLI in node_modules; syntax validated by hand (balanced subgraph/end, quoted special-char labels, valid edge/pipe-label syntax, unique node IDs). GitHub renders ```mermaid natively.
- Only `README.md` and `ARCHITECTURE.md` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)