### PR TITLE
fix: gate Review button on per-action auto-accept setting (#366)

### DIFF
--- a/src/deep-dive/index.ts
+++ b/src/deep-dive/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	NotificationManager, readNote, writeNote, wordCount,
 	CheckpointManager, generateId, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { ContentAnalyzer, DirectoryMatcher } from '../organize';
@@ -490,14 +490,16 @@ export class DeepDiveModule {
 				const depthSummary = Object.entries(run.stats.byDepth)
 					.map(([d, c]) => `depth ${d}: ${c}`)
 					.join(', ');
-				// Review action only when proposals remain pending — auto-accept
-				// (applied right after) creates every note, leaving nothing to
-				// review (#340).
+				// Review action only when proposals were generated AND deep-dive
+				// auto-accept is off — auto-accept (applied right after) creates
+				// every note, leaving nothing to review (#366).
 				genOp.finish(
 					`Generated ${run.stats.totalProposals} proposals (${depthSummary})`,
-					run.stats.totalProposals > 0 && !this.shouldAutoAccept()
-						? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-						: undefined
+					reviewAction({
+						generated: run.stats.totalProposals > 0,
+						shouldAutoAccept: this.shouldAutoAccept,
+						openProposalView: this.onOpenProposalView,
+					})
 				);
 
 				// Auto-accept the whole generated tree if enabled (#228), in

--- a/src/deep-dive/review-toast.test.ts
+++ b/src/deep-dive/review-toast.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeepDiveModule } from './index';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+
+// One new root topic → exactly one generated proposal (a reviewable item).
+vi.mock('./topic-analyzer', () => ({
+	TopicAnalyzer: class MockTopicAnalyzer {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		extractTopics = vi.fn(async () => [
+			{ title: 'Topic A', description: 'About A', relevance: 0.9, existsInVault: false, relatedUrls: [] },
+		]);
+	},
+}));
+
+vi.mock('./note-generator', () => ({
+	NoteGenerator: class MockNoteGenerator {
+		constructor(_getSettings: unknown) {}
+		generateContent = vi.fn(async () => 'Generated content about Topic A with a handful of words.');
+	},
+}));
+
+// Depth 1 keeps the run to the root level (no recursive child extraction).
+vi.mock('./depth-selector-modal', () => ({
+	selectDepth: vi.fn(async () => 1),
+}));
+
+vi.mock('./deep-dive-store', () => ({
+	DeepDiveStore: class MockDeepDiveStore {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		init = vi.fn(async () => {});
+		saveProposal = vi.fn(async () => {});
+		saveRun = vi.fn(async () => {});
+		loadProposal = vi.fn(async () => null);
+		loadProposalsByRunId = vi.fn(async () => []);
+		loadRun = vi.fn(async () => null);
+		loadPendingProposals = vi.fn(async () => []);
+		updateProposalStatus = vi.fn(async () => {});
+	},
+}));
+
+function makeOp(cancelled = false) {
+	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+}
+
+describe('DeepDiveModule Review toast action (#366)', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let settings: SynapseSettings;
+	let scanOp: ReturnType<typeof makeOp>;
+	let genOp: ReturnType<typeof makeOp>;
+	let notifications: {
+		info: ReturnType<typeof vi.fn>;
+		success: ReturnType<typeof vi.fn>;
+		confirm: ReturnType<typeof vi.fn>;
+		notifyError: ReturnType<typeof vi.fn>;
+		startOperation: ReturnType<typeof vi.fn>;
+	};
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		app = createMockApp();
+		sourceFile = new TFile('Source.md');
+		app.vault.getAbstractFileByPath.mockImplementation((p: string) =>
+			p === 'Source.md' ? sourceFile : null
+		);
+		app.vault.read.mockResolvedValue('# Source\n\nText with several distinct topics worth exploring.');
+		plugin = { app } as unknown as Plugin;
+		settings = structuredClone(DEFAULT_SETTINGS);
+
+		scanOp = makeOp();
+		genOp = makeOp();
+		notifications = {
+			info: vi.fn(),
+			success: vi.fn(),
+			confirm: vi.fn().mockResolvedValue(true),
+			notifyError: vi.fn(),
+			startOperation: vi.fn((_label: string, id?: string) =>
+				id === 'deep-dive-generate' ? genOp : scanOp
+			),
+		};
+
+		// Auto-accept walks the generated tree and creates notes; isolate the apply.
+		vi.spyOn(DeepDiveModule.prototype, 'acceptProposal').mockResolvedValue(undefined);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	function build(shouldAutoAccept: () => boolean): DeepDiveModule {
+		const registrar = { register: vi.fn() };
+		return new DeepDiveModule(
+			plugin,
+			() => settings,
+			notifications as never,
+			createMockCheckpointManager() as never,
+			registrar as never,
+			shouldAutoAccept
+		);
+	}
+
+	/** Drive the private deepDive flow the way the editor command would. */
+	function runDeepDive(mod: DeepDiveModule): Promise<void> {
+		return (mod as unknown as { deepDive: (f: TFile) => Promise<void> }).deepDive(sourceFile);
+	}
+
+	it('forwards a Review action to the generation toast when auto-accept is off', async () => {
+		settings.autoAccept['deep-dive'] = false;
+		const mod = build(() => settings.autoAccept['deep-dive']);
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await runDeepDive(mod);
+
+		expect(genOp.finish).toHaveBeenCalledWith(
+			expect.stringContaining('Generated 1 proposals'),
+			expect.objectContaining({ label: 'Review' })
+		);
+		genOp.finish.mock.calls.at(-1)![1].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the Review action when auto-accept is on (every node created, nothing to review)', async () => {
+		settings.autoAccept['deep-dive'] = true;
+		const mod = build(() => settings.autoAccept['deep-dive']);
+
+		await runDeepDive(mod);
+
+		expect(genOp.finish).toHaveBeenCalledWith(
+			expect.stringContaining('Generated 1 proposals'),
+			undefined
+		);
+	});
+});

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar, isInFlow } from '../commands';
 import {
 	buildCallout, CALLOUT_TYPES, FolderPickerModal, getMarkdownFiles,
 	NotificationManager, sanitizeAIResponse, stripCodeFences, CheckpointManager, generateId,
-	fireAndForget,
+	fireAndForget, reviewAction,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { PlaceholderDetector } from './detector';
@@ -180,9 +180,11 @@ export class ElaborationModule {
 		this.dispatchDeferredTasks(tasks);
 		genOp.finish(
 			`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
-			proposalCount - autoAcceptedCount > 0
-				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-				: undefined
+			reviewAction({
+				generated: proposalCount > 0,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
@@ -316,13 +318,15 @@ export class ElaborationModule {
 		// Mark checkpoint completed and dispatch deferred tasks (I1)
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
-		// Review action only when at least one proposal remains pending after
-		// any batch auto-accept (#340).
+		// Review action only when something was generated AND elaboration
+		// auto-accept is off (#366) — the deep-dive rule, centralized.
 		genOp.finish(
 			`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
-			proposalCount - autoAcceptedCount > 0
-				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-				: undefined
+			reviewAction({
+				generated: proposalCount > 0,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
@@ -362,10 +366,14 @@ export class ElaborationModule {
 				}
 				await this.store.save(proposal);
 				// Review action only when the proposal stays pending — auto-accept
-				// (applied right after) leaves nothing to review (#340).
+				// (applied right after) leaves nothing to review (#366).
 				op.finish(
 					'Proposal generated',
-					this.shouldAutoAccept() ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+					reviewAction({
+						generated: true,
+						shouldAutoAccept: this.shouldAutoAccept,
+						openProposalView: this.onOpenProposalView,
+					})
 				);
 				await this.maybeAutoAccept(proposal);
 				await this.refreshView();

--- a/src/elaboration/review-toast.test.ts
+++ b/src/elaboration/review-toast.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ElaborationModule } from './index';
+import { ProposalStore } from './proposal-store';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+import type { DetectionResult, Proposal } from './types';
+
+// Detector flags the note as a stub; proposer returns a concrete proposal — the
+// path that creates a reviewable elaboration item.
+vi.mock('./detector', () => ({
+	PlaceholderDetector: class MockPlaceholderDetector {
+		constructor(_app: unknown, _getSettings: unknown) {}
+		detect = vi.fn(
+			async (file: TFile): Promise<DetectionResult> => ({
+				notePath: file.path,
+				reasons: [{ type: 'short-note', wordCount: 3 }],
+			})
+		);
+	},
+}));
+
+vi.mock('./proposer', () => ({
+	ProposalGenerator: class MockProposalGenerator {
+		constructor(_app: unknown, _getSettings: unknown, _notifications: unknown) {}
+		generate = vi.fn(
+			async (result: DetectionResult): Promise<Proposal> => ({
+				id: 'prop-1',
+				sourceNotePath: result.notePath,
+				createdAt: '2026-06-26T00:00:00.000Z',
+				detectionReasons: result.reasons,
+				originalContent: 'stub',
+				proposedAdditions: 'Generated elaboration body.',
+				insertionPoint: 'append',
+				status: 'pending',
+			})
+		);
+	},
+}));
+
+function makeOp(cancelled = false) {
+	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+}
+
+describe('ElaborationModule Review toast action (#366)', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let settings: SynapseSettings;
+	let op: ReturnType<typeof makeOp>;
+	let notifications: {
+		info: ReturnType<typeof vi.fn>;
+		success: ReturnType<typeof vi.fn>;
+		notifyError: ReturnType<typeof vi.fn>;
+		startOperation: ReturnType<typeof vi.fn>;
+	};
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		app = createMockApp();
+		sourceFile = new TFile('inbox/stub.md');
+		app.vault.getAbstractFileByPath.mockImplementation((p: string) =>
+			p === 'inbox/stub.md' ? sourceFile : null
+		);
+		plugin = { app } as unknown as Plugin;
+		settings = structuredClone(DEFAULT_SETTINGS);
+
+		op = makeOp();
+		notifications = {
+			info: vi.fn(),
+			success: vi.fn(),
+			notifyError: vi.fn(),
+			startOperation: vi.fn(() => op),
+		};
+
+		vi.spyOn(ProposalStore.prototype, 'init').mockResolvedValue(undefined);
+		vi.spyOn(ProposalStore.prototype, 'save').mockResolvedValue(undefined);
+		// Auto-accept applies the proposal; stub the apply so the toast gating is
+		// isolated from vault mutation.
+		vi.spyOn(ElaborationModule.prototype, 'acceptProposal').mockResolvedValue(undefined);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	function build(shouldAutoAccept: () => boolean): ElaborationModule {
+		const registrar = { register: vi.fn() };
+		return new ElaborationModule(
+			plugin,
+			() => settings,
+			notifications as never,
+			createMockCheckpointManager() as never,
+			registrar as never,
+			shouldAutoAccept
+		);
+	}
+
+	it('forwards a Review action to the scan-note toast when auto-accept is off', async () => {
+		settings.autoAccept.elaboration = false;
+		const mod = build(() => settings.autoAccept.elaboration);
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.scanNote(sourceFile as never);
+
+		expect(op.finish).toHaveBeenCalledWith(
+			'Proposal generated',
+			expect.objectContaining({ label: 'Review' })
+		);
+		op.finish.mock.calls.at(-1)![1].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the Review action when auto-accept is on (nothing left to review)', async () => {
+		settings.autoAccept.elaboration = true;
+		const mod = build(() => settings.autoAccept.elaboration);
+
+		await mod.scanNote(sourceFile as never);
+
+		expect(op.finish).toHaveBeenCalledWith('Proposal generated', undefined);
+	});
+});

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, parseFrontmatter,
 	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { EnrichmentApplier } from './enrichment-applier';
@@ -184,9 +184,11 @@ export class EnrichmentModule {
 		this.dispatchDeferredTasks(tasks);
 		genOp.finish(
 			`Resumed -- generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
-			proposalCount - autoAcceptedCount > 0
-				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-				: undefined
+			reviewAction({
+				generated: proposalCount > 0,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
@@ -360,13 +362,15 @@ export class EnrichmentModule {
 		// Mark checkpoint completed and dispatch deferred tasks (I1)
 		const tasks = await this.checkpointManager.complete(checkpoint.id);
 		this.dispatchDeferredTasks(tasks);
-		// Review action only when at least one proposal remains pending after
-		// any batch auto-accept (#340).
+		// Review action only when something was generated AND enrichment
+		// auto-accept is off (#366) — the deep-dive rule, centralized.
 		genOp.finish(
 			`Generated ${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`,
-			proposalCount - autoAcceptedCount > 0
-				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-				: undefined
+			reviewAction({
+				generated: proposalCount > 0,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 		if (autoAcceptedCount > 0) {
 			this.notifications.info(
@@ -381,8 +385,18 @@ export class EnrichmentModule {
 	 * Generate an enrichment proposal for a note.
 	 * Called by main.ts callbacks after other processes complete,
 	 * or directly via command for manual enrichment.
+	 *
+	 * `options.postOp` marks the call as an automatic post-op side effect (the
+	 * chained auto-enrich after elaboration/transcription/summarize/deep-dive),
+	 * which suppresses the SECONDARY Review toast so auto-accepting a PRIMARY
+	 * action doesn't surface an unrelated enrichment Review prompt every time
+	 * (#366). The direct `enrich-current-note` command omits it and keeps Review.
 	 */
-	async enrich(filePath: string, trigger: EnrichmentTrigger): Promise<void> {
+	async enrich(
+		filePath: string,
+		trigger: EnrichmentTrigger,
+		options?: { postOp?: boolean }
+	): Promise<void> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
 
@@ -414,10 +428,16 @@ export class EnrichmentModule {
 			this.topicExtractor.clearPending();
 			if (id) {
 				// Review action only when the proposal stays pending — auto-accept
-				// (applied right after) leaves nothing to review (#340).
+				// (applied right after) leaves nothing to review, and an automatic
+				// post-op run suppresses the secondary Review prompt entirely (#366).
 				op.finish(
 					'Enrichment proposal created',
-					this.shouldAutoAccept() ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+					reviewAction({
+						generated: true,
+						shouldAutoAccept: this.shouldAutoAccept,
+						openProposalView: this.onOpenProposalView,
+						postOp: options?.postOp,
+					})
 				);
 				// Single-note path is final here (no Phase 4 merge), so the
 				// stored proposal is fully formed — safe to auto-accept (#228).

--- a/src/enrichment/review-toast.test.ts
+++ b/src/enrichment/review-toast.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EnrichmentModule } from './index';
+import { EnrichmentStore } from './enrichment-store';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+import type { EnrichmentProposal } from './types';
+
+function makeOp(cancelled = false) {
+	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+}
+
+/** A pending proposal with an empty-but-valid result, for the auto-accept path. */
+function pendingProposal(id: string): EnrichmentProposal {
+	return {
+		id,
+		sourceNotePath: 'inbox/note.md',
+		createdAt: '2026-06-26T00:00:00.000Z',
+		triggerSource: 'manual',
+		result: { tags: [], internalLinks: [], externalLinks: [], frontmatter: [] },
+		status: 'pending',
+	};
+}
+
+describe('EnrichmentModule Review toast action (#366)', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let settings: SynapseSettings;
+	let op: ReturnType<typeof makeOp>;
+	let notifications: {
+		info: ReturnType<typeof vi.fn>;
+		success: ReturnType<typeof vi.fn>;
+		notifyError: ReturnType<typeof vi.fn>;
+		startOperation: ReturnType<typeof vi.fn>;
+	};
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		app = createMockApp();
+		sourceFile = new TFile('inbox/note.md');
+		app.vault.getAbstractFileByPath.mockImplementation((p: string) =>
+			p === 'inbox/note.md' ? sourceFile : null
+		);
+		plugin = { app } as unknown as Plugin;
+		settings = structuredClone(DEFAULT_SETTINGS);
+
+		op = makeOp();
+		notifications = {
+			info: vi.fn(),
+			success: vi.fn(),
+			notifyError: vi.fn(),
+			startOperation: vi.fn(() => op),
+		};
+
+		// enrichFile (heavy classifier pipeline) is stubbed to yield one proposal id.
+		vi.spyOn(
+			EnrichmentModule.prototype as unknown as { enrichFile: () => Promise<string | null> },
+			'enrichFile'
+		).mockResolvedValue('enrich-1');
+		// Auto-accept re-loads the proposal then applies it; isolate the apply.
+		vi.spyOn(EnrichmentStore.prototype, 'load').mockResolvedValue(pendingProposal('enrich-1'));
+		vi.spyOn(EnrichmentModule.prototype, 'acceptSelectedFromView').mockResolvedValue(undefined);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	function build(shouldAutoAccept: () => boolean): EnrichmentModule {
+		const registrar = { register: vi.fn() };
+		return new EnrichmentModule(
+			plugin,
+			() => settings,
+			notifications as never,
+			createMockCheckpointManager() as never,
+			registrar as never,
+			shouldAutoAccept
+		);
+	}
+
+	it('forwards a Review action to the enrich toast when auto-accept is off (manual command)', async () => {
+		settings.autoAccept.enrichment = false;
+		const mod = build(() => settings.autoAccept.enrichment);
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.enrich('inbox/note.md', 'manual');
+
+		expect(op.finish).toHaveBeenCalledWith(
+			'Enrichment proposal created',
+			expect.objectContaining({ label: 'Review' })
+		);
+		op.finish.mock.calls.at(-1)![1].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the Review action when auto-accept is on', async () => {
+		settings.autoAccept.enrichment = true;
+		const mod = build(() => settings.autoAccept.enrichment);
+
+		await mod.enrich('inbox/note.md', 'manual');
+
+		expect(op.finish).toHaveBeenCalledWith('Enrichment proposal created', undefined);
+	});
+
+	it('suppresses the secondary Review toast for an automatic post-op enrich (#366)', async () => {
+		// Auto-accept OFF, so a manual enrich WOULD surface Review — but a chained
+		// post-op run (auto-enrich after a primary action) must not.
+		settings.autoAccept.enrichment = false;
+		const mod = build(() => settings.autoAccept.enrichment);
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.enrich('inbox/note.md', 'elaboration', { postOp: true });
+
+		expect(op.finish).toHaveBeenCalledWith('Enrichment proposal created', undefined);
+	});
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,42 +254,42 @@ export default class SynapsePlugin extends Plugin {
 		// Wire enrichment callbacks -- triggers after other processes complete
 		if (this.settings.enrichment.enabled && this.settings.enrichment.autoEnrich) {
 			this.elaboration.onProposalAccepted = (filePath: string) => {
-				fireAndForget(this.enrichment.enrich(filePath, 'elaboration'), 'Enrich note', { notifications: this.notifications });
+				fireAndForget(this.enrichment.enrich(filePath, 'elaboration', { postOp: true }), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+					fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			this.audio.onTranscriptionComplete = (filePath: string) => {
-				fireAndForget(this.enrichment.enrich(filePath, 'transcription'), 'Enrich note', { notifications: this.notifications });
+				fireAndForget(this.enrichment.enrich(filePath, 'transcription', { postOp: true }), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+					fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			if (this.video) {
 				this.video.onTranscriptionComplete = (filePath: string) => {
-					fireAndForget(this.enrichment.enrich(filePath, 'transcription'), 'Enrich note', { notifications: this.notifications });
+					fireAndForget(this.enrichment.enrich(filePath, 'transcription', { postOp: true }), 'Enrich note', { notifications: this.notifications });
 					if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-						fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+						fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 					}
 				};
 			}
 			this.image.onExtractionComplete = (filePath: string) => {
-				fireAndForget(this.enrichment.enrich(filePath, 'transcription'), 'Enrich note', { notifications: this.notifications });
+				fireAndForget(this.enrichment.enrich(filePath, 'transcription', { postOp: true }), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+					fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			this.summarize.onSummaryComplete = (filePath: string) => {
-				fireAndForget(this.enrichment.enrich(filePath, 'summarization'), 'Enrich note', { notifications: this.notifications });
+				fireAndForget(this.enrichment.enrich(filePath, 'summarization', { postOp: true }), 'Enrich note', { notifications: this.notifications });
 				if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+					fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 				}
 			};
 			if (this.settings.deepDive.autoEnrichOnAccept) {
 				this.deepDive.onNoteAccepted = (filePath: string) => {
-					fireAndForget(this.enrichment.enrich(filePath, 'deep-dive'), 'Enrich note', { notifications: this.notifications });
+					fireAndForget(this.enrichment.enrich(filePath, 'deep-dive', { postOp: true }), 'Enrich note', { notifications: this.notifications });
 					if (this.settings.title.enabled && this.settings.title.checkAfterOperations) {
-						fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+						fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 					}
 				};
 			}
@@ -299,24 +299,24 @@ export default class SynapsePlugin extends Plugin {
 		if (this.settings.title.enabled && this.settings.title.checkAfterOperations &&
 			!(this.settings.enrichment.enabled && this.settings.enrichment.autoEnrich)) {
 			this.elaboration.onProposalAccepted = (filePath: string) => {
-				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+				fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 			};
 			this.audio.onTranscriptionComplete = (filePath: string) => {
-				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+				fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 			};
 			if (this.video) {
 				this.video.onTranscriptionComplete = (filePath: string) => {
-					fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+					fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 				};
 			}
 			this.image.onExtractionComplete = (filePath: string) => {
-				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+				fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 			};
 			this.summarize.onSummaryComplete = (filePath: string) => {
-				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+				fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 			};
 			this.deepDive.onNoteAccepted = (filePath: string) => {
-				fireAndForget(this.title.checkTitle(filePath), 'Check note title', { notifications: this.notifications });
+				fireAndForget(this.title.checkTitle(filePath, { postOp: true }), 'Check note title', { notifications: this.notifications });
 			};
 		}
 

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -4,7 +4,7 @@ import { CommandRegistrar } from '../commands';
 import {
 	FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder,
 	writeNote, generateOrganizeSummary, CheckpointManager, generateId, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import type { MoveRecord } from '../shared';
@@ -174,13 +174,15 @@ export class OrganizeModule {
 		if (movedCount > 0) parts.push(`${movedCount} moved`);
 		if (proposalCount > 0) parts.push(`${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
 		if (errorCount > 0) parts.push(`${errorCount} failed`);
-		// Review action only when at least one new-directory proposal remains
-		// pending after any auto-accept (#340).
+		// Review action only when a new-directory proposal was generated AND
+		// organize auto-accept is off (#366) — the deep-dive rule, centralized.
 		genOp.finish(
 			`Resumed -- ${parts.length > 0 ? parts.join(', ') : 'no changes needed'}`,
-			proposalCount - autoAcceptedCount > 0
-				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-				: undefined
+			reviewAction({
+				generated: proposalCount > 0,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 
 		if (moveRecords.length > 0) {
@@ -233,10 +235,14 @@ export class OrganizeModule {
 				op.finish(`Moved to ${result.action.type === 'move' ? result.action.targetDirectory : ''}`);
 			} else if (result.proposalCreated) {
 				// Review action only when the proposal stays pending — organize
-				// auto-accept moves the note, leaving nothing to review (#340).
+				// auto-accept moves the note, leaving nothing to review (#366).
 				op.finish(
 					'Proposal created for new directory',
-					result.autoAccepted ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+					reviewAction({
+						generated: true,
+						shouldAutoAccept: this.shouldAutoAccept,
+						openProposalView: this.onOpenProposalView,
+					})
 				);
 			} else {
 				op.finish('Note is already well-placed');
@@ -385,13 +391,15 @@ export class OrganizeModule {
 		if (movedCount > 0) parts.push(`${movedCount} moved`);
 		if (proposalCount > 0) parts.push(`${proposalCount} proposal${proposalCount === 1 ? '' : 's'}`);
 		if (errorCount > 0) parts.push(`${errorCount} failed`);
-		// Review action only when at least one new-directory proposal remains
-		// pending after any auto-accept (#340).
+		// Review action only when a new-directory proposal was generated AND
+		// organize auto-accept is off (#366) — the deep-dive rule, centralized.
 		genOp.finish(
 			parts.length > 0 ? parts.join(', ') : 'No changes needed',
-			proposalCount - autoAcceptedCount > 0
-				? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-				: undefined
+			reviewAction({
+				generated: proposalCount > 0,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 
 		// Generate organize summary with move diagram

--- a/src/organize/review-toast.test.ts
+++ b/src/organize/review-toast.test.ts
@@ -137,12 +137,47 @@ describe('OrganizeModule Review toast action (#340)', () => {
 
 		await mod.scanDirectory(undefined, true);
 
-		// proposalCount === autoAcceptedCount, so the guard yields no action.
+		// generated > 0 but auto-accept is on, so the gate yields no action.
 		expect(genOp.finish).toHaveBeenCalledWith(
 			expect.stringContaining('proposal'),
 			undefined
 		);
 		// And the note was actually moved by auto-accept.
+		expect((app.vault as unknown as { rename: ReturnType<typeof vi.fn> }).rename).toHaveBeenCalledTimes(1);
+	});
+
+	it('forwards a Review action to the single-note organize toast when the proposal stays pending', async () => {
+		settings.autoAccept.organize = false;
+		const mod = build(() => settings.autoAccept.organize);
+		await mod.onload();
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.organizeNote(sourceFile as never);
+
+		// organizeNote uses the per-file op (id `organize-<path>`), routed to scanOp.
+		expect(scanOp.finish).toHaveBeenCalledWith(
+			'Proposal created for new directory',
+			expect.objectContaining({ label: 'Review' })
+		);
+		scanOp.finish.mock.calls.at(-1)![1].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+		// Nothing moved — the proposal is left pending for review.
+		expect((app.vault as unknown as { rename: ReturnType<typeof vi.fn> }).rename).not.toHaveBeenCalled();
+	});
+
+	it('omits the Review action on the single-note organize toast when auto-accept moved the note', async () => {
+		settings.autoAccept.organize = true;
+		const mod = build(() => settings.autoAccept.organize);
+		await mod.onload();
+
+		await mod.organizeNote(sourceFile as never);
+
+		expect(scanOp.finish).toHaveBeenCalledWith(
+			'Proposal created for new directory',
+			undefined
+		);
+		// The note was moved by auto-accept.
 		expect((app.vault as unknown as { rename: ReturnType<typeof vi.fn> }).rename).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -5,7 +5,7 @@ import type { CommandRegistrar } from '../commands';
 import type { NotificationManager, CheckpointManager } from '../shared';
 import type { DeferredTask, CheckpointWorkItem } from '../shared';
 import type { RemProposal, RemLinkCandidate } from './types';
-import { generateId, getMarkdownFiles, FolderPickerModal, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule } from '../shared';
+import { generateId, getMarkdownFiles, FolderPickerModal, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction } from '../shared';
 import { MentionScanner } from './mention-scanner';
 import { SemanticMatcher } from './semantic-matcher';
 import { RemApplier } from './rem-applier';
@@ -146,11 +146,15 @@ export class RemModule {
 
 		await this.store.save(proposal);
 		// Review action only when the proposal stays pending — auto-accept
-		// (applied right after) inserts the links, leaving nothing to review (#340).
+		// (applied right after) inserts the links, leaving nothing to review (#366).
 		this.notifications.success(
 			`Found ${allCandidates.length} linkable mention${allCandidates.length === 1 ? '' : 's'}`,
 			undefined,
-			this.shouldAutoAccept() ? undefined : { label: 'Review', onClick: () => this.onOpenProposalView?.() }
+			reviewAction({
+				generated: true,
+				shouldAutoAccept: this.shouldAutoAccept,
+				openProposalView: this.onOpenProposalView,
+			})
 		);
 
 		// Single-note path: auto-accept the whole proposal if enabled (#228).
@@ -245,13 +249,15 @@ export class RemModule {
 		} else {
 			const tasks = await this.checkpointManager.complete(checkpoint.id);
 			this.dispatchDeferredTasks(tasks);
-			// Review action only when at least one proposal remains pending after
-			// any batch auto-accept (#340).
+			// Review action only when something was generated AND REM auto-accept
+			// is off (#366) — the deep-dive rule, centralized.
 			op.finish(
 				`REM scan complete -- ${created} note${created === 1 ? '' : 's'} with linkable mentions`,
-				created - autoAcceptedCount > 0
-					? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-					: undefined
+				reviewAction({
+					generated: created > 0,
+					shouldAutoAccept: this.shouldAutoAccept,
+					openProposalView: this.onOpenProposalView,
+				})
 			);
 			if (autoAcceptedCount > 0) {
 				this.notifications.info(
@@ -331,9 +337,11 @@ export class RemModule {
 			this.dispatchDeferredTasks(tasks);
 			op.finish(
 				`Resumed -- generated ${createdProposalIds.length} proposals`,
-				createdProposalIds.length - autoAcceptedCount > 0
-					? { label: 'Review', onClick: () => this.onOpenProposalView?.() }
-					: undefined
+				reviewAction({
+					generated: createdProposalIds.length > 0,
+					shouldAutoAccept: this.shouldAutoAccept,
+					openProposalView: this.onOpenProposalView,
+				})
 			);
 			if (autoAcceptedCount > 0) {
 				this.notifications.info(

--- a/src/rem/review-toast.test.ts
+++ b/src/rem/review-toast.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RemModule } from './index';
+import { RemStore } from './rem-store';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { TFile } from '../__mocks__/obsidian';
+import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+import type { RemLinkCandidate } from './types';
+
+function candidate(): RemLinkCandidate {
+	return {
+		targetPath: 'Concepts/Neural Networks.md',
+		targetDisplayName: 'Neural Networks',
+		matchedText: 'neural networks',
+		matchType: 'semantic',
+		occurrences: [{ lineNumber: 0, lineText: 'about neural networks', startOffset: 6, endOffset: 21 }],
+		confidence: 0.9,
+	};
+}
+
+describe('RemModule Review toast action (#366)', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let plugin: Plugin;
+	let settings: SynapseSettings;
+	let notifications: {
+		info: ReturnType<typeof vi.fn>;
+		success: ReturnType<typeof vi.fn>;
+		notifyError: ReturnType<typeof vi.fn>;
+		startOperation: ReturnType<typeof vi.fn>;
+	};
+	let sourceFile: TFile;
+
+	beforeEach(() => {
+		app = createMockApp();
+		sourceFile = new TFile('inbox/note.md');
+		app.vault.getAbstractFileByPath.mockImplementation((p: string) =>
+			p === 'inbox/note.md' ? sourceFile : null
+		);
+		plugin = { app } as unknown as Plugin;
+		settings = structuredClone(DEFAULT_SETTINGS);
+
+		notifications = {
+			info: vi.fn(),
+			success: vi.fn(),
+			notifyError: vi.fn(),
+			startOperation: vi.fn(() => ({ progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled: false })),
+		};
+
+		vi.spyOn(RemStore.prototype, 'init').mockResolvedValue(undefined);
+		vi.spyOn(RemStore.prototype, 'save').mockResolvedValue(undefined);
+		// Candidate discovery is the heavy scan pipeline; stub it to one candidate.
+		vi.spyOn(
+			RemModule.prototype as unknown as { gatherCandidates: () => Promise<RemLinkCandidate[]> },
+			'gatherCandidates'
+		).mockResolvedValue([candidate()]);
+		// Auto-accept rewrites the note body; isolate the apply.
+		vi.spyOn(RemModule.prototype, 'acceptProposal').mockResolvedValue(undefined);
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	async function build(shouldAutoAccept: () => boolean): Promise<RemModule> {
+		const registrar = { register: vi.fn() };
+		const mod = new RemModule(
+			plugin,
+			() => settings,
+			notifications as never,
+			createMockCheckpointManager() as never,
+			registrar as never,
+			shouldAutoAccept
+		);
+		await mod.onload();
+		return mod;
+	}
+
+	it('forwards a Review action to the scan-note toast when auto-accept is off', async () => {
+		settings.autoAccept.rem = false;
+		const mod = await build(() => settings.autoAccept.rem);
+		const openSpy = vi.fn();
+		mod.onOpenProposalView = openSpy;
+
+		await mod.remScanNote('inbox/note.md');
+
+		expect(notifications.success).toHaveBeenCalledWith(
+			expect.stringContaining('linkable mention'),
+			undefined,
+			expect.objectContaining({ label: 'Review' })
+		);
+		notifications.success.mock.calls.at(-1)![2].onClick();
+		expect(openSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the Review action when auto-accept is on (links inserted, nothing to review)', async () => {
+		settings.autoAccept.rem = true;
+		const mod = await build(() => settings.autoAccept.rem);
+
+		await mod.remScanNote('inbox/note.md');
+
+		expect(notifications.success).toHaveBeenCalledWith(
+			expect.stringContaining('linkable mention'),
+			undefined,
+			undefined
+		);
+	});
+});

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -25,6 +25,8 @@ export { decorateCredentialField } from './credential-field';
 export type { CredentialFieldOptions, CredentialFieldHandle } from './credential-field';
 export { NotificationManager, linkLoadError } from './notifications';
 export type { OperationHandle, NoticeAction } from './notifications';
+export { reviewAction } from './review-action';
+export type { ReviewActionOptions } from './review-action';
 export { UpdateChecker, isNewerVersion } from './update-checker';
 export type { UpdateCheckerDeps } from './update-checker';
 export { fireAndForget } from './fire-and-forget';

--- a/src/shared/review-action.test.ts
+++ b/src/shared/review-action.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reviewAction } from './review-action';
+
+describe('reviewAction — centralized Review-button gate (#366)', () => {
+	const baseOpen = () => {};
+
+	it('returns a Review action when something was generated and auto-accept is off', () => {
+		const action = reviewAction({
+			generated: true,
+			shouldAutoAccept: () => false,
+			openProposalView: baseOpen,
+		});
+		expect(action).toEqual({ label: 'Review', onClick: expect.any(Function) });
+	});
+
+	it('returns undefined when auto-accept is ON (nothing left to review)', () => {
+		const action = reviewAction({
+			generated: true,
+			shouldAutoAccept: () => true,
+			openProposalView: baseOpen,
+		});
+		expect(action).toBeUndefined();
+	});
+
+	it('returns undefined when nothing was generated', () => {
+		const action = reviewAction({
+			generated: false,
+			shouldAutoAccept: () => false,
+			openProposalView: baseOpen,
+		});
+		expect(action).toBeUndefined();
+	});
+
+	it('returns undefined for an automatic post-op side effect, even with auto-accept off', () => {
+		const action = reviewAction({
+			generated: true,
+			shouldAutoAccept: () => false,
+			openProposalView: baseOpen,
+			postOp: true,
+		});
+		expect(action).toBeUndefined();
+	});
+
+	it('reads the auto-accept flag live through the accessor each call', () => {
+		let auto = false;
+		const opts = {
+			generated: true,
+			shouldAutoAccept: () => auto,
+			openProposalView: baseOpen,
+		};
+		expect(reviewAction(opts)).toBeDefined();
+		auto = true;
+		expect(reviewAction(opts)).toBeUndefined();
+	});
+
+	it("the action's onClick opens the unified proposal view", () => {
+		const open = vi.fn();
+		const action = reviewAction({
+			generated: true,
+			shouldAutoAccept: () => false,
+			openProposalView: open,
+		});
+		action!.onClick();
+		expect(open).toHaveBeenCalledTimes(1);
+	});
+
+	it('tolerates a null openProposalView (not yet wired) without throwing', () => {
+		const action = reviewAction({
+			generated: true,
+			shouldAutoAccept: () => false,
+			openProposalView: null,
+		});
+		expect(() => action!.onClick()).not.toThrow();
+	});
+});

--- a/src/shared/review-action.ts
+++ b/src/shared/review-action.ts
@@ -1,0 +1,57 @@
+import type { NoticeAction } from './notifications';
+
+/**
+ * Inputs to {@link reviewAction} — the single decision point for whether a
+ * completion toast should carry a "Review" button (#366).
+ */
+export interface ReviewActionOptions {
+	/**
+	 * `true` when the run produced at least one proposal/result. A toast with
+	 * nothing generated has nothing to review.
+	 */
+	generated: boolean;
+	/**
+	 * Live accessor for the action-kind's own auto-accept flag (#228). Read
+	 * through a getter (not a captured boolean) so a settings change takes
+	 * effect without a reload — mirroring each module's `shouldAutoAccept`.
+	 */
+	shouldAutoAccept: () => boolean;
+	/**
+	 * Opens the unified proposal review view — each module's `onOpenProposalView`
+	 * hook (may be `null` before main.ts wires it).
+	 */
+	openProposalView: (() => void) | null;
+	/**
+	 * `true` when the completion toast fires as an automatic post-op side effect
+	 * (a chained `enrich()` / `checkTitle()` run), not a user-invoked action.
+	 * Suppresses the Review affordance entirely so auto-accepting a PRIMARY
+	 * action never surfaces an unrelated SECONDARY Review prompt every time
+	 * (#366).
+	 */
+	postOp?: boolean;
+}
+
+/**
+ * Centralized gate for the "Review" completion-toast action (#366), shared by
+ * every proposal-producing module so the six flows stay in sync instead of
+ * re-deriving the rule four divergent ways (setting-based, per-proposal
+ * `!autoAccepted`, and `proposalCount - autoAcceptedCount > 0`).
+ *
+ * Returns a {@link NoticeAction} that opens the unified proposal view **iff**:
+ *   1. something was generated this run (`generated`), AND
+ *   2. auto-accept is OFF for this action's own kind (`!shouldAutoAccept()`) —
+ *      an auto-accepted proposal is already applied, leaving nothing to
+ *      review, AND
+ *   3. this is not an automatic post-op side effect (`!postOp`).
+ *
+ * Otherwise returns `undefined` (the toast renders with no button). This is the
+ * deep-dive pattern (`totalProposals > 0 && !shouldAutoAccept()`) generalized
+ * with post-op suppression.
+ */
+export function reviewAction(opts: ReviewActionOptions): NoticeAction | undefined {
+	if (opts.postOp) return undefined;
+	if (!opts.generated) return undefined;
+	if (opts.shouldAutoAccept()) return undefined;
+	const open = opts.openProposalView;
+	return { label: 'Review', onClick: () => open?.() };
+}

--- a/src/title/index.ts
+++ b/src/title/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, NotificationManager, generateId, readNote, isPathExcluded } from '../shared';
+import { AIClient, NotificationManager, generateId, readNote, isPathExcluded, reviewAction } from '../shared';
 import { TitleProposalStore } from './title-store';
 import { TitleSuggester } from './title-suggester';
 import { isUntitled } from './title-detector';
@@ -71,8 +71,13 @@ export class TitleModule {
 	/**
 	 * Check if a note has an "Untitled" name and generate a title proposal.
 	 * Called after any Synapse operation completes on a note.
+	 *
+	 * `options.postOp` marks an automatic post-op invocation (the chained
+	 * `checkTitle` after a primary action), which suppresses the secondary
+	 * "Title proposal ready" Review toast entirely (#366). The proposal still
+	 * lands in the unified view for review at the user's leisure.
 	 */
-	async checkUntitled(filePath: string): Promise<void> {
+	async checkUntitled(filePath: string, options?: { postOp?: boolean }): Promise<void> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
 
@@ -102,14 +107,20 @@ export class TitleModule {
 
 			await this.store.save(proposal);
 			const autoAccepted = await this.maybeAutoAccept(proposal);
-			// Title's check is silent until a proposal is actually pending: surface
-			// a Review toast so the otherwise-silent title flow is reachable, but
-			// never for an auto-accepted (already-applied) proposal (#340).
+			// Title's check is otherwise silent: the success toast exists ONLY to
+			// carry the Review button, so emit it only when the centralized gate
+			// yields an action — never for an auto-accepted (already-applied)
+			// proposal, and never as an automatic post-op side effect (#366).
 			if (!autoAccepted) {
-				this.notifications.success('Title proposal ready', undefined, {
-					label: 'Review',
-					onClick: () => this.onOpenProposalView?.(),
+				const action = reviewAction({
+					generated: true,
+					shouldAutoAccept: this.shouldAutoAccept,
+					openProposalView: this.onOpenProposalView,
+					postOp: options?.postOp,
 				});
+				if (action) {
+					this.notifications.success('Title proposal ready', undefined, action);
+				}
 			}
 			await this.refreshView();
 		} catch (error) {
@@ -121,8 +132,11 @@ export class TitleModule {
 	/**
 	 * Check if a note's title still matches its content after modification.
 	 * Called after content-modifying operations (elaboration accept, transcription, etc.)
+	 *
+	 * `options.postOp` (see {@link checkUntitled}) suppresses the secondary
+	 * Review toast for automatic post-op invocations (#366).
 	 */
-	async checkMismatch(filePath: string): Promise<void> {
+	async checkMismatch(filePath: string, options?: { postOp?: boolean }): Promise<void> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
 
@@ -153,13 +167,19 @@ export class TitleModule {
 
 			await this.store.save(proposal);
 			const autoAccepted = await this.maybeAutoAccept(proposal);
-			// As in checkUntitled: a Review toast unless the proposal was already
-			// applied via auto-accept (#340).
+			// As in checkUntitled: surface the Review toast only when the gate
+			// yields an action — not for an auto-accepted proposal, and not as an
+			// automatic post-op side effect (#366).
 			if (!autoAccepted) {
-				this.notifications.success('Title proposal ready', undefined, {
-					label: 'Review',
-					onClick: () => this.onOpenProposalView?.(),
+				const action = reviewAction({
+					generated: true,
+					shouldAutoAccept: this.shouldAutoAccept,
+					openProposalView: this.onOpenProposalView,
+					postOp: options?.postOp,
 				});
+				if (action) {
+					this.notifications.success('Title proposal ready', undefined, action);
+				}
 			}
 			await this.refreshView();
 		} catch (error) {
@@ -171,8 +191,13 @@ export class TitleModule {
 	/**
 	 * Run both untitled detection and mismatch detection on a note.
 	 * Convenience method for post-operation hooks.
+	 *
+	 * In production this is ALWAYS a chained post-op side effect (main.ts wires
+	 * it after primary actions; the title module registers no direct command),
+	 * so callers pass `{ postOp: true }` to suppress the secondary Review toast
+	 * (#366). The flag is threaded through to checkUntitled/checkMismatch.
 	 */
-	async checkTitle(filePath: string): Promise<void> {
+	async checkTitle(filePath: string, options?: { postOp?: boolean }): Promise<void> {
 		const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
 		if (!(file instanceof TFile)) return;
 
@@ -181,9 +206,9 @@ export class TitleModule {
 		if (isPathExcluded(file.path, 'title', this.getSettings())) return;
 
 		if (isUntitled(file.basename)) {
-			await this.checkUntitled(filePath);
+			await this.checkUntitled(filePath, options);
 		} else {
-			await this.checkMismatch(filePath);
+			await this.checkMismatch(filePath, options);
 		}
 	}
 

--- a/src/title/review-toast.test.ts
+++ b/src/title/review-toast.test.ts
@@ -127,4 +127,20 @@ describe('TitleModule Review toast action (#340)', () => {
 		expect(mockPlugin.app.vault.rename).toHaveBeenCalledTimes(1);
 		expect(notifications.info).toHaveBeenCalledWith(expect.stringContaining('Auto-accepted title'));
 	});
+
+	it('suppresses the secondary Review toast for an automatic post-op checkTitle (#366)', async () => {
+		// Title auto-accept is OFF, so a directly-invoked check WOULD surface the
+		// Review toast — but a chained post-op run must not (it fires after nearly
+		// every primary action, which is the "button always shows" leak).
+		settings.autoAccept.title = false;
+		const mod = build(() => settings.autoAccept.title);
+		await mod.onload();
+
+		await mod.checkTitle('Inbox/Untitled.md', { postOp: true });
+
+		// No secondary Review toast despite a generated proposal.
+		expect(notifications.success).not.toHaveBeenCalled();
+		// And nothing was applied — the proposal still lands pending in the view.
+		expect(mockPlugin.app.vault.rename).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary
Unifies the **Review** completion-toast gating across all six proposal-producing modules so the button only appears for actions where the user has **not** enabled auto-accept (#366). Previously the gate was implemented three divergent ways (setting-based, per-proposal `!autoAccepted`, and `proposalCount - autoAcceptedCount > 0`), and chained post-op flows (auto-enrich, post-op title check) surfaced their *own* Review toast after nearly every primary action — perceived as "the button always shows."

closes #366

## What changed
- **New centralized helper** `src/shared/review-action.ts` — `reviewAction({ generated, shouldAutoAccept, openProposalView, postOp? }): NoticeAction | undefined`. Single decision point: returns a Review action iff `generated && !shouldAutoAccept() && !postOp`. This is the deep-dive pattern (`totalProposals > 0 && !shouldAutoAccept()`) generalized with post-op suppression. Exported from `src/shared/index.ts`.
- **All six modules** now call the helper instead of inlining the rule:
  - elaboration (`scanNote`, `scanVault`, `resumeFromCheckpoint`)
  - enrichment (`enrich`, `scanVault`, `resumeFromCheckpoint`)
  - organize (`organizeNote`, `scanDirectory`, `resumeFromCheckpoint`)
  - rem (`remScanNote`, `remScanDirectory`, `resumeFromCheckpoint`)
  - deep-dive (`deepDive`)
  - title (`checkUntitled`, `checkMismatch`)
  - Every `proposalCount - autoAcceptedCount > 0` count gate and `!autoAccepted` per-proposal gate is replaced by `generated > 0 && !shouldAutoAccept()`.
- **Chained post-op suppression (the leak fix):** `enrichment.enrich()` and `title.checkTitle()` now accept an `{ postOp?: boolean }` option. The `main.ts` chain call sites (auto-enrich + post-op title check after elaboration/transcription/summarize/deep-dive) pass `{ postOp: true }`, so the *secondary* completion toast omits its Review affordance. User-invoked direct commands (`enrich-current-note`) omit the flag and keep Review. Each secondary flow still respects its own auto-accept flag for *applying* proposals — only the redundant Review button is suppressed. The proposal still lands in the unified view for review at the user's leisure.
  - Title note: the title module registers no direct command — `checkTitle` is *always* a post-op side effect in production — so its otherwise-content-free "Title proposal ready" toast (which existed only to carry the Review button) no longer fires after every operation.

### Scope
Deliberately scoped to Review-button gating, per the issue. Post-op suppression is applied to the two flows the issue names (`enrich` / `checkTitle`); the organize follow-on (`onOrganizeRequested` from deep-dive/summarize) keeps the unified `generated && !shouldAutoAccept()` rule. No dedup / throttling / caching (tracked separately in #395/#396/#397), no new raw `new Notice(...)` sites, no CHANGELOG/docs edits.

## Tests
- New `src/shared/review-action.test.ts` — direct unit coverage of the gate (generated/auto-accept/post-op/live-accessor/null-open).
- New `review-toast.test.ts` suites for **elaboration, enrichment, rem, deep-dive**; extended the existing **title** and **organize** suites.
- Coverage per the issue: auto-accept **ON** ⇒ no Review action; auto-accept **OFF** with a generated proposal ⇒ Review action present; chained **post-op** invocation ⇒ no secondary Review toast (enrichment + title).

Full CI pre-flight all green locally: `tsc`, `eslint`, `check-top-level-requires`, `vitest` (**128 files / 1711 tests passed**), `version-bump --check`, `esbuild production`.

⚠️ **Live-Obsidian visual check still advised:** the test mock no-ops some `Notice` DOM, so the toast/button rendering should be confirmed visually in a real vault.
