### PR TITLE
feat: proposal idempotency — dedup by content key + enforce maxProposalsPerNote

### DIFF
--- a/src/__test-utils__/mock-factories.ts
+++ b/src/__test-utils__/mock-factories.ts
@@ -42,6 +42,10 @@ function buildMockVault() {
 
 	return {
 		read,
+		// Cached read of a vault note (the path proposer/elaboration uses). A
+		// distinct spy from `read` so call-count assertions on either stay
+		// independent.
+		cachedRead: vi.fn<(file: TFile) => Promise<string>>().mockResolvedValue(''),
 		modify: vi.fn().mockResolvedValue(undefined),
 		// Mimics Obsidian's atomic read -> transform -> write. The callback is
 		// synchronous and receives the file's fresh content; its return value is

--- a/src/elaboration/dedup.test.ts
+++ b/src/elaboration/dedup.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ElaborationModule } from './index';
+import { ProposalStore } from './proposal-store';
+import { CommandRegistrar } from '../commands';
+import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import { NotificationManager } from '../shared';
+import { mockFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import { Proposal } from './types';
+
+// The proposer uses AIClient under the hood; stub it so no network is hit and
+// we can count how many times the model is actually invoked.
+const sharedCompleteMock = vi.fn().mockResolvedValue('AI-generated elaboration content');
+vi.mock('../shared/ai-client', () => ({
+	AIClient: class MockAIClient {
+		constructor(_getSettings: unknown) {}
+		complete(...args: unknown[]) {
+			return sharedCompleteMock(...args);
+		}
+	},
+}));
+
+/**
+ * In-memory vault adapter so ProposalStore.save -> load round-trips through real
+ * JSON, letting us assert how many proposal files exist after repeated scans.
+ */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			files.set(path, content);
+		}),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) {
+				if (key.startsWith(path + '/')) return true;
+			}
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => {
+			files.delete(path);
+		}),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) {
+				if (key.startsWith(folder + '/')) out.push(key);
+			}
+			return { files: out, folders: [] };
+		}),
+		mkdir: vi.fn(async () => undefined),
+	};
+}
+
+function createMockPlugin(noteContent: string, adapter: ReturnType<typeof createMemoryAdapter>) {
+	const noteFile = mockFile('notes/topic.md');
+	const vault: any = {
+		read: vi.fn().mockResolvedValue(noteContent),
+		cachedRead: vi.fn().mockResolvedValue(noteContent),
+		modify: vi.fn().mockResolvedValue(undefined),
+		process: vi.fn(async (file: any, fn: (data: string) => string) => fn(await vault.read(file))),
+		create: vi.fn(),
+		createFolder: vi.fn().mockResolvedValue(undefined),
+		getAbstractFileByPath: vi.fn((path: string) => (path === 'notes/topic.md' ? noteFile : null)),
+		getMarkdownFiles: vi.fn().mockReturnValue([]),
+		adapter,
+	};
+	const metadataCache = {
+		getFileCache: vi.fn().mockReturnValue(null),
+		getCache: vi.fn().mockReturnValue(null),
+		getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+	};
+	const workspace = {
+		getLeavesOfType: vi.fn().mockReturnValue([]),
+		getRightLeaf: vi.fn().mockReturnValue(null),
+		revealLeaf: vi.fn(),
+		getActiveFile: vi.fn().mockReturnValue(null),
+	};
+	return {
+		app: { vault, metadataCache, workspace },
+		addCommand: vi.fn(),
+		addRibbonIcon: vi.fn(),
+		addSettingTab: vi.fn(),
+		registerView: vi.fn(),
+		registerEvent: vi.fn(),
+		loadData: vi.fn().mockResolvedValue(null),
+		saveData: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function seedProposal(overrides: Partial<Proposal>): Proposal {
+	return {
+		id: 'seed-0000',
+		contentKey: 'not-a-real-hash-key',
+		sourceNotePath: 'notes/topic.md',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		detectionReasons: [{ type: 'user-requested' }],
+		originalContent: 'old content',
+		proposedAdditions: 'old additions',
+		insertionPoint: 'append',
+		status: 'pending',
+		...overrides,
+	};
+}
+
+describe('ElaborationModule proposal idempotency (#395)', () => {
+	let adapter: ReturnType<typeof createMemoryAdapter>;
+	let mockPlugin: ReturnType<typeof createMockPlugin>;
+	let settings: SynapseSettings;
+	let notifications: NotificationManager;
+
+	// Long enough that the detector does not flag it as a stub, so scanNote takes
+	// the synthetic user-requested path (stable detection reasons across scans).
+	const longContent = '# Topic\n\n' + 'A fully written note with plenty of content. '.repeat(20);
+
+	beforeEach(() => {
+		sharedCompleteMock.mockClear();
+		adapter = createMemoryAdapter();
+		settings = structuredClone(DEFAULT_SETTINGS);
+		// Auto-accept off: the generated proposal stays pending so the dedup guard
+		// has a pending proposal to match on the second scan.
+		settings.autoAccept.elaboration = false;
+		mockPlugin = createMockPlugin(longContent, adapter);
+		notifications = new NotificationManager();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function build(): ElaborationModule {
+		return new ElaborationModule(
+			mockPlugin as never,
+			() => settings,
+			notifications,
+			createMockCheckpointManager() as never,
+			new CommandRegistrar(mockPlugin as never),
+			() => settings.autoAccept.elaboration
+		);
+	}
+
+	it('a second scan of an unchanged note makes no new AI call and creates no new proposal', async () => {
+		const mod = build();
+		const file = mockFile('notes/topic.md');
+
+		await mod.scanNote(file as never);
+		expect(sharedCompleteMock).toHaveBeenCalledTimes(1);
+		const firstPending = await mod.getPendingProposals();
+		expect(firstPending).toHaveLength(1);
+		const fileCountAfterFirst = adapter._files.size;
+
+		// Re-scan the same, unchanged note.
+		await mod.scanNote(file as never);
+
+		// The dedup guard short-circuited before generate(): no second AI call...
+		expect(sharedCompleteMock).toHaveBeenCalledTimes(1);
+		// ...no new proposal file, and the single proposal is byte-for-byte the same.
+		expect(adapter._files.size).toBe(fileCountAfterFirst);
+		const secondPending = await mod.getPendingProposals();
+		expect(secondPending).toHaveLength(1);
+		expect(secondPending[0].id).toBe(firstPending[0].id);
+	});
+
+	it('stops generating once maxProposalsPerNote pending proposals exist for a note', async () => {
+		settings.elaboration.proposal.maxProposalsPerNote = 1;
+		// Pre-seed one pending proposal with a DIFFERENT content key so the dedup
+		// short-circuit cannot fire — the cap is what must stop generation.
+		const seedStore = new ProposalStore(mockPlugin.app as never, () => settings);
+		await seedStore.save(seedProposal({ id: 'seed-cap', contentKey: 'different-key' }));
+
+		const mod = build();
+		await mod.scanNote(mockFile('notes/topic.md') as never);
+
+		// Cap reached -> no AI call, and no new proposal beyond the seed.
+		expect(sharedCompleteMock).not.toHaveBeenCalled();
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+		expect(pending[0].id).toBe('seed-cap');
+	});
+
+	it('a rejected proposal with the same key does NOT block re-generation', async () => {
+		const mod = build();
+		const file = mockFile('notes/topic.md');
+
+		await mod.scanNote(file as never);
+		expect(sharedCompleteMock).toHaveBeenCalledTimes(1);
+		const pending = await mod.getPendingProposals();
+		expect(pending).toHaveLength(1);
+
+		// Reject it: the proposal keeps its (deterministic) key but its status
+		// becomes 'rejected', which the dedup predicate must ignore.
+		await mod.rejectProposal(pending[0].id);
+		expect(await mod.getPendingProposals()).toHaveLength(0);
+
+		// Re-scan: dedup must NOT fire (only the rejected proposal shares the key),
+		// so the model is invoked again and a fresh pending proposal is produced.
+		await mod.scanNote(file as never);
+		expect(sharedCompleteMock).toHaveBeenCalledTimes(2);
+		expect(await mod.getPendingProposals()).toHaveLength(1);
+	});
+});

--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -9,7 +9,7 @@ import {
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { PlaceholderDetector } from './detector';
 import { ProposalStore } from './proposal-store';
-import { ProposalGenerator } from './proposer';
+import { ProposalGenerator, proposalContentKey } from './proposer';
 import { DetectionResult, Proposal } from './types';
 
 export type { DetectionReason, DetectionResult, Proposal } from './types';
@@ -120,6 +120,49 @@ export class ElaborationModule {
 	}
 
 	/**
+	 * Idempotency guard shared by every generate+save site. Returns the
+	 * precomputed content key to hand to the proposer, or a skip decision:
+	 *
+	 * - `duplicate`: a pending or accepted proposal with the same content key
+	 *   already exists, so re-generating would be a no-op — and would waste an
+	 *   AI call. A `rejected` proposal with the same key does NOT block: the user
+	 *   already declined that exact suggestion, so a fresh attempt is allowed.
+	 * - `cap`: the note already has `maxProposalsPerNote` pending proposals, so
+	 *   stop adding more until some are reviewed.
+	 *
+	 * The note body is read via `cachedRead` (already warm from detection), so
+	 * the key matches what `proposer.generate` would compute for the same inputs.
+	 */
+	private async guardProposal(
+		detection: DetectionResult
+	): Promise<{ skip: false; key?: string } | { skip: true; reason: 'duplicate' | 'cap' }> {
+		const file = this.plugin.app.vault.getAbstractFileByPath(detection.notePath);
+		// Missing/non-file: defer to proposer.generate, which surfaces the error
+		// exactly as it did before this guard existed.
+		if (!(file instanceof TFile)) return { skip: false };
+
+		const content = await this.plugin.app.vault.cachedRead(file);
+		const key = proposalContentKey(
+			detection.notePath,
+			content,
+			detection.reasons,
+			this.getSettings()
+		);
+		const existing = await this.store.loadByNote(detection.notePath);
+
+		if (existing.some(p => p.contentKey === key && (p.status === 'pending' || p.status === 'accepted'))) {
+			return { skip: true, reason: 'duplicate' };
+		}
+		if (
+			existing.filter(p => p.status === 'pending').length >=
+			this.getSettings().elaboration.proposal.maxProposalsPerNote
+		) {
+			return { skip: true, reason: 'cap' };
+		}
+		return { skip: false, key };
+	}
+
+	/**
 	 * Resume elaboration from a checkpoint (C1).
 	 * Re-generates proposals for the remaining detected files.
 	 */
@@ -147,7 +190,16 @@ export class ElaborationModule {
 				const result = await this.detector.detect(file);
 				if (!result) continue;
 
-				const proposal = await this.proposer.generate(result);
+				const guard = await this.guardProposal(result);
+				if (guard.skip) {
+					// Already proposed (unchanged note) or per-note cap reached:
+					// skip generate+save but still complete the item so resume
+					// advances past it.
+					await this.checkpointManager.completeItem(checkpoint.id, item.id);
+					continue;
+				}
+
+				const proposal = await this.proposer.generate(result, guard.key);
 				if (!proposal) {
 					// Link-only note whose links all failed: skip the fabricated
 					// proposal but still complete the item so resume advances.
@@ -275,7 +327,20 @@ export class ElaborationModule {
 				if (genOp.cancelled) break;
 
 				genOp.progress(i + 1, detected.length, 'Generating proposals');
-				const proposal = await this.proposer.generate(detected[i]);
+
+				const guard = await this.guardProposal(detected[i]);
+				if (guard.skip) {
+					// Already proposed (unchanged note) or per-note cap reached:
+					// skip generate+save (and the AI call) but still mark the item
+					// done so the checkpoint advances.
+					await this.checkpointManager.completeItem(
+						checkpoint.id,
+						checkpointItems[i].id
+					);
+					continue;
+				}
+
+				const proposal = await this.proposer.generate(detected[i], guard.key);
 				if (!proposal) {
 					// Link-only note whose links all failed: skip without creating a
 					// fabricated proposal, but still mark the item done so the
@@ -355,7 +420,21 @@ export class ElaborationModule {
 
 			if (result) {
 				op.update(`Generating proposal for ${file.basename}`);
-				const proposal = await this.proposer.generate(result);
+
+				const guard = await this.guardProposal(result);
+				if (guard.skip) {
+					// Nothing new to propose: either this exact note state was
+					// already proposed/accepted, or the per-note pending cap is
+					// reached. Finish honestly without spending an AI call.
+					op.finish(
+						guard.reason === 'cap'
+							? 'No new proposal -- this note already has the maximum pending proposals'
+							: 'No new proposal -- this note is unchanged since its last elaboration'
+					);
+					return;
+				}
+
+				const proposal = await this.proposer.generate(result, guard.key);
 				if (!proposal) {
 					// generate() returns null when the note is essentially just
 					// unreadable link(s): no proposal is created and the link-load

--- a/src/elaboration/proposal-store.test.ts
+++ b/src/elaboration/proposal-store.test.ts
@@ -104,6 +104,52 @@ describe('ProposalStore', () => {
 		expect(result[0].id).toBe('p1');
 	});
 
+	it('loadByNote returns only proposals whose sourceNotePath matches exactly', async () => {
+		const a1 = makeProposal({ id: 'a1', sourceNotePath: 'notes/a.md' });
+		const a2 = makeProposal({ id: 'a2', sourceNotePath: 'notes/a.md' });
+		const b1 = makeProposal({ id: 'b1', sourceNotePath: 'notes/b.md' });
+
+		mockAdapter.list.mockResolvedValue({
+			files: ['a1.json', 'a2.json', 'b1.json'],
+			folders: [],
+		});
+		mockAdapter.read
+			.mockResolvedValueOnce(JSON.stringify(a1))
+			.mockResolvedValueOnce(JSON.stringify(a2))
+			.mockResolvedValueOnce(JSON.stringify(b1));
+
+		const result = await store.loadByNote('notes/a.md');
+		expect(result.map(p => p.id).sort()).toEqual(['a1', 'a2']);
+	});
+
+	it('loadByNote does not prefix-match a different note that shares a name stem', async () => {
+		// 'notes/a.md' must not match 'notes/a-extra.md' — exact path only.
+		const a = makeProposal({ id: 'a', sourceNotePath: 'notes/a.md' });
+		const aExtra = makeProposal({ id: 'a-extra', sourceNotePath: 'notes/a-extra.md' });
+
+		mockAdapter.list.mockResolvedValue({ files: ['a.json', 'extra.json'], folders: [] });
+		mockAdapter.read
+			.mockResolvedValueOnce(JSON.stringify(a))
+			.mockResolvedValueOnce(JSON.stringify(aExtra));
+
+		const result = await store.loadByNote('notes/a.md');
+		expect(result.map(p => p.id)).toEqual(['a']);
+	});
+
+	it('still loads legacy proposals that predate the contentKey field', async () => {
+		// makeProposal omits contentKey; isProposal must keep accepting it so old
+		// proposal files continue to load.
+		const legacy = makeProposal({ id: 'legacy-1' });
+		expect('contentKey' in legacy).toBe(false);
+		mockAdapter.list.mockResolvedValue({ files: ['legacy.json'], folders: [] });
+		mockAdapter.read.mockResolvedValue(JSON.stringify(legacy));
+
+		const result = await store.loadAll();
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe('legacy-1');
+		expect(result[0].contentKey).toBeUndefined();
+	});
+
 	it('loads all proposals including rejected', async () => {
 		const p1 = makeProposal({ id: 'p1', status: 'pending' });
 		const p2 = makeProposal({ id: 'p2', status: 'rejected' });

--- a/src/elaboration/proposal-store.ts
+++ b/src/elaboration/proposal-store.ts
@@ -73,6 +73,19 @@ export class ProposalStore {
 		return all.filter(p => p.status === 'pending');
 	}
 
+	/**
+	 * Load every proposal whose source note is exactly `notePath`.
+	 *
+	 * Implemented as loadAll + filter rather than a filename-prefix scan:
+	 * `proposalFileName` lossily maps `/` to `-`, so the on-disk name can't be
+	 * reversed to a unique note path and a prefix match would be unsafe. Counts
+	 * are tiny (the per-note cap is a handful), so a full scan is cheap.
+	 */
+	async loadByNote(notePath: string): Promise<Proposal[]> {
+		const all = await this.loadAll();
+		return all.filter(p => p.sourceNotePath === notePath);
+	}
+
 	async delete(id: string): Promise<void> {
 		const files = await this.listProposalFiles();
 		for (const filePath of files) {

--- a/src/elaboration/proposer.test.ts
+++ b/src/elaboration/proposer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TFile, requestUrl } from '../__mocks__/obsidian';
-import { ProposalGenerator } from './proposer';
+import { ProposalGenerator, proposalContentKey } from './proposer';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { DetectionResult } from './types';
 import type { NotificationManager } from '../shared';
@@ -783,5 +783,107 @@ describe('ProposalGenerator -- note title as elaboration signal (#387)', () => {
 		expect(proposal).toBeNull();
 		expect(mockComplete).not.toHaveBeenCalled();
 		expect(notifications.info).toHaveBeenCalledOnce();
+	});
+});
+
+describe('proposalContentKey (deterministic proposal identity, #395)', () => {
+	it('returns the same key for identical inputs', () => {
+		const settings = makeSettings();
+		const key1 = proposalContentKey(
+			'notes/topic.md',
+			'# Topic\n\nSome body text.',
+			[{ type: 'short-note', wordCount: 5 }],
+			settings
+		);
+		const key2 = proposalContentKey(
+			'notes/topic.md',
+			'# Topic\n\nSome body text.',
+			[{ type: 'short-note', wordCount: 5 }],
+			settings
+		);
+		expect(key1).toBe(key2);
+		expect(key1).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it('is independent of detection-reason ordering (sorted before hashing)', () => {
+		const settings = makeSettings();
+		const reasonsA = proposalContentKey('notes/x.md', 'body', [
+			{ type: 'short-note', wordCount: 5 },
+			{ type: 'todo-marker', markers: ['TODO'] },
+		], settings);
+		const reasonsB = proposalContentKey('notes/x.md', 'body', [
+			{ type: 'todo-marker', markers: ['TODO'] },
+			{ type: 'short-note', wordCount: 5 },
+		], settings);
+		expect(reasonsA).toBe(reasonsB);
+	});
+
+	it('changes when the note body changes', () => {
+		const settings = makeSettings();
+		const before = proposalContentKey('notes/x.md', 'original body', [{ type: 'user-requested' }], settings);
+		const after = proposalContentKey('notes/x.md', 'edited body', [{ type: 'user-requested' }], settings);
+		expect(before).not.toBe(after);
+	});
+
+	it('changes when the AI model settings change', () => {
+		const settings = makeSettings();
+		const baseline = proposalContentKey('notes/x.md', 'body', [{ type: 'user-requested' }], settings);
+		const swapped = makeSettings();
+		swapped.ai.model = `${settings.ai.model}-different`;
+		const changed = proposalContentKey('notes/x.md', 'body', [{ type: 'user-requested' }], swapped);
+		expect(baseline).not.toBe(changed);
+	});
+});
+
+describe('ProposalGenerator -- deterministic id (#395)', () => {
+	let generator: ProposalGenerator;
+
+	beforeEach(() => {
+		mockComplete.mockClear();
+		// Temperature > 0 sampling would vary the OUTPUT; keying on inputs keeps
+		// the id stable regardless, so vary the response between calls to prove
+		// the id does not depend on the model's output.
+		mockComplete
+			.mockResolvedValueOnce('First sampled expansion.')
+			.mockResolvedValueOnce('A totally different sampled expansion.');
+
+		const mockApp = {
+			vault: {
+				getAbstractFileByPath: vi.fn().mockImplementation((path: string) => new TFile(path)),
+				cachedRead: vi.fn().mockResolvedValue('# Note\n\nStable body content.'),
+				read: vi.fn(),
+				readBinary: vi.fn(),
+			},
+			metadataCache: {
+				getCache: vi.fn().mockReturnValue(null),
+				getFirstLinkpathDest: vi.fn().mockReturnValue(null),
+			},
+		};
+		const settings = makeSettings();
+		settings.elaboration.proposal.includeSourceContext = false;
+		settings.image.enabled = false;
+		generator = new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('sets id === contentKey and reproduces both for an unchanged note', async () => {
+		const detection: DetectionResult = {
+			notePath: 'notes/test.md',
+			reasons: [{ type: 'user-requested' }],
+		};
+
+		const first = await generator.generate(detection);
+		const second = await generator.generate(detection);
+
+		expect(first).not.toBeNull();
+		expect(second).not.toBeNull();
+		// id is the content key, and identical inputs reproduce it even though
+		// the mocked AI output differed between the two calls.
+		expect(first!.id).toBe(first!.contentKey);
+		expect(second!.id).toBe(first!.id);
+		expect(second!.contentKey).toBe(first!.contentKey);
 	});
 });

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -1,8 +1,37 @@
-import { App, TFile } from 'obsidian';
+import { App, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, sanitizeAIResponse, stripCodeFences, isTwitterUrl, fetchTweetContent, isRedditUrl, fetchRedditContent, fetchArticleContent, linkLoadError, NotificationManager, isGenericTitle } from '../shared';
+import { AIClient, sanitizeAIResponse, stripCodeFences, isTwitterUrl, fetchTweetContent, isRedditUrl, fetchRedditContent, fetchArticleContent, linkLoadError, NotificationManager, isGenericTitle, hashString, contentKey } from '../shared';
 import { ImageAnalyzer, ImageAnalysis } from './image-analyzer';
-import { DetectionResult, Proposal } from './types';
+import { DetectionResult, DetectionReason, Proposal } from './types';
+
+/**
+ * Compute the deterministic content key for a proposal from its inputs.
+ *
+ * Keying on the *inputs* (note path + content + detection reasons + the AI
+ * settings that shape the request) rather than the model's *output* is what
+ * makes re-scanning an unchanged note idempotent: temperature > 0 sampling
+ * would otherwise yield different text — and thus a different key — every run.
+ *
+ * `detectionReasons` are sorted by `type` before serializing because detector
+ * order isn't guaranteed stable; an unstable serialization would change the key
+ * for an otherwise-identical note and defeat dedup.
+ */
+export function proposalContentKey(
+	notePath: string,
+	content: string,
+	reasons: DetectionReason[],
+	settings: SynapseSettings
+): string {
+	return contentKey([
+		normalizePath(notePath),
+		hashString(content),
+		JSON.stringify([...reasons].sort((a, b) => a.type.localeCompare(b.type))),
+		settings.ai.provider,
+		settings.ai.model,
+		String(settings.ai.temperature),
+		String(settings.ai.maxTokens),
+	]);
+}
 
 /**
  * Matches bare http(s) URLs in note text. Reserved for the `matchAll` in
@@ -24,7 +53,7 @@ export class ProposalGenerator {
 		this.imageAnalyzer = new ImageAnalyzer(app, getSettings);
 	}
 
-	async generate(detection: DetectionResult): Promise<Proposal | null> {
+	async generate(detection: DetectionResult, precomputedKey?: string): Promise<Proposal | null> {
 		// Vault API (not adapter) — vault notes must go through vault.cachedRead
 		// per the Obsidian plugin guidelines; the adapter is reserved for the
 		// plugin's own .synapse/ storage.
@@ -34,6 +63,10 @@ export class ProposalGenerator {
 		}
 		const content = await this.app.vault.cachedRead(noteFile);
 		const settings = this.getSettings();
+		// Reuse the caller's key when it already computed one for the dedup guard
+		// (avoids a second hash); otherwise derive it here so direct callers still
+		// get a deterministic id.
+		const key = precomputedKey ?? proposalContentKey(detection.notePath, content, detection.reasons, settings);
 
 		// Anti-fabrication guard (sibling to the link-dominated guard below): a note
 		// with no body offers only its title as signal. When that title is also
@@ -86,7 +119,8 @@ export class ProposalGenerator {
 		const proposedAdditions = stripCodeFences(sanitizeAIResponse(rawAdditions));
 
 		return {
-			id: this.generateId(),
+			id: key,
+			contentKey: key,
 			sourceNotePath: detection.notePath,
 			createdAt: new Date().toISOString(),
 			detectionReasons: detection.reasons,
@@ -281,16 +315,6 @@ export class ProposalGenerator {
 		}
 	}
 
-	private generateId(): string {
-		return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(
-			/[xy]/g,
-			(c) => {
-				const r = (Math.random() * 16) | 0;
-				const v = c === 'x' ? r : (r & 0x3) | 0x8;
-				return v.toString(16);
-			}
-		);
-	}
 }
 
 /**

--- a/src/elaboration/review-toast.test.ts
+++ b/src/elaboration/review-toast.test.ts
@@ -37,6 +37,9 @@ vi.mock('./proposer', () => ({
 			})
 		);
 	},
+	// The dedup guard (index.ts) imports this from the real proposer; the mock
+	// must provide it so guardProposal can compute a key without the real impl.
+	proposalContentKey: vi.fn(() => 'mock-content-key'),
 }));
 
 function makeOp(cancelled = false) {

--- a/src/elaboration/types.ts
+++ b/src/elaboration/types.ts
@@ -14,6 +14,13 @@ export interface DetectionResult {
 
 export interface Proposal {
 	id: string;
+	/**
+	 * Deterministic hash of the inputs that produced this proposal (note path,
+	 * content, detection reasons, and AI settings). Used to dedup re-scans of an
+	 * unchanged note. Optional so proposal files written before this field
+	 * existed still satisfy the `isProposal` guard and keep loading.
+	 */
+	contentKey?: string;
 	sourceNotePath: string;
 	createdAt: string;
 	detectionReasons: DetectionReason[];

--- a/src/shared/hash-utils.test.ts
+++ b/src/shared/hash-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { hashString, contentKey } from './hash-utils';
+
+describe('hashString', () => {
+	it('is deterministic — the same input yields an identical digest across calls', () => {
+		const input = 'The quick brown fox jumps over the lazy dog';
+		expect(hashString(input)).toBe(hashString(input));
+	});
+
+	it('always returns a 16-character lowercase hex digest', () => {
+		for (const input of ['', 'a', 'hello world', '🦊 unicode ☃', 'x'.repeat(1000)]) {
+			const digest = hashString(input);
+			expect(digest).toMatch(/^[0-9a-f]{16}$/);
+		}
+	});
+
+	it('produces different digests for different inputs', () => {
+		expect(hashString('alpha')).not.toBe(hashString('beta'));
+		// A single-character change must diverge.
+		expect(hashString('note-v1')).not.toBe(hashString('note-v2'));
+	});
+
+	it('is order-sensitive', () => {
+		expect(hashString('ab')).not.toBe(hashString('ba'));
+	});
+});
+
+describe('contentKey', () => {
+	it('is deterministic for the same ordered parts', () => {
+		const parts = ['notes/a.md', 'deadbeefdeadbeef', 'openai', 'gpt-4o'];
+		expect(contentKey(parts)).toBe(contentKey(parts));
+	});
+
+	it('length-prefixing prevents boundary collisions between part lists', () => {
+		// Without length-prefixing both lists join to "abc" and would collide.
+		expect(contentKey(['a', 'bc'])).not.toBe(contentKey(['ab', 'c']));
+	});
+
+	it('distinguishes an empty trailing part from a missing one', () => {
+		expect(contentKey(['a', ''])).not.toBe(contentKey(['a']));
+	});
+
+	it('returns a 16-character hex digest', () => {
+		expect(contentKey(['x', 'y', 'z'])).toMatch(/^[0-9a-f]{16}$/);
+	});
+});

--- a/src/shared/hash-utils.ts
+++ b/src/shared/hash-utils.ts
@@ -1,0 +1,60 @@
+/**
+ * Deterministic, browser-safe string hashing.
+ *
+ * Hand-written FNV-1a so it runs inside the Obsidian bundle, where Node's
+ * `crypto` module is unavailable (and pulling it in would break the mobile
+ * build). The hash is used purely for content-addressing proposals (dedup /
+ * idempotency), not for security — collision resistance only needs to be good
+ * enough that two genuinely different inputs almost never share a key.
+ */
+
+// FNV-1a 32-bit constants.
+const FNV_PRIME = 0x01000193;
+// Two distinct offset bases let us run two independent 32-bit lanes and
+// concatenate them into a 64-bit (16 hex char) digest from a single pass.
+const OFFSET_BASIS_LANE_A = 0x811c9dc5;
+const OFFSET_BASIS_LANE_B = 0x84222325;
+
+/**
+ * Hash a string to a 16-character lowercase hex digest.
+ *
+ * Implementation notes:
+ * - FNV-1a: for each code unit, XOR into the accumulator first, then multiply
+ *   by the prime.
+ * - The prime multiply MUST use `Math.imul`. Plain `*` promotes the operands to
+ *   IEEE-754 doubles and silently loses the low 32 bits of precision once the
+ *   product exceeds 2^53, which makes the result non-deterministic across
+ *   inputs. `Math.imul` performs a true 32-bit integer multiply.
+ * - Each lane is coerced with `>>> 0` to an unsigned 32-bit value before being
+ *   rendered as 8 hex chars; the two lanes are concatenated.
+ */
+export function hashString(input: string): string {
+	let laneA = OFFSET_BASIS_LANE_A;
+	let laneB = OFFSET_BASIS_LANE_B;
+
+	for (let i = 0; i < input.length; i++) {
+		const code = input.charCodeAt(i);
+		laneA ^= code;
+		laneA = Math.imul(laneA, FNV_PRIME);
+		laneB ^= code;
+		laneB = Math.imul(laneB, FNV_PRIME);
+	}
+
+	const hexA = (laneA >>> 0).toString(16).padStart(8, '0');
+	const hexB = (laneB >>> 0).toString(16).padStart(8, '0');
+	return hexA + hexB;
+}
+
+/**
+ * Hash an ordered list of string parts into a single content key.
+ *
+ * Each part is length-prefixed as `${p.length}:${p}` before the parts are
+ * joined. The prefix makes the encoding unambiguous (netstring-style), so two
+ * different part lists can never produce the same joined string — e.g.
+ * `["a", "bc"]` and `["ab", "c"]` both naively concatenate to `"abc"` but
+ * length-prefix to `"1:a2:bc"` vs `"2:ab1:c"`, which hash differently.
+ */
+export function contentKey(parts: string[]): string {
+	const encoded = parts.map((p) => `${p.length}:${p}`).join('');
+	return hashString(encoded);
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -115,6 +115,7 @@ export {
 } from './content-schemas';
 export type { ContentSchema, PipelineStage, SchemaMode } from './content-schemas';
 export { generateId, isValidCheckpointId } from './id-utils';
+export { hashString, contentKey } from './hash-utils';
 export { isUntitled, isGenericTitle } from './title-detector';
 export {
 	loadNodeModules,


### PR DESCRIPTION
## Summary

Re-running an elaboration scan on an unchanged note used to mint a brand-new proposal every time (random id, no "already proposed?" guard), and `maxProposalsPerNote` was declared but never enforced. This fixes both, built on a new shared hash primitive.

closes #395

## What changed

- **New shared hash primitive — `src/shared/hash-utils.ts`** (exported from the `shared` barrel):
  - `hashString(input)` — FNV-1a, two 32-bit lanes (offset bases `0x811c9dc5` / `0x84222325`), using `Math.imul` for the prime multiply so the result is deterministic. Returns a 16-char hex digest. No `crypto` (unavailable in the Obsidian bundle).
  - `contentKey(parts)` — length-prefixes each part (`${p.length}:${p}`) before hashing, so part-boundary collisions (`["a","bc"]` vs `["ab","c"]`) can't happen.
- **Deterministic proposal identity — `proposer.ts`**: new exported `proposalContentKey(notePath, content, reasons, settings)` (detection reasons sorted by `type` for stability). `generate()` now accepts an optional precomputed key and sets `id === contentKey` from the inputs, replacing the random `generateId()`. Keying on inputs (not the model's output) means temperature>0 sampling never re-generates for an unchanged note. The deterministic id also makes the on-disk filename deterministic, so a re-save overwrites in place.
- **Per-note lookup — `proposal-store.ts`**: `loadByNote(notePath)` = `loadAll()` filtered by exact `sourceNotePath` (filenames are lossy, so no prefix matching).
- **Dedup + cap guard — `elaboration/index.ts`**: a shared `guardProposal()` runs at all three generate+save sites (`scanVault`, `scanNote`, `resumeFromCheckpoint`). It computes the key from the warm `cachedRead` body and:
  - **short-circuits before the `aiClient.complete()` call** when a `pending`/`accepted` proposal with the same key already exists (a `rejected` one does not block);
  - enforces `maxProposalsPerNote` on a key-miss.
  Each site still advances its checkpoint/loop bookkeeping on a skip.
- `Proposal.contentKey` is optional so pre-existing proposal files still pass the `isProposal` guard and keep loading.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` — 1730 passed (130 files)
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

New/extended tests: `hash-utils.test.ts` (determinism, divergence, boundary-collision), `proposer.test.ts` (deterministic id/key, reason-order independence), `proposal-store.test.ts` (`loadByNote`, legacy proposals without `contentKey`), and `dedup.test.ts` (a second scan makes no new AI call / no new proposal; the cap stops generation; a rejected proposal with the same key doesn't block).

Co-Authored-By: bot <bot@wafflenet.io>