### PR TITLE
feat: notice throttle/dedup + centralize ad-hoc new Notice sites

### DIFF
--- a/src/elaboration/image-analyzer.test.ts
+++ b/src/elaboration/image-analyzer.test.ts
@@ -31,7 +31,7 @@ describe('ImageAnalyzer.findImageReferences', () => {
 			vault: { readBinary: vi.fn() },
 			metadataCache: { getFirstLinkpathDest: vi.fn() },
 		};
-		analyzer = new ImageAnalyzer(mockApp as any, () => settings);
+		analyzer = new ImageAnalyzer(mockApp as any, () => settings, { info: vi.fn() } as any);
 	});
 
 	it('finds wiki-link images', () => {
@@ -139,7 +139,7 @@ describe('ImageAnalyzer.parseAnalysisResponse', () => {
 			vault: { readBinary: vi.fn() },
 			metadataCache: { getFirstLinkpathDest: vi.fn() },
 		};
-		analyzer = new ImageAnalyzer(mockApp as any, () => settings);
+		analyzer = new ImageAnalyzer(mockApp as any, () => settings, { info: vi.fn() } as any);
 	});
 
 	it('parses well-formed DESCRIPTION/LOCATION/METADATA response', () => {
@@ -213,7 +213,7 @@ describe('ImageAnalyzer.analyzeImagesInNote', () => {
 			},
 		};
 
-		analyzer = new ImageAnalyzer(mockApp as any, () => settings);
+		analyzer = new ImageAnalyzer(mockApp as any, () => settings, { info: vi.fn() } as any);
 	});
 
 	afterEach(() => {

--- a/src/elaboration/image-analyzer.ts
+++ b/src/elaboration/image-analyzer.ts
@@ -1,5 +1,5 @@
-import { App, Notice, TFile } from 'obsidian';
-import { AIClient, arrayBufferToBase64 } from '../shared';
+import { App, TFile } from 'obsidian';
+import { AIClient, arrayBufferToBase64, NotificationManager } from '../shared';
 import type { ContentBlock } from '../shared';
 import { SynapseSettings } from '../settings';
 import { preprocessImage } from '../image';
@@ -27,7 +27,8 @@ export class ImageAnalyzer {
 
 	constructor(
 		private app: App,
-		private getSettings: () => SynapseSettings
+		private getSettings: () => SynapseSettings,
+		private notifications: NotificationManager
 	) {
 		this.aiClient = new AIClient(getSettings);
 	}
@@ -116,7 +117,9 @@ export class ImageAnalyzer {
 		const maxBytes = (settings.image.maxImageSizeMb || 5) * 1024 * 1024;
 		const processed = await preprocessImage(data, sourceMediaType, maxBytes);
 		if (processed.downscaled) {
-			new Notice('Synapse: large image auto-downscaled to fit the API limit');
+			// Routed through the manager so the 3s dedup collapses this otherwise
+			// once-per-image flood into a single toast (#396).
+			this.notifications.info('large image auto-downscaled to fit the API limit');
 		}
 		const base64 = arrayBufferToBase64(processed.data);
 		const mediaType = processed.mediaType;

--- a/src/elaboration/proposer.ts
+++ b/src/elaboration/proposer.ts
@@ -21,7 +21,7 @@ export class ProposalGenerator {
 		private notifications: NotificationManager
 	) {
 		this.aiClient = new AIClient(getSettings);
-		this.imageAnalyzer = new ImageAnalyzer(app, getSettings);
+		this.imageAnalyzer = new ImageAnalyzer(app, getSettings, notifications);
 	}
 
 	async generate(detection: DetectionResult): Promise<Proposal | null> {

--- a/src/image/extractor.test.ts
+++ b/src/image/extractor.test.ts
@@ -28,7 +28,7 @@ describe('ImageExtractor', () => {
 		mockChat.mockClear();
 		mockChat.mockResolvedValue('Extracted text from image');
 		settings = makeSettings();
-		extractor = new ImageExtractor(() => settings);
+		extractor = new ImageExtractor(() => settings, { info: vi.fn() } as any);
 	});
 
 	afterEach(() => {

--- a/src/image/extractor.ts
+++ b/src/image/extractor.ts
@@ -1,5 +1,4 @@
-import { Notice } from 'obsidian';
-import { AIClient } from '../shared';
+import { AIClient, NotificationManager } from '../shared';
 import type { ContentBlock } from '../shared';
 import { SynapseSettings } from '../settings';
 import { OCRResult } from './types';
@@ -8,7 +7,10 @@ import { arrayBufferToBase64, preprocessImage } from './preprocess';
 export class ImageExtractor {
 	private aiClient: AIClient;
 
-	constructor(private getSettings: () => SynapseSettings) {
+	constructor(
+		private getSettings: () => SynapseSettings,
+		private notifications: NotificationManager
+	) {
 		this.aiClient = new AIClient(getSettings);
 	}
 
@@ -19,7 +21,9 @@ export class ImageExtractor {
 		const maxBytes = (settings.image.maxImageSizeMb || 5) * 1024 * 1024;
 		const processed = await preprocessImage(imageData, sourceMediaType, maxBytes);
 		if (processed.downscaled) {
-			new Notice('Synapse: large image auto-downscaled to fit the API limit');
+			// Routed through the manager so the 3s dedup collapses this otherwise
+			// once-per-image flood into a single toast (#396).
+			this.notifications.info('large image auto-downscaled to fit the API limit');
 		}
 
 		const base64 = arrayBufferToBase64(processed.data);

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -24,7 +24,7 @@ export class ImageModule {
 		private notifications: NotificationManager,
 		private checkpointManager: CheckpointManager
 	) {
-		this.extractor = new ImageExtractor(getSettings);
+		this.extractor = new ImageExtractor(getSettings, notifications);
 	}
 
 	async onload(): Promise<void> {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Notice, Platform, Plugin, TFile } from 'obsidian';
+import { MarkdownView, Platform, Plugin, TFile } from 'obsidian';
 import { SynapseSettings, DEFAULT_SETTINGS } from './settings';
 import { SynapseSettingTab } from './settings-tab';
 import { ElaborationModule } from './elaboration';
@@ -413,7 +413,7 @@ export default class SynapsePlugin extends Plugin {
 		this.intake = new IntakeModule(this, getSettings, this.notifications, {
 			fireOnFile: (file) => synapseRunner.fireOnFile(file),
 			transcribeUrlToNote: async (_url, _mediaType, _file) => {
-				new Notice('Synapse: URL transcription from intake is coming soon (#112)');
+				this.notifications.info('URL transcription from intake is coming soon (#112)');
 			},
 		});
 		if (this.settings.intake.enabled) {
@@ -549,7 +549,8 @@ export default class SynapsePlugin extends Plugin {
 				onTranscribeUrl: this.video
 					? (url, timeRange) => this.video!.transcribeUrlToActiveNote(url, timeRange)
 					: async () => { /* unreachable: video hidden on mobile */ },
-			}
+			},
+			this.notifications
 		).open();
 	}
 
@@ -587,6 +588,7 @@ export default class SynapsePlugin extends Plugin {
 					: async () => { /* unreachable: video hidden on mobile */ },
 				onExtractImages: (selected) => this.image.extractAndInsert(file, selected),
 			},
+			this.notifications,
 			ffmpegAvailable
 		).open();
 	}
@@ -666,7 +668,7 @@ export default class SynapsePlugin extends Plugin {
 		if (REGISTRY_BY_ID.get(id)?.context === 'note') {
 			const file = this.activeMarkdownFile();
 			if (!file) {
-				new Notice('Synapse: open a note first to use this action.');
+				this.notifications.info('open a note first to use this action.');
 				return;
 			}
 			const mdLeaf = this.app.workspace
@@ -902,8 +904,8 @@ export default class SynapsePlugin extends Plugin {
 			}
 
 			await adapter.rename(OLD_FOLDER, NEW_FOLDER);
-			new Notice(
-				`Synapse: migrated data folder from ${OLD_FOLDER}/ to ${NEW_FOLDER}/`
+			this.notifications.success(
+				`migrated data folder from ${OLD_FOLDER}/ to ${NEW_FOLDER}/`
 			);
 		} catch (error) {
 			console.error('[Synapse] Failed to migrate data folder:', error);

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -330,4 +330,84 @@ describe('NotificationManager', () => {
 			consoleSpy.mockRestore();
 		});
 	});
+
+	describe('equal-message throttling (#396)', () => {
+		// Date.now() is the throttle's time source; vitest fake timers mock it so
+		// advanceTimersByTime moves the dedup window deterministically.
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		/** Total Notices constructed so far (the mock records every one). */
+		function noticeCount(): number {
+			return (Notice as unknown as { instances: any[] }).instances.length;
+		}
+
+		it('suppresses a second identical info() within the 3s window', () => {
+			manager.info('Saved');
+			manager.info('Saved');
+			expect(noticeCount()).toBe(1);
+		});
+
+		it('keeps suppressing right up to the window edge (2999ms)', () => {
+			manager.info('Saved');
+			vi.advanceTimersByTime(2999);
+			manager.info('Saved');
+			expect(noticeCount()).toBe(1);
+		});
+
+		it('shows the message again once the window has elapsed (>3s)', () => {
+			manager.info('Saved');
+			vi.advanceTimersByTime(3001);
+			manager.info('Saved');
+			expect(noticeCount()).toBe(2);
+		});
+
+		it('does not throttle distinct messages within the window', () => {
+			manager.info('First message');
+			manager.info('Second message');
+			expect(noticeCount()).toBe(2);
+		});
+
+		it('does not collapse the same text across different levels', () => {
+			manager.info('Heads up');
+			manager.success('Heads up');
+			manager.error('Heads up');
+			expect(noticeCount()).toBe(3);
+		});
+
+		it('throttles repeated success() and error() the same way', () => {
+			manager.success('Done');
+			manager.success('Done'); // suppressed
+			manager.error('Boom');
+			manager.error('Boom'); // suppressed
+			expect(noticeCount()).toBe(2);
+		});
+
+		it('collapses a per-image downscale loop into a single toast', () => {
+			const msg = 'large image auto-downscaled to fit the API limit';
+			for (let i = 0; i < 5; i++) manager.info(msg);
+			expect(noticeCount()).toBe(1);
+		});
+
+		it('leaves startOperation (tracked ops) and confirm unaffected', () => {
+			// Two operations sharing a label still each create their own notice —
+			// the throttle never touches tracked-operation toasts...
+			manager.startOperation('Scanning', 'op-a');
+			manager.startOperation('Scanning', 'op-b');
+			// ...and a confirm snackbar carrying the same text shows regardless.
+			void manager.confirm('Scanning');
+			expect(noticeCount()).toBe(3);
+		});
+
+		it('clears the dedup window on dispose so the next show is not suppressed', () => {
+			manager.info('Reusable');
+			manager.dispose();
+			manager.info('Reusable');
+			expect(noticeCount()).toBe(2);
+		});
+	});
 });

--- a/src/shared/notifications.ts
+++ b/src/shared/notifications.ts
@@ -71,6 +71,16 @@ const CLS = 'synapse-notice';
  */
 const ACTION_NOTICE_DURATION = 8000;
 
+/**
+ * Dedup window (ms) for fire-and-forget one-shot toasts (#396). A second
+ * identical toast — same level AND message — requested within this window of
+ * the first is suppressed, so a per-item loop (e.g. the per-image
+ * "auto-downscaled" notice) or a quickly-repeated action can't flood the user
+ * with a stack of identical toasts. Deliberately short so a genuinely later
+ * recurrence of the same message still surfaces.
+ */
+const NOTICE_THROTTLE_MS = 3000;
+
 /** Get the underlying DOM element from a Notice */
 function getNoticeEl(notice: Notice): HTMLElement {
 	return (notice as unknown as { noticeEl: HTMLElement }).noticeEl;
@@ -138,6 +148,13 @@ export class NotificationManager {
 	private operations = new Map<string, TrackedOperation>();
 	private statusBarEl: HTMLElement | null = null;
 	private idCounter = 0;
+	/**
+	 * Last-shown timestamps for fire-and-forget one-shot toasts, keyed
+	 * `${level}:${message}` (#396). Consulted by {@link isThrottled} to suppress
+	 * an identical toast requested again within {@link NOTICE_THROTTLE_MS}.
+	 * Cleared in {@link dispose}.
+	 */
+	private lastShown = new Map<string, number>();
 
 	setStatusBarEl(el: HTMLElement): void {
 		this.statusBarEl = el;
@@ -157,6 +174,9 @@ export class NotificationManager {
 			op.notice.hide();
 		}
 		this.operations.clear();
+		// Drop dedup timestamps too, so a re-enabled plugin starts with a clean
+		// throttle window rather than inheriting stale last-shown times (#396).
+		this.lastShown.clear();
 	}
 
 	/**
@@ -333,6 +353,33 @@ export class NotificationManager {
 	}
 
 	/**
+	 * Equal-message throttle for fire-and-forget one-shot toasts (#396). Returns
+	 * true when an identical toast — same `level` AND `message` — was shown within
+	 * {@link NOTICE_THROTTLE_MS}, signalling the caller to SUPPRESS the new toast.
+	 * Otherwise records `Date.now()` for this key and returns false so the caller
+	 * proceeds to build the Notice. Keyed on `${level}:${message}` so the same
+	 * text at different severities (e.g. info vs error) never collapses into one.
+	 *
+	 * Only the fire-and-forget one-shot entry points (info/success/error without
+	 * an action) consult this. Tracked-operation toasts, confirm(), and
+	 * interactive action notices (showActionNotice/infoSticky) deliberately do
+	 * NOT — their stateful/lifecycle behavior must never be silently dropped.
+	 *
+	 * `Date.now()` is the time source: correct in production, and vitest fake
+	 * timers mock it so tests can advance deterministically across the window.
+	 */
+	private isThrottled(level: NoticeLevel, message: string): boolean {
+		const key = `${level}:${message}`;
+		const now = Date.now();
+		const last = this.lastShown.get(key);
+		if (last !== undefined && now - last < NOTICE_THROTTLE_MS) {
+			return true;
+		}
+		this.lastShown.set(key, now);
+		return false;
+	}
+
+	/**
 	 * Show a one-shot informational notice (not tracked, dismissible).
 	 * When `action` is supplied the toast renders an action button (e.g. "Review").
 	 */
@@ -341,6 +388,9 @@ export class NotificationManager {
 			this.showActionNotice(message, 'info', Math.max(duration, ACTION_NOTICE_DURATION), action);
 			return;
 		}
+		// Suppress an identical info toast fired again within the dedup window
+		// (#396) — e.g. the same per-image message emitted once per loop iteration.
+		if (this.isThrottled('info', message)) return;
 		const notice = new Notice(`Synapse: ${message}`, duration);
 		styleNotice(notice, 'info');
 	}
@@ -365,6 +415,8 @@ export class NotificationManager {
 			this.showActionNotice(message, 'success', Math.max(duration, ACTION_NOTICE_DURATION), action);
 			return;
 		}
+		// Suppress an identical success toast fired again within the dedup window (#396).
+		if (this.isThrottled('success', message)) return;
 		const notice = new Notice(`Synapse: ${message}`, duration);
 		styleNotice(notice, 'success');
 	}
@@ -377,6 +429,11 @@ export class NotificationManager {
 	 * error object plus a context label.
 	 */
 	error(message: string): void {
+		// Throttle is applied HERE — at the one-shot error entry point — not inside
+		// showErrorNotice (#396). That keeps tracked-operation error toasts (via
+		// completeOperation) and contextual notifyError() unthrottled, since both
+		// reach showErrorNotice directly and are exempt per the dedup design.
+		if (this.isThrottled('error', message)) return;
 		this.showErrorNotice(message);
 	}
 

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -257,7 +257,8 @@ export class SummarizeModule {
 			{
 				includeNoteContent: settings.includeNoteContent,
 				combineSummaries: settings.combineSummaries,
-			}
+			},
+			this.notifications
 		).open();
 	}
 

--- a/src/summarize/summarize-modal.test.ts
+++ b/src/summarize/summarize-modal.test.ts
@@ -46,7 +46,8 @@ function openModal(targets: SummarizeTarget[], defaults: SummarizeModalDefaults 
 		{} as any,
 		targets,
 		vi.fn().mockResolvedValue(undefined),
-		defaults
+		defaults,
+		{ info: vi.fn() } as any
 	);
 	(modal as any).contentEl = stubEl();
 	modal.onOpen();

--- a/src/summarize/summarize-modal.ts
+++ b/src/summarize/summarize-modal.ts
@@ -1,5 +1,6 @@
-import { App, Modal, Notice, Setting } from 'obsidian';
+import { App, Modal, Setting } from 'obsidian';
 import { SummarizeTarget } from './types';
+import type { NotificationManager } from '../shared';
 
 export interface SummarizeModalDefaults {
 	/** Default state of the "Include note content" toggle (#367). */
@@ -20,7 +21,8 @@ export class SummarizeSelectionModal extends Modal {
 		app: App,
 		targets: SummarizeTarget[],
 		onSummarize: (targets: SummarizeTarget[], combine: boolean) => Promise<void>,
-		defaults: SummarizeModalDefaults
+		defaults: SummarizeModalDefaults,
+		private notifications: NotificationManager
 	) {
 		super(app);
 		// The note's own prose (#367) is presented as a dedicated toggle rather
@@ -93,7 +95,7 @@ export class SummarizeSelectionModal extends Modal {
 				.onClick(async () => {
 					const chosen = this.collectChosen();
 					if (chosen.length === 0) {
-						new Notice('Please select at least one item');
+						this.notifications.info('Please select at least one item');
 						return;
 					}
 					this.close();

--- a/src/transcription/note-media-modal.test.ts
+++ b/src/transcription/note-media-modal.test.ts
@@ -46,7 +46,7 @@ function openModal(n: number, ffmpeg: boolean) {
 		onTranscribeVideo: vi.fn().mockResolvedValue(undefined),
 		onExtractImages: vi.fn().mockResolvedValue(undefined),
 	};
-	const modal = new NoteMediaModal({} as any, audioEmbeds(n) as any, [], [], callbacks, ffmpeg);
+	const modal = new NoteMediaModal({} as any, audioEmbeds(n) as any, [], [], callbacks, { info: vi.fn() } as any, ffmpeg);
 	(modal as any).contentEl = stubEl();
 	modal.onOpen();
 	return modal;

--- a/src/transcription/note-media-modal.ts
+++ b/src/transcription/note-media-modal.ts
@@ -1,7 +1,8 @@
-import { App, Modal, Notice, Setting } from 'obsidian';
+import { App, Modal, Setting } from 'obsidian';
 import { AudioEmbed } from '../audio';
 import { VideoUrlEmbed } from '../video';
 import { ImageEmbed } from '../image';
+import type { NotificationManager } from '../shared';
 
 export class NoteMediaModal extends Modal {
 	private selectedAudio: Set<string>;
@@ -19,6 +20,7 @@ export class NoteMediaModal extends Modal {
 			onTranscribeVideo: (embeds: VideoUrlEmbed[]) => Promise<void>;
 			onExtractImages: (embeds: ImageEmbed[]) => Promise<void>;
 		},
+		private notifications: NotificationManager,
 		private ffmpegAvailable = false
 	) {
 		super(app);
@@ -97,7 +99,7 @@ export class NoteMediaModal extends Modal {
 					const chosenImage = this.imageEmbeds.filter(e => this.selectedImage.has(e.fileName));
 
 					if (chosenAudio.length === 0 && chosenVideo.length === 0 && chosenImage.length === 0) {
-						new Notice('Please select at least one item');
+						this.notifications.info('Please select at least one item');
 						return;
 					}
 

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -3,7 +3,7 @@ import { SynapseSettings } from '../settings';
 import { AUDIO_EXTENSIONS } from '../audio';
 import { detectPlatform } from '../video';
 import { validateTimeRange, isPathExcluded } from '../shared';
-import type { TimeRange } from '../shared';
+import type { TimeRange, NotificationManager } from '../shared';
 import {
 	detectLocalFileDuration,
 	detectUrlDuration,
@@ -22,7 +22,8 @@ export class UnifiedTranscriptionModal extends Modal {
 		private callbacks: {
 			onTranscribeFile: (file: TFile, timeRange?: TimeRange) => Promise<void>;
 			onTranscribeUrl: (url: string, timeRange?: TimeRange) => Promise<void>;
-		}
+		},
+		private notifications: NotificationManager
 	) {
 		super(app);
 	}
@@ -120,12 +121,12 @@ export class UnifiedTranscriptionModal extends Modal {
 			await this.handleFileTranscribe(this.selectedFile);
 		} else if (this.url) {
 			if (!detectPlatform(this.url)) {
-				new Notice('Unsupported URL. Please use YouTube or TikTok.');
+				this.notifications.info('Unsupported URL. Please use YouTube or TikTok.');
 				return;
 			}
 			await this.handleUrlTranscribe(this.url);
 		} else {
-			new Notice('Please select a file or enter a URL');
+			this.notifications.info('Please select a file or enter a URL');
 		}
 	}
 
@@ -257,7 +258,7 @@ export class UnifiedTranscriptionModal extends Modal {
 				e.stopPropagation();
 				if (resolved) return;
 				if (!startValue || !endValue) {
-					new Notice('Both start and end times are required');
+					this.notifications.info('Both start and end times are required');
 					return;
 				}
 				try {
@@ -266,7 +267,7 @@ export class UnifiedTranscriptionModal extends Modal {
 					notice.hide();
 					resolve(range);
 				} catch (err) {
-					new Notice(err instanceof Error ? err.message : String(err));
+					this.notifications.info(err instanceof Error ? err.message : String(err));
 				}
 			});
 

--- a/src/video/settings-section.test.ts
+++ b/src/video/settings-section.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createEl, ToggleComponent, ButtonComponent, Notice } from '../__mocks__/obsidian';
-import { createSettingsSectionContext } from '../shared';
+import { createSettingsSectionContext, NotificationManager } from '../shared';
 import { renderVideoSettings } from './settings-section';
 import { DEFAULT_SETTINGS } from '../settings';
 import type { SynapseSettings } from '../settings';
@@ -44,7 +44,9 @@ function makeCtx(mutate?: (s: SynapseSettings) => void) {
 	const settings = structuredClone(DEFAULT_SETTINGS);
 	mutate?.(settings);
 	const saveSettings = vi.fn().mockResolvedValue(undefined);
-	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	// Real manager so the copy-failure path routes through it (#396); the routed
+	// info() prepends "Synapse: " and creates a real Notice under the mock.
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' }, notifications: new NotificationManager() };
 	const containerEl = createEl();
 	const ctx = createSettingsSectionContext({
 		containerEl,
@@ -166,7 +168,7 @@ describe('renderVideoSettings', () => {
 		await Promise.resolve();
 		await Promise.resolve();
 
-		expect(Notice.instances.some((n) => n.message === "Couldn't copy to clipboard")).toBe(true);
+		expect(Notice.instances.some((n) => n.message === "Synapse: Couldn't copy to clipboard")).toBe(true);
 		expect(errSpy).toHaveBeenCalled();
 	});
 

--- a/src/video/settings-section.ts
+++ b/src/video/settings-section.ts
@@ -1,5 +1,5 @@
-import { Setting, setIcon, Notice } from 'obsidian';
-import type { SettingsSectionContext } from '../shared';
+import { Setting, setIcon } from 'obsidian';
+import type { SettingsSectionContext, NotificationManager } from '../shared';
 
 /** A single copy-able install command shown in a path setting's help panel (#382/#383). */
 interface InstallCommand {
@@ -49,6 +49,7 @@ function buildInstallHelpPanel(
 	body: HTMLElement,
 	heading: string,
 	commands: InstallCommand[],
+	notifications: NotificationManager,
 ): HTMLElement {
 	const panel = body.createDiv({ cls: 'synapse-install-help' });
 	panel.createDiv({ cls: 'synapse-install-help-heading', text: heading });
@@ -80,7 +81,7 @@ function buildInstallHelpPanel(
 				})
 				.catch((err) => {
 					console.error('[Synapse] Could not copy install command:', err);
-					new Notice("Couldn't copy to clipboard");
+					notifications.info("Couldn't copy to clipboard");
 				});
 		});
 	}
@@ -105,7 +106,11 @@ interface PathSettingOptions {
  * panel. The `?` help button toggles the panel open/closed (#382/#383); the
  * panel is created as the row's sibling so it expands directly beneath the field.
  */
-function addPathSetting(body: HTMLElement, opts: PathSettingOptions): void {
+function addPathSetting(
+	body: HTMLElement,
+	opts: PathSettingOptions,
+	notifications: NotificationManager,
+): void {
 	let panel: HTMLElement;
 	let open = false;
 
@@ -131,7 +136,7 @@ function addPathSetting(body: HTMLElement, opts: PathSettingOptions): void {
 
 	// Sibling after the row so it expands beneath the field (closure above
 	// references it; the `?` handler only runs after this assignment).
-	panel = buildInstallHelpPanel(body, opts.heading, opts.commands);
+	panel = buildInstallHelpPanel(body, opts.heading, opts.commands, notifications);
 }
 
 /**
@@ -160,7 +165,7 @@ export function renderVideoSettings(ctx: SettingsSectionContext): void {
 		get: () => plugin.settings.video.ytDlpPath,
 		set: (value) => { plugin.settings.video.ytDlpPath = value; },
 		save: () => plugin.saveSettings(),
-	});
+	}, plugin.notifications);
 
 	addPathSetting(videoBody, {
 		name: 'ffmpeg path',
@@ -170,7 +175,7 @@ export function renderVideoSettings(ctx: SettingsSectionContext): void {
 		get: () => plugin.settings.video.ffmpegPath,
 		set: (value) => { plugin.settings.video.ffmpegPath = value; },
 		save: () => plugin.saveSettings(),
-	});
+	}, plugin.notifications);
 
 	new Setting(videoBody)
 		.setName('Video download folder')

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -1,4 +1,4 @@
-import { ItemView, Notice, WorkspaceLeaf } from 'obsidian';
+import { ItemView, WorkspaceLeaf } from 'obsidian';
 import type { Proposal } from '../elaboration';
 import type { AcceptedItems, EnrichmentProposal } from '../enrichment';
 import type { OrganizeProposal } from '../organize';
@@ -218,7 +218,7 @@ export class UnifiedProposalView extends ItemView {
 		}
 
 		this.acceptAllInProgress = false;
-		new Notice(`${accepted} proposal${accepted === 1 ? '' : 's'} accepted`);
+		this.notifications.success(`${accepted} proposal${accepted === 1 ? '' : 's'} accepted`);
 		this.render();
 	}
 
@@ -324,7 +324,7 @@ export class UnifiedProposalView extends ItemView {
 		}
 
 		this.rejectAllInProgress = false;
-		new Notice(`${rejected} proposal${rejected === 1 ? '' : 's'} rejected`);
+		this.notifications.info(`${rejected} proposal${rejected === 1 ? '' : 's'} rejected`);
 		this.render();
 	}
 


### PR DESCRIPTION
## Summary

Repeating an operation (or a per-item loop emitting the same message) used to flood the user with a stack of identical toasts, because every notice path built a fresh `new Notice(...)` with no dedup. This adds equal-message throttling to `NotificationManager` and routes the scattered ad-hoc notice sites through the already-threaded manager instance.

closes #396

## Throttle/dedup (`src/shared/notifications.ts`)

- New `Map<string, number>` of last-shown timestamps keyed on `${level}:${message}`.
- The three fire-and-forget one-shot paths — `info()`, `success()`, and the public `error()` — suppress an identical toast requested again within a **3000ms** window (record `Date.now()` and proceed otherwise).
- The throttle for the error path is applied at the public `error()` entry point (not inside `showErrorNotice`) so **tracked-operation error toasts** (via `completeOperation`) and contextual `notifyError()` stay unthrottled — honoring the exemption.
- **Exempt** (unchanged): `startOperation()` + tracked-op toasts (replace-by-id), `confirm()`, and `showActionNotice()`/`infoSticky`.
- Map is cleared in the existing `dispose()`. `Synapse:` prefix/styling behavior unchanged.

## Sites routed through the manager (simple messages)

- `src/main.ts` — intake "coming soon", "open a note first", and data-folder migration success.
- `src/views/unified-proposal-view.ts` — Accept All (`success`) / Reject All (`info`) summaries.
- `src/elaboration/image-analyzer.ts` + `src/image/extractor.ts` — **the poster child**: the per-image "large image auto-downscaled…" notice now routes through the manager, so the 3s dedup collapses the downscale-loop flood into one toast. `NotificationManager` threaded into `ImageAnalyzer` (via `ProposalGenerator`) and `ImageExtractor` (via `ImageModule`).
- `src/transcription/note-media-modal.ts`, `src/transcription/unified-modal.ts` (4 validations), `src/summarize/summarize-modal.ts`, `src/video/settings-section.ts` — manager threaded into the constructors/helpers and validation/error messages routed.

## Intentionally left raw (not touched)

- `src/transcription/unified-modal.ts` `new Notice('', 0)` and `src/transcription/time-range-toast.ts` `new Notice('', 0)` — custom-DOM progress/slider surfaces, not messages.
- `src/shared/fire-and-forget.ts` raw fallback — by-design manager-less path (already routes to the manager when one is supplied).
- The 8 `new Notice(...)` inside `notifications.ts` itself — correct as-is.

No singleton/global accessor introduced — every site uses the manager instance it already reaches via constructor threading.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` (128 files, 1720 tests)
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

New tests in `src/shared/notifications.test.ts` (vitest fake timers) prove: two identical `info()` within 3s → one toast; shows again after >3s; distinct messages/levels both show; `success`/`error` throttle too; a 5-iteration downscale loop yields one toast; `startOperation`/`confirm` unaffected; `dispose()` clears the window.

> Note: the centralized Obsidian mock no-ops Notice DOM (tests assert via `Notice.instances`/`.message`), so **live-Obsidian verification of the actual toast rendering is recommended**.

Co-Authored-By: bot <bot@wafflenet.io>