### PR TITLE
feat: AI-request idempotency — in-flight coalescing + opt-in response cache

### DIFF
--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -394,6 +394,22 @@ export class SynapseSettingTab extends PluginSettingTab {
 				},
 			},
 		);
+
+		new Setting(aiBody)
+			.setName('Cache identical AI responses')
+			.setDesc(
+				'Reuse the previous result for an identical request instead of spending again. ' +
+				'Caching is automatic at temperature 0; turn this on to cache at any temperature. ' +
+				'"Regenerate" actions always bypass the cache.'
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.ai.cacheResponses)
+					.onChange(async (value) => {
+						this.plugin.settings.ai.cacheResponses = value;
+						await this.plugin.saveSettings();
+					})
+			);
 	}
 
 	/**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,6 +43,13 @@ export interface AISettings {
 	model: string;
 	maxTokens: number;
 	temperature: number;
+	/**
+	 * Opt-in response cache (#397). When `true`, an identical AI request reuses
+	 * the previous result instead of spending again. Caching is automatic at
+	 * temperature 0 (deterministic) regardless of this flag; enabling it extends
+	 * caching to any temperature. "Regenerate" actions always bypass the cache.
+	 */
+	cacheResponses: boolean;
 }
 
 export interface DetectionSettings {
@@ -345,6 +352,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		model: 'gpt-4o',
 		maxTokens: 2048,
 		temperature: 0.7,
+		cacheResponses: false,
 	},
 	elaboration: {
 		enabled: true,

--- a/src/shared/ai-client.test.ts
+++ b/src/shared/ai-client.test.ts
@@ -479,3 +479,121 @@ describe('AIClient — shared error handling and routing', () => {
 		expect(mockRequestUrl).not.toHaveBeenCalled();
 	});
 });
+
+describe('AIClient — idempotency: in-flight coalescing and response cache', () => {
+	let settings: SynapseSettings;
+	let client: AIClient;
+
+	const QUESTION: ChatMessage[] = [{ role: 'user', content: 'What is the capital of France?' }];
+
+	beforeEach(() => {
+		settings = makeSettings((s) => {
+			s.ai.provider = 'openai';
+			s.ai.model = 'gpt-4o';
+			s.ai.apiKey = 'sk-test123456789012345';
+			s.ai.maxTokens = 512;
+			// Per-case temperature/cacheResponses are set inside each test so the
+			// caching gate is exercised explicitly.
+			s.ai.temperature = 0;
+			s.ai.cacheResponses = false;
+		});
+		client = new AIClient(() => settings);
+		// Shared vi.fn() — reset so a previous case's queued return can't satisfy
+		// (and mask) a missing call here.
+		mockRequestUrl.mockReset();
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	it('coalesces two concurrent identical requests into a single dispatch', async () => {
+		// Caching OFF (temp > 0, flag off) so this isolates in-flight coalescing.
+		settings.ai.temperature = 0.7;
+		settings.ai.cacheResponses = false;
+		mockRequestUrl.mockResolvedValue(openAIResponse('shared answer'));
+
+		// Do NOT await the first before issuing the second — they must overlap.
+		const p1 = client.chat(QUESTION);
+		const p2 = client.chat(QUESTION);
+		const [r1, r2] = await Promise.all([p1, p2]);
+
+		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		expect(r1).toBe('shared answer');
+		expect(r2).toBe('shared answer');
+	});
+
+	it('serves a second identical request from cache at temperature 0', async () => {
+		settings.ai.temperature = 0;
+		mockRequestUrl.mockResolvedValue(openAIResponse('Paris'));
+
+		const first = await client.chat(QUESTION);
+		const second = await client.chat(QUESTION);
+
+		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		expect(first).toBe('Paris');
+		expect(second).toBe('Paris');
+	});
+
+	it('does not cache when temperature > 0 and cacheResponses is false', async () => {
+		settings.ai.temperature = 0.7;
+		settings.ai.cacheResponses = false;
+		mockRequestUrl.mockResolvedValue(openAIResponse('fresh'));
+
+		await client.chat(QUESTION);
+		await client.chat(QUESTION);
+
+		expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+	});
+
+	it('caches at temperature > 0 once cacheResponses is opted in', async () => {
+		settings.ai.temperature = 0.7;
+		settings.ai.cacheResponses = true;
+		mockRequestUrl.mockResolvedValue(openAIResponse('memoized'));
+
+		const first = await client.chat(QUESTION);
+		const second = await client.chat(QUESTION);
+
+		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+		expect(first).toBe('memoized');
+		expect(second).toBe('memoized');
+	});
+
+	it('never caches a rejected dispatch — a later identical call retries and can succeed', async () => {
+		// Caching ON (temp 0) to prove the rejection specifically is not cached.
+		settings.ai.temperature = 0;
+		mockRequestUrl
+			.mockResolvedValueOnce({
+				status: 500,
+				json: { error: { message: 'upstream boom' } },
+				text: '',
+				headers: {},
+			})
+			.mockResolvedValueOnce(openAIResponse('recovered'));
+
+		await expect(client.chat(QUESTION)).rejects.toThrow(/API error \(500\)/);
+		const second = await client.chat(QUESTION);
+
+		expect(second).toBe('recovered');
+		expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+	});
+
+	it('bypasses the cache on a refresh and updates it with the fresh result', async () => {
+		settings.ai.temperature = 0; // caching ON
+		mockRequestUrl
+			.mockResolvedValueOnce(openAIResponse('v1'))
+			.mockResolvedValue(openAIResponse('v2'));
+
+		// Prime the cache with v1.
+		expect(await client.chat(QUESTION)).toBe('v1');
+		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+
+		// Bypass must dispatch again even though v1 is cached, and refresh the cache.
+		const refreshed = await client.chat(QUESTION, { bypassCache: true });
+		expect(refreshed).toBe('v2');
+		expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+
+		// A subsequent normal call now serves the refreshed v2 from cache.
+		const third = await client.chat(QUESTION);
+		expect(third).toBe('v2');
+		expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/shared/ai-client.ts
+++ b/src/shared/ai-client.ts
@@ -3,6 +3,7 @@ import { SynapseSettings } from '../settings';
 import { ChatMessage, ContentBlock, TextContentBlock } from './types';
 import { redactSecrets } from './redact';
 import { isRecord } from './json-utils';
+import { contentKey } from './hash-utils';
 
 // Re-exported for back-compat: existing callers and tests import `redactSecrets`
 // from this module. The implementation now lives in ./redact (single source of
@@ -11,6 +12,22 @@ export { redactSecrets };
 
 /** Default timeout for AI API requests (2 minutes). */
 const AI_REQUEST_TIMEOUT_MS = 120_000;
+
+/**
+ * Upper bound on the per-instance response cache (#397). Keeps memory bounded
+ * for a long-lived client while comfortably covering a single re-scan pass.
+ */
+const AI_RESPONSE_CACHE_MAX = 50;
+
+/** Optional per-call controls threaded through {@link AIClient.complete}/{@link AIClient.chat}. */
+export interface AIRequestOptions {
+	/**
+	 * Force a fresh dispatch for "regenerate" actions: skip the cache read AND
+	 * the in-flight coalescing map, but still refresh the cache with the new
+	 * result when caching is active.
+	 */
+	bypassCache?: boolean;
+}
 
 async function safeRequest(options: RequestUrlParam): Promise<RequestUrlResponse> {
 	// Race the request against a timeout to prevent indefinite hangs
@@ -270,18 +287,107 @@ function toOllamaMessage(role: string, blocks: ContentBlock[]): Record<string, u
 }
 
 export class AIClient {
+	/**
+	 * In-flight coalescing map (#397): keyed by the deterministic request key,
+	 * holds the live dispatch promise so a concurrent identical request shares
+	 * the single network call instead of issuing a second one. Entries are
+	 * removed in a `.finally()` once settled (success OR failure) so a rejection
+	 * never sticks — mirroring intake's in-flight discipline.
+	 */
+	private readonly inFlight = new Map<string, Promise<string>>();
+
+	/**
+	 * Opt-in response cache (#397): an insertion-ordered (LRU) map of request
+	 * key → successful response, bounded to {@link AI_RESPONSE_CACHE_MAX}.
+	 *
+	 * Scope is intentionally per-instance: it matches the long-lived `AIClient`
+	 * a `ProposalGenerator` owns, so a re-scan within one session hits the cache.
+	 * It does NOT coalesce across separate `new AIClient(...)` instances — a
+	 * shared-static cache is a deliberately deferred option.
+	 */
+	private readonly cache = new Map<string, string>();
+
 	constructor(private getSettings: () => SynapseSettings) {}
 
-	async complete(prompt: string, systemPrompt?: string): Promise<string> {
+	async complete(prompt: string, systemPrompt?: string, opts?: AIRequestOptions): Promise<string> {
 		const messages: ChatMessage[] = [];
 		if (systemPrompt) {
 			messages.push({ role: 'system', content: systemPrompt });
 		}
 		messages.push({ role: 'user', content: prompt });
-		return this.chat(messages);
+		return this.chat(messages, opts);
 	}
 
-	async chat(messages: ChatMessage[]): Promise<string> {
+	/**
+	 * Send a chat request, transparently coalescing concurrent identical calls
+	 * and (when enabled) serving/refreshing a response cache. The raw provider
+	 * dispatch lives in {@link dispatch}; this method is the caching wrapper.
+	 */
+	async chat(messages: ChatMessage[], opts?: AIRequestOptions): Promise<string> {
+		const { ai } = this.getSettings();
+
+		// Deterministic key over the fully-resolved request. `messages` already
+		// embeds the system prompt, so it is covered by the JSON serialization.
+		const key = contentKey([
+			JSON.stringify(messages),
+			ai.provider,
+			ai.model,
+			String(ai.temperature),
+			String(ai.maxTokens),
+		]);
+
+		// Cache participation is opt-in: automatic at temperature 0 (the response
+		// is meant to be deterministic), or whenever the user enables it.
+		const cacheable = ai.temperature === 0 || ai.cacheResponses === true;
+		const bypass = opts?.bypassCache === true;
+
+		// Cache read — skipped on bypass so a "regenerate" always re-dispatches.
+		if (cacheable && !bypass) {
+			const cached = this.cacheGet(key);
+			if (cached !== undefined) {
+				return cached;
+			}
+		}
+
+		// In-flight coalescing — a concurrent identical request joins the live
+		// dispatch. Bypass never joins (it must produce a fresh result).
+		if (!bypass) {
+			const existing = this.inFlight.get(key);
+			if (existing) {
+				return existing;
+			}
+		}
+
+		// Populate the cache only on success, INSIDE the `.then()`, so a rejected
+		// dispatch can never be cached. A bypass still refreshes the cache here.
+		const dispatchPromise = this.dispatch(messages).then((res) => {
+			if (cacheable) {
+				this.cacheSet(key, res);
+			}
+			return res;
+		});
+
+		if (bypass) {
+			return dispatchPromise;
+		}
+
+		// Register for coalescing and clear the entry once settled. The cleanup is
+		// chained onto the RETURNED promise so its possible rejection stays
+		// handled by the caller (no floating/unhandled rejection).
+		this.inFlight.set(key, dispatchPromise);
+		return dispatchPromise.finally(() => {
+			if (this.inFlight.get(key) === dispatchPromise) {
+				this.inFlight.delete(key);
+			}
+		});
+	}
+
+	/**
+	 * Raw provider dispatch — selects the provider and issues the network call.
+	 * Behavior is unchanged from the pre-cache `chat()`; the caching/coalescing
+	 * wrapper lives in {@link chat}.
+	 */
+	private async dispatch(messages: ChatMessage[]): Promise<string> {
 		const { ai } = this.getSettings();
 
 		switch (ai.provider) {
@@ -295,6 +401,38 @@ export class AIClient {
 				return this.callOllama(messages);
 			default:
 				throw new Error(`Unsupported AI provider: ${ai.provider}`);
+		}
+	}
+
+	/**
+	 * LRU read: return the cached value (moving it to most-recently-used) or
+	 * `undefined` when absent. Uses `has` so an empty-string response — a valid
+	 * cached value — is not mistaken for a miss.
+	 */
+	private cacheGet(key: string): string | undefined {
+		if (!this.cache.has(key)) {
+			return undefined;
+		}
+		const val = this.cache.get(key) as string;
+		this.cache.delete(key);
+		this.cache.set(key, val);
+		return val;
+	}
+
+	/**
+	 * LRU write: insert/refresh `key` as most-recently-used and evict the oldest
+	 * entry once the cache exceeds {@link AI_RESPONSE_CACHE_MAX}.
+	 */
+	private cacheSet(key: string, val: string): void {
+		if (this.cache.has(key)) {
+			this.cache.delete(key);
+		}
+		this.cache.set(key, val);
+		if (this.cache.size > AI_RESPONSE_CACHE_MAX) {
+			const oldest = this.cache.keys().next().value;
+			if (oldest !== undefined) {
+				this.cache.delete(oldest);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

`AIClient` dispatched a provider request on every call — two concurrent identical requests both hit the network, and a repeated request repeated the spend. This adds both **in-flight coalescing** and an **opt-in response cache**, keyed by a deterministic `contentKey` over the resolved request (`messages` + `provider`/`model`/`temperature`/`maxTokens`).

closes #397

## What changed

- **Extracted dispatcher** — the `switch (ai.provider)` block moved out of `chat()` into a private `dispatch()`; `chat()` is now the caching/coalescing wrapper (raw provider behavior unchanged).
- **In-flight coalescing** — a `Map<string, Promise<string>>` shares one live dispatch across concurrent identical requests; the entry is cleared in `.finally()` so a rejection never sticks (mirrors intake's discipline).
- **Opt-in response cache** — a bounded (~50-entry) insertion-ordered LRU on the instance. Gate: `cacheable = temperature === 0 || cacheResponses === true`. Writes happen only inside the success `.then()`, so **errors are never cached**.
- **Bypass/refresh** — an optional `{ bypassCache?: boolean }` threads through `complete()` → `chat()`. A bypass skips the cache read and the in-flight map (always a fresh dispatch) but still refreshes the cache when cacheable — for future "regenerate" actions.
- **New setting** — `ai.cacheResponses` (default `false`) on the `AISettings` interface + `DEFAULT_SETTINGS`, surfaced as a toggle in the AI configuration settings section.

The cache is **instance-level** by design: it matches the long-lived `AIClient` a `ProposalGenerator` owns, so a re-scan within a session hits it. It does **not** coalesce across separate `new AIClient(...)` instances; a shared-static cache is a deliberately deferred option (documented in a code comment).

## Stacking

This is a **stacked PR**: its base is `feat/issue-395-proposal-dedup` (#404), **not** `main` — it depends on the `src/shared/hash-utils.ts` `contentKey` primitive added there. Review/merge #404 first.

## Tests (`src/shared/ai-client.test.ts`)

Added a dedicated describe block (shared `requestUrl` mock reset between cases so a cached return can't mask a missing call):

- Coalescing: two concurrent identical `chat()` → `requestUrl` called once; both resolve identically.
- Cache hit at temperature 0: two sequential identical calls → one network call.
- Opt-in at temperature > 0: caching only kicks in with `cacheResponses: true`.
- No cache when off: `temperature > 0` + `cacheResponses: false` → two calls dispatch twice.
- Errors not cached: a rejected first call → a later identical call re-dispatches and can succeed.
- Bypass refreshes: a `bypassCache: true` call dispatches even with a cached value and updates the cache.

## Pre-flight (all green)

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm run lint`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm test` (1736 passed)
- [x] `node scripts/version-bump.mjs --check` (no version change)
- [x] `node esbuild.config.mjs production`

Co-Authored-By: bot <bot@wafflenet.io>