### PR TITLE
fix: pre-check title-proposal path collisions, offer suffix or merge

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -164,7 +164,8 @@ export default class SynapsePlugin extends Plugin {
 				onOrganizeReject: (id) => this.organize.rejectProposal(id),
 				onDeepDiveAccept: (id) => this.deepDive.acceptProposal(id),
 				onDeepDiveReject: (id) => this.deepDive.rejectProposal(id),
-				onTitleAccept: (id) => this.title.acceptProposal(id),
+				onTitleAccept: (id, resolution) =>
+					this.title.acceptProposal(id, resolution ? { resolution } : undefined).then(() => {}),
 				onTitleReject: (id) => this.title.rejectProposal(id),
 				onRemAcceptSelected: (id, texts) => this.rem.acceptProposal(id, texts),
 				onRemReject: (id) => this.rem.rejectProposal(id),

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -31,6 +31,7 @@ import { renderSummarizeSettings } from './summarize';
 import { renderTidySettings } from './tidy';
 import { renderOrganizeSettings } from './organize';
 import { renderDeepDiveSettings } from './deep-dive';
+import { renderTitleSettings } from './title';
 import { renderRemSettings } from './rem';
 import { applyApiKeyEmphasis } from './onboarding';
 import { foldActiveNoteProperties } from './properties-fold';
@@ -110,6 +111,7 @@ const FEATURE_SECTION_RENDERERS: Array<(ctx: SettingsSectionContext) => void> = 
 	renderTidySettings,
 	renderOrganizeSettings,
 	renderDeepDiveSettings,
+	renderTitleSettings,
 	renderRemSettings,
 ];
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,8 @@ import type { ProposalKind } from './views/types';
 // Type-only import of the exclusion model (centralized in shared/exclusions.ts).
 // Erased at compile time; the DEFAULT_SETTINGS values below are plain literals.
 import type { ExclusionRule } from './shared/exclusions';
+// Type-only import. title/types.ts has no imports, so this never forms a cycle.
+import type { TitleDuplicateStrategy } from './title/types';
 
 export type AIProvider = 'openai' | 'anthropic' | 'gemini' | 'ollama';
 
@@ -218,6 +220,12 @@ export interface TitleSettings {
 	enabled: boolean;
 	proposalFolderPath: string;
 	checkAfterOperations: boolean;
+	/**
+	 * How to resolve a proposed title that collides with an existing file in the
+	 * same folder (#408). Drives auto-accept and the settings dropdown; the
+	 * proposal card always offers both choices regardless of this default.
+	 */
+	duplicateHandling: TitleDuplicateStrategy;
 }
 
 export interface IntakeSettings {
@@ -475,6 +483,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		enabled: true,
 		proposalFolderPath: '.synapse/title-proposals',
 		checkAfterOperations: true,
+		duplicateHandling: 'iterate',
 	},
 	rem: {
 		enabled: true,

--- a/src/shared/file-utils.test.ts
+++ b/src/shared/file-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getIncludedMarkdownFiles } from './file-utils';
+import { getIncludedMarkdownFiles, findAvailableVaultPath } from './file-utils';
 import { TFile } from '../__mocks__/obsidian';
 import type { ExclusionRule } from './exclusions';
 
@@ -65,5 +65,50 @@ describe('getIncludedMarkdownFiles', () => {
 			'Notes'
 		);
 		expect(result).toEqual([inFolder]);
+	});
+});
+
+/** App stub whose vault reports a fixed set of taken paths. */
+function appWithPaths(taken: string[]) {
+	const set = new Set(taken);
+	return {
+		vault: {
+			getAbstractFileByPath: vi.fn((path: string) =>
+				set.has(path) ? new TFile(path) : null
+			),
+		},
+	} as any;
+}
+
+describe('findAvailableVaultPath', () => {
+	it('returns the desired path unchanged when it is free', () => {
+		const app = appWithPaths([]);
+		expect(findAvailableVaultPath(app, 'Notes/Idea.md')).toBe('Notes/Idea.md');
+	});
+
+	it('appends -1 before the extension on a single collision', () => {
+		const app = appWithPaths(['Notes/Idea.md']);
+		expect(findAvailableVaultPath(app, 'Notes/Idea.md')).toBe('Notes/Idea-1.md');
+	});
+
+	it('skips to -2 when both the base and -1 are taken', () => {
+		const app = appWithPaths(['Notes/Idea.md', 'Notes/Idea-1.md']);
+		expect(findAvailableVaultPath(app, 'Notes/Idea.md')).toBe('Notes/Idea-2.md');
+	});
+
+	it('suffixes the whole name when the path has no extension', () => {
+		const app = appWithPaths(['Notes/Idea']);
+		expect(findAvailableVaultPath(app, 'Notes/Idea')).toBe('Notes/Idea-1');
+	});
+
+	it('treats a dot in a folder name (not the basename) as part of the path, not an extension', () => {
+		// `my.notes/file` has no real extension: the last dot is in the folder.
+		const app = appWithPaths(['my.notes/file']);
+		expect(findAvailableVaultPath(app, 'my.notes/file')).toBe('my.notes/file-1');
+	});
+
+	it('suffixes before the extension even when the folder also contains a dot', () => {
+		const app = appWithPaths(['my.notes/file.md']);
+		expect(findAvailableVaultPath(app, 'my.notes/file.md')).toBe('my.notes/file-1.md');
 	});
 });

--- a/src/shared/file-utils.ts
+++ b/src/shared/file-utils.ts
@@ -73,3 +73,38 @@ export function getIncludedMarkdownFiles(
 export function wordCount(text: string): number {
 	return text.split(/\s+/).filter(w => w.length > 0).length;
 }
+
+/**
+ * Resolve a vault path that does not collide with an existing file.
+ *
+ * Mirrors Obsidian's de-duplication: if `desiredPath` is free it is returned
+ * as-is; otherwise append `-1`, `-2`, … before the extension until an unused
+ * path is found. The dot is only treated as an extension separator when it sits
+ * in the basename (`dotIndex > slashIndex`), so a dotted folder name like
+ * `my.notes/file` (no extension) suffixes as `my.notes/file-1`, not
+ * `my-1.notes/file`.
+ *
+ * Shared by VideoModule (same-day `<date>-<title>.mp4` re-downloads) and the
+ * title module's "Add suffix" duplicate resolution (#408).
+ */
+export function findAvailableVaultPath(app: App, desiredPath: string): string {
+	const vault = app.vault;
+	if (!vault.getAbstractFileByPath(desiredPath)) {
+		return desiredPath;
+	}
+
+	const slashIndex = desiredPath.lastIndexOf('/');
+	const dotIndex = desiredPath.lastIndexOf('.');
+	// Only treat a dot as an extension separator if it sits in the basename.
+	const hasExt = dotIndex > slashIndex;
+	const stem = hasExt ? desiredPath.slice(0, dotIndex) : desiredPath;
+	const ext = hasExt ? desiredPath.slice(dotIndex) : '';
+
+	let counter = 1;
+	let candidate = `${stem}-${counter}${ext}`;
+	while (vault.getAbstractFileByPath(candidate)) {
+		counter++;
+		candidate = `${stem}-${counter}${ext}`;
+	}
+	return candidate;
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -14,6 +14,7 @@ export {
 	getMarkdownFiles,
 	getIncludedMarkdownFiles,
 	wordCount,
+	findAvailableVaultPath,
 } from './file-utils';
 export { arrayBufferToBase64, base64EncodedLength } from './encoding';
 export { redactSecrets } from './redact';

--- a/src/title/content-key.test.ts
+++ b/src/title/content-key.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { titleContentKey } from './content-key';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+function settings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
+	const s = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(s);
+	return s;
+}
+
+const PATH = 'Inbox/Untitled.md';
+const CONTENT = '# Neural networks\n\nA primer on backprop.';
+
+describe('titleContentKey', () => {
+	it('is deterministic for identical inputs', () => {
+		const a = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+		const b = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+		expect(a).toBe(b);
+	});
+
+	it('changes when the note content changes', () => {
+		const a = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+		const b = titleContentKey(PATH, CONTENT + ' edit', 'Untitled', 'untitled', settings());
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when the current title changes', () => {
+		const a = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+		const b = titleContentKey(PATH, CONTENT, 'Untitled 1', 'untitled', settings());
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when the trigger changes', () => {
+		const a = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+		const b = titleContentKey(PATH, CONTENT, 'Untitled', 'content-mismatch', settings());
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when the note path changes', () => {
+		const a = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+		const b = titleContentKey('Other/Untitled.md', CONTENT, 'Untitled', 'untitled', settings());
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when AI provider/model/temperature/maxTokens change', () => {
+		const base = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings());
+
+		const provider = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings((s) => { s.ai.provider = 'gemini'; }));
+		const model = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings((s) => { s.ai.model = 'different-model'; }));
+		const temp = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings((s) => { s.ai.temperature = s.ai.temperature + 0.3; }));
+		const tokens = titleContentKey(PATH, CONTENT, 'Untitled', 'untitled', settings((s) => { s.ai.maxTokens = s.ai.maxTokens + 100; }));
+
+		expect(new Set([base, provider, model, temp, tokens]).size).toBe(5);
+	});
+});

--- a/src/title/content-key.ts
+++ b/src/title/content-key.ts
@@ -1,0 +1,37 @@
+import { normalizePath } from 'obsidian';
+import { contentKey, hashString } from '../shared';
+import { SynapseSettings } from '../settings';
+import { TitleProposalTrigger } from './types';
+
+/**
+ * Compute the deterministic content key for a title proposal from its inputs
+ * (#408). Mirrors `proposalContentKey` in elaboration/proposer.ts.
+ *
+ * Keying on the *inputs* (note path + content hash + current title + trigger +
+ * the AI settings that shape the request) rather than the model's *output* is
+ * what makes re-scanning an unchanged note idempotent: temperature > 0 sampling
+ * would otherwise yield a different proposed title — and thus a different key —
+ * every run, defeating the reject-loop guard.
+ *
+ * The key lets the proposal-time dedup guard skip re-proposing the SAME title
+ * for UNCHANGED content after a reject. Editing the note changes the content
+ * hash, which changes the key, so a fresh proposal is still allowed.
+ */
+export function titleContentKey(
+	notePath: string,
+	content: string,
+	currentTitle: string,
+	trigger: TitleProposalTrigger,
+	settings: SynapseSettings,
+): string {
+	return contentKey([
+		normalizePath(notePath),
+		hashString(content),
+		currentTitle,
+		trigger,
+		settings.ai.provider,
+		settings.ai.model,
+		String(settings.ai.temperature),
+		String(settings.ai.maxTokens),
+	]);
+}

--- a/src/title/duplicate-handling.test.ts
+++ b/src/title/duplicate-handling.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TitleModule } from './index';
+import { DEFAULT_SETTINGS } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile, TFolder, Notice } from '../__mocks__/obsidian';
+
+// Deterministic suggester output, mutated per test via hoisted state. `calls`
+// counts suggestTitle invocations — the dedup guard returns BEFORE the suggester
+// runs, so this is a robust signal for "a new proposal was (not) generated".
+const mockSuggester = vi.hoisted(() => ({
+	title: 'Neural Networks',
+	reasoning: 'Content is about neural networks',
+	calls: 0,
+}));
+
+vi.mock('./title-suggester', () => ({
+	TitleSuggester: class MockTitleSuggester {
+		constructor(_client: unknown) {}
+		suggestTitle = vi.fn(async () => {
+			mockSuggester.calls++;
+			return { title: mockSuggester.title, reasoning: mockSuggester.reasoning };
+		});
+		checkTitleMismatch = vi.fn(async () => ({ isMismatch: false }));
+	},
+}));
+
+/** In-memory adapter so TitleProposalStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		_files: files,
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => { files.set(path, content); }),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => { files.delete(path); }),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+/** A TFile whose `parent` folder path is derived from the path. */
+function makeFile(path: string): TFile {
+	const file = new TFile(path);
+	const slash = path.lastIndexOf('/');
+	if (slash >= 0) file.parent = new TFolder(path.slice(0, slash));
+	return file;
+}
+
+/**
+ * Build a TitleModule over an in-memory vault. `notes` seeds path → content;
+ * each becomes a TFile so `getAbstractFileByPath` returns it and `read`/`process`
+ * operate on its content.
+ */
+function harness(notes: Record<string, string>, opts?: { autoAccept?: boolean }) {
+	const adapter = createMemoryAdapter();
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	if (opts?.autoAccept) settings.autoAccept.title = true;
+	const notifications = new NotificationManager();
+
+	const files = new Map<string, TFile | TFolder>();
+	const contents = new Map<string, string>();
+	for (const [path, content] of Object.entries(notes)) {
+		files.set(path, makeFile(path));
+		contents.set(path, content);
+	}
+
+	const addNote = (path: string, content: string) => {
+		files.set(path, makeFile(path));
+		contents.set(path, content);
+	};
+	const removeNote = (path: string) => {
+		files.delete(path);
+		contents.delete(path);
+	};
+	const addFolder = (path: string) => { files.set(path, new TFolder(path)); };
+
+	const renameSpy = vi.fn(async (file: TFile, newPath: string) => {
+		contents.set(newPath, contents.get(file.path) ?? '');
+		contents.delete(file.path);
+		files.delete(file.path);
+		files.set(newPath, makeFile(newPath));
+	});
+	const processSpy = vi.fn(async (file: TFile, fn: (c: string) => string) => {
+		const next = fn(contents.get(file.path) ?? '');
+		contents.set(file.path, next);
+		return next;
+	});
+	const trashSpy = vi.fn(async (file: TFile) => {
+		files.delete(file.path);
+		contents.delete(file.path);
+	});
+
+	const mockPlugin = {
+		app: {
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) => files.get(path) ?? null),
+				read: vi.fn(async (file: TFile) => contents.get(file.path) ?? ''),
+				rename: renameSpy,
+				process: processSpy,
+				createFolder: vi.fn().mockResolvedValue(undefined),
+				adapter,
+			},
+			fileManager: { trashFile: trashSpy },
+			metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		},
+	};
+
+	const mod = new TitleModule(
+		mockPlugin as never,
+		() => settings,
+		notifications,
+		() => settings.autoAccept.title,
+	);
+
+	return { mod, settings, adapter, files, contents, addNote, removeNote, addFolder, renameSpy, processSpy, trashSpy };
+}
+
+const SOURCE = 'Inbox/Untitled.md';
+const TARGET = 'Inbox/Neural Networks.md';
+const BODY = '# Notes\n\nDetailed content about neural networks and training.';
+
+async function firstPending(mod: TitleModule) {
+	const pending = await mod.getPendingProposals();
+	return pending[0];
+}
+
+describe('TitleModule duplicate handling (#408)', () => {
+	beforeEach(() => {
+		Notice.instances.length = 0;
+		mockSuggester.title = 'Neural Networks';
+		mockSuggester.reasoning = 'Content is about neural networks';
+		mockSuggester.calls = 0;
+	});
+	afterEach(() => { vi.restoreAllMocks(); });
+
+	it('flags a collision at proposal time via conflictsWith', async () => {
+		const h = harness({ [SOURCE]: BODY, [TARGET]: 'existing' });
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+
+		const p = await firstPending(h.mod);
+		expect(p.conflictsWith).toBe(TARGET);
+		expect(p.contentKey).toBeTruthy();
+		expect(h.renameSpy).not.toHaveBeenCalled(); // auto-accept off → stays pending
+	});
+
+	it('resolves a collision with "iterate" by renaming to a suffixed path', async () => {
+		const h = harness({ [SOURCE]: BODY, [TARGET]: 'existing' });
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		await h.mod.acceptProposal(p.id, { resolution: 'iterate' });
+
+		expect(h.renameSpy).toHaveBeenCalledTimes(1);
+		expect(h.renameSpy.mock.calls[0][1]).toBe('Inbox/Neural Networks-1.md');
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('resolves a collision with "merge": unions frontmatter, joins bodies with a rule, trashes the source', async () => {
+		const sourceContent = `---\ntags: [src]\naliases: [oldname]\nfoo: sourceval\n---\nSource body`;
+		const targetContent = `---\ntags: [tgt]\ntitle: Keep\n---\nTarget body`;
+		const h = harness({ [SOURCE]: sourceContent, [TARGET]: targetContent });
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		await h.mod.acceptProposal(p.id, { resolution: 'merge' });
+
+		expect(h.processSpy).toHaveBeenCalledTimes(1);
+		const written = h.contents.get(TARGET)!;
+		// Bodies joined target-first by a horizontal rule.
+		expect(written).toContain('Target body\n\n---\n\nSource body');
+		// Frontmatter union: target wins on scalars; tags + aliases unioned.
+		expect(written).toContain('- tgt');
+		expect(written).toContain('- src');
+		expect(written).toContain('- oldname');
+		expect(written).toContain('foo: sourceval');
+		expect(written).toContain('title: Keep');
+		// Source trashed (recoverable), not renamed.
+		expect(h.trashSpy).toHaveBeenCalledTimes(1);
+		expect(h.trashSpy.mock.calls[0][0].path).toBe(SOURCE);
+		expect(h.files.has(SOURCE)).toBe(false);
+		expect(h.renameSpy).not.toHaveBeenCalled();
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('auto-accept honors the "iterate" strategy and announces the suffixed name', async () => {
+		const h = harness({ [SOURCE]: BODY, [TARGET]: 'existing' }, { autoAccept: true });
+		h.settings.title.duplicateHandling = 'iterate';
+		await h.mod.onload();
+
+		await h.mod.checkUntitled(SOURCE);
+
+		expect(h.renameSpy).toHaveBeenCalledTimes(1);
+		expect(h.renameSpy.mock.calls[0][1]).toBe('Inbox/Neural Networks-1.md');
+		expect(Notice.instances.some(n => n.message === 'Synapse: Auto-accepted title "Neural Networks-1"')).toBe(true);
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('auto-accept honors the "merge" strategy and announces the merge target', async () => {
+		const h = harness({ [SOURCE]: `Source body`, [TARGET]: `Target body` }, { autoAccept: true });
+		h.settings.title.duplicateHandling = 'merge';
+		await h.mod.onload();
+
+		await h.mod.checkUntitled(SOURCE);
+
+		expect(h.processSpy).toHaveBeenCalledTimes(1);
+		expect(h.trashSpy).toHaveBeenCalledTimes(1);
+		expect(h.contents.get(TARGET)).toContain('Target body\n\n---\n\nSource body');
+		expect(Notice.instances.some(n => n.message === 'Synapse: Auto-merged into "Neural Networks"')).toBe(true);
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('accept-time recheck: a collision that appeared after the proposal surfaces a choice and does NOT overwrite', async () => {
+		const h = harness({ [SOURCE]: BODY }); // no target yet → no conflict at proposal time
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+		expect(p.conflictsWith).toBeUndefined();
+
+		// Collision appears, then a plain Accept (no resolution).
+		h.addNote(TARGET, 'existing');
+		await h.mod.acceptProposal(p.id);
+
+		expect(h.renameSpy).not.toHaveBeenCalled();
+		expect(h.contents.get(TARGET)).toBe('existing'); // never overwritten
+		const still = await firstPending(h.mod);
+		expect(still.status).toBe('pending');
+		expect(still.conflictsWith).toBe(TARGET); // hint persisted for the card
+		expect(Notice.instances.some(n => n.message?.includes('already exists'))).toBe(true);
+	});
+
+	it('accept-time recheck: a stale conflictsWith is ignored when the collision disappeared, renaming cleanly', async () => {
+		const h = harness({ [SOURCE]: BODY, [TARGET]: 'existing' });
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+		expect(p.conflictsWith).toBe(TARGET);
+
+		// Target removed before accept; a plain Accept should rename cleanly.
+		h.removeNote(TARGET);
+		await h.mod.acceptProposal(p.id);
+
+		expect(h.renameSpy).toHaveBeenCalledTimes(1);
+		expect(h.renameSpy.mock.calls[0][1]).toBe(TARGET); // clean path, no spurious suffix
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('does not re-propose a rejected colliding title for unchanged content, but does after a content edit', async () => {
+		const h = harness({ [SOURCE]: BODY, [TARGET]: 'existing' });
+		await h.mod.onload();
+
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+		expect(mockSuggester.calls).toBe(1);
+		await h.mod.rejectProposal(p.id);
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+
+		// Re-scan with UNCHANGED content → contentKey guard suppresses a new
+		// proposal: the suggester is never reached, so no regeneration occurs.
+		await h.mod.checkUntitled(SOURCE);
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+		expect(mockSuggester.calls).toBe(1);
+
+		// Edit the note → key changes → a new proposal is allowed.
+		h.addNote(SOURCE, BODY + '\n\nNew paragraph.');
+		await h.mod.checkUntitled(SOURCE);
+		expect(await h.mod.getPendingProposals()).toHaveLength(1);
+		expect(mockSuggester.calls).toBe(2);
+	});
+
+	it('merge falls back to a plain rename when the target is not a note (e.g. a folder)', async () => {
+		const h = harness({ [SOURCE]: BODY });
+		h.addFolder(TARGET); // a folder occupies the target path
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+		expect(p.conflictsWith).toBe(TARGET);
+
+		await h.mod.acceptProposal(p.id, { resolution: 'merge' });
+
+		expect(h.processSpy).not.toHaveBeenCalled();
+		expect(h.trashSpy).not.toHaveBeenCalled();
+		expect(h.renameSpy).toHaveBeenCalledTimes(1);
+		expect(h.renameSpy.mock.calls[0][1]).toBe(TARGET);
+		expect(Notice.instances.some(n => n.message?.includes('Nothing to merge into'))).toBe(true);
+	});
+});

--- a/src/title/index.ts
+++ b/src/title/index.ts
@@ -1,13 +1,30 @@
 import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
-import { AIClient, NotificationManager, generateId, readNote, isPathExcluded, reviewAction } from '../shared';
+import {
+	AIClient, NotificationManager, generateId, readNote, isPathExcluded, reviewAction,
+	findAvailableVaultPath, parseFrontmatter, serializeFrontmatter, mergeTags, normalizeFrontmatterTags,
+} from '../shared';
 import { TitleProposalStore } from './title-store';
 import { TitleSuggester } from './title-suggester';
 import { isUntitled } from './title-detector';
-import { TitleProposal } from './types';
+import { titleContentKey } from './content-key';
+import { TitleProposal, TitleDuplicateStrategy } from './types';
 
-export type { TitleProposal, TitleProposalTrigger, TitleProposalStatus } from './types';
+export type { TitleProposal, TitleProposalTrigger, TitleProposalStatus, TitleDuplicateStrategy } from './types';
 export { isUntitled } from './title-detector';
+
+/**
+ * What {@link TitleModule.acceptProposal} did, so auto-accept can announce the
+ * REAL outcome — the suffixed name for `iterate`, or "merged into …" for
+ * `merge` — instead of always echoing the originally proposed title (#408).
+ * `conflict` means a plain accept hit a live collision and surfaced the choice
+ * without changing anything; `skipped` means nothing was eligible.
+ */
+export type TitleAcceptOutcome =
+	| { status: 'renamed'; path: string }
+	| { status: 'merged'; into: string }
+	| { status: 'conflict'; target: string }
+	| { status: 'skipped' };
 
 export class TitleModule {
 	private store: TitleProposalStore;
@@ -50,10 +67,16 @@ export class TitleModule {
 	 */
 	private async maybeAutoAccept(proposal: TitleProposal): Promise<boolean> {
 		if (!this.shouldAutoAccept()) return false;
-		await this.acceptProposal(proposal.id, { silent: true });
-		this.notifications.info(
-			`Auto-accepted title "${proposal.proposedTitle}"`
-		);
+		// acceptProposal derives the resolution from the duplicateHandling setting
+		// on a live collision, so a colliding title is resolved automatically. The
+		// notice reflects the ACTUAL outcome (suffixed name / merge target), not
+		// the originally proposed title (#408).
+		const outcome = await this.acceptProposal(proposal.id, { silent: true });
+		if (outcome.status === 'renamed') {
+			this.notifications.info(`Auto-accepted title "${this.baseName(outcome.path)}"`);
+		} else if (outcome.status === 'merged') {
+			this.notifications.info(`Auto-merged into "${this.baseName(outcome.into)}"`);
+		}
 		return true;
 	}
 
@@ -85,12 +108,18 @@ export class TitleModule {
 
 		if (!isUntitled(file.basename)) return;
 
-		// Skip if there's already a pending title proposal for this note
-		const existing = await this.store.loadForNote(filePath);
-		if (existing.some(p => p.status === 'pending')) return;
-
+		// Read content BEFORE the guards: the dedup key is computed from it (#408).
 		const content = await readNote(this.plugin.app, filePath);
 		if (!content || content.trim().length === 0) return;
+
+		const key = titleContentKey(filePath, content, file.basename, 'untitled', this.getSettings());
+		const existing = await this.store.loadForNote(filePath);
+		// Skip if there's already a pending title proposal for this note.
+		if (existing.some(p => p.status === 'pending')) return;
+		// Dedup (#408): don't re-propose the SAME title for UNCHANGED content after
+		// a reject. The key is over inputs, so a content edit changes it and a new
+		// proposal is allowed; an 'accepted' proposal never blocks (the file moved).
+		if (existing.some(p => p.contentKey === key && p.status !== 'accepted')) return;
 
 		try {
 			const { title, reasoning } = await this.suggester.suggestTitle(content, file.basename);
@@ -105,7 +134,16 @@ export class TitleModule {
 				reasoning,
 				createdAt: new Date().toISOString(),
 				status: 'pending',
+				contentKey: key,
 			};
+
+			// Flag a same-folder name collision at proposal time as a UI hint; it is
+			// always re-validated live at accept time (#408).
+			const targetPath = this.computeTargetPath(file, title);
+			const existingAtTarget = this.plugin.app.vault.getAbstractFileByPath(targetPath);
+			if (existingAtTarget && existingAtTarget.path !== file.path) {
+				proposal.conflictsWith = targetPath;
+			}
 
 			await this.store.save(proposal);
 			// maybeAutoAccept applies + announces the rename when auto-accept is on.
@@ -145,12 +183,17 @@ export class TitleModule {
 		// Don't check mismatch if the note is already untitled (handled by checkUntitled)
 		if (isUntitled(file.basename)) return;
 
-		// Skip if there's already a pending title proposal for this note
-		const existing = await this.store.loadForNote(filePath);
-		if (existing.some(p => p.status === 'pending')) return;
-
+		// Read content BEFORE the guards: the dedup key is computed from it (#408).
 		const content = await readNote(this.plugin.app, filePath);
 		if (!content || content.trim().length === 0) return;
+
+		const key = titleContentKey(filePath, content, file.basename, 'content-mismatch', this.getSettings());
+		const existing = await this.store.loadForNote(filePath);
+		// Skip if there's already a pending title proposal for this note.
+		if (existing.some(p => p.status === 'pending')) return;
+		// Dedup (#408): a rejected colliding title is not re-proposed for unchanged
+		// content; editing the note changes the key and re-enables proposals.
+		if (existing.some(p => p.contentKey === key && p.status !== 'accepted')) return;
 
 		try {
 			const result = await this.suggester.checkTitleMismatch(content, file.basename);
@@ -165,7 +208,16 @@ export class TitleModule {
 				reasoning: result.reasoning || 'Title does not reflect current content',
 				createdAt: new Date().toISOString(),
 				status: 'pending',
+				contentKey: key,
 			};
+
+			// Flag a same-folder name collision at proposal time as a UI hint; it is
+			// always re-validated live at accept time (#408).
+			const targetPath = this.computeTargetPath(file, result.suggestedTitle);
+			const existingAtTarget = this.plugin.app.vault.getAbstractFileByPath(targetPath);
+			if (existingAtTarget && existingAtTarget.path !== file.path) {
+				proposal.conflictsWith = targetPath;
+			}
 
 			await this.store.save(proposal);
 			// maybeAutoAccept applies + announces the rename when auto-accept is on.
@@ -214,51 +266,148 @@ export class TitleModule {
 	}
 
 	/**
-	 * Accept a title proposal: rename the file via vault.rename().
-	 *
-	 * `options.silent` suppresses the success Notice and view refresh; used by
-	 * auto-accept, which emits its own distinct Notice. Error and conflict
-	 * Notices still fire.
+	 * The vault path a proposal would rename its note to: `<parent>/<title>.md`.
+	 * Shared by proposal-time collision flagging and accept-time re-validation so
+	 * both compute the target identically (#408).
 	 */
-	async acceptProposal(id: string, options?: { silent?: boolean }): Promise<void> {
+	private computeTargetPath(file: TFile, proposedTitle: string): string {
+		const parentPath = file.parent?.path || '';
+		const fileName = `${proposedTitle}.md`;
+		return parentPath
+			? normalizePath(`${parentPath}/${fileName}`)
+			: normalizePath(fileName);
+	}
+
+	/** Basename without the `.md` extension, for user-facing notices. */
+	private baseName(path: string): string {
+		return path.split('/').pop()?.replace(/\.md$/, '') ?? path;
+	}
+
+	/** Emit the success notice + refresh, unless the caller is silent (auto-accept). */
+	private async announceAccept(silent: boolean | undefined, message: string): Promise<void> {
+		if (silent) return;
+		this.notifications.success(message);
+		await this.refreshView();
+	}
+
+	/**
+	 * Accept a title proposal, re-validating any name collision LIVE (a stale
+	 * `conflictsWith` is ignored) (#408).
+	 *
+	 * - No collision → plain rename to the proposed path (happy path).
+	 * - Collision + no resolution (a plain manual Accept) → NEVER overwrite:
+	 *   persist the conflict hint and surface "Add suffix or Merge", leaving the
+	 *   proposal pending.
+	 * - Collision + `iterate` → rename to the next free `-1`/`-2` path.
+	 * - Collision + `merge` → fold this note into the existing one and trash it.
+	 *
+	 * Auto-accept passes `silent: true` and lets the resolution default to
+	 * `settings.title.duplicateHandling`. Returns a {@link TitleAcceptOutcome} so
+	 * auto-accept can announce the real result.
+	 */
+	async acceptProposal(
+		id: string,
+		options?: { silent?: boolean; resolution?: TitleDuplicateStrategy }
+	): Promise<TitleAcceptOutcome> {
 		const proposal = await this.store.load(id);
-		if (!proposal) return;
+		if (!proposal) return { status: 'skipped' };
 		// Guard against double-acceptance (cascade safety): never rename twice.
-		if (proposal.status !== 'pending') return;
+		if (proposal.status !== 'pending') return { status: 'skipped' };
 
 		const file = this.plugin.app.vault.getAbstractFileByPath(proposal.sourceNotePath);
 		if (!(file instanceof TFile)) {
 			this.notifications.info('Source note no longer exists');
 			await this.store.updateStatus(id, 'rejected');
 			await this.refreshView();
-			return;
+			return { status: 'skipped' };
 		}
 
-		const parentPath = file.parent?.path || '';
-		const newFileName = `${proposal.proposedTitle}.md`;
-		const newPath = parentPath
-			? normalizePath(`${parentPath}/${newFileName}`)
-			: normalizePath(newFileName);
-
-		// Check if a file already exists at the target path
-		const existingFile = this.plugin.app.vault.getAbstractFileByPath(newPath);
-		if (existingFile) {
-			this.notifications.info(`Cannot rename -- a file already exists at ${newPath}`);
-			return;
-		}
+		const targetPath = this.computeTargetPath(file, proposal.proposedTitle);
+		const existing = this.plugin.app.vault.getAbstractFileByPath(targetPath);
+		const collision = !!existing && existing.path !== file.path;
 
 		try {
-			await this.plugin.app.vault.rename(file, newPath);
-			await this.store.updateStatus(id, 'accepted');
-			if (!options?.silent) {
-				this.notifications.success(`Renamed to "${proposal.proposedTitle}"`);
-				await this.refreshView();
+			if (!collision) {
+				// Happy path: target is free (or the collision vanished since the
+				// proposal was created) — plain rename, no suffix.
+				await this.plugin.app.vault.rename(file, targetPath);
+				await this.store.updateStatus(id, 'accepted');
+				await this.announceAccept(options?.silent, `Renamed to "${this.baseName(targetPath)}"`);
+				return { status: 'renamed', path: targetPath };
 			}
+
+			// Live collision. Manual plain Accept supplies no resolution and must
+			// never overwrite; auto-accept derives one from the setting.
+			const resolution = options?.resolution
+				?? (this.shouldAutoAccept() ? this.getSettings().title.duplicateHandling : undefined);
+
+			if (!resolution) {
+				// Surface the choice; leave the proposal pending. Persist the live
+				// target as the UI hint so the card shows the suffix/merge buttons.
+				proposal.conflictsWith = targetPath;
+				await this.store.save(proposal);
+				this.notifications.info(
+					`"${proposal.proposedTitle}" already exists — choose Add suffix or Merge`
+				);
+				await this.refreshView();
+				return { status: 'conflict', target: targetPath };
+			}
+
+			if (resolution === 'merge') {
+				if (existing instanceof TFile) {
+					await this.mergeNotes(file, existing);
+					await this.store.updateStatus(id, 'accepted');
+					await this.announceAccept(options?.silent, `Merged into "${this.baseName(existing.path)}"`);
+					return { status: 'merged', into: existing.path };
+				}
+				// Nothing mergeable at the target (e.g. a folder) — fall back to a
+				// plain rename so the accept still resolves, with a heads-up.
+				this.notifications.info('Nothing to merge into — renamed instead');
+				await this.plugin.app.vault.rename(file, targetPath);
+				await this.store.updateStatus(id, 'accepted');
+				if (!options?.silent) await this.refreshView();
+				return { status: 'renamed', path: targetPath };
+			}
+
+			// resolution === 'iterate': suffix before the extension so the existing
+			// note is never clobbered.
+			const freePath = findAvailableVaultPath(this.plugin.app, targetPath);
+			await this.plugin.app.vault.rename(file, freePath);
+			await this.store.updateStatus(id, 'accepted');
+			await this.announceAccept(options?.silent, `Renamed to "${this.baseName(freePath)}"`);
+			return { status: 'renamed', path: freePath };
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			this.notifications.notifyError('Failed to rename note', error);
 			throw new Error(`Rename failed: ${msg}`);
 		}
+	}
+
+	/**
+	 * Merge `source` into `target` (#408): full frontmatter union (target wins on
+	 * scalar conflicts; tags/aliases unioned), bodies joined by a horizontal rule
+	 * (`target` first), then trash the source (recoverable). The target is
+	 * rewritten atomically via `vault.process`.
+	 */
+	private async mergeNotes(source: TFile, target: TFile): Promise<void> {
+		const sourceContent = await this.plugin.app.vault.read(source);
+		await this.plugin.app.vault.process(target, (current) => {
+			const t = parseFrontmatter(current);
+			const s = parseFrontmatter(sourceContent);
+			// Target wins on scalar conflicts.
+			const merged: Record<string, unknown> = { ...s.frontmatter, ...t.frontmatter };
+			// Union tags (mergeTags reads merged.tags, then adds the source's).
+			mergeTags(merged, normalizeFrontmatterTags(s.frontmatter.tags));
+			// Union aliases, target order first; only set when non-empty.
+			const aliases = [...new Set([
+				...normalizeFrontmatterTags(t.frontmatter.aliases),
+				...normalizeFrontmatterTags(s.frontmatter.aliases),
+			])];
+			if (aliases.length > 0) merged.aliases = aliases;
+			const body = `${t.body.trimEnd()}\n\n---\n\n${s.body.trim()}\n`;
+			return serializeFrontmatter(merged, body);
+		});
+		await this.plugin.app.fileManager.trashFile(source);
 	}
 
 	async rejectProposal(id: string): Promise<void> {
@@ -271,3 +420,6 @@ export class TitleModule {
 		await this.onViewRefreshNeeded?.();
 	}
 }
+
+// Settings section renderer (#408)
+export { renderTitleSettings } from './settings-section';

--- a/src/title/settings-section.test.ts
+++ b/src/title/settings-section.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createEl, ToggleComponent } from '../__mocks__/obsidian';
+import { createSettingsSectionContext } from '../shared';
+import { renderTitleSettings } from './settings-section';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+const FEATURE_TOOLTIP =
+	'Propose better titles for untitled notes and notes whose title no longer matches their content';
+
+function makeCtx(mutate?: (s: SynapseSettings) => void) {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	mutate?.(settings);
+	const saveSettings = vi.fn().mockResolvedValue(undefined);
+	const plugin = { settings, saveSettings, manifest: { version: '0.0.0-test' } };
+	const containerEl = createEl();
+	const ctx = createSettingsSectionContext({
+		containerEl,
+		plugin: plugin as never,
+		onFeatureToggle: vi.fn(),
+		rerender: vi.fn(),
+	});
+	return { ctx, plugin, containerEl, saveSettings };
+}
+
+describe('renderTitleSettings', () => {
+	beforeEach(() => { ToggleComponent.instances.length = 0; });
+
+	it('renders an accordion with the header toggle reflecting enabled state', () => {
+		const { ctx, containerEl } = makeCtx((s) => { s.title.enabled = true; });
+		renderTitleSettings(ctx);
+		expect(containerEl.children.length).toBeGreaterThan(0);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP);
+		expect(headerToggle).toBeDefined();
+		expect(headerToggle!.getValue()).toBe(true);
+	});
+
+	it('writes the enabled flag and saves when the header toggle changes', async () => {
+		const { ctx, plugin, saveSettings } = makeCtx((s) => { s.title.enabled = true; });
+		renderTitleSettings(ctx);
+		const headerToggle = ToggleComponent.instances.find((t) => t.tooltip === FEATURE_TOOLTIP)!;
+		await headerToggle._trigger(false);
+		expect(plugin.settings.title.enabled).toBe(false);
+		expect(saveSettings).toHaveBeenCalled();
+	});
+
+	it('defaults duplicateHandling to "iterate"', () => {
+		expect(DEFAULT_SETTINGS.title.duplicateHandling).toBe('iterate');
+	});
+});

--- a/src/title/settings-section.ts
+++ b/src/title/settings-section.ts
@@ -1,0 +1,39 @@
+import { Setting } from 'obsidian';
+import type { SettingsSectionContext } from '../shared';
+import { TitleDuplicateStrategy } from './types';
+
+/**
+ * Render the Title settings accordion (#408).
+ *
+ * The feature header toggle binds `settings.title.enabled` (like every other
+ * section). The "Duplicate handling" dropdown sets the DEFAULT resolution used
+ * by auto-accept when a proposed title collides with an existing note; the
+ * proposal card always offers both choices regardless of this default.
+ */
+export function renderTitleSettings(ctx: SettingsSectionContext): void {
+	const { plugin } = ctx;
+
+	const titleBody = ctx.featureSection(
+		'title',
+		'Title',
+		() => plugin.settings.title.enabled,
+		(v) => { plugin.settings.title.enabled = v; },
+		'Propose better titles for untitled notes and notes whose title no longer matches their content',
+	);
+
+	new Setting(titleBody)
+		.setName('Duplicate handling')
+		.setDesc('Default action when a proposed title matches an existing note in the same folder (used by auto-accept). The proposal card always lets you choose per-proposal.')
+		.addDropdown((dd) =>
+			dd
+				.addOptions({
+					iterate: 'Add suffix',
+					merge: 'Merge into existing note',
+				})
+				.setValue(plugin.settings.title.duplicateHandling)
+				.onChange(async (value) => {
+					plugin.settings.title.duplicateHandling = value as TitleDuplicateStrategy;
+					await plugin.saveSettings();
+				})
+		);
+}

--- a/src/title/types.ts
+++ b/src/title/types.ts
@@ -4,6 +4,16 @@ export type TitleProposalTrigger =
 
 export type TitleProposalStatus = 'pending' | 'accepted' | 'rejected';
 
+/**
+ * How to resolve a title proposal whose target filename already exists in the
+ * same folder (#408):
+ * - `iterate`: keep the proposed title but append `-1`, `-2`, … so the rename
+ *   never clobbers the existing note.
+ * - `merge`: fold this note into the existing one (frontmatter union, bodies
+ *   joined by a horizontal rule) and trash the source.
+ */
+export type TitleDuplicateStrategy = 'iterate' | 'merge';
+
 export interface TitleProposal {
 	id: string;
 	sourceNotePath: string;
@@ -13,4 +23,17 @@ export interface TitleProposal {
 	reasoning: string;
 	createdAt: string;
 	status: TitleProposalStatus;
+	/**
+	 * Deterministic content-addressed key over the proposal's INPUTS (note path,
+	 * content hash, current title, trigger, AI settings). OPTIONAL for back-compat
+	 * with proposals already persisted before #408. Used to suppress re-proposing
+	 * the SAME colliding title for UNCHANGED content after a reject.
+	 */
+	contentKey?: string;
+	/**
+	 * The existing target path this proposal would collide with, captured at
+	 * proposal time as a UI hint only. OPTIONAL (no collision → unset). Always
+	 * re-validated live at accept time, so a stale value never drives a rename.
+	 */
+	conflictsWith?: string;
 }

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -5,7 +5,7 @@ import { AudioModule, TranscriptionResult } from '../audio';
 import {
 	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, calloutForTranscriptionResult,
 	CheckpointManager, generateId, formatTimeRange, detectPlatform, loadNodeModules,
-	isPathExcluded, findMatchingRule,
+	isPathExcluded, findMatchingRule, findAvailableVaultPath,
 } from '../shared';
 import type { TimeRange } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
@@ -355,7 +355,8 @@ export class VideoModule {
 			videoData.byteOffset,
 			videoData.byteOffset + videoData.byteLength
 		);
-		const vaultPath = this.findAvailableVaultPath(
+		const vaultPath = findAvailableVaultPath(
+			this.plugin.app,
 			normalizePath(`${settings.downloadFolder}/${fileName}`)
 		);
 		await this.plugin.app.vault.createBinary(vaultPath, data);
@@ -364,36 +365,6 @@ export class VideoModule {
 		try { await fs.promises.unlink(tempPath); } catch { /* ignore */ }
 
 		return vaultPath;
-	}
-
-	/**
-	 * Resolve a vault path that does not collide with an existing file.
-	 * Mirrors Obsidian's de-duplication: append `-1`, `-2`, ... before the
-	 * extension until an unused path is found. Unlike the Adapter API (which
-	 * silently overwrites), vault.createBinary() throws on an existing file,
-	 * and the generated `<date>-<title>.mp4` name can collide on same-day
-	 * re-downloads -- so suffix rather than clobber the user's existing file.
-	 */
-	private findAvailableVaultPath(desiredPath: string): string {
-		const vault = this.plugin.app.vault;
-		if (!vault.getAbstractFileByPath(desiredPath)) {
-			return desiredPath;
-		}
-
-		const slashIndex = desiredPath.lastIndexOf('/');
-		const dotIndex = desiredPath.lastIndexOf('.');
-		// Only treat a dot as an extension separator if it sits in the basename.
-		const hasExt = dotIndex > slashIndex;
-		const stem = hasExt ? desiredPath.slice(0, dotIndex) : desiredPath;
-		const ext = hasExt ? desiredPath.slice(dotIndex) : '';
-
-		let counter = 1;
-		let candidate = `${stem}-${counter}${ext}`;
-		while (vault.getAbstractFileByPath(candidate)) {
-			counter++;
-			candidate = `${stem}-${counter}${ext}`;
-		}
-		return candidate;
 	}
 
 	private async checkDependencies(): Promise<void> {

--- a/src/views/types.ts
+++ b/src/views/types.ts
@@ -2,7 +2,7 @@ import type { Proposal } from '../elaboration';
 import type { AcceptedItems, EnrichmentProposal } from '../enrichment';
 import type { OrganizeProposal } from '../organize';
 import type { DeepDiveProposal } from '../deep-dive';
-import type { TitleProposal } from '../title';
+import type { TitleProposal, TitleDuplicateStrategy } from '../title';
 import type { RemProposal } from '../rem';
 
 /**
@@ -60,8 +60,9 @@ export interface UnifiedViewCallbacks {
 	// Deep Dive
 	onDeepDiveAccept: (id: string) => Promise<void>;
 	onDeepDiveReject: (id: string) => Promise<void>;
-	// Title
-	onTitleAccept: (id: string) => Promise<void>;
+	// Title. `resolution` picks a duplicate-handling strategy when the proposed
+	// title collides with an existing file (#408); omitted for a plain accept.
+	onTitleAccept: (id: string, resolution?: TitleDuplicateStrategy) => Promise<void>;
 	onTitleReject: (id: string) => Promise<void>;
 	// REM
 	onRemAcceptSelected: (id: string, acceptedMatchTexts: string[]) => Promise<void>;

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -975,6 +975,14 @@ export class UnifiedProposalView extends ItemView {
 			cls: 'synapse-preview',
 		});
 
+		// Collision hint (#408): the proposed title already exists in this folder.
+		if (proposal.conflictsWith) {
+			card.createEl('small', {
+				text: `"${proposal.proposedTitle}" already exists here — add a suffix or merge.`,
+				cls: 'synapse-reasons synapse-title-conflict',
+			});
+		}
+
 		const actions = card.createDiv({ cls: 'synapse-actions' });
 
 		const viewBtn = actions.createEl('button', { text: 'Review' });
@@ -983,8 +991,17 @@ export class UnifiedProposalView extends ItemView {
 			this.render();
 		});
 
-		const acceptBtn = actions.createEl('button', { text: 'Accept' });
-		this.onClick(acceptBtn, () => this.callbacks.onTitleAccept(proposal.id), 'Accept title');
+		if (proposal.conflictsWith) {
+			// Replace the single Accept with the two collision resolutions (#408).
+			const suffixBtn = actions.createEl('button', { text: 'Add suffix' });
+			this.onClick(suffixBtn, () => this.callbacks.onTitleAccept(proposal.id, 'iterate'), 'Add suffix to title');
+
+			const mergeBtn = actions.createEl('button', { text: 'Merge into existing' });
+			this.onClick(mergeBtn, () => this.callbacks.onTitleAccept(proposal.id, 'merge'), 'Merge into existing note');
+		} else {
+			const acceptBtn = actions.createEl('button', { text: 'Accept' });
+			this.onClick(acceptBtn, () => this.callbacks.onTitleAccept(proposal.id), 'Accept title');
+		}
 
 		const rejectBtn = actions.createEl('button', { text: 'Reject' });
 		this.onClick(rejectBtn, () => this.callbacks.onTitleReject(proposal.id), 'Reject title');
@@ -1046,13 +1063,34 @@ export class UnifiedProposalView extends ItemView {
 			cls: 'synapse-organize-reasoning synapse-review-box--title',
 		});
 
+		// Collision hint (#408): the proposed title already exists in this folder.
+		if (proposal.conflictsWith) {
+			contentEl.createEl('small', {
+				text: `A note named "${proposal.proposedTitle}" already exists in this folder. Add a suffix to keep both, or merge into the existing note.`,
+				cls: 'synapse-review-reasons synapse-title-conflict',
+			});
+		}
+
 		// Action bar
 		const actionBar = contentEl.createDiv({ cls: 'synapse-review-actions' });
-		const acceptBtn = actionBar.createEl('button', { text: 'Accept', cls: 'mod-cta' });
-		acceptBtn.addEventListener('click', () => {
-			this.reviewingTitle = null;
-			fireAndForget(this.callbacks.onTitleAccept(proposal.id), 'Accept title');
-		});
+		if (proposal.conflictsWith) {
+			const suffixBtn = actionBar.createEl('button', { text: 'Add suffix', cls: 'mod-cta' });
+			suffixBtn.addEventListener('click', () => {
+				this.reviewingTitle = null;
+				fireAndForget(this.callbacks.onTitleAccept(proposal.id, 'iterate'), 'Add suffix to title');
+			});
+			const mergeBtn = actionBar.createEl('button', { text: 'Merge into existing' });
+			mergeBtn.addEventListener('click', () => {
+				this.reviewingTitle = null;
+				fireAndForget(this.callbacks.onTitleAccept(proposal.id, 'merge'), 'Merge into existing note');
+			});
+		} else {
+			const acceptBtn = actionBar.createEl('button', { text: 'Accept', cls: 'mod-cta' });
+			acceptBtn.addEventListener('click', () => {
+				this.reviewingTitle = null;
+				fireAndForget(this.callbacks.onTitleAccept(proposal.id), 'Accept title');
+			});
+		}
 		const rejectBtn = actionBar.createEl('button', { text: 'Reject' });
 		rejectBtn.addEventListener('click', () => {
 			this.reviewingTitle = null;


### PR DESCRIPTION
## Summary

Title proposals could suggest a filename that already exists in the same folder. The collision was only caught at accept time (in `acceptProposal`), which silently aborted the rename and left the proposal stuck in `pending`. Because `TitleProposal` had no content-dedup key and the regeneration guards only skipped *pending* proposals, the next post-op `checkTitle` regenerated the SAME colliding title — an inescapable loop unless the user rejected (which just restarted it).

This PR detects the collision at proposal time AND re-validates it live at accept time, offers two resolutions (suffix or merge), and closes the reject loop with a deterministic `contentKey`.

closes #408

## What changed

- **Proposal-time detection**: `checkUntitled` / `checkMismatch` now compute the target path and set `proposal.conflictsWith` (a UI hint) when a different file already occupies it. Content is read before the guards so the dedup key can be computed.
- **Reject-loop fix (`contentKey`)**: a new `titleContentKey()` (mirroring elaboration's `proposalContentKey`) keys on *inputs* (note path, content hash, current title, trigger, AI settings) so re-scans are idempotent under temperature > 0. A rejected colliding title is not re-proposed for unchanged content; editing the note changes the key and re-enables proposals.
- **Accept-time recheck + resolutions**: `acceptProposal(id, { silent?, resolution? })` re-validates the collision LIVE (stale `conflictsWith` ignored):
  - no collision → plain rename (clean path, no spurious suffix);
  - collision + no resolution (plain manual Accept) → never overwrites; persists the hint and surfaces "Add suffix or Merge", leaving the proposal pending;
  - collision + `iterate` → rename to the next free `-1`/`-2` path;
  - collision + `merge` → fold into the existing note and trash the source.
- **Auto-accept** honors `settings.title.duplicateHandling` on a live collision and announces the real outcome (suffixed name / "merged into …").
- **UI**: the proposal card and review pane show a conflict hint and replace the single Accept with "Add suffix" / "Merge into existing" when `conflictsWith` is set; Review/Reject unchanged.
- **New Title settings section** with a "Duplicate handling" dropdown (Add suffix / Merge into existing note), defaulting to `iterate`.
- **Shared util**: extracted `findAvailableVaultPath(app, desiredPath)` into `shared/file-utils.ts` (ported from VideoModule, which now reuses it).

## Merge semantics

- Frontmatter: full union of keys — target wins on scalar conflicts; `tags`/`aliases` unioned.
- Body: `${targetBody}\n\n---\n\n${sourceBody}` (target first, horizontal rule).
- Source: moved to trash via `fileManager.trashFile()` (recoverable); no tombstone/redirect.
- Target rewritten atomically via `vault.process`.

## Test coverage

- `src/shared/file-utils.test.ts`: `findAvailableVaultPath` — free path, `-1`/`-2` suffixing, no-extension, dot-in-folder paths.
- `src/title/content-key.test.ts`: determinism; key changes on content / current title / trigger / path / AI settings changes.
- `src/title/duplicate-handling.test.ts`: proposal-time `conflictsWith`; iterate (suffixed rename); merge (frontmatter union + body rule + source trashed); auto-accept honoring each strategy with accurate notices; accept-time recheck (collision appeared → plain Accept surfaces choice, does not overwrite; collision disappeared → clean rename); reject-loop guard (no re-propose for unchanged content, re-enabled after an edit); merge fallback when the target is not a note.
- `src/title/settings-section.test.ts`: section renders; feature toggle works; `duplicateHandling` default is `iterate`.

## Preflight (all green)

- `tsc --noEmit --skipLibCheck` — pass
- `npm run lint` — pass
- `node scripts/check-top-level-requires.mjs` — pass
- `npm test` — 1779 passed (134 files)
- `node scripts/version-bump.mjs --check` — pass (no version bump; regular fix)
- `node esbuild.config.mjs production` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqCNfQ3REzK2y7VbUWnvKK