### PR TITLE
docs: explain why subscription plans can't replace API billing

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,14 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-06-28: Subscription plans can't replace API billing (documented; wontfix)
+
+**Context**: A recurring user request (#364) is to power Synapse with an existing Claude Pro/Max (or ChatGPT Plus / Gemini Advanced) **subscription** instead of metered, per-token **API** billing — the cost ask is one flat monthly fee, not a second usage-based bill.
+
+**Decision**: Document it as a canonical wontfix — it is blocked by provider policy, not by Synapse's architecture. A subscription authorizes the provider's own chat app, not third-party API access: Anthropic's Consumer Terms prohibit third-party use of subscription tokens (enforced with suspensions) and the Messages API rejects the `sk-ant-oat…` setup token; OpenAI "Sign in with ChatGPT" is identity-only; Google Gemini Advanced has no API, only AI Studio / Vertex (facts re-verified 2026-06). The supported, compliant cost answers are a pay-as-you-go provider API key and Ollama (local, free). The README **FAQ** is the canonical user-facing answer; this entry is its decision-log counterpart and the billing-model twin of the 2026-06-16 "Guided key onboarding + live validation (OAuth deferred)" entry (#335) — same provider-policy facts, viewed from cost rather than auth UX.
+
+---
+
 ## 2026-06-26: Idempotency foundation — scoping spike (#390)
 
 **Context**: Synapse has no shared notion of *idempotency* — same input → same outcome, repeating an operation doesn't multiply its effects. This spike investigated three layers and confirmed the current state against the live code (all citations verified in-tree):

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ These are the only services Synapse contacts, what each one is used for, and wha
 
 Synapse proposes, you decide -- and that holds for the network too: nothing is requested until you ask for it.
 
+## FAQ
+
+### Can I use my Claude Pro/Max plan (or ChatGPT Plus / Gemini Advanced) instead of an API key?
+
+No. A consumer subscription pays for the provider's own chat app -- it is not API access, which every provider authorizes and bills separately. Synapse talks to each provider's API, so it needs an API key, not a subscription login.
+
+- **Anthropic (Claude Pro/Max)** -- third-party use of subscription tokens is prohibited by the Consumer Terms of Service (updated 2026-02-19) and enforced with account suspensions. The `sk-ant-oat01-…` setup token works only in Claude Code and is rejected by the Messages API.
+- **OpenAI (ChatGPT Plus/Pro)** -- "Sign in with ChatGPT" is identity only; the subscription includes no API access. API usage is metered separately.
+- **Google (Gemini Advanced / AI Pro)** -- a consumer chat product with no API access; the Gemini API bills separately through AI Studio or Vertex.
+
+Reverse-engineering subscription credentials is both blocked technically and a Terms violation that risks *your* account -- so Synapse won't do it.
+
+**What does work -- and answers the cost concern:**
+
+- A provider **API key** (OpenAI, Anthropic, or Google Gemini) -- pay-as-you-go, for only what you use.
+- **Ollama** -- fully local and free, already a first-class provider. Set **Settings > Synapse > AI provider** to **Ollama** (default endpoint `http://localhost:11434`, no key, nothing leaves your machine).
+
+This is the billing-model counterpart to the auth decision recorded in [`DECISIONS.md`](DECISIONS.md), which chose guided API-key onboarding over a one-click OAuth "connect" button for the same provider-policy reasons.
+
 ## Installation
 
 Synapse is not yet published to the Obsidian Community Plugin directory. To install manually:
@@ -213,7 +232,7 @@ Open **Settings > Synapse** to configure the plugin. All features can be individ
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| AI provider | OpenAI, Anthropic, or Ollama (local) | OpenAI |
+| AI provider | OpenAI, Anthropic, Google Gemini, or Ollama (local) | OpenAI |
 | API key | Your API key for the selected provider | -- |
 | Ollama endpoint | URL for local Ollama server (shown when Ollama selected) | `http://localhost:11434` |
 | Model | AI model for the selected provider | GPT-4o |

--- a/src/onboarding.test.ts
+++ b/src/onboarding.test.ts
@@ -9,6 +9,7 @@ import {
 	REQUIRED_FIELD_CLASS,
 	API_KEY_DESC,
 	API_KEY_REQUIRED_DESC,
+	API_KEY_NO_SUBSCRIPTION_NOTE,
 } from './onboarding';
 
 function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
@@ -117,5 +118,23 @@ describe('WELCOME_MESSAGE copy (#89)', () => {
 		// Brand voice: no exclamation points, no emoji (an em dash is fine).
 		expect(WELCOME_MESSAGE).not.toContain('!');
 		expect(WELCOME_MESSAGE).not.toMatch(/\p{Extended_Pictographic}/u);
+	});
+});
+
+describe('API_KEY_NO_SUBSCRIPTION_NOTE copy (#364)', () => {
+	it('names the three subscription products it rules out', () => {
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE).toMatch(/Pro\/Max/);
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE).toMatch(/ChatGPT Plus/);
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE).toMatch(/Gemini Advanced/);
+	});
+
+	it('points to both supported paths — an API key and Ollama', () => {
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE.toLowerCase()).toContain('api key');
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE).toContain('Ollama');
+	});
+
+	it('stays in brand voice: no exclamation points, no emoji', () => {
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE).not.toContain('!');
+		expect(API_KEY_NO_SUBSCRIPTION_NOTE).not.toMatch(/\p{Extended_Pictographic}/u);
 	});
 });

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -36,6 +36,15 @@ export const API_KEY_REQUIRED_DESC =
 	'Required — add your provider API key to activate AI features.';
 
 /**
+ * Note shown under the API key field for hosted providers (#364): a consumer
+ * subscription is not API access, so it cannot power Synapse. Points to the two
+ * paths that do work — a pay-as-you-go API key, or local/free Ollama. Brand
+ * voice: precise and dry, no hype. See the README FAQ for the full rationale.
+ */
+export const API_KEY_NO_SUBSCRIPTION_NOTE =
+	"Subscriptions (Claude Pro/Max, ChatGPT Plus, Gemini Advanced) can't be used here — use an API key, or Ollama for free local AI.";
+
+/**
  * Whether the configured provider still needs an API key. Ollama runs locally
  * and authenticates against a URL endpoint, so it never counts as missing — only
  * the hosted providers (OpenAI, Anthropic, Gemini) require a key here.

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -75,6 +75,21 @@ function findAnchors(el: any, out: any[] = []): any[] {
 	return out;
 }
 
+/**
+ * Recursively collect stub elements whose own text contains `needle`. The mock's
+ * `textContent` is per-element (it does not aggregate descendants), so a match is
+ * the element that was created with that text — not an ancestor.
+ */
+function findByText(el: any, needle: string, out: any[] = []): any[] {
+	for (const child of el?.children ?? []) {
+		if (typeof child.textContent === 'string' && child.textContent.includes(needle)) {
+			out.push(child);
+		}
+		findByText(child, needle, out);
+	}
+	return out;
+}
+
 describe('SynapseSettingTab — Auto-Accept disabled state', () => {
 	beforeEach(() => {
 		ToggleComponent.instances.length = 0;
@@ -443,5 +458,35 @@ describe('SynapseSettingTab — General section / auto-fold properties (#381)', 
 		await updateToggle()._trigger(false);
 		expect(plugin.settings.updates.enableUpdateNotifications).toBe(false);
 		expect(saveSettings).toHaveBeenCalled();
+	});
+});
+
+describe('SynapseSettingTab — no-subscription note in AI Configuration (#364)', () => {
+	beforeEach(() => {
+		ToggleComponent.instances.length = 0;
+	});
+
+	function subscriptionNotes(tab: SynapseSettingTab): any[] {
+		const container = (tab as unknown as { containerEl: any }).containerEl;
+		return findByText(container, 'Subscriptions');
+	}
+
+	it.each(['openai', 'anthropic', 'gemini'] as const)(
+		'shows the no-subscription note for hosted provider %s',
+		(provider) => {
+			const { tab } = makeTab((s) => {
+				s.ai.provider = provider;
+			});
+			tab.display();
+			expect(subscriptionNotes(tab).length).toBeGreaterThan(0);
+		},
+	);
+
+	it('omits the note when the local Ollama provider is selected', () => {
+		const { tab } = makeTab((s) => {
+			s.ai.provider = 'ollama';
+		});
+		tab.display();
+		expect(subscriptionNotes(tab)).toHaveLength(0);
 	});
 });

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -33,7 +33,7 @@ import { renderOrganizeSettings } from './organize';
 import { renderDeepDiveSettings } from './deep-dive';
 import { renderTitleSettings } from './title';
 import { renderRemSettings } from './rem';
-import { applyApiKeyEmphasis } from './onboarding';
+import { applyApiKeyEmphasis, API_KEY_NO_SUBSCRIPTION_NOTE } from './onboarding';
 import { foldActiveNoteProperties } from './properties-fold';
 import { ChangelogModal } from './changelog-modal';
 
@@ -300,6 +300,13 @@ export class SynapseSettingTab extends PluginSettingTab {
 				setting: apiKeySetting,
 				provider: cred,
 				getKey: () => this.plugin.settings.ai.apiKey,
+			});
+			// The recurring "can I use my Pro/Max subscription instead?" question
+			// answered at the point of confusion (#364). Hosted-only — the "or use
+			// Ollama" advice is moot once Ollama (which needs no key) is selected.
+			aiBody.createDiv({
+				cls: 'setting-item-description synapse-api-key-note',
+				text: API_KEY_NO_SUBSCRIPTION_NOTE,
 			});
 		}
 


### PR DESCRIPTION
Documents the recurring "can I use my Claude Pro/Max (or ChatGPT Plus / Gemini Advanced) subscription instead of metered API billing?" question (#364) as a canonical wontfix — it's blocked by provider policy, not Synapse's architecture.

## Changes
- **README** — new `## FAQ` section answering the question, with the per-provider policy reasons (Anthropic Consumer Terms prohibit third-party subscription-token use and the Messages API rejects `sk-ant-oat…`; OpenAI "Sign in with ChatGPT" is identity-only; Google Gemini Advanced has no API) and the two supported, compliant paths: a pay-as-you-go provider API key, and local/free Ollama.
- **Settings** — a one-line note under the API-key field for hosted providers, surfacing the same answer at the point of confusion (omitted for Ollama, which needs no key).
- **DECISIONS.md** — an entry marking this the canonical billing/subscription reference and the billing-model twin of the 2026-06-16 #335 OAuth decision.
- **Fix** — the Configuration table omitted Google Gemini from the provider list.

## Tests
- `onboarding.test.ts` — assertions on the in-app note copy (names the three products; points to both supported paths; brand voice: no exclamation/emoji).
- `settings-tab.test.ts` — the note renders for each hosted provider and is absent for Ollama.
- Full suite: 1786 pass. tsc / lint / check-top-level-requires / version-bump --check / production build all green. No version bump, no CHANGELOG (docs + minor UI copy).

closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqCNfQ3REzK2y7VbUWnvKK
