### PR TITLE
feat: add version-stamped settings migration framework

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,8 @@ import { CommandRegistrar, auditCommands, listPaletteActions, REGISTRY_BY_ID } f
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
-import { FolderPickerModal, NotificationManager, CheckpointManager, UpdateChecker, fireAndForget, buildMigratedExclusions } from './shared';
-import type { DeferredTask, LegacyModuleExclusions } from './shared';
+import { FolderPickerModal, NotificationManager, CheckpointManager, UpdateChecker, fireAndForget, migrateSettings, readSettingsVersion, CURRENT_SETTINGS_VERSION } from './shared';
+import type { DeferredTask } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
 import { findVideoUrls } from './video';
@@ -475,38 +475,40 @@ export default class SynapsePlugin extends Plugin {
 	}
 
 	async loadSettings(): Promise<void> {
-		// `loadData()` returns `any`; narrow it to the persisted-settings shape so
-		// the fresh-install check and merge are type-safe. Persisted data is a
-		// (possibly partial / older-schema) settings object, or null on first run.
-		const data = (await this.loadData()) as Partial<SynapseSettings> | null;
+		// `loadData()` returns `any`; narrow it to a raw record so the migration
+		// runner and merge stay type-safe. Persisted data is a (possibly partial /
+		// older-schema) settings object, or null on first run.
+		const raw = (await this.loadData()) as Record<string, unknown> | null;
 		// No persisted data (null) or an empty object means this is the plugin's
 		// first run in this vault — used to gate the first-run welcome (#89).
-		this.isFreshInstall = !data || Object.keys(data).length === 0;
-		// A partial settings object satisfies deepMerge's `Record<string, unknown>`
-		// source param directly — no boundary cast needed. deepMerge itself is
-		// left untouched (its prototype-pollution-safe recursion is out of scope).
-		this.settings = this.deepMerge(DEFAULT_SETTINGS, data ?? {});
-
-		// One-time migration of the legacy per-module `excludeFolders` lists into
-		// the centralized `exclusions` list (#307). Gated on the RAW persisted
-		// data lacking an `exclusions` key (no settings-version system exists —
-		// that's #93), so it runs exactly once and never re-runs even if the user
-		// later empties the list. Fresh installs already get the default
-		// exclusions from DEFAULT_SETTINGS, so they skip migration entirely.
-		if (!this.isFreshInstall && data && data.exclusions === undefined) {
+		this.isFreshInstall = !raw || Object.keys(raw).length === 0;
+		// Version-stamped migration framework (#93): replay every migration newer
+		// than the persisted `settingsVersion` over the RAW object BEFORE merging
+		// defaults. Version 0 is the pre-versioning baseline (absent/invalid
+		// `settingsVersion`); fresh installs already carry CURRENT_SETTINGS_VERSION
+		// from DEFAULT_SETTINGS and skip migration entirely.
+		const fromVersion = readSettingsVersion(raw);
+		let migrated: Record<string, unknown> = raw ?? {};
+		if (!this.isFreshInstall && raw) {
 			try {
-				// Read legacy folders off the raw object via a narrow read type
-				// (the fields no longer exist on SynapseSettings).
-				const migrated = buildMigratedExclusions(data as LegacyModuleExclusions);
-				// Atomic assign of the fully-built list, then persist so the
-				// `exclusions` key is present on the next load.
-				this.settings.exclusions = migrated;
-				await this.saveData(this.settings);
+				migrated = migrateSettings(raw, fromVersion);
 			} catch (error) {
-				// Swallow-and-warn (mirrors migrateDataFolder): on failure keep the
-				// merged default exclusions rather than breaking load.
-				console.warn('[Synapse] Failed to migrate excludeFolders to exclusions:', error);
+				// Resilient fallback — load must never break. migrateSettings clones
+				// before mutating, so `raw` is still the untouched original here.
+				console.warn('[Synapse] settings migration failed:', error);
+				migrated = raw;
 			}
+		}
+		// deepMerge treats arrays as leaf values, so a migrated `exclusions` array
+		// cleanly overrides DEFAULT_SETTINGS.exclusions — same end state as the old
+		// post-merge assignment. deepMerge itself is left untouched (its
+		// prototype-pollution-safe recursion is out of scope).
+		this.settings = this.deepMerge(DEFAULT_SETTINGS, migrated);
+		this.settings.settingsVersion = CURRENT_SETTINGS_VERSION;
+		// One-time stamp/persist on upgrade so the new schema version (and any
+		// migrated data) lands in data.json and migrations don't re-run next load.
+		if (!this.isFreshInstall && fromVersion < CURRENT_SETTINGS_VERSION) {
+			await this.saveData(this.settings);
 		}
 	}
 

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DEFAULT_SETTINGS, MODEL_OPTIONS } from './settings';
 import type { AIProvider } from './settings';
 import { PROPOSAL_KINDS } from './views/types';
+import { CURRENT_SETTINGS_VERSION } from './shared/settings-migrations';
 
 describe('autoAccept settings (#228)', () => {
 	it('defines an autoAccept flag for every proposal kind', () => {
@@ -109,5 +110,11 @@ describe('exclusions settings (#307)', () => {
 		expect(DEFAULT_SETTINGS.summarize.excludeTags).toContain('no-summarize');
 		expect(DEFAULT_SETTINGS.organize.excludeTags).toContain('no-organize');
 		expect(DEFAULT_SETTINGS.deepDive.excludeTags).toContain('no-deep-dive');
+	});
+});
+
+describe('settings version stamp (#93)', () => {
+	it('stamps DEFAULT_SETTINGS with the current schema version', () => {
+		expect(DEFAULT_SETTINGS.settingsVersion).toBe(CURRENT_SETTINGS_VERSION);
 	});
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,11 @@ import type { ProposalKind } from './views/types';
 import type { ExclusionRule } from './shared/exclusions';
 // Type-only import. title/types.ts has no imports, so this never forms a cycle.
 import type { TitleDuplicateStrategy } from './title/types';
+// Runtime value import — the sanctioned `settings → shared` direction. Imported
+// DIRECTLY from the module (not via the `./shared` barrel) to stay clear of any
+// barrel import cycle; settings-migrations only depends on shared/exclusions, so
+// the graph stays acyclic.
+import { CURRENT_SETTINGS_VERSION } from './shared/settings-migrations';
 
 export type AIProvider = 'openai' | 'anthropic' | 'gemini' | 'ollama';
 
@@ -325,6 +330,13 @@ export interface OnboardingSettings {
 export type AutoAcceptSettings = Record<ProposalKind, boolean>;
 
 export interface SynapseSettings {
+	/**
+	 * Schema version of the persisted settings (#93). Stamped to
+	 * {@link CURRENT_SETTINGS_VERSION} on save; drives the version-gated migration
+	 * runner in `shared/settings-migrations.ts`, which replays every newer
+	 * migration over the raw `data.json` before defaults are merged in.
+	 */
+	settingsVersion: number;
 	ai: AISettings;
 	elaboration: ElaborationSettings;
 	audio: AudioSettings;
@@ -353,6 +365,7 @@ export interface SynapseSettings {
 }
 
 export const DEFAULT_SETTINGS: SynapseSettings = {
+	settingsVersion: CURRENT_SETTINGS_VERSION,
 	ai: {
 		provider: 'openai',
 		apiKey: '',

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -105,6 +105,13 @@ export {
 } from './exclusions';
 export type { FeatureId, ExclusionRule, LegacyModuleExclusions, ExclusionSettings } from './exclusions';
 export {
+	migrateSettings,
+	readSettingsVersion,
+	CURRENT_SETTINGS_VERSION,
+	SETTINGS_MIGRATIONS,
+} from './settings-migrations';
+export type { SettingsMigration } from './settings-migrations';
+export {
 	CONTENT_SCHEMAS,
 	detectSchemaFor,
 	isRecipeContent,

--- a/src/shared/settings-migrations.test.ts
+++ b/src/shared/settings-migrations.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+	CURRENT_SETTINGS_VERSION,
+	SETTINGS_MIGRATIONS,
+	readSettingsVersion,
+	migrateSettings,
+	foldExcludeFoldersIntoExclusions,
+	dropSemanticMatching,
+} from './settings-migrations';
+import type { ExclusionRule } from './exclusions';
+
+describe('readSettingsVersion (#93)', () => {
+	it('returns 0 when the settingsVersion field is missing', () => {
+		expect(readSettingsVersion({})).toBe(0);
+	});
+
+	it('returns 0 for null or undefined input', () => {
+		expect(readSettingsVersion(null)).toBe(0);
+		expect(readSettingsVersion(undefined)).toBe(0);
+	});
+
+	it('returns 0 when settingsVersion is a non-number (e.g. a numeric string)', () => {
+		expect(readSettingsVersion({ settingsVersion: '2' })).toBe(0);
+	});
+
+	it('returns the value when settingsVersion is a number', () => {
+		expect(readSettingsVersion({ settingsVersion: 2 })).toBe(2);
+		expect(readSettingsVersion({ settingsVersion: 0 })).toBe(0);
+	});
+});
+
+describe('migrateSettings — ordering (#93)', () => {
+	it('runs both migrations from version 0', () => {
+		const raw = {
+			enrichment: { excludeFolders: ['Templates'] },
+			rem: { semanticMatching: true, titleMatchWeight: 0.6 },
+		};
+		const out = migrateSettings(raw, 0);
+		// to:1 synthesized exclusions from the legacy folder list...
+		expect(Array.isArray(out.exclusions)).toBe(true);
+		expect((out.exclusions as ExclusionRule[]).length).toBeGreaterThan(0);
+		// ...and to:2 dropped the inert flag (but kept the renamed field).
+		expect(out.rem).not.toHaveProperty('semanticMatching');
+		expect((out.rem as Record<string, unknown>).titleMatchWeight).toBe(0.6);
+	});
+
+	it('runs only the to:2 migration from version 1', () => {
+		const raw = {
+			enrichment: { excludeFolders: ['Templates'] },
+			rem: { semanticMatching: true },
+		};
+		const out = migrateSettings(raw, 1);
+		// to:1 skipped → no exclusions synthesized from the legacy folders.
+		expect(out.exclusions).toBeUndefined();
+		// to:2 still ran.
+		expect(out.rem).not.toHaveProperty('semanticMatching');
+	});
+
+	it('runs no migrations from the current version', () => {
+		const raw = {
+			enrichment: { excludeFolders: ['Templates'] },
+			rem: { semanticMatching: true },
+		};
+		const out = migrateSettings(raw, CURRENT_SETTINGS_VERSION);
+		expect(out.exclusions).toBeUndefined();
+		expect(out.rem).toHaveProperty('semanticMatching');
+	});
+
+	it('does not mutate the input object (proves the clone)', () => {
+		const raw = {
+			enrichment: { excludeFolders: ['Templates'] },
+			rem: { semanticMatching: true, titleMatchWeight: 0.6 },
+		};
+		const snapshot = JSON.parse(JSON.stringify(raw));
+		migrateSettings(raw, 0);
+		// Deep-equal to its pre-call snapshot: no field added or removed.
+		expect(raw).toEqual(snapshot);
+		expect(raw).not.toHaveProperty('exclusions');
+		expect(raw.rem).toHaveProperty('semanticMatching');
+	});
+});
+
+describe('migrateSettings — error propagation (#93)', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('lets a throwing migration propagate out so loadSettings can fall back', () => {
+		const boom = new Error('migration exploded');
+		vi.spyOn(SETTINGS_MIGRATIONS[0], 'migrate').mockImplementation(() => {
+			throw boom;
+		});
+		expect(() => migrateSettings({}, 0)).toThrow(boom);
+	});
+});
+
+describe('foldExcludeFoldersIntoExclusions — to:1 migration (#93)', () => {
+	it('builds exclusions from legacy excludeFolders when exclusions is absent', () => {
+		const raw: Record<string, unknown> = {
+			enrichment: { excludeFolders: ['Templates'] },
+		};
+		const out = foldExcludeFoldersIntoExclusions(raw);
+		const rules = out.exclusions as ExclusionRule[];
+		expect(Array.isArray(rules)).toBe(true);
+		expect(rules.some((r) => r.pattern === 'Templates/**')).toBe(true);
+	});
+
+	it('is a no-op when exclusions is already present (keeps the existing list)', () => {
+		const existing: ExclusionRule[] = [{ pattern: 'Keep/**', features: 'all' }];
+		const raw: Record<string, unknown> = {
+			enrichment: { excludeFolders: ['Templates'] },
+			exclusions: existing,
+		};
+		const out = foldExcludeFoldersIntoExclusions(raw);
+		// Same array reference — nothing rebuilt.
+		expect(out.exclusions).toBe(existing);
+	});
+
+	it('preserves an empty exclusions array (user deliberately cleared it)', () => {
+		const raw: Record<string, unknown> = {
+			enrichment: { excludeFolders: ['Templates'] },
+			exclusions: [],
+		};
+		const out = foldExcludeFoldersIntoExclusions(raw);
+		expect(out.exclusions).toEqual([]);
+	});
+
+	it('is idempotent on a second run', () => {
+		const raw: Record<string, unknown> = {
+			enrichment: { excludeFolders: ['Templates'] },
+		};
+		const first = foldExcludeFoldersIntoExclusions(raw);
+		const built = first.exclusions;
+		const second = foldExcludeFoldersIntoExclusions(first);
+		// Second pass sees exclusions present → no rebuild, same reference.
+		expect(second.exclusions).toBe(built);
+	});
+});
+
+describe('dropSemanticMatching — to:2 migration (#93)', () => {
+	it('removes rem.semanticMatching when present, leaving sibling fields intact', () => {
+		const raw: Record<string, unknown> = {
+			rem: { semanticMatching: true, titleMatchWeight: 0.6 },
+		};
+		const out = dropSemanticMatching(raw);
+		expect(out.rem).not.toHaveProperty('semanticMatching');
+		expect((out.rem as Record<string, unknown>).titleMatchWeight).toBe(0.6);
+	});
+
+	it('is idempotent — a second run is a no-op', () => {
+		const raw: Record<string, unknown> = { rem: { semanticMatching: true } };
+		dropSemanticMatching(raw);
+		const out = dropSemanticMatching(raw);
+		expect(out.rem).not.toHaveProperty('semanticMatching');
+	});
+
+	it('tolerates a missing rem', () => {
+		const raw: Record<string, unknown> = {};
+		expect(() => dropSemanticMatching(raw)).not.toThrow();
+		expect(raw.rem).toBeUndefined();
+	});
+
+	it('tolerates a non-object rem', () => {
+		const raw: Record<string, unknown> = { rem: 'not-an-object' };
+		expect(() => dropSemanticMatching(raw)).not.toThrow();
+		expect(raw.rem).toBe('not-an-object');
+	});
+
+	it('tolerates a null rem', () => {
+		const raw: Record<string, unknown> = { rem: null };
+		expect(() => dropSemanticMatching(raw)).not.toThrow();
+		expect(raw.rem).toBeNull();
+	});
+});
+
+describe('settings-migration drift guard (#93)', () => {
+	it('CURRENT_SETTINGS_VERSION equals the highest migration `to`', () => {
+		expect(CURRENT_SETTINGS_VERSION).toBe(
+			Math.max(...SETTINGS_MIGRATIONS.map((m) => m.to)),
+		);
+	});
+
+	it('orders the migrations ascending by `to`', () => {
+		const tos = SETTINGS_MIGRATIONS.map((m) => m.to);
+		expect(tos).toEqual([...tos].sort((a, b) => a - b));
+	});
+});

--- a/src/shared/settings-migrations.ts
+++ b/src/shared/settings-migrations.ts
@@ -1,0 +1,115 @@
+import { buildMigratedExclusions } from './exclusions';
+import type { LegacyModuleExclusions } from './exclusions';
+
+/**
+ * Version-stamped settings migration framework (#93).
+ *
+ * A small, PURE runner that transforms the RAW persisted settings object (the
+ * value `loadData()` returns) BEFORE it is merged with `DEFAULT_SETTINGS`. It is
+ * driven by a `settingsVersion` field on the stored data: every migration whose
+ * `to` exceeds the persisted version is replayed, in ascending order, to bring
+ * the object up to {@link CURRENT_SETTINGS_VERSION}.
+ *
+ * Layering: this module is part of the lowest (`shared/`) layer. It imports
+ * `buildMigratedExclusions`/`LegacyModuleExclusions` DIRECTLY from `./exclusions`
+ * (same layer, not via the barrel) and operates only on `Record<string, unknown>`.
+ * It must NEVER import `../settings` — keeping `shared/` the bottom layer is what
+ * keeps the `settings → settings-migrations → exclusions` import graph acyclic.
+ */
+
+/**
+ * The schema version {@link DEFAULT_SETTINGS} currently targets. Bump this each
+ * time a migration is appended to {@link SETTINGS_MIGRATIONS}; a drift-guard test
+ * asserts it always equals the highest migration `to`.
+ */
+export const CURRENT_SETTINGS_VERSION = 2;
+
+/**
+ * A single ordered migration. `to` is the schema version this step upgrades the
+ * raw object *to*; `migrate` transforms the object it is handed (the clone
+ * {@link migrateSettings} owns) and returns it.
+ */
+export interface SettingsMigration {
+	to: number;
+	migrate: (raw: Record<string, unknown>) => Record<string, unknown>;
+}
+
+/**
+ * Read the persisted schema version off a raw settings object. An absent, null,
+ * or non-numeric `settingsVersion` is treated as version 0 — the pre-versioning
+ * baseline — so a legacy `data.json` replays every migration from the start.
+ */
+export function readSettingsVersion(raw: Record<string, unknown> | null | undefined): number {
+	if (raw && typeof raw.settingsVersion === 'number') {
+		return raw.settingsVersion;
+	}
+	return 0;
+}
+
+/**
+ * v1 — fold the legacy per-module `excludeFolders` lists into the centralized
+ * `exclusions` list (#307), wrapping {@link buildMigratedExclusions}. KEEPS the
+ * original presence guard: only build the list when `exclusions` is absent. This
+ * preserves today's exact behavior — including a user who deliberately cleared
+ * exclusions to `[]` (which must stay `[]`) — and makes the step idempotent.
+ */
+export function foldExcludeFoldersIntoExclusions(
+	raw: Record<string, unknown>,
+): Record<string, unknown> {
+	if (raw.exclusions === undefined) {
+		// `LegacyModuleExclusions` is an all-optional read shape, so the raw record
+		// satisfies it directly (a typed annotation, not an assertion);
+		// buildMigratedExclusions defensively coerces each legacy value it reads.
+		const legacy: LegacyModuleExclusions = raw;
+		raw.exclusions = buildMigratedExclusions(legacy);
+	}
+	return raw;
+}
+
+/**
+ * v2 — drop the inert `rem.semanticMatching` flag left behind by the REM rename
+ * to `titleMatchWeight`. DELETE-ONLY: REM is always-on now and the old boolean
+ * has no faithful target, so it is not mapped to `titleMatchWeight`. Tolerates a
+ * missing or non-object `rem`; idempotent.
+ */
+export function dropSemanticMatching(
+	raw: Record<string, unknown>,
+): Record<string, unknown> {
+	const rem = raw.rem;
+	if (
+		typeof rem === 'object' &&
+		rem !== null &&
+		Object.prototype.hasOwnProperty.call(rem, 'semanticMatching')
+	) {
+		delete (rem as Record<string, unknown>).semanticMatching;
+	}
+	return raw;
+}
+
+/**
+ * The ordered migration chain, ascending by `to`. {@link migrateSettings}
+ * applies, in order, every entry whose `to` exceeds the persisted version.
+ */
+export const SETTINGS_MIGRATIONS: SettingsMigration[] = [
+	{ to: 1, migrate: foldExcludeFoldersIntoExclusions },
+	{ to: 2, migrate: dropSemanticMatching },
+];
+
+/**
+ * Apply every migration newer than `fromVersion` to `raw`, in ascending order,
+ * returning the transformed object. The input is CLONED once via a JSON
+ * round-trip up front (the data is JSON-origin from `loadData`, so this is safe)
+ * so a throwing migration can never half-mutate the caller's fallback object.
+ */
+export function migrateSettings(
+	raw: Record<string, unknown>,
+	fromVersion: number,
+): Record<string, unknown> {
+	let working = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+	for (const migration of SETTINGS_MIGRATIONS) {
+		if (migration.to > fromVersion) {
+			working = migration.migrate(working);
+		}
+	}
+	return working;
+}


### PR DESCRIPTION
## Summary

Adds a small, pure, version-stamped settings migration framework (#93). Migrations now run against the raw persisted `data.json` object **before** `deepMerge`, driven by a new `settingsVersion` field, instead of the ad-hoc presence-keyed block that previously lived inline in `loadSettings`.

- New module `src/shared/settings-migrations.ts` (lowest `shared/` layer):
  - `CURRENT_SETTINGS_VERSION = 2`, `readSettingsVersion()`, `SETTINGS_MIGRATIONS` (ordered ascending by `to`), and `migrateSettings()`.
  - `migrateSettings` clones its input once via a JSON round-trip, then applies every migration whose `to` exceeds the persisted version — so a throwing migration can never half-mutate the caller's fallback object.
  - **to:1** `foldExcludeFoldersIntoExclusions` — wraps the existing `buildMigratedExclusions`, keeping its presence guard (only builds when `exclusions` is absent, so a deliberately-cleared `[]` stays `[]`). Idempotent.
  - **to:2** `dropSemanticMatching` — delete-only removal of the inert `rem.semanticMatching` key left by the REM rename to `titleMatchWeight`. Tolerates missing/non-object `rem`. Idempotent.
- `settings.ts`: adds `settingsVersion` to `SynapseSettings` and `DEFAULT_SETTINGS` (imports `CURRENT_SETTINGS_VERSION` directly from the module, the sanctioned `settings → shared` direction).
- `main.ts`: `loadSettings` rewritten to run the version-gated runner inside a resilient try/catch (load must never break), stamp `CURRENT_SETTINGS_VERSION`, and persist once on upgrade. Removed the now-unused `buildMigratedExclusions` / `LegacyModuleExclusions` imports.
- Layering stays acyclic: `settings-migrations` imports `exclusions` directly and never imports `settings.ts`.

`deepMerge` is untouched (its prototype-pollution-safe recursion is out of scope). `buildMigratedExclusions` / `LegacyModuleExclusions` in `exclusions.ts` are reused unchanged.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npx vitest run` — 1807 passed (135 files); new `settings-migrations.test.ts` adds 20 (ordering, immutability/clone, error propagation, both migrations incl. the cleared-`[]` and idempotency cases, drift guard); `settings.test.ts` asserts the default version stamp
- [x] `npm run lint` (Obsidian eslint gate)
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `node scripts/version-bump.mjs --check`
- [x] `node esbuild.config.mjs production`

closes #93

Co-Authored-By: Claude <bot@wafflenet.io>