### PR TITLE
feat: surface title-proposal filename collisions as a distinct UI state

### DIFF
--- a/src/views/proposal-styles.test.ts
+++ b/src/views/proposal-styles.test.ts
@@ -78,3 +78,15 @@ describe('class-name helpers (#342)', () => {
 		}
 	});
 });
+
+describe('title collision styles (#414)', () => {
+	it('defines the previously-dead conflict classes so the callout actually renders', () => {
+		// Regression guard for #414: `.synapse-title-conflict` shipped with zero
+		// rules, so the collision hint rendered as ordinary muted text. The callout
+		// box, its heading, body, and the Conflict badge modifier must all exist.
+		expect(stylesCss).toContain('.synapse-title-conflict {');
+		expect(stylesCss).toContain('.synapse-title-conflict-heading');
+		expect(stylesCss).toContain('.synapse-title-conflict-body');
+		expect(stylesCss).toContain('.synapse-badge--conflict');
+	});
+});

--- a/src/views/unified-proposal-view.test.ts
+++ b/src/views/unified-proposal-view.test.ts
@@ -5,6 +5,8 @@ import type { Proposal } from '../elaboration';
 import type { EnrichmentProposal } from '../enrichment';
 import type { OrganizeProposal } from '../organize';
 import type { DeepDiveProposal } from '../deep-dive';
+import type { TitleProposal } from '../title';
+import { createEl } from '../__mocks__/obsidian';
 
 // --- Helpers ----------------------------------------------------------------
 
@@ -104,6 +106,46 @@ function makeDeepDiveItem(id = 'dd-1'): UnifiedItem {
 		} as DeepDiveProposal,
 	};
 }
+
+/** Minimal title proposal; pass a vault path to simulate a filename collision. */
+function makeTitleProposal(conflictsWith?: string): TitleProposal {
+	return {
+		id: 'title-1',
+		sourceNotePath: 'notes/test.md',
+		currentTitle: 'Untitled',
+		proposedTitle: 'Q3 Plan',
+		trigger: 'untitled',
+		reasoning: 'AI suggests a clearer title.',
+		createdAt: '2024-01-01T00:00:00Z',
+		status: 'pending',
+		...(conflictsWith ? { conflictsWith } : {}),
+	};
+}
+
+// DOM-assertion harness mirroring changelog.test.ts: the centralized obsidian
+// mock faithfully tracks `cls`/`text` on createEl-built elements, so walking the
+// tree by class/tag and reading textContent are reliable here (plain DOM, not a
+// Notice — the inner-element gotcha does not apply).
+
+/** Recursively collect every element in a createEl() stub tree. */
+function walkEls(el: any, out: any[] = []): any[] {
+	for (const child of el?.children ?? []) {
+		out.push(child);
+		walkEls(child, out);
+	}
+	return out;
+}
+// Split on className rather than classList.contains(): the obsidian mock stores
+// a multi-class `cls` string (e.g. "synapse-badge synapse-badge--conflict") as a
+// single combined entry, so contains() of an individual token misses. className
+// rejoins+splits cleanly and works for single- and multi-class elements alike.
+const elsWithClass = (root: any, cls: string): any[] =>
+	walkEls(root).filter((e) => String(e.className ?? '').split(/\s+/).includes(cls));
+const elsWithTag = (root: any, tag: string): any[] =>
+	walkEls(root).filter((e) => e.tagName === tag);
+/** Concatenate an element's own text with all descendant text. */
+const textOf = (el: any): string =>
+	[el?.textContent ?? '', ...walkEls(el).map((c) => c.textContent ?? '')].join(' ');
 
 // --- Tests ------------------------------------------------------------------
 
@@ -276,6 +318,71 @@ describe('UnifiedProposalView reject-all', () => {
 			await view.acceptAll();
 
 			expect(callbacks.onElaborationAccept).not.toHaveBeenCalled();
+		});
+	});
+});
+
+describe('UnifiedProposalView title collision UI (#414)', () => {
+	/** Fresh view; cast to any to reach the private render methods. */
+	function makeView(): any {
+		return new UnifiedProposalView(mockLeaf(), mockCallbacks(), new NotificationManager());
+	}
+
+	describe('renderTitleCard', () => {
+		it('shows one conflict callout + Conflict badge (Title badge kept) when conflictsWith is set', () => {
+			const container = createEl();
+			makeView().renderTitleCard(container, makeTitleProposal('Projects/Roadmap.md'));
+
+			const callouts = elsWithClass(container, 'synapse-title-conflict');
+			expect(callouts).toHaveLength(1);
+			expect(elsWithClass(container, 'synapse-badge--conflict')).toHaveLength(1);
+			// The proposal kind stays legible: the Title badge is still present.
+			expect(elsWithClass(container, 'synapse-badge--title')).toHaveLength(1);
+
+			const text = textOf(callouts[0]);
+			expect(text).toContain('Roadmap'); // existing note name (derived from conflictsWith)
+			expect(text).toContain('Projects'); // its folder
+			expect(text).toContain('trash'); // merge is destructive
+		});
+
+		it('shows no conflict UI and a plain Accept button when conflictsWith is unset', () => {
+			const container = createEl();
+			makeView().renderTitleCard(container, makeTitleProposal());
+
+			expect(elsWithClass(container, 'synapse-title-conflict')).toHaveLength(0);
+			expect(elsWithClass(container, 'synapse-badge--conflict')).toHaveLength(0);
+			const buttons = elsWithTag(container, 'BUTTON').map((b) => b.textContent);
+			expect(buttons).toContain('Accept');
+		});
+	});
+
+	describe('renderTitleReview', () => {
+		it('shows one conflict callout + Conflict header badge when conflictsWith is set', () => {
+			const view = makeView();
+			view.contentEl = createEl();
+			view.renderTitleReview(makeTitleProposal('Projects/Roadmap.md'));
+			const { contentEl } = view;
+
+			const callouts = elsWithClass(contentEl, 'synapse-title-conflict');
+			expect(callouts).toHaveLength(1);
+			expect(elsWithClass(contentEl, 'synapse-badge--conflict')).toHaveLength(1);
+
+			const text = textOf(callouts[0]);
+			expect(text).toContain('Roadmap');
+			expect(text).toContain('Projects');
+			expect(text).toContain('trash');
+		});
+
+		it('shows no conflict UI and a plain Accept button when conflictsWith is unset', () => {
+			const view = makeView();
+			view.contentEl = createEl();
+			view.renderTitleReview(makeTitleProposal());
+			const { contentEl } = view;
+
+			expect(elsWithClass(contentEl, 'synapse-title-conflict')).toHaveLength(0);
+			expect(elsWithClass(contentEl, 'synapse-badge--conflict')).toHaveLength(0);
+			const buttons = elsWithTag(contentEl, 'BUTTON').map((b) => b.textContent);
+			expect(buttons).toContain('Accept');
 		});
 	});
 });

--- a/src/views/unified-proposal-view.ts
+++ b/src/views/unified-proposal-view.ts
@@ -954,6 +954,22 @@ export class UnifiedProposalView extends ItemView {
 
 	// ── Title Card ───────────────────────────────────────────
 
+	/**
+	 * Describe a title collision for user-facing copy (#414). From the full
+	 * vault path in {@link TitleProposal.conflictsWith}, derive the existing
+	 * note's display `name` (basename without the `.md` extension) and the
+	 * `folder` it lives in — rendered as the literal "the vault root" when the
+	 * note sits at the top level so the copy never says "in ".
+	 */
+	private describeConflict(conflictsWith: string): { name: string; folder: string } {
+		const slashIndex = conflictsWith.lastIndexOf('/');
+		const base = slashIndex >= 0 ? conflictsWith.slice(slashIndex + 1) : conflictsWith;
+		const name = base.replace(/\.md$/i, '');
+		const dir = slashIndex >= 0 ? conflictsWith.slice(0, slashIndex) : '';
+		const folder = dir === '' || dir === '.' ? 'the vault root' : dir;
+		return { name, folder };
+	}
+
 	private renderTitleCard(container: HTMLElement, proposal: TitleProposal): void {
 		const card = container.createDiv({
 			cls: `synapse-proposal-card ${cardClass('title')}`,
@@ -963,6 +979,12 @@ export class UnifiedProposalView extends ItemView {
 			text: 'Title',
 			cls: `synapse-badge ${badgeClass('title')}`,
 		});
+
+		// Second badge so the collision is obvious at a glance (#414). 'conflict'
+		// is not a ProposalKind, so the literal class is used (not badgeClass()).
+		if (proposal.conflictsWith) {
+			card.createEl('span', { text: 'Conflict', cls: 'synapse-badge synapse-badge--conflict' });
+		}
 
 		const triggerLabel = proposal.trigger === 'untitled' ? 'Untitled note' : 'Content mismatch';
 		card.createEl('small', {
@@ -975,11 +997,14 @@ export class UnifiedProposalView extends ItemView {
 			cls: 'synapse-preview',
 		});
 
-		// Collision hint (#408): the proposed title already exists in this folder.
+		// Collision callout (#414): name the existing note + warn that merge is destructive.
 		if (proposal.conflictsWith) {
-			card.createEl('small', {
-				text: `"${proposal.proposedTitle}" already exists here — add a suffix or merge.`,
-				cls: 'synapse-reasons synapse-title-conflict',
+			const { name, folder } = this.describeConflict(proposal.conflictsWith);
+			const callout = card.createDiv({ cls: 'synapse-title-conflict' });
+			callout.createEl('div', { text: '⚠ Conflict', cls: 'synapse-title-conflict-heading' });
+			callout.createEl('small', {
+				text: `A note named "${name}" already exists in ${folder}. "Add suffix" keeps both; "Merge into existing" moves this note's content there and trashes this note (recoverable).`,
+				cls: 'synapse-title-conflict-body',
 			});
 		}
 
@@ -1024,6 +1049,11 @@ export class UnifiedProposalView extends ItemView {
 		});
 		titleLink.addEventListener('click', () => this.openNote(proposal.sourceNotePath));
 
+		// Header marker so a colliding proposal reads as a distinct state (#414).
+		if (proposal.conflictsWith) {
+			header.createEl('span', { text: 'Conflict', cls: 'synapse-badge synapse-badge--conflict' });
+		}
+
 		const triggerLabel = proposal.trigger === 'untitled' ? 'Untitled note detected' : 'Title/content mismatch detected';
 		contentEl.createEl('small', {
 			text: `${triggerLabel} | ${proposal.createdAt.split('T')[0]}`,
@@ -1063,11 +1093,14 @@ export class UnifiedProposalView extends ItemView {
 			cls: 'synapse-organize-reasoning synapse-review-box--title',
 		});
 
-		// Collision hint (#408): the proposed title already exists in this folder.
+		// Collision callout (#414): name the existing note + warn that merge is destructive.
 		if (proposal.conflictsWith) {
-			contentEl.createEl('small', {
-				text: `A note named "${proposal.proposedTitle}" already exists in this folder. Add a suffix to keep both, or merge into the existing note.`,
-				cls: 'synapse-review-reasons synapse-title-conflict',
+			const { name, folder } = this.describeConflict(proposal.conflictsWith);
+			const callout = contentEl.createDiv({ cls: 'synapse-title-conflict' });
+			callout.createEl('div', { text: '⚠ Conflict', cls: 'synapse-title-conflict-heading' });
+			callout.createEl('small', {
+				text: `A note named "${name}" already exists in ${folder}. Choose "Add suffix" to keep both notes, or "Merge into existing" to fold this note's content into "${name}" and trash the current note (recoverable from trash).`,
+				cls: 'synapse-title-conflict-body',
 			});
 		}
 

--- a/styles.css
+++ b/styles.css
@@ -1010,6 +1010,31 @@
   border-color: var(--synapse-color-title);
 }
 
+/* ── Title collision (#414) ── */
+.synapse-badge--conflict {
+  background: var(--color-orange);
+  color: var(--text-on-accent);
+}
+.synapse-title-conflict {
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--background-secondary);
+  border-radius: 6px;
+  border-left: 3px solid var(--color-orange);
+}
+.synapse-title-conflict-heading {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-orange);
+  margin-bottom: 4px;
+}
+.synapse-title-conflict-body {
+  display: block;
+  color: var(--text-muted);
+}
+
 /* ── Checkpoint Banner ── */
 .synapse-checkpoint-banner {
   margin-bottom: 12px;


### PR DESCRIPTION
## Summary

When an AI-proposed title collides with an existing note in the same folder, the plugin already detects it and offers **Add suffix** vs **Merge into existing**. But the collision was communicated poorly: the `synapse-title-conflict` hint class had **zero CSS rules** (rendered as plain muted text), the copy never named *which* note it collided with, and it never warned that **Merge into existing is destructive** (it trashes the current note, recoverable from trash).

This makes the collision an unmistakable, distinct UI state in **both** surfaces — the proposal card and the review pane — with enriched, destructive-aware copy.

This is a **presentation + copy change only**. Detection, `conflictsWith` semantics, `mergeNotes`, and the suffix/merge/accept handlers are untouched.

## Changes

- **`styles.css`** — give the dead `.synapse-title-conflict` class a real orange warning callout (box + heading + body) and add a `.synapse-badge--conflict` modifier. All colors use theme-aware Obsidian tokens (`--color-orange`, `--background-secondary`, `--text-muted`, `--text-on-accent`), so light/dark are handled automatically. Orange reads as a warning distinct from the cyan Title color.
- **`src/views/unified-proposal-view.ts`** — in both `renderTitleCard` and `renderTitleReview`, add a `Conflict` badge alongside the kept `Title` badge, and replace the one-line hint with a callout box that names the existing note **and its folder** (derived from `conflictsWith` via a small `describeConflict` helper; root-level collisions render as "the vault root") and states that merge **trashes the current note (recoverable)**.
- **Tests** — DOM-assertion coverage (`unified-proposal-view.test.ts`) for both render paths in the conflict-set and conflict-unset states, plus a `styles.css` class-presence guard (`proposal-styles.test.ts`) against the exact dead-class regression #414 fixes.

## Acceptance criteria

- [x] Collision is a distinct UI state in the proposal card (Conflict badge + callout)
- [x] Collision is a distinct UI state in the review pane (Conflict header badge + callout)
- [x] Copy names the conflicting note (and its folder) in both surfaces
- [x] Copy warns that "Merge into existing" trashes the current note in both surfaces
- [x] The dead `.synapse-title-conflict` class now has real styling
- [x] No behavior change: detection, `mergeNotes`, and the suffix/merge/accept handlers are unchanged

## Verification

Full CI guard set passes locally: `tsc --noEmit`, `npm run lint` (incl. the obsidianmd gate), `check-top-level-requires.mjs`, `npm test` (1812 tests), `version-bump.mjs --check`, and the production build.

CSS **rendering** was verified by class-presence tests (the centralized obsidian test mock tracks `cls`/`text` but not computed styles); the actual orange callout appearance still warrants a quick live Obsidian check.

closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqCNfQ3REzK2y7VbUWnvKK