### PR TITLE
feat: unify folder-scan picker and default to vault root

### DIFF
--- a/src/elaboration/index.ts
+++ b/src/elaboration/index.ts
@@ -2,9 +2,9 @@ import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { CommandRegistrar, isInFlow } from '../commands';
 import {
-	buildCallout, CALLOUT_TYPES, FolderPickerModal, getMarkdownFiles,
+	buildCallout, CALLOUT_TYPES, getMarkdownFiles,
 	NotificationManager, sanitizeAIResponse, stripCodeFences, CheckpointManager, generateId,
-	fireAndForget, reviewAction,
+	fireAndForget, reviewAction, openScanFolderPicker,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { PlaceholderDetector } from './detector';
@@ -56,18 +56,9 @@ export class ElaborationModule {
 
 		this.registrar.register('scan-vault', this.getSettings().elaboration.enabled, {
 			callback: () => {
-				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
-				new FolderPickerModal(
-					this.plugin.app,
-					(folder) => {
-						fireAndForget(
-							this.scanVault(folder.isRoot() ? undefined : folder.path),
-							'Scan folder for stub notes',
-							{ notifications: this.notifications },
-						);
-					},
-					defaultPath
-				).open();
+				openScanFolderPicker(this.plugin.app, (path) => {
+					fireAndForget(this.scanVault(path), 'Scan folder for stub notes', { notifications: this.notifications });
+				});
 			},
 		});
 

--- a/src/enrichment/index.ts
+++ b/src/enrichment/index.ts
@@ -2,9 +2,9 @@ import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
-	FolderPickerModal, getMarkdownFiles, NotificationManager, parseFrontmatter,
+	getMarkdownFiles, NotificationManager, parseFrontmatter,
 	CheckpointManager, generateId, isTwitterUrl, fetchTweetContent, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction, openScanFolderPicker,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { EnrichmentApplier } from './enrichment-applier';
@@ -88,18 +88,9 @@ export class EnrichmentModule {
 
 		this.registrar.register('scan-vault-enrichment', this.getSettings().enrichment.enabled, {
 			callback: () => {
-				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
-				new FolderPickerModal(
-					this.plugin.app,
-					(folder) => {
-						fireAndForget(
-							this.scanVault(folder.isRoot() ? undefined : folder.path),
-							'Scan folder for enrichment',
-							{ notifications: this.notifications },
-						);
-					},
-					defaultPath
-				).open();
+				openScanFolderPicker(this.plugin.app, (path) => {
+					fireAndForget(this.scanVault(path), 'Scan folder for enrichment', { notifications: this.notifications });
+				});
 			},
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { CommandRegistrar, auditCommands, listPaletteActions, REGISTRY_BY_ID } f
 import { planFirstRun, WELCOME_MESSAGE, WELCOME_NOTICE_DURATION_MS } from './onboarding';
 import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
-import { FolderPickerModal, NotificationManager, CheckpointManager, UpdateChecker, fireAndForget, migrateSettings, readSettingsVersion, CURRENT_SETTINGS_VERSION } from './shared';
+import { openScanFolderPicker, NotificationManager, CheckpointManager, UpdateChecker, fireAndForget, migrateSettings, readSettingsVersion, CURRENT_SETTINGS_VERSION } from './shared';
 import type { DeferredTask } from './shared';
 import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
 import { findAudioEmbeds } from './audio';
@@ -423,18 +423,9 @@ export default class SynapsePlugin extends Plugin {
 
 		registrar.register('fire', true, {
 			callback: () => {
-				const defaultPath = this.app.workspace.getActiveFile()?.parent?.path || '';
-				new FolderPickerModal(
-					this.app,
-					(folder) => {
-						fireAndForget(
-							synapseRunner.fire(folder.isRoot() ? undefined : folder.path),
-							'Run all features on a folder',
-							{ notifications: this.notifications },
-						);
-					},
-					defaultPath,
-				).open();
+				openScanFolderPicker(this.app, (path) => {
+					fireAndForget(synapseRunner.fire(path), 'Run all features on a folder', { notifications: this.notifications });
+				});
 			},
 		});
 

--- a/src/organize/index.ts
+++ b/src/organize/index.ts
@@ -2,9 +2,9 @@ import { Plugin, TFile, normalizePath } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
-	FolderPickerModal, getMarkdownFiles, NotificationManager, ensureFolder,
+	getMarkdownFiles, NotificationManager, ensureFolder,
 	writeNote, generateOrganizeSummary, CheckpointManager, generateId, fireAndForget,
-	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction,
+	isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction, openScanFolderPicker,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import type { MoveRecord } from '../shared';
@@ -71,18 +71,9 @@ export class OrganizeModule {
 
 		this.registrar.register('scan-directory-organize', this.getSettings().organize.enabled, {
 			callback: () => {
-				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
-				new FolderPickerModal(
-					this.plugin.app,
-					(folder) => {
-						fireAndForget(
-							this.scanDirectory(folder.isRoot() ? undefined : folder.path),
-							'Scan folder for organization',
-							{ notifications: this.notifications },
-						);
-					},
-					defaultPath
-				).open();
+				openScanFolderPicker(this.plugin.app, (path) => {
+					fireAndForget(this.scanDirectory(path), 'Scan folder for organization', { notifications: this.notifications });
+				});
 			},
 		});
 

--- a/src/rem/index.ts
+++ b/src/rem/index.ts
@@ -5,7 +5,7 @@ import type { CommandRegistrar } from '../commands';
 import type { NotificationManager, CheckpointManager } from '../shared';
 import type { DeferredTask, CheckpointWorkItem } from '../shared';
 import type { RemProposal, RemLinkCandidate } from './types';
-import { generateId, getMarkdownFiles, FolderPickerModal, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction } from '../shared';
+import { generateId, getMarkdownFiles, openScanFolderPicker, fireAndForget, isPathExcluded, matchesExcludeTag, findMatchingRule, reviewAction } from '../shared';
 import { MentionScanner } from './mention-scanner';
 import { SemanticMatcher } from './semantic-matcher';
 import { RemApplier } from './rem-applier';
@@ -67,15 +67,9 @@ export class RemModule {
 		// Command: scan directory
 		this.registrar.register('rem-directory', this.getSettings().rem.enabled, {
 			callback: () => {
-				new FolderPickerModal(
-					this.plugin.app,
-					(folder) => {
-						const path = folder.isRoot() ? undefined : folder.path;
-						fireAndForget(this.remScanDirectory(path), 'Discover REM links in folder', {
-							notifications: this.notifications,
-						});
-					}
-				).open();
+				openScanFolderPicker(this.plugin.app, (path) => {
+					fireAndForget(this.remScanDirectory(path), 'Discover REM links in folder', { notifications: this.notifications });
+				});
 			},
 		});
 	}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -33,6 +33,7 @@ export type { UpdateCheckerDeps } from './update-checker';
 export { fireAndForget } from './fire-and-forget';
 export type { FireAndForgetOptions } from './fire-and-forget';
 export { FolderPickerModal } from './folder-picker-modal';
+export { openScanFolderPicker } from './open-scan-folder-picker';
 export {
 	sanitizeUrl,
 	sanitizePath,

--- a/src/shared/open-scan-folder-picker.test.ts
+++ b/src/shared/open-scan-folder-picker.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TFolder } from 'obsidian';
+
+// Capture how openScanFolderPicker constructs the modal and whether it opens it.
+// `mock`-prefixed names are referenced lazily inside the (hoisted) vi.mock
+// factory — matching the codebase convention (see mockFindAudioEmbeds elsewhere).
+const mockConstructed: Array<{
+	app: unknown;
+	onChoose: (folder: TFolder) => void;
+	defaultPath: unknown;
+}> = [];
+const mockOpen = vi.fn();
+
+vi.mock('./folder-picker-modal', () => ({
+	FolderPickerModal: class {
+		constructor(
+			public app: unknown,
+			public onChoose: (folder: TFolder) => void,
+			public defaultPath?: string,
+		) {
+			mockConstructed.push({ app, onChoose, defaultPath });
+		}
+		open = mockOpen;
+	},
+}));
+
+import { openScanFolderPicker } from './open-scan-folder-picker';
+
+function makeFolder(path: string, root: boolean): TFolder {
+	const f = new TFolder();
+	f.path = path;
+	f.name = path.split('/').pop() || '';
+	f.children = [];
+	f.isRoot = () => root;
+	return f;
+}
+
+const mockApp = {} as any;
+
+describe('openScanFolderPicker', () => {
+	beforeEach(() => {
+		mockConstructed.length = 0;
+		mockOpen.mockClear();
+	});
+
+	it('constructs a FolderPickerModal with the given app and opens it', () => {
+		openScanFolderPicker(mockApp, vi.fn());
+
+		expect(mockConstructed).toHaveLength(1);
+		expect(mockConstructed[0].app).toBe(mockApp);
+		expect(mockOpen).toHaveBeenCalledTimes(1);
+	});
+
+	it('passes no defaultPath so the picker opens root-first', () => {
+		openScanFolderPicker(mockApp, vi.fn());
+
+		expect(mockConstructed[0].defaultPath).toBeUndefined();
+	});
+
+	it('maps the vault root folder to undefined', () => {
+		const onChoose = vi.fn();
+		openScanFolderPicker(mockApp, onChoose);
+
+		mockConstructed[0].onChoose(makeFolder('/', true));
+
+		expect(onChoose).toHaveBeenCalledWith(undefined);
+	});
+
+	it('maps a non-root folder to its path', () => {
+		const onChoose = vi.fn();
+		openScanFolderPicker(mockApp, onChoose);
+
+		mockConstructed[0].onChoose(makeFolder('projects', false));
+
+		expect(onChoose).toHaveBeenCalledWith('projects');
+	});
+});

--- a/src/shared/open-scan-folder-picker.ts
+++ b/src/shared/open-scan-folder-picker.ts
@@ -1,0 +1,16 @@
+import type { App } from 'obsidian';
+import { FolderPickerModal } from './folder-picker-modal';
+
+/**
+ * Unified scan folder picker. Opens with an empty query, which FolderPickerModal
+ * sorts root-first, so Enter-on-open scans the whole vault. `onChoose` receives
+ * the chosen folder path, or `undefined` for the vault root.
+ */
+export function openScanFolderPicker(
+	app: App,
+	onChoose: (path: string | undefined) => void,
+): void {
+	new FolderPickerModal(app, (folder) => {
+		onChoose(folder.isRoot() ? undefined : folder.path);
+	}).open();
+}

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -2,9 +2,9 @@ import { Plugin, TFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import { CommandRegistrar } from '../commands';
 import {
-	FolderPickerModal, getMarkdownFiles, NotificationManager, buildCallout,
+	getMarkdownFiles, NotificationManager, buildCallout,
 	CALLOUT_TYPES, CheckpointManager, generateId, fireAndForget,
-	isPathExcluded, matchesExcludeTag, detectSchemaFor,
+	isPathExcluded, matchesExcludeTag, detectSchemaFor, openScanFolderPicker,
 } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { OperationHandle } from '../shared';
@@ -144,18 +144,9 @@ export class SummarizeModule {
 
 		this.registrar.register('scan-vault-summarize', this.getSettings().summarize.enabled, {
 			callback: () => {
-				const defaultPath = this.plugin.app.workspace.getActiveFile()?.parent?.path || '';
-				new FolderPickerModal(
-					this.plugin.app,
-					(folder) => {
-						fireAndForget(
-							this.scanVault(folder.isRoot() ? undefined : folder.path),
-							'Scan folder for notes to summarize',
-							{ notifications: this.notifications },
-						);
-					},
-					defaultPath
-				).open();
+				openScanFolderPicker(this.plugin.app, (path) => {
+					fireAndForget(this.scanVault(path), 'Scan folder for notes to summarize', { notifications: this.notifications });
+				});
 			},
 		});
 	}


### PR DESCRIPTION
## Summary
Unifies the six "scan a folder" entry points behind a single shared helper and makes the vault root the default selection everywhere.

Previously five sites (elaboration, organize, summarize, enrichment, and the all-features Fire run) pre-filled the picker with the active note's parent folder via a copy-pasted `getActiveFile()?.parent?.path` snippet, while rem passed no default at all. The new `openScanFolderPicker(app, onChoose)` helper (`src/shared/open-scan-folder-picker.ts`) opens `FolderPickerModal` with no defaultPath; the modal already includes the vault root, renders it as "/ (vault root)", and sorts it first on an empty query — so every scan now opens root-first and Enter-on-open scans the whole vault.

`FolderPickerModal` itself is unchanged. The exclusions folder picker in `settings-tab.ts` is intentionally out of scope (it builds an exclude glob, not a scan).

## Acceptance criteria
- [x] All scan folder pickers are visually and behaviorally identical except for their operation label.
- [x] Opening any scan picker highlights the vault root by default; Enter-on-open scans the whole vault.
- [x] `rem-directory` matches the others (no empty / divergent default).
- [x] No duplicated `defaultPath` snippets remain — one shared entry point.

## Test plan
- [x] New `src/shared/open-scan-folder-picker.test.ts` (4 tests): constructs + opens the modal, passes no defaultPath, maps root to `undefined` and non-root to `folder.path`.
- [x] `npm test` — 1823 tests pass (incl. the 4 summarize tests that stub `FolderPickerModal`, unchanged).
- [x] `npx tsc --noEmit --skipLibCheck`, `npm run lint`, `node scripts/check-top-level-requires.mjs`, `node scripts/version-bump.mjs --check`, and `node esbuild.config.mjs production` all green.

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGH9tfLMizhAfo1nR9EPck