### PR TITLE
refactor: type-safety cleanup of src/shared test files (#422)

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -71,6 +71,48 @@ export class Modal {
 	onClose(): void {}
 }
 
+/** Synthetic event accepted by the stub's `dispatchEvent` test helper. */
+interface StubEvent {
+	type: string;
+	[key: string]: unknown;
+}
+
+/**
+ * The `cls`/`text`/`attr` subset of Obsidian's `DomElementInfo` the stub
+ * actually applies (see {@link createStubEl}). Other `DomElementInfo` keys a
+ * caller may pass are ignored at runtime; the consumer-facing `createEl`/
+ * `createDiv`/`createSpan` signatures come from the global Obsidian
+ * augmentation on `HTMLElement`, not from this internal helper type.
+ */
+type StubElInfo =
+	| string
+	| {
+			cls?: string | string[];
+			text?: string | number;
+			attr?: Record<string, string | number | boolean>;
+	  };
+
+/**
+ * Concrete type for the DOM stub produced by {@link createStubEl} /
+ * {@link createEl}.
+ *
+ * It extends the (Obsidian-augmented) global `HTMLElement` so a stub is
+ * accepted anywhere shipped code expects a real `containerEl: HTMLElement`
+ * (e.g. `renderFeatureChipSelect(container: HTMLElement)`), which is how the
+ * ~56 consuming `*.test.ts` files feed it in. The augmentation already supplies
+ * `createEl`/`createDiv`/`createSpan`/`empty`/`setText`/`addClass`/… with their
+ * real return types, so tests keep introspecting the stub tree without `any`.
+ * Only the deltas from a real element are declared here: an optional `value`
+ * (read off `<option>`/input stubs) and a `dispatchEvent` widened to accept the
+ * synthetic {@link StubEvent} payloads tests fire.
+ */
+export interface StubEl extends HTMLElement {
+	/** Present on `<option>`/input stubs; absent on plain elements. */
+	value?: string;
+	/** Test helper: dispatch accepts a synthetic `{ type, … }`, not only `Event`. */
+	dispatchEvent(evt: Event | StubEvent): boolean;
+}
+
 /**
  * Helper to create a stub DOM element with Obsidian's augmented methods.
  *
@@ -78,19 +120,19 @@ export class Modal {
  * plugin. Class state, attributes, children, and event listeners are tracked
  * so tests can introspect structure and dispatch synthetic events.
  */
-function createStubEl(tag = 'div'): any {
+function createStubEl(tag = 'div'): StubEl {
 	const classes = new Set<string>();
 	const attributes: Record<string, string> = {};
-	const listeners: Record<string, Array<(evt: any) => void>> = {};
-	const children: any[] = [];
+	const listeners: Record<string, Array<(evt: StubEvent) => void>> = {};
+	const children: StubEl[] = [];
 
-	const applyInfo = (child: any, info?: any): any => {
+	const applyInfo = (child: StubEl, info?: StubElInfo): StubEl => {
 		if (typeof info === 'string') {
-			info.split(/\s+/).filter(Boolean).forEach((c: string) => child.classList.add(c));
+			info.split(/\s+/).filter(Boolean).forEach((c) => child.classList.add(c));
 		} else if (info && typeof info === 'object') {
 			if (info.cls) {
 				const clsList = Array.isArray(info.cls) ? info.cls : [info.cls];
-				clsList.forEach((c: string) => child.classList.add(c));
+				clsList.forEach((c) => child.classList.add(c));
 			}
 			if (info.text != null) child.textContent = String(info.text);
 			if (info.attr) {
@@ -100,15 +142,17 @@ function createStubEl(tag = 'div'): any {
 		return child;
 	};
 
-	const make = (childTag: string) => (info?: any, cb?: (el: any) => void) => {
-		const child = createStubEl(childTag);
-		applyInfo(child, info);
-		children.push(child);
-		if (cb) cb(child);
-		return child;
-	};
+	const make =
+		(childTag: string) =>
+		(info?: StubElInfo, cb?: (el: StubEl) => void): StubEl => {
+			const child = createStubEl(childTag);
+			applyInfo(child, info);
+			children.push(child);
+			if (cb) cb(child);
+			return child;
+		};
 
-	const el: any = {
+	const el: StubEl = {
 		tagName: tag.toUpperCase(),
 		classList: {
 			add: vi.fn((...c: string[]) => c.forEach((x) => classes.add(x))),
@@ -131,7 +175,7 @@ function createStubEl(tag = 'div'): any {
 		empty: vi.fn(() => {
 			children.length = 0;
 		}),
-		createEl: vi.fn((t: string, info?: any, cb?: (el: any) => void) =>
+		createEl: vi.fn((t: string, info?: StubElInfo, cb?: (el: StubEl) => void) =>
 			make(t)(info, cb),
 		),
 		createDiv: vi.fn(make('div')),
@@ -152,18 +196,18 @@ function createStubEl(tag = 'div'): any {
 		removeAttribute: vi.fn((k: string) => {
 			delete attributes[k];
 		}),
-		addEventListener: vi.fn((type: string, cb: (evt: any) => void) => {
+		addEventListener: vi.fn((type: string, cb: (evt: StubEvent) => void) => {
 			(listeners[type] ??= []).push(cb);
 		}),
 		removeEventListener: vi.fn(),
 		/** Test helper: synchronously invoke registered listeners for an event. */
-		dispatchEvent: (evt: { type: string; [k: string]: unknown }) => {
+		dispatchEvent: (evt: StubEvent) => {
 			(listeners[evt.type] ?? []).forEach((cb) => cb(evt));
 			return true;
 		},
 		closest: vi.fn().mockReturnValue(null),
 		style: {},
-	};
+	} as unknown as StubEl;
 	return el;
 }
 
@@ -172,19 +216,18 @@ function createStubEl(tag = 'div'): any {
  * helpers (createDiv/createSpan/createEl/empty/classList/…). Useful for
  * rendering components that expect a real `containerEl`.
  */
-export function createEl(tag = 'div'): any {
+export function createEl(tag = 'div'): StubEl {
 	return createStubEl(tag);
 }
 
 export class Notice {
 	/** Test helper: every Notice ever constructed (clear between tests). */
 	static instances: Notice[] = [];
-	noticeEl: any;
+	noticeEl = createStubEl();
 	duration?: number;
 	/** Test helper: the raw string message the Notice was constructed with. */
 	message?: string;
 	constructor(_message: string | DocumentFragment, _duration?: number) {
-		this.noticeEl = createStubEl();
 		this.duration = _duration;
 		if (typeof _message === 'string') {
 			this.message = _message;
@@ -218,8 +261,8 @@ export class MarkdownView {
 	app: unknown = {};
 	leaf: unknown;
 	file: TFile | null = null;
-	contentEl: any = createStubEl();
-	containerEl: any = createStubEl();
+	contentEl = createStubEl();
+	containerEl = createStubEl();
 	constructor(leaf?: unknown) {
 		this.leaf = leaf;
 	}
@@ -248,7 +291,7 @@ export class ItemView {
 
 export class SuggestModal<T = unknown> {
 	app: unknown;
-	inputEl: any = { value: '', focus: vi.fn() };
+	inputEl = { value: '', focus: vi.fn() };
 	constructor(app: unknown) {
 		this.app = app;
 	}
@@ -266,7 +309,7 @@ export class SuggestModal<T = unknown> {
 export class ToggleComponent {
 	/** Test helper: every instance ever constructed (clear between tests). */
 	static instances: ToggleComponent[] = [];
-	toggleEl: any = createStubEl();
+	toggleEl = createStubEl();
 	tooltip = '';
 	private value = false;
 	private changeCb: ((value: boolean) => unknown) | undefined;
@@ -339,10 +382,10 @@ export class Setting {
 	 * container in tests. Falls back to an orphan stub when no container is passed
 	 * (e.g. credential-field.test.ts passes `{}` and inspects the stub directly).
 	 */
-	settingEl: any;
+	settingEl: StubEl;
 	/** Child components created via add*, mirroring Obsidian's `components`. */
 	components: ToggleComponent[] = [];
-	constructor(containerEl?: any) {
+	constructor(containerEl?: { createDiv?: (cls: string) => StubEl }) {
 		this.settingEl = containerEl?.createDiv?.('setting-item') ?? createStubEl();
 	}
 	setName = vi.fn().mockReturnThis();
@@ -377,7 +420,13 @@ export class WorkspaceLeaf {
 
 // --- Metadata helpers ---
 
-export function getAllTags(cache: any): string[] | null {
+/** The slice of Obsidian's `CachedMetadata` this stub reads tags out of. */
+interface TagsCache {
+	tags?: Array<{ tag: string }>;
+	frontmatter?: { tags?: string | string[] };
+}
+
+export function getAllTags(cache: TagsCache | null | undefined): string[] | null {
 	const tags: string[] = [];
 	if (cache?.tags) {
 		for (const t of cache.tags) tags.push(t.tag);
@@ -393,9 +442,9 @@ export function getAllTags(cache: any): string[] | null {
 	return tags.length > 0 ? tags : null;
 }
 
-export function parseYaml(yaml: string): any {
+export function parseYaml(yaml: string): Record<string, unknown> {
 	// Simple YAML parser for tests — handles key: value lines
-	const result: Record<string, any> = {};
+	const result: Record<string, unknown> = {};
 	for (const line of yaml.split('\n')) {
 		const match = line.match(/^(\w[\w-]*)\s*:\s*(.+)/);
 		if (match) {
@@ -411,14 +460,14 @@ export function parseYaml(yaml: string): any {
 	return result;
 }
 
-export function stringifyYaml(obj: any): string {
+export function stringifyYaml(obj: Record<string, unknown>): string {
 	const lines: string[] = [];
 	for (const [key, value] of Object.entries(obj)) {
 		if (Array.isArray(value)) {
 			lines.push(`${key}:`);
-			for (const item of value) lines.push(`  - ${item}`);
+			for (const item of value) lines.push(`  - ${String(item)}`);
 		} else {
-			lines.push(`${key}: ${value}`);
+			lines.push(`${key}: ${String(value)}`);
 		}
 	}
 	return lines.join('\n') + '\n';
@@ -444,7 +493,7 @@ export const Platform = {
 // --- SliderComponent (stub for slider-helper.ts) ---
 
 export class SliderComponent {
-	sliderEl: any = createStubEl();
+	sliderEl = createStubEl();
 	setLimits = vi.fn().mockReturnThis();
 	setValue = vi.fn().mockReturnThis();
 	setDynamicTooltip = vi.fn().mockReturnThis();

--- a/src/__test-utils__/mock-factories.ts
+++ b/src/__test-utils__/mock-factories.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { vi, type Mock } from 'vitest';
 import { TFile, TFolder } from '../__mocks__/obsidian';
 
 /**
@@ -92,9 +92,26 @@ export function createMockApp(): MockApp {
 }
 
 /**
+ * Shape returned by {@link createMockPlugin}. Mirrors the {@link MockApp}
+ * pattern: a named contract pinning the spy-backed Plugin surface the tests
+ * use, so consumers reference a stable, non-`any` type. `app` is the
+ * {@link MockApp} bag; the rest are the registered-lifecycle spies.
+ */
+export interface MockPlugin {
+	app: MockApp;
+	addCommand: Mock;
+	addRibbonIcon: Mock;
+	addSettingTab: Mock;
+	registerView: Mock;
+	registerEvent: Mock;
+	loadData: Mock;
+	saveData: Mock;
+}
+
+/**
  * Create a mock Plugin with a settings getter.
  */
-export function createMockPlugin(settingsOverrides?: Record<string, unknown>) {
+export function createMockPlugin(settingsOverrides?: Record<string, unknown>): MockPlugin {
 	const app = createMockApp();
 
 	return {
@@ -114,7 +131,7 @@ export function createMockPlugin(settingsOverrides?: Record<string, unknown>) {
  * Import DEFAULT_SETTINGS from settings.ts to use this.
  */
 export function makeSettings<T>(defaults: T, overrides?: Partial<T>): T {
-	return { ...structuredClone(defaults), ...overrides } as T;
+	return { ...structuredClone(defaults), ...overrides };
 }
 
 /**

--- a/src/shared/ai-client.test.ts
+++ b/src/shared/ai-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { requestUrl } from '../__mocks__/obsidian';
+import { requestUrl, type RequestUrlParam } from '../__mocks__/obsidian';
 import { AIClient, redactSecrets } from './ai-client';
 import { SynapseSettings, DEFAULT_SETTINGS } from '../settings';
 import type { ChatMessage, ContentBlock } from './types';
@@ -22,9 +22,22 @@ function geminiResponse(text: string) {
 	};
 }
 
-function lastRequestBody(): Record<string, any> {
-	const call = mockRequestUrl.mock.calls[0][0] as any;
-	return JSON.parse(call.body);
+/** Shape of the JSON request bodies these provider tests introspect. */
+interface ParsedRequestBody {
+	model?: string;
+	max_tokens?: number;
+	temperature?: number;
+	stream?: boolean;
+	system?: string;
+	system_instruction?: unknown;
+	generationConfig?: unknown;
+	contents: Array<{ role: string; parts: unknown }>;
+	messages: Array<{ role?: string; content: unknown }>;
+}
+
+function lastRequestBody(): ParsedRequestBody {
+	const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
+	return JSON.parse(call.body as string) as ParsedRequestBody;
 }
 
 describe('redactSecrets', () => {
@@ -73,13 +86,13 @@ describe('AIClient — Gemini provider', () => {
 		const result = await client.complete('Hello');
 
 		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
-		const call = mockRequestUrl.mock.calls[0][0] as any;
+		const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 		expect(call.url).toBe(
 			'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent'
 		);
 		expect(call.method).toBe('POST');
-		expect(call.headers['x-goog-api-key']).toBe('AIzaSyTestKey1234567890123456789012345');
-		expect(call.headers['Content-Type']).toBe('application/json');
+		expect(call.headers?.['x-goog-api-key']).toBe('AIzaSyTestKey1234567890123456789012345');
+		expect(call.headers?.['Content-Type']).toBe('application/json');
 		expect(result).toBe('hi there');
 	});
 
@@ -184,7 +197,7 @@ describe('AIClient — Gemini provider', () => {
 			headers: {},
 		});
 
-		const err: Error = await client.complete('Hello').catch((e) => e);
+		const err = (await client.complete('Hello').catch((e: unknown) => e)) as Error;
 		expect(err).toBeInstanceOf(Error);
 		expect(err.message).toContain('MAX_TOKENS');
 		expect(err.message).toMatch(/max tokens/i);
@@ -211,7 +224,7 @@ describe('AIClient — Gemini provider', () => {
 			headers: {},
 		});
 
-		const err: Error = await client.complete('Hello').catch((e) => e);
+		const err = (await client.complete('Hello').catch((e: unknown) => e)) as Error;
 		expect(err).toBeInstanceOf(Error);
 		expect(err.message).toContain('API error (400)');
 		expect(err.message).toContain('[REDACTED]');
@@ -272,10 +285,10 @@ describe('AIClient — OpenAI provider', () => {
 
 		const result = await client.complete('Hi', 'Be brief.');
 
-		const call = mockRequestUrl.mock.calls[0][0] as any;
+		const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 		expect(call.url).toBe('https://api.openai.com/v1/chat/completions');
 		expect(call.method).toBe('POST');
-		expect(call.headers['Authorization']).toBe('Bearer sk-test123456789012345');
+		expect(call.headers?.['Authorization']).toBe('Bearer sk-test123456789012345');
 		const body = lastRequestBody();
 		expect(body.model).toBe('gpt-4o');
 		expect(body.max_tokens).toBe(512);
@@ -326,10 +339,10 @@ describe('AIClient — Anthropic provider', () => {
 
 		const result = await client.complete('Hello', 'You are terse.');
 
-		const call = mockRequestUrl.mock.calls[0][0] as any;
+		const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 		expect(call.url).toBe('https://api.anthropic.com/v1/messages');
-		expect(call.headers['x-api-key']).toBe('anthropic-key-1234567890');
-		expect(call.headers['anthropic-version']).toBe('2023-06-01');
+		expect(call.headers?.['x-api-key']).toBe('anthropic-key-1234567890');
+		expect(call.headers?.['anthropic-version']).toBe('2023-06-01');
 		const body = lastRequestBody();
 		expect(body.model).toBe('claude-sonnet-4-6');
 		// system message is lifted out of messages into the top-level system field
@@ -385,7 +398,7 @@ describe('AIClient — Ollama provider', () => {
 
 		const result = await client.complete('Hi');
 
-		const call = mockRequestUrl.mock.calls[0][0] as any;
+		const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 		expect(call.url).toBe('http://localhost:11434/api/chat');
 		const body = lastRequestBody();
 		expect(body.model).toBe('llama3');

--- a/src/shared/collapsible-section.test.ts
+++ b/src/shared/collapsible-section.test.ts
@@ -1,81 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createEl, ToggleComponent, type StubEl } from '../__mocks__/obsidian';
 import { addCollapsibleSection } from './collapsible-section';
 
 /**
- * Recursive stub element mirroring the Obsidian DOM augmentation, with enough
- * introspection (classes, attributes, children, listeners) to assert accordion
- * behavior. Matches the shape produced by the obsidian mock's createStubEl.
+ * Dispatch a synthetic event on a stub element. The stub's `dispatchEvent`
+ * accepts a plain `{ type, ... }` payload rather than a real-DOM `Event`.
  */
-function stubEl(tag = 'div'): any {
-	const classes = new Set<string>();
-	const attributes: Record<string, string> = {};
-	const listeners: Record<string, Array<(evt: any) => void>> = {};
-	const children: any[] = [];
-
-	const apply = (child: any, info?: any) => {
-		if (info && typeof info === 'object') {
-			if (info.cls) {
-				(Array.isArray(info.cls) ? info.cls : [info.cls]).forEach((c: string) =>
-					child.classList.add(c),
-				);
-			}
-			if (info.text != null) child.textContent = String(info.text);
-		}
-		return child;
-	};
-	const make = (t: string) => (info?: any, cb?: (el: any) => void) => {
-		const child = stubEl(t);
-		apply(child, info);
-		children.push(child);
-		if (cb) cb(child);
-		return child;
-	};
-
-	const el: any = {
-		tagName: tag.toUpperCase(),
-		textContent: '',
-		children,
-		classList: {
-			add: (...c: string[]) => c.forEach((x) => classes.add(x)),
-			remove: (...c: string[]) => c.forEach((x) => classes.delete(x)),
-			contains: (c: string) => classes.has(c),
-		},
-		hasClass: (c: string) => classes.has(c),
-		addClass: (...c: string[]) => c.forEach((x) => classes.add(x)),
-		removeClass: (...c: string[]) => c.forEach((x) => classes.delete(x)),
-		setText: (t: string) => {
-			el.textContent = t;
-		},
-		setAttribute: (k: string, v: string) => {
-			attributes[k] = v;
-		},
-		getAttribute: (k: string) => (k in attributes ? attributes[k] : null),
-		createDiv: make('div'),
-		createSpan: make('span'),
-		createEl: (t: string, info?: any, cb?: (el: any) => void) => make(t)(info, cb),
-		addEventListener: (type: string, cb: (evt: any) => void) => {
-			(listeners[type] ??= []).push(cb);
-		},
-		dispatchEvent: (evt: { type: string; [k: string]: unknown }) => {
-			(listeners[evt.type] ?? []).forEach((cb) => cb(evt));
-			return true;
-		},
-	};
-	return el;
-}
-
-/**
- * Dispatch a synthetic event on a stub element. Casts away the real-DOM
- * `Event` type since stub elements accept plain `{ type, ... }` payloads.
- */
-function fire(el: any, evt: Record<string, unknown> & { type: string }): void {
+function fire(el: StubEl, evt: Record<string, unknown> & { type: string }): void {
 	el.dispatchEvent(evt);
 }
 
 /** Recursively find the first descendant element whose class set contains `cls`. */
-function findByClass(root: any, cls: string): any | undefined {
-	for (const child of root.children ?? []) {
-		if (child.hasClass?.(cls)) return child;
+function findByClass(root: HTMLElement, cls: string): HTMLElement | undefined {
+	for (const child of root.children as unknown as StubEl[]) {
+		if (child.hasClass(cls)) return child;
 		const nested = findByClass(child, cls);
 		if (nested) return nested;
 	}
@@ -83,10 +21,10 @@ function findByClass(root: any, cls: string): any | undefined {
 }
 
 describe('addCollapsibleSection', () => {
-	let container: any;
+	let container: StubEl;
 
 	beforeEach(() => {
-		container = stubEl();
+		container = createEl();
 	});
 
 	describe('structure', () => {
@@ -230,7 +168,7 @@ describe('addCollapsibleSection', () => {
 				onCollapseChange,
 			});
 
-			await (section.toggle as any)._trigger(false);
+			await (section.toggle as unknown as ToggleComponent)._trigger(false);
 
 			expect(section.isCollapsed()).toBe(true);
 			expect(onCollapseChange).toHaveBeenCalledWith(true);
@@ -248,7 +186,7 @@ describe('addCollapsibleSection', () => {
 				onCollapseChange,
 			});
 
-			await (section.toggle as any)._trigger(true);
+			await (section.toggle as unknown as ToggleComponent)._trigger(true);
 
 			expect(section.isCollapsed()).toBe(false);
 			expect(onCollapseChange).toHaveBeenCalledWith(false);
@@ -268,7 +206,7 @@ describe('addCollapsibleSection', () => {
 				},
 			});
 
-			await (section.toggle as any)._trigger(false);
+			await (section.toggle as unknown as ToggleComponent)._trigger(false);
 
 			expect(order).toEqual(['collapseChange', 'toggle:collapsed=true']);
 		});

--- a/src/shared/credential-field.test.ts
+++ b/src/shared/credential-field.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Setting as ObsidianSetting } from 'obsidian';
-import { Setting, ButtonComponent, createEl } from '../__mocks__/obsidian';
+import { Setting, ButtonComponent, createEl, type StubEl } from '../__mocks__/obsidian';
 import { decorateCredentialField } from './credential-field';
 import type { ValidationResult } from './credential-validator';
 import { PROVIDER_METADATA } from './provider-metadata';
@@ -13,17 +13,23 @@ import { PROVIDER_METADATA } from './provider-metadata';
  * directly. The Setting is typed as the real one so it satisfies the decorator API.
  */
 function makeCtx() {
-	const setting = new Setting({} as never) as unknown as ObsidianSetting;
+	const setting = new Setting({}) as unknown as ObsidianSetting;
 	const container = createEl();
 	return { setting, container };
 }
 
-const extrasEl = (setting: any) =>
-	setting.settingEl.children.find((el: any) => el.classList?.contains('synapse-credential-extras'));
-const chipEl = (setting: any) =>
-	extrasEl(setting)?.children.find((el: any) => el.classList?.contains('synapse-credential-chip'));
-const anchorEl = (setting: any) =>
-	extrasEl(setting)?.children.find((el: any) => el.tagName === 'A');
+const extrasEl = (setting: ObsidianSetting): StubEl | undefined =>
+	(setting.settingEl.children as unknown as StubEl[]).find((el) =>
+		el.classList.contains('synapse-credential-extras'),
+	);
+const chipEl = (setting: ObsidianSetting): StubEl | undefined =>
+	(extrasEl(setting)?.children as unknown as StubEl[] | undefined)?.find((el) =>
+		el.classList.contains('synapse-credential-chip'),
+	);
+const anchorEl = (setting: ObsidianSetting): StubEl | undefined =>
+	(extrasEl(setting)?.children as unknown as StubEl[] | undefined)?.find(
+		(el) => el.tagName === 'A',
+	);
 
 function testButton(): ButtonComponent {
 	const btn = ButtonComponent.instances.find((b) => b.buttonText === 'Test');
@@ -57,7 +63,7 @@ describe('decorateCredentialField', () => {
 		// The extras block now lives inside the setting row's own `.setting-item`…
 		expect(extrasEl(setting)).toBeDefined();
 		// …and the host row is marked so CSS can wrap the helper onto its own line.
-		expect((setting.settingEl as any).classList.contains('synapse-setting--has-helper')).toBe(true);
+		expect(setting.settingEl.classList.contains('synapse-setting--has-helper')).toBe(true);
 		// …and nothing leaked into the section-body container.
 		expect(container.children).toHaveLength(0);
 	});
@@ -65,7 +71,7 @@ describe('decorateCredentialField', () => {
 	it('renders a get-key anchor pointing at the provider console', () => {
 		const { setting } = makeCtx();
 		decorateCredentialField({ setting, provider: 'openai', getKey: () => 'sk-x' });
-		const a = anchorEl(setting);
+		const a = anchorEl(setting)!;
 		expect(a).toBeDefined();
 		expect(a.getAttribute('href')).toBe(PROVIDER_METADATA.openai.getKeyUrl);
 		expect(a.getAttribute('target')).toBe('_blank');
@@ -85,7 +91,7 @@ describe('decorateCredentialField', () => {
 	it('starts with a neutral format-hint chip', () => {
 		const { setting } = makeCtx();
 		decorateCredentialField({ setting, provider: 'openai', getKey: () => '' });
-		const chip = chipEl(setting);
+		const chip = chipEl(setting)!;
 		expect(chip.textContent).toBe(PROVIDER_METADATA.openai.formatHint);
 		expect(chip.classList.contains('is-hint')).toBe(true);
 	});
@@ -103,7 +109,7 @@ describe('decorateCredentialField', () => {
 		await flush();
 
 		expect(validate).toHaveBeenCalledWith('openai', 'sk-good', { endpoint: undefined });
-		const chip = chipEl(setting);
+		const chip = chipEl(setting)!;
 		expect(chip.textContent).toContain('Connected to OpenAI');
 		expect(chip.classList.contains('is-valid')).toBe(true);
 	});
@@ -120,7 +126,7 @@ describe('decorateCredentialField', () => {
 		testButton()._click();
 		await flush();
 
-		const chip = chipEl(setting);
+		const chip = chipEl(setting)!;
 		expect(chip.textContent).toContain('Invalid key');
 		expect(chip.classList.contains('is-invalid')).toBe(true);
 	});
@@ -162,10 +168,10 @@ describe('decorateCredentialField', () => {
 
 		testButton()._click();
 		await flush();
-		expect(chipEl(setting).classList.contains('is-valid')).toBe(true);
+		expect(chipEl(setting)!.classList.contains('is-valid')).toBe(true);
 
 		handle.reset();
-		const chip = chipEl(setting);
+		const chip = chipEl(setting)!;
 		expect(chip.textContent).toBe(PROVIDER_METADATA.openai.formatHint);
 		expect(chip.classList.contains('is-hint')).toBe(true);
 		expect(chip.classList.contains('is-valid')).toBe(false);

--- a/src/shared/credential-validator.test.ts
+++ b/src/shared/credential-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { requestUrl } from '../__mocks__/obsidian';
+import { requestUrl, type RequestUrlParam } from '../__mocks__/obsidian';
 import { validateCredentials } from './credential-validator';
 
 const mockRequestUrl = vi.mocked(requestUrl);
@@ -28,36 +28,36 @@ describe('validateCredentials', () => {
 			expect(result.status).toBe('valid');
 			expect(result.message).toContain('OpenAI');
 			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
-			const call = mockRequestUrl.mock.calls[0][0] as any;
+			const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(call.url).toBe('https://api.openai.com/v1/models');
 			expect(call.method).toBe('GET');
-			expect(call.headers.Authorization).toBe('Bearer sk-test');
+			expect(call.headers?.Authorization).toBe('Bearer sk-test');
 			expect(call.throw).toBe(false);
 		});
 
 		it('sends the Anthropic x-api-key + version headers', async () => {
 			mockRequestUrl.mockResolvedValue(ok());
 			await validateCredentials('anthropic', 'sk-ant-test');
-			const call = mockRequestUrl.mock.calls[0][0] as any;
+			const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(call.url).toBe('https://api.anthropic.com/v1/models');
-			expect(call.headers['x-api-key']).toBe('sk-ant-test');
-			expect(call.headers['anthropic-version']).toBe('2023-06-01');
+			expect(call.headers?.['x-api-key']).toBe('sk-ant-test');
+			expect(call.headers?.['anthropic-version']).toBe('2023-06-01');
 		});
 
 		it('sends the Gemini x-goog-api-key header', async () => {
 			mockRequestUrl.mockResolvedValue(ok());
 			await validateCredentials('gemini', 'AIzaTest');
-			const call = mockRequestUrl.mock.calls[0][0] as any;
+			const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(call.url).toBe('https://generativelanguage.googleapis.com/v1beta/models');
-			expect(call.headers['x-goog-api-key']).toBe('AIzaTest');
+			expect(call.headers?.['x-goog-api-key']).toBe('AIzaTest');
 		});
 
 		it('sends the Deepgram Token header', async () => {
 			mockRequestUrl.mockResolvedValue(ok());
 			await validateCredentials('deepgram', 'dgkey');
-			const call = mockRequestUrl.mock.calls[0][0] as any;
+			const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(call.url).toBe('https://api.deepgram.com/v1/projects');
-			expect(call.headers.Authorization).toBe('Token dgkey');
+			expect(call.headers?.Authorization).toBe('Token dgkey');
 		});
 
 		it('reports reachability (not "connected") for a keyless ollama probe', async () => {
@@ -67,7 +67,7 @@ describe('validateCredentials', () => {
 			});
 			expect(result.status).toBe('valid');
 			expect(result.message.toLowerCase()).toContain('reachable');
-			const call = mockRequestUrl.mock.calls[0][0] as any;
+			const call = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(call.url).toBe('http://localhost:11434/api/tags');
 		});
 	});

--- a/src/shared/encoding.test.ts
+++ b/src/shared/encoding.test.ts
@@ -4,7 +4,7 @@ import { arrayBufferToBase64, base64EncodedLength } from './encoding';
 describe('arrayBufferToBase64', () => {
 	it('encodes bytes to base64', () => {
 		const bytes = new TextEncoder().encode('Hi');
-		expect(arrayBufferToBase64(bytes.buffer as ArrayBuffer)).toBe('SGk=');
+		expect(arrayBufferToBase64(bytes.buffer)).toBe('SGk=');
 	});
 
 	it('encodes an empty buffer to an empty string', () => {
@@ -13,7 +13,7 @@ describe('arrayBufferToBase64', () => {
 
 	it('handles buffers larger than one encoding chunk', () => {
 		const big = new Uint8Array(0x8000 + 16).fill(65); // 'A' × (chunk + 16)
-		const encoded = arrayBufferToBase64(big.buffer as ArrayBuffer);
+		const encoded = arrayBufferToBase64(big.buffer);
 		expect(atob(encoded)).toBe('A'.repeat(0x8000 + 16));
 	});
 });
@@ -29,7 +29,7 @@ describe('base64EncodedLength', () => {
 
 	it('matches the actual encoded length', () => {
 		for (const n of [1, 2, 3, 100, 1000]) {
-			const encoded = arrayBufferToBase64(new Uint8Array(n).buffer as ArrayBuffer);
+			const encoded = arrayBufferToBase64(new Uint8Array(n).buffer);
 			expect(base64EncodedLength(n)).toBe(encoded.length);
 		}
 	});

--- a/src/shared/feature-chip-select.test.ts
+++ b/src/shared/feature-chip-select.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createEl } from '../__mocks__/obsidian';
+import { createEl, type StubEl } from '../__mocks__/obsidian';
 import { renderFeatureChipSelect } from './feature-chip-select';
 import { ALL_FEATURE_IDS } from './exclusions';
 import type { FeatureId } from './exclusions';
@@ -23,32 +23,32 @@ const LABELS: Record<FeatureId, string> = {
 const ORDER = Object.keys(ALL_FEATURE_IDS) as FeatureId[];
 
 // ── Stub-tree introspection helpers ──
-function walk(el: any, out: any[] = []): any[] {
-	for (const c of el?.children ?? []) {
+function walk(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const c of el.children as unknown as StubEl[]) {
 		out.push(c);
 		walk(c, out);
 	}
 	return out;
 }
-function byClass(root: any, cls: string): any[] {
-	return walk(root).filter((e) => e.classList?.contains(cls));
+function byClass(root: StubEl, cls: string): StubEl[] {
+	return walk(root).filter((e) => e.classList.contains(cls));
 }
-function byTag(root: any, tag: string): any[] {
+function byTag(root: StubEl, tag: string): StubEl[] {
 	return walk(root).filter((e) => e.tagName === tag);
 }
-function chipLabels(root: any): string[] {
+function chipLabels(root: StubEl): (string | null)[] {
 	return byClass(root, 'synapse-chip-label').map((e) => e.textContent);
 }
-function selectEl(root: any): any {
+function selectEl(root: StubEl): StubEl {
 	return byTag(root, 'SELECT')[0];
 }
-function optionValues(root: any): string[] {
+function optionValues(root: StubEl): (string | undefined)[] {
 	return byTag(root, 'OPTION').map((e) => e.value);
 }
-function optionTexts(root: any): string[] {
+function optionTexts(root: StubEl): (string | null)[] {
 	return byTag(root, 'OPTION').map((e) => e.textContent);
 }
-function removeButton(root: any, ariaLabel: string): any {
+function removeButton(root: StubEl, ariaLabel: string): StubEl | undefined {
 	return byClass(root, 'synapse-chip-remove').find(
 		(b) => b.getAttribute('aria-label') === ariaLabel,
 	);
@@ -109,7 +109,7 @@ describe('renderFeatureChipSelect — add dropdown options', () => {
 
 	it('renders a disabled placeholder as the first option', () => {
 		const { container } = render([]);
-		const placeholder = byTag(container, 'OPTION')[0];
+		const placeholder = byTag(container, 'OPTION')[0] as StubEl & { disabled?: boolean };
 		expect(placeholder.textContent).toBe('+ add feature…');
 		expect(placeholder.value).toBe('');
 		expect(placeholder.disabled).toBe(true);
@@ -120,7 +120,7 @@ describe('renderFeatureChipSelect — add dropdown options', () => {
 });
 
 describe('renderFeatureChipSelect — adding via the dropdown', () => {
-	function pick(container: any, value: string): void {
+	function pick(container: StubEl, value: string): void {
 		const select = selectEl(container);
 		select.value = value;
 		select.dispatchEvent({ type: 'change' });
@@ -155,8 +155,8 @@ describe('renderFeatureChipSelect — adding via the dropdown', () => {
 });
 
 describe('renderFeatureChipSelect — removing via chips', () => {
-	function clickRemove(container: any, ariaLabel: string): void {
-		removeButton(container, ariaLabel).dispatchEvent({ type: 'click' });
+	function clickRemove(container: StubEl, ariaLabel: string): void {
+		removeButton(container, ariaLabel)?.dispatchEvent({ type: 'click' });
 	}
 
 	it("removing the 'All features' chip drops to the inactive empty list", () => {

--- a/src/shared/file-utils.test.ts
+++ b/src/shared/file-utils.test.ts
@@ -1,18 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { getIncludedMarkdownFiles, findAvailableVaultPath } from './file-utils';
 import { TFile } from '../__mocks__/obsidian';
+import { createMockApp } from '../__test-utils__/mock-factories';
+import type { App } from 'obsidian';
 import type { ExclusionRule } from './exclusions';
 
 function settingsWith(exclusions: ExclusionRule[]) {
 	return { exclusions };
 }
 
-function appWith(files: TFile[]) {
-	return {
-		vault: {
-			getMarkdownFiles: vi.fn().mockReturnValue(files),
-		},
-	} as any;
+function appWith(files: TFile[]): App {
+	const app = createMockApp();
+	app.vault.getMarkdownFiles.mockReturnValue(files);
+	return app as unknown as App;
 }
 
 describe('getIncludedMarkdownFiles', () => {
@@ -69,15 +69,13 @@ describe('getIncludedMarkdownFiles', () => {
 });
 
 /** App stub whose vault reports a fixed set of taken paths. */
-function appWithPaths(taken: string[]) {
+function appWithPaths(taken: string[]): App {
 	const set = new Set(taken);
-	return {
-		vault: {
-			getAbstractFileByPath: vi.fn((path: string) =>
-				set.has(path) ? new TFile(path) : null
-			),
-		},
-	} as any;
+	const app = createMockApp();
+	app.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+		set.has(path) ? new TFile(path) : null
+	);
+	return app as unknown as App;
 }
 
 describe('findAvailableVaultPath', () => {

--- a/src/shared/fire-and-forget.test.ts
+++ b/src/shared/fire-and-forget.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import { Notice } from 'obsidian';
 import { fireAndForget } from './fire-and-forget';
 import type { NotificationManager } from './notifications';
@@ -29,7 +29,7 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 describe('fireAndForget', () => {
-	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: MockInstance<(...args: unknown[]) => void>;
 
 	beforeEach(() => {
 		vi.mocked(Notice).mockClear();

--- a/src/shared/folder-picker-modal.test.ts
+++ b/src/shared/folder-picker-modal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { TFolder } from 'obsidian';
+import { TFolder, type App } from 'obsidian';
+import { createEl } from '../__mocks__/obsidian';
 import { FolderPickerModal } from './folder-picker-modal';
 
 function makeFolder(path: string): TFolder {
@@ -25,11 +26,11 @@ function buildFolderTree() {
 	return { root, notes, daily, projects, templates };
 }
 
-function createMockApp(root: TFolder) {
+function createMockApp(root: TFolder): App {
 	return {
 		vault: { getRoot: () => root },
 		workspace: { getActiveFile: () => null },
-	} as any;
+	} as unknown as App;
 }
 
 describe('FolderPickerModal', () => {
@@ -109,7 +110,7 @@ describe('FolderPickerModal', () => {
 		const { root } = buildFolderTree();
 		const app = createMockApp(root);
 		const modal = new FolderPickerModal(app, vi.fn());
-		const el = { createEl: vi.fn() } as any;
+		const el = createEl();
 
 		modal.renderSuggestion(root, el);
 
@@ -120,7 +121,7 @@ describe('FolderPickerModal', () => {
 		const { root, projects } = buildFolderTree();
 		const app = createMockApp(root);
 		const modal = new FolderPickerModal(app, vi.fn());
-		const el = { createEl: vi.fn() } as any;
+		const el = createEl();
 
 		modal.renderSuggestion(projects, el);
 

--- a/src/shared/notifications.test.ts
+++ b/src/shared/notifications.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Notice } from 'obsidian';
+import { Notice, type StubEl } from '../__mocks__/obsidian';
 import { NotificationManager } from './notifications';
 
 /** Recursively locate the first <button> element in a stub-element tree. */
-function findButton(el: any): any | null {
-	for (const child of el.children ?? []) {
+function findButton(el: StubEl): StubEl | null {
+	for (const child of el.children as unknown as StubEl[]) {
 		if (child.tagName === 'BUTTON') return child;
 		const nested = findButton(child);
 		if (nested) return nested;
@@ -13,8 +13,8 @@ function findButton(el: any): any | null {
 }
 
 /** The most recently constructed Notice (the visible completion/success toast). */
-function lastNotice(): any {
-	return (Notice as unknown as { instances: any[] }).instances.at(-1);
+function lastNotice(): Notice {
+	return Notice.instances.at(-1)!;
 }
 
 /**
@@ -31,7 +31,7 @@ describe('NotificationManager', () => {
 
 	beforeEach(() => {
 		manager = new NotificationManager();
-		(Notice as unknown as { instances: any[] }).instances.length = 0;
+		Notice.instances.length = 0;
 		// Error toasts copy to the clipboard on click; the node test env has no
 		// navigator.clipboard, so stub a resolving one. Individual tests can
 		// override writeText (e.g. mockRejectedValueOnce) to exercise failure.
@@ -130,36 +130,40 @@ describe('NotificationManager', () => {
 
 	describe('status bar', () => {
 		it('shows idle text when no operations are running', () => {
-			const mockEl = { setText: vi.fn() } as unknown as HTMLElement;
+			const setText = vi.fn<(text: string) => void>();
+			const mockEl = { setText } as unknown as HTMLElement;
 			manager.setStatusBarEl(mockEl);
-			expect((mockEl as any).setText).toHaveBeenCalledWith('Synapse');
+			expect(setText).toHaveBeenCalledWith('Synapse');
 		});
 
 		it('shows operation label when one operation is running', () => {
-			const mockEl = { setText: vi.fn() } as unknown as HTMLElement;
+			const setText = vi.fn<(text: string) => void>();
+			const mockEl = { setText } as unknown as HTMLElement;
 			manager.setStatusBarEl(mockEl);
 			manager.startOperation('Scanning vault', 'sb-test');
-			expect((mockEl as any).setText).toHaveBeenCalledWith(
+			expect(setText).toHaveBeenCalledWith(
 				'Synapse: Scanning vault'
 			);
 		});
 
 		it('shows task count when multiple operations are running', () => {
-			const mockEl = { setText: vi.fn() } as unknown as HTMLElement;
+			const setText = vi.fn<(text: string) => void>();
+			const mockEl = { setText } as unknown as HTMLElement;
 			manager.setStatusBarEl(mockEl);
 			manager.startOperation('Op A', 'sb-a');
 			manager.startOperation('Op B', 'sb-b');
-			expect((mockEl as any).setText).toHaveBeenCalledWith(
+			expect(setText).toHaveBeenCalledWith(
 				'Synapse: 2 tasks running'
 			);
 		});
 
 		it('returns to idle after operations finish', () => {
-			const mockEl = { setText: vi.fn() } as unknown as HTMLElement;
+			const setText = vi.fn<(text: string) => void>();
+			const mockEl = { setText } as unknown as HTMLElement;
 			manager.setStatusBarEl(mockEl);
 			const handle = manager.startOperation('Work', 'sb-done');
 			handle.finish();
-			expect((mockEl as any).setText).toHaveBeenLastCalledWith('Synapse');
+			expect(setText).toHaveBeenLastCalledWith('Synapse');
 		});
 	});
 
@@ -171,11 +175,11 @@ describe('NotificationManager', () => {
 			const notice = lastNotice();
 			const button = findButton(notice.noticeEl);
 			expect(button).not.toBeNull();
-			expect(button.textContent).toBe('Review');
-			expect(button.classList.contains('mod-cta')).toBe(true);
+			expect(button!.textContent).toBe('Review');
+			expect(button!.classList.contains('mod-cta')).toBe(true);
 
 			// Clicking invokes the handler exactly once, then hides the toast.
-			button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+			button!.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
 			expect(onClick).toHaveBeenCalledTimes(1);
 			expect(notice.hide).toHaveBeenCalledTimes(1);
 		});
@@ -194,7 +198,7 @@ describe('NotificationManager', () => {
 			const button = findButton(notice.noticeEl);
 			expect(button?.textContent).toBe('Review');
 
-			button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+			button?.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
 			expect(onClick).toHaveBeenCalledTimes(1);
 			expect(notice.hide).toHaveBeenCalledTimes(1);
 		});
@@ -228,7 +232,7 @@ describe('NotificationManager', () => {
 			manager.infoSticky('Update available', { label: 'Update', onClick });
 
 			const notice = lastNotice();
-			findButton(notice.noticeEl).dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+			findButton(notice.noticeEl)?.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
 
 			expect(onClick).toHaveBeenCalledTimes(1);
 			expect(notice.hide).toHaveBeenCalledTimes(1);
@@ -262,7 +266,7 @@ describe('NotificationManager', () => {
 		}
 		/** The stubbed clipboard writer (see top-level beforeEach). */
 		function writeText() {
-			return navigator.clipboard.writeText as unknown as ReturnType<typeof vi.fn>;
+			return vi.mocked(navigator.clipboard.writeText);
 		}
 
 		it('builds a persistent (duration 0) error toast on op.error()', () => {
@@ -343,7 +347,7 @@ describe('NotificationManager', () => {
 
 		/** Total Notices constructed so far (the mock records every one). */
 		function noticeCount(): number {
-			return (Notice as unknown as { instances: any[] }).instances.length;
+			return Notice.instances.length;
 		}
 
 		it('suppresses a second identical info() within the 3s window', () => {

--- a/src/shared/open-scan-folder-picker.test.ts
+++ b/src/shared/open-scan-folder-picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TFolder } from 'obsidian';
+import { TFolder, type App } from 'obsidian';
 
 // Capture how openScanFolderPicker constructs the modal and whether it opens it.
 // `mock`-prefixed names are referenced lazily inside the (hoisted) vi.mock
@@ -35,7 +35,7 @@ function makeFolder(path: string, root: boolean): TFolder {
 	return f;
 }
 
-const mockApp = {} as any;
+const mockApp = {} as unknown as App;
 
 describe('openScanFolderPicker', () => {
 	beforeEach(() => {

--- a/src/shared/reddit-fetcher.test.ts
+++ b/src/shared/reddit-fetcher.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { fetchRedditContent, isRedditUrl, extractCanonicalPostUrl } from './reddit-fetcher';
+import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from '../__mocks__/obsidian';
+
+/**
+ * The `requestUrl` mock viewed with a precise async signature. The shared mock is
+ * loosely typed (`vi.fn()`), so `mockImplementation(async …)` would otherwise be
+ * seen as a void-returning callback and trip no-misused-promises. The view also
+ * lets stubs return partial responses (only the fields the fetcher reads).
+ */
+const mockRequestUrl = vi.mocked(requestUrl) as unknown as Mock<
+	(params: RequestUrlParam) => Promise<Partial<RequestUrlResponse>>
+>;
 
 /** XML-escape a string the way Reddit's Atom feed escapes its title/content. */
 function esc(s: string): string {
@@ -92,14 +103,12 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('parses a post Atom feed into formatted output', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockFeed({
 				author: 'someuser',
 				title: 'Great Immich tip',
 				bodyHtml: '<p>Here is the body of the post.</p>',
-			}) as never
-		);
+			})		);
 
 		const result = await fetchRedditContent(CANONICAL, 10000);
 		expect(result).toContain('u/someuser: Great Immich tip');
@@ -108,9 +117,8 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('requests the .rss?sort=top endpoint with an Atom Accept header', async () => {
-		const { requestUrl } = await import('obsidian');
 		let captured: { url: string; headers?: Record<string, string> } | undefined;
-		(vi.mocked(requestUrl) as any).mockImplementation(async (params: any) => {
+		mockRequestUrl.mockImplementation(async (params) => {
 			captured = { url: params.url, headers: params.headers };
 			return mockFeed({ author: 'u', title: 't', bodyHtml: '<p>b</p>' });
 		});
@@ -121,8 +129,7 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('includes up to the top three comments and labels them', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockFeed(
 				{ author: 'op', title: 'Question', bodyHtml: '<p>body</p>' },
 				[
@@ -131,8 +138,7 @@ describe('fetchRedditContent', () => {
 					{ bodyHtml: '<p>third answer</p>' },
 					{ bodyHtml: '<p>fourth answer</p>' },
 				]
-			) as never
-		);
+			)		);
 
 		const result = await fetchRedditContent(CANONICAL, 10000);
 		expect(result).toContain('Comment 1: first answer');
@@ -142,16 +148,14 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('strips the "submitted by" footer from the post selftext', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockFeed({
 				author: 'op',
 				title: 'Title',
 				bodyHtml:
 					'<p>Real body text.</p> submitted by <a href="x">/u/op</a> ' +
 					'<span><a href="y">[link]</a></span> <span><a href="z">[comments]</a></span>',
-			}) as never
-		);
+			})		);
 
 		const result = await fetchRedditContent(CANONICAL, 10000);
 		expect(result).toContain('Real body text.');
@@ -160,16 +164,14 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('decodes numeric character references and double-escaped entities', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			// `I&#39;ve` survives esc() as `I&amp;#39;ve` (double-escaped); `&#32;`
 			// is Reddit's numeric-space separator.
 			mockFeed({
 				author: 'op',
 				title: 'T',
 				bodyHtml: '<p>I&#39;ve&#32;done it</p>',
-			}) as never
-		);
+			})		);
 
 		const result = await fetchRedditContent(CANONICAL, 10000);
 		expect(result).toContain("I've done it");
@@ -177,11 +179,10 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('resolves a /s/ share link to canonical, then fetches its .rss feed', async () => {
-		const { requestUrl } = await import('obsidian');
 		const shareUrl = 'https://www.reddit.com/r/immich/s/DaHMD1DJhv';
 		const requestedUrls: string[] = [];
 
-		(vi.mocked(requestUrl) as any).mockImplementation(async (params: any) => {
+		mockRequestUrl.mockImplementation(async (params) => {
 			const reqUrl = typeof params === 'string' ? params : params.url;
 			requestedUrls.push(reqUrl);
 			// First call: the share page HTML carrying the canonical permalink.
@@ -204,11 +205,10 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('throws when a share link cannot be resolved to a post', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue({
+		mockRequestUrl.mockResolvedValue({
 			status: 200,
 			text: '<html><body>blocked</body></html>',
-		} as never);
+		});
 
 		await expect(
 			fetchRedditContent('https://www.reddit.com/r/immich/s/DaHMD1DJhv', 10000)
@@ -216,10 +216,10 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('falls back to "unknown" author and empty fields when missing', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
-			{ status: 200, text: '<?xml version="1.0"?><feed><entry></entry></feed>' } as never
-		);
+		mockRequestUrl.mockResolvedValue({
+			status: 200,
+			text: '<?xml version="1.0"?><feed><entry></entry></feed>',
+		});
 
 		const result = await fetchRedditContent(CANONICAL, 10000);
 		expect(result).toContain('u/unknown');
@@ -227,41 +227,36 @@ describe('fetchRedditContent', () => {
 	});
 
 	it('throws `Reddit returned HTTP <status>` on a blocked/error response', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue({ status: 403, text: '<html>forbidden</html>' } as never);
+		mockRequestUrl.mockResolvedValue({ status: 403, text: '<html>forbidden</html>' });
 
 		await expect(fetchRedditContent(CANONICAL, 10000))
 			.rejects.toThrow('Failed to fetch Reddit post: Reddit returned HTTP 403');
 	});
 
 	it('throws when the feed has no post entry', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue({
+		mockRequestUrl.mockResolvedValue({
 			status: 200,
 			text: '<?xml version="1.0"?><feed></feed>',
-		} as never);
+		});
 
 		await expect(fetchRedditContent(CANONICAL, 10000))
 			.rejects.toThrow('Failed to fetch Reddit post');
 	});
 
 	it('throws a descriptive error on network failure', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockRejectedValue(new Error('Network error'));
+		mockRequestUrl.mockRejectedValue(new Error('Network error'));
 
 		await expect(fetchRedditContent(CANONICAL, 10000))
 			.rejects.toThrow('Failed to fetch Reddit post: Network error');
 	});
 
 	it('truncates to maxLength', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockFeed({
 				author: 'user',
 				title: 'A very long title that should be cut off',
 				bodyHtml: '<p>And a very long body that goes on and on and on.</p>',
-			}) as never
-		);
+			})		);
 
 		const result = await fetchRedditContent(CANONICAL, 20);
 		expect(result.length).toBeLessThanOrEqual(20);
@@ -279,11 +274,10 @@ describe('fetchRedditContent -- retry on transient errors', () => {
 	});
 
 	it('retries on HTTP 429 and succeeds when a later attempt returns 200', async () => {
-		const { requestUrl } = await import('obsidian');
 		vi.useFakeTimers();
 		try {
 			let calls = 0;
-			(vi.mocked(requestUrl) as any).mockImplementation(async () => {
+			mockRequestUrl.mockImplementation(async () => {
 				calls++;
 				if (calls === 1) return { status: 429, text: '' };
 				return mockFeed({ author: 'op', title: 'Recovered', bodyHtml: '<p>body after retry</p>' });
@@ -302,11 +296,10 @@ describe('fetchRedditContent -- retry on transient errors', () => {
 	});
 
 	it('retries on HTTP 503 as well', async () => {
-		const { requestUrl } = await import('obsidian');
 		vi.useFakeTimers();
 		try {
 			let calls = 0;
-			(vi.mocked(requestUrl) as any).mockImplementation(async () => {
+			mockRequestUrl.mockImplementation(async () => {
 				calls++;
 				if (calls === 1) return { status: 503, text: '' };
 				return mockFeed({ author: 'op', title: 'Up again', bodyHtml: '<p>back online</p>' });
@@ -324,11 +317,10 @@ describe('fetchRedditContent -- retry on transient errors', () => {
 	});
 
 	it('gives up after exhausting retries and surfaces the final 429', async () => {
-		const { requestUrl } = await import('obsidian');
 		vi.useFakeTimers();
 		try {
 			let calls = 0;
-			(vi.mocked(requestUrl) as any).mockImplementation(async () => {
+			mockRequestUrl.mockImplementation(async () => {
 				calls++;
 				return { status: 429, text: '' };
 			});
@@ -347,9 +339,8 @@ describe('fetchRedditContent -- retry on transient errors', () => {
 	});
 
 	it('does not retry a permanent 403', async () => {
-		const { requestUrl } = await import('obsidian');
 		let calls = 0;
-		(vi.mocked(requestUrl) as any).mockImplementation(async () => {
+		mockRequestUrl.mockImplementation(async () => {
 			calls++;
 			return { status: 403, text: '' };
 		});

--- a/src/shared/review-action.test.ts
+++ b/src/shared/review-action.test.ts
@@ -10,7 +10,14 @@ describe('reviewAction — centralized Review-button gate (#366)', () => {
 			shouldAutoAccept: () => false,
 			openProposalView: baseOpen,
 		});
-		expect(action).toEqual({ label: 'Review', onClick: expect.any(Function) });
+		// `expect.any(Function)` is an asymmetric matcher (typed `any`); a typed
+		// intermediate lands it in an `unknown` slot (any→unknown is safe) without
+		// an unnecessary cast.
+		const expected: { label: string; onClick: unknown } = {
+			label: 'Review',
+			onClick: expect.any(Function),
+		};
+		expect(action).toEqual(expected);
 	});
 
 	it('returns undefined when auto-accept is ON (nothing left to review)', () => {

--- a/src/shared/settings-migrations.test.ts
+++ b/src/shared/settings-migrations.test.ts
@@ -71,7 +71,7 @@ describe('migrateSettings — ordering (#93)', () => {
 			enrichment: { excludeFolders: ['Templates'] },
 			rem: { semanticMatching: true, titleMatchWeight: 0.6 },
 		};
-		const snapshot = JSON.parse(JSON.stringify(raw));
+		const snapshot: unknown = JSON.parse(JSON.stringify(raw));
 		migrateSettings(raw, 0);
 		// Deep-equal to its pre-call snapshot: no field added or removed.
 		expect(raw).toEqual(snapshot);

--- a/src/shared/tweet-fetcher.test.ts
+++ b/src/shared/tweet-fetcher.test.ts
@@ -1,8 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { fetchTweetContent, isTwitterUrl } from './tweet-fetcher';
+import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from '../__mocks__/obsidian';
 
-function mockOEmbedResponse(authorName: string, tweetHtml: string) {
+/**
+ * The `requestUrl` mock viewed with a precise async signature. The shared mock is
+ * loosely typed (`vi.fn()`), so `mockImplementation(async …)` would otherwise be
+ * seen as a void-returning callback and trip no-misused-promises. The view also
+ * lets stubs return partial responses (only the fields the fetcher reads).
+ */
+const mockRequestUrl = vi.mocked(requestUrl) as unknown as Mock<
+	(params: RequestUrlParam | string) => Promise<Partial<RequestUrlResponse>>
+>;
+
+function mockOEmbedResponse(authorName: string, tweetHtml: string): RequestUrlResponse {
 	return {
+		status: 200,
+		headers: {},
+		json: null,
 		text: JSON.stringify({
 			html: tweetHtml,
 			author_name: authorName,
@@ -36,12 +50,11 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('succeeds on first try via oEmbed', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockOEmbedResponse(
 				'testuser',
 				'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hello world!</p></blockquote>'
-			) as never
+			)
 		);
 
 		const result = await fetchTweetContent('https://twitter.com/testuser/status/123', 10000);
@@ -51,12 +64,11 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('falls back to fxtwitter when oEmbed returns 503', async () => {
-		const { requestUrl } = await import('obsidian');
 		const error503 = new Error('Request failed: 503');
 
 		// oEmbed fails on both retry attempts (withRetry makes 2 attempts)
 		let callCount = 0;
-		(vi.mocked(requestUrl) as any).mockImplementation(async (params: any) => {
+		mockRequestUrl.mockImplementation(async (params) => {
 			const url = typeof params === 'string' ? params : params.url;
 			if (url.includes('publish.twitter.com')) {
 				callCount++;
@@ -78,10 +90,9 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('falls back to vxtwitter when oEmbed and fxtwitter both fail', async () => {
-		const { requestUrl } = await import('obsidian');
 		const error503 = new Error('Request failed: 503');
 
-		(vi.mocked(requestUrl) as any).mockImplementation(async (params: any) => {
+		mockRequestUrl.mockImplementation(async (params) => {
 			const url = typeof params === 'string' ? params : params.url;
 			if (url.includes('publish.twitter.com') || url.includes('fxtwitter.com/oembed')) {
 				throw error503;
@@ -103,18 +114,16 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('throws when all endpoints fail', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockRejectedValue(new Error('Network error'));
+		mockRequestUrl.mockRejectedValue(new Error('Network error'));
 
 		await expect(fetchTweetContent('https://x.com/user/status/000', 10000))
 			.rejects.toThrow('Failed to fetch tweet from all sources');
 	});
 
 	it('retries oEmbed once before falling through', async () => {
-		const { requestUrl } = await import('obsidian');
 		let oembedCalls = 0;
 
-		(vi.mocked(requestUrl) as any).mockImplementation(async (params: any) => {
+		mockRequestUrl.mockImplementation(async (params) => {
 			const url = typeof params === 'string' ? params : params.url;
 			if (url.includes('publish.twitter.com')) {
 				oembedCalls++;
@@ -135,12 +144,11 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('truncates to maxLength', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockOEmbedResponse(
 				'user',
 				'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">A very long tweet content here</p></blockquote>'
-			) as never
+			)
 		);
 
 		const result = await fetchTweetContent('https://x.com/user/status/999', 20);
@@ -148,12 +156,11 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('calls sanitizeUrl on input', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockOEmbedResponse(
 				'user',
 				'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">test</p></blockquote>'
-			) as never
+			)
 		);
 
 		// sanitizeUrl rejects non-HTTP URLs
@@ -162,12 +169,11 @@ describe('fetchTweetContent', () => {
 	});
 
 	it('handles HTML entities in tweet text', async () => {
-		const { requestUrl } = await import('obsidian');
-		vi.mocked(requestUrl).mockResolvedValue(
+		mockRequestUrl.mockResolvedValue(
 			mockOEmbedResponse(
 				'user',
 				'<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Tom &amp; Jerry &lt;3</p></blockquote>'
-			) as never
+			)
 		);
 
 		const result = await fetchTweetContent('https://x.com/user/status/456', 10000);

--- a/src/shared/update-checker.test.ts
+++ b/src/shared/update-checker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Notice, requestUrl } from 'obsidian';
+import { Notice, requestUrl, type StubEl } from '../__mocks__/obsidian';
 import { DEFAULT_SETTINGS } from '../settings';
 import type { SynapseSettings } from '../settings';
 import { NotificationManager } from './notifications';
@@ -8,8 +8,8 @@ import { UpdateChecker, isNewerVersion } from './update-checker';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Recursively locate the first <button> element in a stub-element tree. */
-function findButton(el: any): any | null {
-	for (const child of el.children ?? []) {
+function findButton(el: StubEl): StubEl | null {
+	for (const child of el.children as unknown as StubEl[]) {
 		if (child.tagName === 'BUTTON') return child;
 		const nested = findButton(child);
 		if (nested) return nested;
@@ -17,21 +17,21 @@ function findButton(el: any): any | null {
 	return null;
 }
 
-function notices(): any[] {
-	return (Notice as unknown as { instances: any[] }).instances;
+function notices(): Notice[] {
+	return Notice.instances;
 }
-function lastNotice(): any {
-	return notices().at(-1);
+function lastNotice(): Notice {
+	return notices().at(-1)!;
 }
 
 /**
  * Collect a notice's full text. Action notices (#365) put the message in a child
  * div rather than on `noticeEl.textContent`, so recurse through the stub tree.
  */
-function noticeText(notice: any): string {
-	const collect = (el: any): string => {
+function noticeText(notice: Notice): string {
+	const collect = (el: StubEl): string => {
 		let text = el.textContent ?? '';
-		for (const child of el.children ?? []) text += collect(child);
+		for (const child of el.children as unknown as StubEl[]) text += collect(child);
 		return text;
 	};
 	return collect(notice.noticeEl);
@@ -77,7 +77,7 @@ function mockRelease(tag: string | null, status = 200): void {
 		json: tag === null ? {} : { tag_name: tag },
 		text: '',
 		headers: {},
-	} as never);
+	});
 }
 
 describe('isNewerVersion', () => {
@@ -261,7 +261,7 @@ describe('UpdateChecker.maybeCheck', () => {
 
 		const button = findButton(lastNotice().noticeEl);
 		expect(button?.textContent).toBe('Update');
-		button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+		button?.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
 
 		expect(app.setting?.open).toHaveBeenCalledTimes(1);
 		expect(app.setting?.openTabById).toHaveBeenCalledWith('community-plugins');
@@ -276,7 +276,7 @@ describe('UpdateChecker.maybeCheck', () => {
 
 		const button = findButton(lastNotice().noticeEl);
 		expect(() =>
-			button.dispatchEvent({ type: 'click', stopPropagation: vi.fn() }),
+			button?.dispatchEvent({ type: 'click', stopPropagation: vi.fn() }),
 		).not.toThrow();
 
 		// The click surfaced a plain guidance notice instead of throwing.


### PR DESCRIPTION
Type-safety cleanup of the `src/shared` test files: drop now-unnecessary `any` casts in favor of the foundation's typed mock helpers (`StubEl`/`createEl`, `MockApp`/`MockPlugin`, precise `requestUrl` mock views) and give ad-hoc per-test mocks real types, so the six `no-unsafe-*` / `no-unnecessary-type-assertion` rules reach zero under `src/shared`. Types only — no runtime/test behavior change.

closes #422

Part of #321

Stacked on #421 (PR #430) — the first link in the #421 → #428 chain. Base branch is `refactor/issue-421-typesafe-foundation` (not `main`); review/merge after #421.

## Verification
- **Bucket gate → 0** (was 373): `npx eslint src/shared --rule '{ the six no-unsafe-* / no-unnecessary-type-assertion : error }'` exits clean.
- **Full CI green:** `tsc --noEmit --skipLibCheck` clean · `npm run lint` clean · `node scripts/check-top-level-requires.mjs` clean · `npm test` → **1823 passed** (136 files) · `node scripts/version-bump.mjs --check` consistent at 1.0.8 · `node esbuild.config.mjs production` OK.
- **Scope:** 16 files changed, all `src/shared/*.test.ts`. No shipped code, foundation mocks, or `eslint.config.mjs` touched. Zero inline `eslint-disable` for the six rules; zero remaining `any` in the changed files.
