### PR TITLE
refactor: type-safety cleanup of summarize/transcription/pipeline/deep-dive test files (#423)

### DIFF
--- a/src/deep-dive/depth-selector-modal.test.ts
+++ b/src/deep-dive/depth-selector-modal.test.ts
@@ -3,6 +3,16 @@ import { DepthSelectorModal, MIN_DEPTH, MAX_DEPTH, selectDepth } from './depth-s
 
 vi.mock('obsidian');
 
+/** Typed view of the modal's private confirm internals the UI callbacks drive. */
+function internals(
+	modal: DepthSelectorModal,
+): { resolved: boolean; resolve: (depth: number | null) => void } {
+	return modal as unknown as {
+		resolved: boolean;
+		resolve: (depth: number | null) => void;
+	};
+}
+
 describe('DepthSelectorModal', () => {
 	const mockApp = {} as ConstructorParameters<typeof DepthSelectorModal>[0];
 
@@ -12,8 +22,8 @@ describe('DepthSelectorModal', () => {
 		modal.setResolver(resolve);
 
 		// Simulate the confirm button callback
-		(modal as any).resolved = true;
-		(modal as any).resolve(5);
+		internals(modal).resolved = true;
+		internals(modal).resolve(5);
 
 		expect(resolve).toHaveBeenCalledWith(5);
 	});
@@ -23,8 +33,8 @@ describe('DepthSelectorModal', () => {
 		const resolve = vi.fn();
 		modal.setResolver(resolve);
 
-		(modal as any).resolved = true;
-		(modal as any).resolve(3);
+		internals(modal).resolved = true;
+		internals(modal).resolve(3);
 
 		expect(resolve).toHaveBeenCalledWith(3);
 	});
@@ -45,8 +55,8 @@ describe('DepthSelectorModal', () => {
 		modal.setResolver(resolve);
 
 		// Simulate confirm
-		(modal as any).resolved = true;
-		(modal as any).resolve(5);
+		internals(modal).resolved = true;
+		internals(modal).resolve(5);
 
 		// Then close fires
 		modal.onClose();

--- a/src/deep-dive/note-generator.test.ts
+++ b/src/deep-dive/note-generator.test.ts
@@ -3,7 +3,9 @@ import { NoteGenerator } from './note-generator';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { ExtractedTopic } from './types';
 
-const mockComplete = vi.fn().mockResolvedValue('---\ntags: [topic]\n---\n\n## Overview\n\nGenerated content.');
+const mockComplete = vi
+	.fn<(prompt: string, systemPrompt?: string, opts?: unknown) => Promise<string>>()
+	.mockResolvedValue('---\ntags: [topic]\n---\n\n## Overview\n\nGenerated content.');
 
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {

--- a/src/deep-dive/review-toast.test.ts
+++ b/src/deep-dive/review-toast.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import type { Plugin } from 'obsidian';
+import type { NoticeAction } from '../shared';
 
 // One new root topic → exactly one generated proposal (a reviewable item).
 vi.mock('./topic-analyzer', () => ({
@@ -42,7 +43,13 @@ vi.mock('./deep-dive-store', () => ({
 }));
 
 function makeOp(cancelled = false) {
-	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+	return {
+		progress: vi.fn(),
+		update: vi.fn(),
+		finish: vi.fn<(message?: string, action?: NoticeAction) => void>(),
+		error: vi.fn(),
+		cancelled,
+	};
 }
 
 describe('DeepDiveModule Review toast action (#366)', () => {
@@ -117,7 +124,7 @@ describe('DeepDiveModule Review toast action (#366)', () => {
 			expect.stringContaining('Generated 1 proposals'),
 			expect.objectContaining({ label: 'Review' })
 		);
-		genOp.finish.mock.calls.at(-1)![1].onClick();
+		genOp.finish.mock.calls.at(-1)![1]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/pipeline/fire-flow-gate.test.ts
+++ b/src/pipeline/fire-flow-gate.test.ts
@@ -9,6 +9,7 @@ vi.mock('../commands', () => ({ isPipelineKeyInFlow: isPipelineKeyInFlowMock }))
 import { SynapseRunner } from './synapse-runner';
 import { DEFAULT_SETTINGS } from '../settings';
 import type { PipelineModuleMap } from './types';
+import type { NotificationManager } from '../shared';
 
 function createMockNotifications() {
 	const handle = { update: vi.fn(), progress: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled: false };
@@ -42,7 +43,11 @@ describe('SynapseRunner — registry fire-synapse gate', () => {
 			(settings[key] as { enabled: boolean }).enabled = true;
 		}
 		mockModules = createMockModules();
-		runner = new SynapseRunner(mockModules, () => settings, createMockNotifications() as any);
+		runner = new SynapseRunner(
+			mockModules,
+			() => settings,
+			createMockNotifications() as unknown as NotificationManager,
+		);
 	});
 
 	it('runs every enabled phase when all are in the fire-synapse flow', async () => {

--- a/src/pipeline/synapse-runner.test.ts
+++ b/src/pipeline/synapse-runner.test.ts
@@ -3,6 +3,8 @@ import { SynapseRunner } from './synapse-runner';
 import { DEFAULT_SETTINGS } from '../settings';
 import type { PipelineModuleMap, PipelineScanFn } from './types';
 import { TFile, TFolder } from '../__mocks__/obsidian';
+import type { TFile as ObsidianTFile } from 'obsidian';
+import type { NotificationManager } from '../shared';
 
 function createMockNotifications() {
 	const handle = {
@@ -53,7 +55,7 @@ describe('SynapseRunner', () => {
 		runner = new SynapseRunner(
 			mockModules,
 			() => settings,
-			mockNotifications as any,
+			mockNotifications as unknown as NotificationManager,
 		);
 	});
 
@@ -209,13 +211,13 @@ describe('SynapseRunner', () => {
 	});
 
 	describe('fireOnFile (per-note scoping, #111)', () => {
-		// Returns `any`: the mock TFile is structurally compatible with the
-		// real obsidian.TFile that fireOnFile expects, but its `vault: unknown`
-		// trips strict assignability — the established pattern is to cast.
-		function fileIn(folder: string, name: string): any {
+		// The mock TFile is structurally compatible with the real obsidian.TFile
+		// that fireOnFile expects, but its `vault: unknown` trips strict
+		// assignability — the established pattern is a single `as unknown as` cast.
+		function fileIn(folder: string, name: string): ObsidianTFile {
 			const file = new TFile(`${folder}/${name}`);
 			file.parent = new TFolder(folder);
-			return file;
+			return file as unknown as ObsidianTFile;
 		}
 
 		it('runs each active phase exactly once for the file', async () => {
@@ -239,10 +241,10 @@ describe('SynapseRunner', () => {
 		});
 
 		it('passes undefined folderPath for a root-level note', async () => {
-			const file: any = new TFile('note.md');
+			const file = new TFile('note.md');
 			file.parent = new TFolder('/'); // root
 
-			await runner.fireOnFile(file);
+			await runner.fireOnFile(file as unknown as ObsidianTFile);
 
 			expect(mockModules.elaboration).toHaveBeenCalledWith(undefined, true, file);
 		});

--- a/src/summarize/audio-summarize.test.ts
+++ b/src/summarize/audio-summarize.test.ts
@@ -4,6 +4,38 @@ import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Mock } from 'vitest';
+import type { Plugin, TFile as ObsidianTFile } from 'obsidian';
+import type { NotificationManager, CheckpointManager } from '../shared';
+import type { AudioEmbed } from '../audio';
+
+/** The slice of an Obsidian Command the tests read back off addCommand. */
+interface MockCommand {
+	id: string;
+	name: string;
+	editorCallback?: (editor: unknown, ctx: unknown) => unknown;
+}
+
+/** Typed shape of the hand-built plugin stub the module + registrar consume. */
+interface MockPlugin {
+	app: {
+		vault: {
+			read: Mock<(file: unknown) => Promise<string>>;
+			modify: ReturnType<typeof vi.fn>;
+			process: Mock<(file: unknown, fn: (data: string) => string) => Promise<string>>;
+			create: ReturnType<typeof vi.fn>;
+			getAbstractFileByPath: ReturnType<typeof vi.fn>;
+			readBinary: ReturnType<typeof vi.fn>;
+		};
+		metadataCache: {
+			getFileCache: ReturnType<typeof vi.fn>;
+			getFirstLinkpathDest: ReturnType<typeof vi.fn>;
+		};
+		workspace: { getActiveFile: ReturnType<typeof vi.fn> };
+	};
+	addCommand: Mock<(cmd: MockCommand) => void>;
+	registerEvent: ReturnType<typeof vi.fn>;
+}
 
 // Mock the summarizer to return a canned summary
 vi.mock('./summarizer', () => ({
@@ -28,9 +60,12 @@ vi.mock('../video', () => ({
 }));
 
 // Mock the audio module — findAudioEmbeds returns controlled results
-const mockFindAudioEmbeds = vi.fn().mockReturnValue([]);
+const mockFindAudioEmbeds = vi
+	.fn<(content: string, sourcePath: string, metadataCache: unknown) => AudioEmbed[]>()
+	.mockReturnValue([]);
 vi.mock('../audio', () => ({
-	findAudioEmbeds: (...args: any[]) => mockFindAudioEmbeds(...args),
+	findAudioEmbeds: (content: string, sourcePath: string, metadataCache: unknown) =>
+		mockFindAudioEmbeds(content, sourcePath, metadataCache),
 }));
 
 // Mock the shared module. Content fetchers are stubbed here (they moved from
@@ -87,17 +122,18 @@ function createMockNotifications() {
 	};
 }
 
-function makeTFile(path: string): TFile {
-	const file = new TFile(path);
-	return file;
+function makeTFile(path: string): ObsidianTFile {
+	// Mock TFile bridges to the real obsidian TFile that AudioEmbed.file / the
+	// editor ctx expect; a single boundary cast keeps the call sites clean.
+	return new TFile(path) as unknown as ObsidianTFile;
 }
 
 describe('SummarizeModule audio target detection', () => {
 	let module: SummarizeModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let mockNotifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
-	let transcribeAudioFn: TranscribeAudioFn & ReturnType<typeof vi.fn>;
+	let transcribeAudioFn: Mock<TranscribeAudioFn>;
 
 	beforeEach(() => {
 		settings = structuredClone(DEFAULT_SETTINGS);
@@ -106,17 +142,17 @@ describe('SummarizeModule audio target detection', () => {
 		settings.summarize.includeNoteContent = false;
 		mockFindAudioEmbeds.mockReset();
 
-		transcribeAudioFn = vi.fn().mockResolvedValue('Transcribed audio content.') as any;
+		transcribeAudioFn = vi.fn<TranscribeAudioFn>().mockResolvedValue('Transcribed audio content.');
 
 		const audioFile = makeTFile('audio/recording.mp3');
 
 		mockPlugin = {
 			app: {
 				vault: {
-					read: vi.fn().mockResolvedValue('# Note\n\n![[recording.mp3]]\n'),
+					read: vi.fn<(file: unknown) => Promise<string>>().mockResolvedValue('# Note\n\n![[recording.mp3]]\n'),
 					modify: vi.fn().mockResolvedValue(undefined),
 					// Atomic read -> transform -> write (mirrors Vault.process).
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					create: vi.fn().mockResolvedValue(new TFile()),
@@ -131,17 +167,19 @@ describe('SummarizeModule audio target detection', () => {
 					getActiveFile: vi.fn().mockReturnValue(null),
 				},
 			},
-			addCommand: vi.fn(),
+			addCommand: vi.fn<(cmd: MockCommand) => void>(),
 			registerEvent: vi.fn(),
 		};
 
 		mockNotifications = createMockNotifications();
 		module = new SummarizeModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			mockNotifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any),
+			mockNotifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 			undefined,
 			transcribeAudioFn
 		);
@@ -155,11 +193,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// transcribeAudioFn should have been called because the audio target was detected
 		expect(transcribeAudioFn).toHaveBeenCalled();
@@ -173,17 +211,17 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// The vault should have been modified with the summary
 		expect(mockPlugin.app.vault.process).toHaveBeenCalled();
 
 		// The content written should contain the summary callout
-		const modifiedContent = await mockPlugin.app.vault.process.mock.results[0].value;
+		const modifiedContent = (await mockPlugin.app.vault.process.mock.results[0].value) as string;
 		expect(modifiedContent).toContain('Summary of recording.mp3');
 	});
 
@@ -195,11 +233,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// MetadataCache should have been used to resolve the audio file
 		expect(mockPlugin.app.metadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
@@ -227,11 +265,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// Should not transcribe because the audio embed already has a summary
 		expect(transcribeAudioFn).not.toHaveBeenCalled();
@@ -244,11 +282,13 @@ describe('SummarizeModule audio target detection', () => {
 	it('does not detect audio embeds when no transcribeAudio callback is provided', async () => {
 		// Create module without audio callback
 		const moduleNoAudio = new SummarizeModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			mockNotifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any),
+			mockNotifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 			undefined,
 			undefined
 		);
@@ -260,11 +300,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await moduleNoAudio.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// findAudioEmbeds should not have been called when there is no audio callback
 		expect(mockFindAudioEmbeds).not.toHaveBeenCalled();
@@ -291,11 +331,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// findAudioEmbeds should have been called to detect audio targets
 		expect(mockFindAudioEmbeds).toHaveBeenCalled();
@@ -314,11 +354,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// Should report an error rather than crash
 		expect(mockNotifications.notifyError).toHaveBeenCalled();
@@ -334,11 +374,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/test.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// Should report error about empty content (standardized link-load notice)
 		expect(mockNotifications.error).toHaveBeenCalledWith(
@@ -376,11 +416,11 @@ describe('SummarizeModule audio target detection', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
 		const file = makeTFile('notes/lecture.md');
-		await summarizeCmd.editorCallback({}, { file });
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		// findAudioEmbeds was called, confirming both embeds were detected
 		expect(mockFindAudioEmbeds).toHaveBeenCalled();

--- a/src/summarize/combine-summarize.test.ts
+++ b/src/summarize/combine-summarize.test.ts
@@ -1,10 +1,51 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { SummarizeModule, TranscribeAudioFn } from './index';
 import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import { SummarizeTarget } from './types';
+import type { Plugin } from 'obsidian';
+import type { NotificationManager, CheckpointManager } from '../shared';
+import type { AudioEmbed } from '../audio';
+
+/** Typed shape of the hand-built plugin stub the module consumes. */
+interface MockPlugin {
+	app: {
+		vault: {
+			read: Mock<(file: unknown) => Promise<string>>;
+			modify: ReturnType<typeof vi.fn>;
+			process: Mock<(file: unknown, fn: (data: string) => string) => Promise<string>>;
+			create: ReturnType<typeof vi.fn>;
+			getAbstractFileByPath: ReturnType<typeof vi.fn>;
+			readBinary: ReturnType<typeof vi.fn>;
+		};
+		metadataCache: {
+			getFileCache: ReturnType<typeof vi.fn>;
+			getFirstLinkpathDest: ReturnType<typeof vi.fn>;
+		};
+		workspace: { getActiveFile: ReturnType<typeof vi.fn> };
+	};
+	addCommand: ReturnType<typeof vi.fn>;
+	registerEvent: ReturnType<typeof vi.fn>;
+}
+
+/** Typed view of the private combined-summary entry point the tests drive. */
+function internals(module: SummarizeModule): {
+	processTargetsCombined: (
+		file: TFile,
+		targets: SummarizeTarget[],
+		content: string,
+	) => Promise<void>;
+} {
+	return module as unknown as {
+		processTargetsCombined: (
+			file: TFile,
+			targets: SummarizeTarget[],
+			content: string,
+		) => Promise<void>;
+	};
+}
 
 vi.mock('./summarizer', () => ({
 	Summarizer: class MockSummarizer {
@@ -17,9 +58,12 @@ vi.mock('./note-scanner', async (importOriginal) => {
 	return { ...actual };
 });
 
-const mockFindAudioEmbeds = vi.fn().mockReturnValue([]);
+const mockFindAudioEmbeds = vi
+	.fn<(content: string, sourcePath: string, metadataCache: unknown) => AudioEmbed[]>()
+	.mockReturnValue([]);
 vi.mock('../audio', () => ({
-	findAudioEmbeds: (...args: any[]) => mockFindAudioEmbeds(...args),
+	findAudioEmbeds: (content: string, sourcePath: string, metadataCache: unknown) =>
+		mockFindAudioEmbeds(content, sourcePath, metadataCache),
 }));
 
 vi.mock('../shared', async () => ({
@@ -69,7 +113,7 @@ function createMockNotifications() {
 		startOperation: vi.fn().mockReturnValue(handle),
 		info: vi.fn(),
 		success: vi.fn(),
-		error: vi.fn(),
+		error: vi.fn<(message: string) => void>(),
 		notifyError: vi.fn(),
 		confirm: vi.fn().mockResolvedValue(true),
 		_handle: handle,
@@ -80,10 +124,10 @@ const NOTE = '# Lecture\n\n![[part1.mp3]]\n\n![[part2.wav]]\n';
 
 describe('SummarizeModule combined summarization (#367)', () => {
 	let module: SummarizeModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let notifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
-	let transcribeAudio: TranscribeAudioFn & ReturnType<typeof vi.fn>;
+	let transcribeAudio: Mock<TranscribeAudioFn>;
 
 	const part1 = new TFile('audio/part1.mp3');
 	const part2 = new TFile('audio/part2.wav');
@@ -93,15 +137,15 @@ describe('SummarizeModule combined summarization (#367)', () => {
 		mockFindAudioEmbeds.mockReset();
 		mockFindAudioEmbeds.mockReturnValue([]);
 
-		transcribeAudio = vi.fn().mockResolvedValue('single transcript') as any;
+		transcribeAudio = vi.fn<TranscribeAudioFn>().mockResolvedValue('single transcript');
 
 		mockPlugin = {
 			app: {
 				vault: {
-					read: vi.fn().mockResolvedValue(NOTE),
+					read: vi.fn<(file: unknown) => Promise<string>>().mockResolvedValue(NOTE),
 					modify: vi.fn().mockResolvedValue(undefined),
 					// Atomic read -> transform -> write (mirrors Vault.process).
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					create: vi.fn().mockResolvedValue(new TFile()),
@@ -124,13 +168,15 @@ describe('SummarizeModule combined summarization (#367)', () => {
 
 		notifications = createMockNotifications();
 		module = new SummarizeModule(
-			mockPlugin,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			notifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any),
+			notifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 			undefined,
-			transcribeAudio
+			transcribeAudio,
 		);
 	});
 
@@ -143,7 +189,7 @@ describe('SummarizeModule combined summarization (#367)', () => {
 	}
 
 	it('transcribes each selected audio once and writes a single combined summary', async () => {
-		await (module as any).processTargetsCombined(file(), [audio('part1.mp3', 2), audio('part2.wav', 4)], NOTE);
+		await internals(module).processTargetsCombined(file(), [audio('part1.mp3', 2), audio('part2.wav', 4)], NOTE);
 
 		// One transcription per file -- no combined-file transcription pass.
 		expect(transcribeAudio).toHaveBeenCalledTimes(2);
@@ -157,14 +203,14 @@ describe('SummarizeModule combined summarization (#367)', () => {
 	});
 
 	it('appends the combined callout at the end of the note', async () => {
-		await (module as any).processTargetsCombined(file(), [audio('part1.mp3', 2), audio('part2.wav', 4)], NOTE);
+		await internals(module).processTargetsCombined(file(), [audio('part1.mp3', 2), audio('part2.wav', 4)], NOTE);
 
 		const out = await written();
 		expect(out.indexOf('Combined summary')).toBeGreaterThan(out.indexOf('part2.wav'));
 	});
 
 	it('falls back to a per-item summary for a single selected item', async () => {
-		await (module as any).processTargetsCombined(file(), [audio('part1.mp3', 2)], '# Lecture\n\n![[part1.mp3]]\n');
+		await internals(module).processTargetsCombined(file(), [audio('part1.mp3', 2)], '# Lecture\n\n![[part1.mp3]]\n');
 
 		expect(transcribeAudio).toHaveBeenCalledTimes(1);
 		const out = await written();
@@ -176,7 +222,7 @@ describe('SummarizeModule combined summarization (#367)', () => {
 		const transcription: SummarizeTarget = {
 			type: 'transcription', source: 'clip.mp4', line: 1, endLine: 3, content: 'existing transcript text',
 		};
-		await (module as any).processTargetsCombined(file(), [transcription, audio('part1.mp3', 5)], NOTE);
+		await internals(module).processTargetsCombined(file(), [transcription, audio('part1.mp3', 5)], NOTE);
 
 		// Only the audio target is transcribed; the transcription block is reused.
 		expect(transcribeAudio).toHaveBeenCalledTimes(1);
@@ -191,7 +237,7 @@ describe('SummarizeModule combined summarization (#367)', () => {
 			type: 'note-content', source: 'lecture', line: 9, endLine: 9, content: 'The lecture covered A and B.',
 		};
 		const url: SummarizeTarget = { type: 'url', source: 'https://example.com', line: 2, endLine: 2 };
-		await (module as any).processTargetsCombined(file(), [noteContent, url], NOTE);
+		await internals(module).processTargetsCombined(file(), [noteContent, url], NOTE);
 
 		// Prose is reused (never transcribed); the URL is fetched.
 		expect(transcribeAudio).not.toHaveBeenCalled();
@@ -209,12 +255,12 @@ describe('SummarizeModule combined summarization (#367)', () => {
 
 		const url1: SummarizeTarget = { type: 'url', source: 'https://example.com/a', line: 2, endLine: 2 };
 		const url2: SummarizeTarget = { type: 'url', source: 'https://example.com/b', line: 3, endLine: 3 };
-		await (module as any).processTargetsCombined(file(), [url1, url2], NOTE);
+		await internals(module).processTargetsCombined(file(), [url1, url2], NOTE);
 
 		// Both failure shapes (thrown + empty) now use notifications.error(linkLoadError(...)),
 		// matching the per-item summarize path and Elaborate -- NOT the old notifyError.
 		expect(notifications.notifyError).not.toHaveBeenCalled();
-		const messages = notifications.error.mock.calls.map((c: any[]) => c[0]);
+		const messages = notifications.error.mock.calls.map((c) => c[0]);
 		expect(messages).toContain('Could not load content from https://example.com/a: Reddit returned HTTP 429');
 		expect(messages).toContain('Could not load content from https://example.com/b: page returned no readable text');
 	});

--- a/src/summarize/summarize-modal.test.ts
+++ b/src/summarize/summarize-modal.test.ts
@@ -3,16 +3,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const { settingNames } = vi.hoisted(() => ({ settingNames: [] as string[] }));
 
 vi.mock('obsidian', async (importOriginal) => {
-	const actual = await importOriginal<any>();
+	const actual = await importOriginal<typeof import('obsidian')>();
 	class TrackedSetting {
 		constructor(_el: unknown) {}
 		setName = vi.fn((n: string) => { settingNames.push(n); return this; });
 		setDesc = vi.fn().mockReturnThis();
-		addToggle = vi.fn((cb: (t: any) => void) => {
+		addToggle = vi.fn((cb: (t: unknown) => void) => {
 			cb({ setValue: vi.fn().mockReturnThis(), onChange: vi.fn().mockReturnThis() });
 			return this;
 		});
-		addButton = vi.fn((cb: (b: any) => void) => {
+		addButton = vi.fn((cb: (b: unknown) => void) => {
 			cb({ setButtonText: vi.fn().mockReturnThis(), setCta: vi.fn().mockReturnThis(), onClick: vi.fn().mockReturnThis() });
 			return this;
 		});
@@ -22,12 +22,24 @@ vi.mock('obsidian', async (importOriginal) => {
 
 import { SummarizeSelectionModal, SummarizeModalDefaults } from './summarize-modal';
 import { SummarizeTarget } from './types';
+import type { App } from 'obsidian';
+import type { NotificationManager } from '../shared';
+import { createEl } from '../__mocks__/obsidian';
 
 const COMBINE_LABEL = 'Combine into one summary';
 const NOTE_LABEL = 'Include note content';
 
-function stubEl(): any {
-	return { empty: vi.fn(), createEl: vi.fn(() => stubEl()), createDiv: vi.fn(() => stubEl()) };
+/** Typed view of the modal's private toggle state / selection internals. */
+function internals(modal: SummarizeSelectionModal): {
+	includeNote: boolean;
+	combine: boolean;
+	collectChosen: () => SummarizeTarget[];
+} {
+	return modal as unknown as {
+		includeNote: boolean;
+		combine: boolean;
+		collectChosen: () => SummarizeTarget[];
+	};
 }
 
 const refTargets = (): SummarizeTarget[] => [
@@ -43,13 +55,13 @@ const DEFAULTS: SummarizeModalDefaults = { includeNoteContent: true, combineSumm
 
 function openModal(targets: SummarizeTarget[], defaults: SummarizeModalDefaults = DEFAULTS) {
 	const modal = new SummarizeSelectionModal(
-		{} as any,
+		{} as unknown as App,
 		targets,
 		vi.fn().mockResolvedValue(undefined),
 		defaults,
-		{ info: vi.fn() } as any
+		{ info: vi.fn() } as unknown as NotificationManager,
 	);
-	(modal as any).contentEl = stubEl();
+	(modal as unknown as { contentEl: HTMLElement }).contentEl = createEl();
 	modal.onOpen();
 	return modal;
 }
@@ -79,22 +91,22 @@ describe('SummarizeSelectionModal toggles (#367)', () => {
 			includeNoteContent: false,
 			combineSummaries: false,
 		});
-		expect((modal as any).includeNote).toBe(false);
-		expect((modal as any).combine).toBe(false);
+		expect(internals(modal).includeNote).toBe(false);
+		expect(internals(modal).combine).toBe(false);
 	});
 
 	it('includes the note-content target in the selection when its toggle is on', () => {
 		const modal = openModal([...refTargets(), noteContentTarget()]);
-		(modal as any).includeNote = true;
-		const chosen = (modal as any).collectChosen() as SummarizeTarget[];
+		internals(modal).includeNote = true;
+		const chosen = internals(modal).collectChosen();
 		expect(chosen.some((t) => t.type === 'note-content')).toBe(true);
 		expect(chosen).toHaveLength(3);
 	});
 
 	it('excludes the note-content target when its toggle is off', () => {
 		const modal = openModal([...refTargets(), noteContentTarget()]);
-		(modal as any).includeNote = false;
-		const chosen = (modal as any).collectChosen() as SummarizeTarget[];
+		internals(modal).includeNote = false;
+		const chosen = internals(modal).collectChosen();
 		expect(chosen.some((t) => t.type === 'note-content')).toBe(false);
 		// Reference targets remain selected by default.
 		expect(chosen).toHaveLength(2);

--- a/src/summarize/summarize-module.test.ts
+++ b/src/summarize/summarize-module.test.ts
@@ -6,6 +6,33 @@ import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import { fetchPageContent, fetchRedditContent } from '../shared';
 import { findSummarizeTargets, extractNoteProse } from './note-scanner';
+import type { Mock } from 'vitest';
+import type { Plugin } from 'obsidian';
+import type { NotificationManager, CheckpointManager } from '../shared';
+
+/** The slice of an Obsidian Command the tests read back off addCommand. */
+interface MockCommand {
+	id: string;
+	name: string;
+	editorCallback?: (editor: unknown, ctx: unknown) => unknown;
+}
+
+/** Typed shape of the hand-built plugin stub the module + registrar consume. */
+interface MockPlugin {
+	app: {
+		vault: {
+			read: Mock<(file: unknown) => Promise<string>>;
+			modify?: ReturnType<typeof vi.fn>;
+			process: Mock<(file: unknown, fn: (data: string) => string) => Promise<string>>;
+			create: ReturnType<typeof vi.fn>;
+			getAbstractFileByPath: ReturnType<typeof vi.fn>;
+		};
+		metadataCache: { getFileCache: ReturnType<typeof vi.fn> };
+		workspace: { getActiveFile: ReturnType<typeof vi.fn> };
+	};
+	addCommand: Mock<(cmd: MockCommand) => void>;
+	registerEvent: ReturnType<typeof vi.fn>;
+}
 
 // Mock the summarizer to return a canned summary.
 // Track the last created instance so tests can inspect call args.
@@ -15,7 +42,7 @@ vi.mock('./summarizer', () => ({
 		summarize = vi.fn().mockResolvedValue('This is a test summary.');
 		constructor() {
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
-			lastSummarizerInstance = this as any;
+			lastSummarizerInstance = this;
 		}
 	},
 }));
@@ -96,7 +123,7 @@ function createMockNotifications() {
 
 describe('SummarizeModule organize scope', () => {
 	let module: SummarizeModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let mockNotifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
 
@@ -107,10 +134,10 @@ describe('SummarizeModule organize scope', () => {
 		mockPlugin = {
 			app: {
 				vault: {
-					read: vi.fn().mockResolvedValue('# Note\n\nhttps://example.com\n'),
+					read: vi.fn<(file: unknown) => Promise<string>>().mockResolvedValue('# Note\n\nhttps://example.com\n'),
 					modify: vi.fn().mockResolvedValue(undefined),
 					// Atomic read -> transform -> write (mirrors Vault.process).
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					create: vi.fn().mockResolvedValue(new TFile()),
@@ -123,17 +150,19 @@ describe('SummarizeModule organize scope', () => {
 					getActiveFile: vi.fn().mockReturnValue(null),
 				},
 			},
-			addCommand: vi.fn(),
+			addCommand: vi.fn<(cmd: MockCommand) => void>(),
 			registerEvent: vi.fn(),
 		};
 
 		mockNotifications = createMockNotifications();
 		module = new SummarizeModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			mockNotifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any)
+			mockNotifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 		);
 	});
 
@@ -144,11 +173,11 @@ describe('SummarizeModule organize scope', () => {
 		// Register commands so we can invoke the summarize command
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
-		const file = new TFile('notes/test.md') as any;
-		await summarizeCmd.editorCallback({}, { file });
+		const file = new TFile('notes/test.md');
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		expect(organizeCallback).toHaveBeenCalledTimes(1);
 		expect(organizeCallback).toHaveBeenCalledWith(file);
@@ -162,11 +191,11 @@ describe('SummarizeModule organize scope', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
-		const file = new TFile('notes/test.md') as any;
-		await summarizeCmd.editorCallback({}, { file });
+		const file = new TFile('notes/test.md');
+		await summarizeCmd.editorCallback?.({}, { file });
 
 		expect(organizeCallback).not.toHaveBeenCalled();
 	});
@@ -178,14 +207,14 @@ describe('SummarizeModule organize scope', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
-		const file = new TFile('notes/test.md') as any;
+		const file = new TFile('notes/test.md');
 
 		// Should not throw even with autoOrganizeOnSummarize enabled
 		await expect(
-			summarizeCmd.editorCallback({}, { file })
+			summarizeCmd.editorCallback?.({}, { file })
 		).resolves.not.toThrow();
 	});
 
@@ -197,11 +226,11 @@ describe('SummarizeModule organize scope', () => {
 
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
 
-		const specificFile = new TFile('projects/research/my-note.md') as any;
-		await summarizeCmd.editorCallback({}, { file: specificFile });
+		const specificFile = new TFile('projects/research/my-note.md');
+		await summarizeCmd.editorCallback?.({}, { file: specificFile });
 
 		// The callback receives the EXACT file that was summarized
 		expect(organizeCallback).toHaveBeenCalledWith(specificFile);
@@ -231,7 +260,7 @@ const NON_RECIPE_CONTENT = 'This is a plain news article about the economy.';
 
 describe('SummarizeModule content-aware templates', () => {
 	let module: SummarizeModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let mockNotifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
 
@@ -242,10 +271,10 @@ describe('SummarizeModule content-aware templates', () => {
 		mockPlugin = {
 			app: {
 				vault: {
-					read: vi.fn().mockResolvedValue('# Note\n\nhttps://example.com\n'),
+					read: vi.fn<(file: unknown) => Promise<string>>().mockResolvedValue('# Note\n\nhttps://example.com\n'),
 					modify: vi.fn().mockResolvedValue(undefined),
 					// Atomic read -> transform -> write (mirrors Vault.process).
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					create: vi.fn().mockResolvedValue(new TFile()),
@@ -258,26 +287,28 @@ describe('SummarizeModule content-aware templates', () => {
 					getActiveFile: vi.fn().mockReturnValue(null),
 				},
 			},
-			addCommand: vi.fn(),
+			addCommand: vi.fn<(cmd: MockCommand) => void>(),
 			registerEvent: vi.fn(),
 		};
 
 		mockNotifications = createMockNotifications();
 		module = new SummarizeModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			mockNotifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any)
+			mockNotifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 		);
 	});
 
-	async function invokeCommand(file: any): Promise<void> {
+	async function invokeCommand(file: TFile): Promise<void> {
 		await module.onload();
 		const summarizeCmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
-		await summarizeCmd.editorCallback({}, { file });
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
+		await summarizeCmd.editorCallback?.({}, { file });
 	}
 
 	it('uses recipe template prompt when autoDetectTemplates is true and content matches', async () => {
@@ -287,7 +318,7 @@ describe('SummarizeModule content-aware templates', () => {
 		// Return recipe content from the content fetcher
 		vi.mocked(fetchPageContent).mockResolvedValueOnce(RECIPE_CONTENT);
 
-		const file = new TFile('notes/recipe.md') as any;
+		const file = new TFile('notes/recipe.md');
 		await invokeCommand(file);
 
 		// The summarizer should have been called with the recipe template prompt
@@ -303,7 +334,7 @@ describe('SummarizeModule content-aware templates', () => {
 
 		vi.mocked(fetchPageContent).mockResolvedValueOnce(RECIPE_CONTENT);
 
-		const file = new TFile('notes/recipe.md') as any;
+		const file = new TFile('notes/recipe.md');
 		await invokeCommand(file);
 
 		// The summarizer should have been called with undefined (style default)
@@ -317,7 +348,7 @@ describe('SummarizeModule content-aware templates', () => {
 
 		vi.mocked(fetchPageContent).mockResolvedValueOnce(RECIPE_CONTENT);
 
-		const file = new TFile('notes/recipe.md') as any;
+		const file = new TFile('notes/recipe.md');
 		await invokeCommand(file);
 
 		// The summarizer should have been called with the custom prompt
@@ -331,7 +362,7 @@ describe('SummarizeModule content-aware templates', () => {
 
 		vi.mocked(fetchPageContent).mockResolvedValueOnce(NON_RECIPE_CONTENT);
 
-		const file = new TFile('notes/article.md') as any;
+		const file = new TFile('notes/article.md');
 		await invokeCommand(file);
 
 		// The summarizer should have been called with undefined (style default)
@@ -343,12 +374,12 @@ describe('SummarizeModule content-aware templates', () => {
 		const redditUrl = 'https://www.reddit.com/r/immich/comments/abc123/title/';
 		vi.mocked(findSummarizeTargets).mockReturnValueOnce([
 			{ type: 'url', source: redditUrl, line: 2, endLine: 2 },
-		] as any);
+		]);
 		// Clear cross-test accumulation so the assertions reflect only this run.
 		vi.mocked(fetchPageContent).mockClear();
 		vi.mocked(fetchRedditContent).mockClear();
 
-		const file = new TFile('notes/reddit.md') as any;
+		const file = new TFile('notes/reddit.md');
 		await invokeCommand(file);
 
 		expect(fetchRedditContent).toHaveBeenCalledWith(redditUrl, expect.any(Number));
@@ -360,7 +391,7 @@ describe('SummarizeModule content-aware templates', () => {
 
 describe('SummarizeModule note content (#367)', () => {
 	let module: SummarizeModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let mockNotifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
 
@@ -370,8 +401,8 @@ describe('SummarizeModule note content (#367)', () => {
 		mockPlugin = {
 			app: {
 				vault: {
-					read: vi.fn().mockResolvedValue('# Title\n\nThe note body prose.\n'),
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					read: vi.fn<(file: unknown) => Promise<string>>().mockResolvedValue('# Title\n\nThe note body prose.\n'),
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					create: vi.fn().mockResolvedValue(new TFile()),
@@ -380,26 +411,28 @@ describe('SummarizeModule note content (#367)', () => {
 				metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
 				workspace: { getActiveFile: vi.fn().mockReturnValue(null) },
 			},
-			addCommand: vi.fn(),
+			addCommand: vi.fn<(cmd: MockCommand) => void>(),
 			registerEvent: vi.fn(),
 		};
 
 		mockNotifications = createMockNotifications();
 		module = new SummarizeModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			mockNotifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any)
+			mockNotifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 		);
 	});
 
 	async function runSummarize(path = 'notes/My Note.md'): Promise<void> {
 		await module.onload();
 		const cmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
-		await cmd.editorCallback({}, { file: new TFile(path) });
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
+		await cmd.editorCallback?.({}, { file: new TFile(path) });
 	}
 
 	it('summarizes a prose-only note when includeNoteContent is on', async () => {

--- a/src/summarize/summarizer.test.ts
+++ b/src/summarize/summarizer.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Summarizer } from './summarizer';
-import type { SynapseSettings } from '../settings';
 import { DEFAULT_SETTINGS } from '../settings';
 
-const mockComplete = vi.fn().mockResolvedValue('- Key point 1\n- Key point 2');
+const mockComplete = vi
+	.fn<(prompt: string, systemPrompt?: string, opts?: unknown) => Promise<string>>()
+	.mockResolvedValue('- Key point 1\n- Key point 2');
 
 // Mock the AIClient as a class (required by vitest)
 vi.mock('../shared/ai-client', () => ({
@@ -18,7 +19,7 @@ describe('Summarizer', () => {
 	beforeEach(() => {
 		mockComplete.mockReset();
 		mockComplete.mockResolvedValue('- Key point 1\n- Key point 2');
-		summarizer = new Summarizer(() => DEFAULT_SETTINGS as SynapseSettings);
+		summarizer = new Summarizer(() => DEFAULT_SETTINGS);
 	});
 
 	it('calls AI with content and source', async () => {

--- a/src/summarize/video-dependency-notice.test.ts
+++ b/src/summarize/video-dependency-notice.test.ts
@@ -1,9 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { SummarizeModule, TranscribeUrlFn } from './index';
 import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin } from 'obsidian';
+import type { NotificationManager, CheckpointManager } from '../shared';
+
+/** The slice of an Obsidian Command the test reads back off addCommand. */
+interface MockCommand {
+	id: string;
+	name: string;
+	editorCallback?: (editor: unknown, ctx: unknown) => unknown;
+}
+
+/** Typed shape of the hand-built plugin stub the module + registrar consume. */
+interface MockPlugin {
+	app: {
+		vault: {
+			read: Mock<(file: unknown) => Promise<string>>;
+			process: Mock<(file: unknown, fn: (data: string) => string) => Promise<string>>;
+			create: ReturnType<typeof vi.fn>;
+			getAbstractFileByPath: ReturnType<typeof vi.fn>;
+		};
+		metadataCache: { getFileCache: ReturnType<typeof vi.fn> };
+		workspace: { getActiveFile: ReturnType<typeof vi.fn> };
+		setting?: { open: ReturnType<typeof vi.fn>; openTabById: ReturnType<typeof vi.fn> };
+	};
+	saveSettings: ReturnType<typeof vi.fn>;
+	addCommand: Mock<(cmd: MockCommand) => void>;
+	registerEvent: ReturnType<typeof vi.fn>;
+}
 
 // Video-dependency onboarding (#382): a failed video-URL transcription whose
 // cause is a missing yt-dlp/ffmpeg must surface an actionable "Open settings"
@@ -74,7 +101,7 @@ function createMockNotifications() {
 	};
 	return {
 		startOperation: vi.fn().mockReturnValue(handle),
-		info: vi.fn(),
+		info: vi.fn<(message: string, duration?: number, action?: NoticeAction) => void>(),
 		success: vi.fn(),
 		error: vi.fn(),
 		notifyError: vi.fn(),
@@ -92,7 +119,7 @@ function depError(tool: 'yt-dlp' | 'ffmpeg', message: string): Error {
 
 describe('SummarizeModule video-dependency onboarding (#382)', () => {
 	let module: SummarizeModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let notifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
 	let settingOpen: ReturnType<typeof vi.fn>;
@@ -101,11 +128,13 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 
 	function build(transcribeUrl: TranscribeUrlFn): SummarizeModule {
 		return new SummarizeModule(
-			mockPlugin,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			notifications as any,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin),
+			notifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(
+				mockPlugin as unknown as ConstructorParameters<typeof CommandRegistrar>[0],
+			),
 			transcribeUrl,
 		);
 	}
@@ -113,9 +142,9 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 	async function runSummarize(file = new TFile('notes/video.md')): Promise<void> {
 		await module.onload();
 		const cmd = mockPlugin.addCommand.mock.calls.find(
-			(c: any) => c[0].id === 'summarize-current-note'
-		)[0];
-		await cmd.editorCallback({}, { file });
+			(c) => c[0].id === 'summarize-current-note',
+		)![0];
+		await cmd.editorCallback?.({}, { file });
 	}
 
 	beforeEach(() => {
@@ -127,8 +156,10 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 		mockPlugin = {
 			app: {
 				vault: {
-					read: vi.fn().mockResolvedValue(`# Note\n\n${VIDEO_URL}\n`),
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					read: vi
+						.fn<(file: unknown) => Promise<string>>()
+						.mockResolvedValue(`# Note\n\n${VIDEO_URL}\n`),
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					create: vi.fn().mockResolvedValue(new TFile()),
@@ -139,7 +170,7 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 				setting: { open: settingOpen, openTabById },
 			},
 			saveSettings,
-			addCommand: vi.fn(),
+			addCommand: vi.fn<(cmd: MockCommand) => void>(),
 			registerEvent: vi.fn(),
 		};
 
@@ -156,9 +187,9 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 		// Routed to the actionable info notice, NOT the plain persistent error.
 		const actionCall = notifications.info.mock.calls.find((c) => c[2] !== undefined);
 		expect(actionCall).toBeDefined();
-		const [message, , action] = actionCall as [string, number, NoticeAction];
+		const [message, , action] = actionCall!;
 		expect(message).toMatch(/yt-dlp not found/);
-		expect(action.label).toBe('Open settings');
+		expect(action!.label).toBe('Open settings');
 		expect(notifications.error).not.toHaveBeenCalled();
 		expect(notifications.notifyError).not.toHaveBeenCalled();
 	});
@@ -172,8 +203,8 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 
 		const actionCall = notifications.info.mock.calls.find((c) => c[2] !== undefined);
 		expect(actionCall).toBeDefined();
-		expect((actionCall as any)[0]).toMatch(/ffmpeg\/ffprobe not found/);
-		expect((actionCall as any)[2].label).toBe('Open settings');
+		expect(actionCall![0]).toMatch(/ffmpeg\/ffprobe not found/);
+		expect(actionCall![2]!.label).toBe('Open settings');
 	});
 
 	it('keeps the plain link-load error notice for a non-dependency failure', async () => {

--- a/src/transcription/duration-detector.test.ts
+++ b/src/transcription/duration-detector.test.ts
@@ -72,7 +72,9 @@ describe('MIN_SLIDER_DURATION', () => {
 // execFile/fs and assert on subprocess wiring without spawning a process.
 
 /** execFile stub shared across the DI tests; reset per-test. */
-const execFileMock = vi.fn();
+const execFileMock = vi.fn<
+	(cmd: string, args: string[], opts: unknown, cb: (e: unknown, o: string) => void) => void
+>();
 
 /**
  * Build a NodeDeps with a stubbed execFile and recording fs.promises so tests

--- a/src/transcription/note-media-modal.test.ts
+++ b/src/transcription/note-media-modal.test.ts
@@ -6,16 +6,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const { settingNames } = vi.hoisted(() => ({ settingNames: [] as string[] }));
 
 vi.mock('obsidian', async (importOriginal) => {
-	const actual = await importOriginal<any>();
+	const actual = await importOriginal<typeof import('obsidian')>();
 	class TrackedSetting {
 		constructor(_el: unknown) {}
 		setName = vi.fn((n: string) => { settingNames.push(n); return this; });
 		setDesc = vi.fn().mockReturnThis();
-		addToggle = vi.fn((cb: (t: any) => void) => {
+		addToggle = vi.fn((cb: (t: unknown) => void) => {
 			cb({ setValue: vi.fn().mockReturnThis(), onChange: vi.fn().mockReturnThis() });
 			return this;
 		});
-		addButton = vi.fn((cb: (b: any) => void) => {
+		addButton = vi.fn((cb: (b: unknown) => void) => {
 			cb({ setButtonText: vi.fn().mockReturnThis(), setCta: vi.fn().mockReturnThis(), onClick: vi.fn().mockReturnThis() });
 			return this;
 		});
@@ -24,18 +24,18 @@ vi.mock('obsidian', async (importOriginal) => {
 });
 
 import { NoteMediaModal } from './note-media-modal';
-import { TFile } from '../__mocks__/obsidian';
+import { TFile, createEl } from '../__mocks__/obsidian';
+import type { App, TFile as ObsidianTFile } from 'obsidian';
+import type { AudioEmbed } from '../audio';
+import type { NotificationManager } from '../shared';
 
 const COMBINE_LABEL = 'Combine all selected audio into one transcription';
 
-function stubEl(): any {
-	return { empty: vi.fn(), createEl: vi.fn(() => stubEl()), createDiv: vi.fn(() => stubEl()) };
-}
-
-function audioEmbeds(n: number) {
+function audioEmbeds(n: number): AudioEmbed[] {
 	return Array.from({ length: n }, (_, i) => ({
 		fileName: `clip${i}.mp3`,
-		file: new TFile(`clip${i}.mp3`),
+		// Mock TFile bridges to the real obsidian TFile the AudioEmbed type expects.
+		file: new TFile(`clip${i}.mp3`) as unknown as ObsidianTFile,
 		line: i,
 	}));
 }
@@ -46,8 +46,16 @@ function openModal(n: number, ffmpeg: boolean) {
 		onTranscribeVideo: vi.fn().mockResolvedValue(undefined),
 		onExtractImages: vi.fn().mockResolvedValue(undefined),
 	};
-	const modal = new NoteMediaModal({} as any, audioEmbeds(n) as any, [], [], callbacks, { info: vi.fn() } as any, ffmpeg);
-	(modal as any).contentEl = stubEl();
+	const modal = new NoteMediaModal(
+		{} as unknown as App,
+		audioEmbeds(n),
+		[],
+		[],
+		callbacks,
+		{ info: vi.fn() } as unknown as NotificationManager,
+		ffmpeg,
+	);
+	(modal as unknown as { contentEl: HTMLElement }).contentEl = createEl();
 	modal.onOpen();
 	return modal;
 }


### PR DESCRIPTION
Type-safety cleanup of test files under `src/summarize/`, `src/transcription/`, `src/pipeline/`, and `src/deep-dive/`: drop now-unnecessary `any` casts in favor of the typed mock helpers (`StubEl`/`createEl`/mock classes) and type ad-hoc per-test mocks so the six type-safety rules report zero findings under these dirs. No runtime/test behavior change.

closes #423

Part of #321

## Stacked PR
This is stacked on **#422** (PR #431). Base branch is `refactor/issue-422-typesafe-shared`, not `main`. `closingIssuesReferences` will be empty until the chain retargets to `main` — the `closes #423` keyword activates then.

## Verification
- Bucket gate (six rules: `no-unsafe-assignment/call/member-access/argument/return` + `no-unnecessary-type-assertion`) across the four dirs: **290 → 0**.
- Full CI guard set green: `tsc --noEmit --skipLibCheck` (exit 0), `npm run lint` (exit 0), `check-top-level-requires.mjs` (exit 0), `version-bump.mjs --check` (exit 0), `esbuild production` (exit 0).
- `npm test`: **1823 passed** (136 files) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qUbEnsc6vk1qyk16w4gi8
