### PR TITLE
refactor: type-safety cleanup of audio/video/image test files (#424)

### DIFF
--- a/src/audio/combine-transcription.test.ts
+++ b/src/audio/combine-transcription.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -21,9 +21,28 @@ vi.mock('./post-processor', () => ({
 import { AudioModule } from './index';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin, TFile as ObsidianTFile } from 'obsidian';
+import type { NotificationManager, CheckpointManager } from '../shared';
+import type { AudioExtractor } from '../video';
+import type { AudioEmbed } from './types';
+import type { SynapseSettings } from '../settings';
 
-// Mock TFile's `vault` is typed `unknown`; cast for typed method signatures.
-const tfile = (p: string): any => new TFile(p);
+/** Typed shape of the hand-built plugin stub the module consumes. */
+interface MockPlugin {
+	app: {
+		vault: {
+			read: Mock<(file: unknown) => Promise<string>>;
+			modify: ReturnType<typeof vi.fn>;
+			process: Mock<(file: unknown, fn: (data: string) => string) => Promise<string>>;
+			readBinary: ReturnType<typeof vi.fn>;
+		};
+		workspace: { getActiveFile: ReturnType<typeof vi.fn> };
+	};
+}
+
+// Mock TFile's `vault` is typed `unknown`; bridge to the real obsidian TFile the
+// module's method signatures expect via a single boundary cast.
+const tfile = (p: string): ObsidianTFile => new TFile(p) as unknown as ObsidianTFile;
 
 function createMockNotifications() {
 	const handle = {
@@ -57,7 +76,7 @@ function createFakeExtractor(byteSize = 1024) {
 }
 
 describe('AudioModule.transcribeAndInsertCombined', () => {
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let notifications: ReturnType<typeof createMockNotifications>;
 	let extractor: ReturnType<typeof createFakeExtractor>;
 
@@ -73,7 +92,7 @@ describe('AudioModule.transcribeAndInsertCombined', () => {
 					modify: vi.fn().mockResolvedValue(undefined),
 					// Atomic read -> transform -> write; the callback's return
 					// value is the written content (mirrors Vault.process).
-					process: vi.fn(async (file: any, fn: (data: string) => string) =>
+					process: vi.fn(async (file: unknown, fn: (data: string) => string) =>
 						fn(await mockPlugin.app.vault.read(file))
 					),
 					readBinary: vi.fn().mockResolvedValue(new ArrayBuffer(64)),
@@ -83,20 +102,24 @@ describe('AudioModule.transcribeAndInsertCombined', () => {
 		};
 	});
 
-	function makeModule(ex: any = extractor, provider = 'whisper-api') {
+	function makeModule(
+		ex: ReturnType<typeof createFakeExtractor> | null = extractor,
+		provider = 'whisper-api',
+	) {
 		return new AudioModule(
-			mockPlugin,
-			() => ({
-				video: { ffmpegPath: 'ffmpeg' },
-				audio: { transcriptionProvider: provider },
-			}) as any,
-			notifications as any,
-			createMockCheckpointManager() as any,
-			ex
+			mockPlugin as unknown as Plugin,
+			() =>
+				({
+					video: { ffmpegPath: 'ffmpeg' },
+					audio: { transcriptionProvider: provider },
+				}) as unknown as SynapseSettings,
+			notifications as unknown as NotificationManager,
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			ex as unknown as AudioExtractor | undefined
 		);
 	}
 
-	function embeds(): any[] {
+	function embeds(): AudioEmbed[] {
 		return [
 			{ fileName: 'part1.mp3', file: tfile('audio/part1.mp3'), line: 2 },
 			{ fileName: 'part2.wav', file: tfile('audio/part2.wav'), line: 4 },
@@ -148,7 +171,7 @@ describe('AudioModule.transcribeAndInsertCombined', () => {
 		// Combined output cleaned up.
 		for (const p of combinedPaths) expect(fs.existsSync(p)).toBe(false);
 		// Input temp files cleaned up.
-		const inputs = extractor.concatAudio.mock.calls[0][0] as string[];
+		const inputs = extractor.concatAudio.mock.calls[0][0];
 		for (const i of inputs) expect(fs.existsSync(i)).toBe(false);
 	});
 
@@ -190,7 +213,7 @@ describe('AudioModule.transcribeAndInsertCombined', () => {
 
 	it('combines via per-file transcription when ffmpeg/extractor is unavailable', async () => {
 		const module = makeModule(null); // mobile: no ffmpeg
-		(module as any).interFileDelayMs = 0; // skip rate-limit delay in tests
+		(module as unknown as { interFileDelayMs: number }).interFileDelayMs = 0; // skip rate-limit delay in tests
 
 		await module.transcribeAndInsertCombined(tfile('notes/lecture.md'), embeds());
 

--- a/src/audio/lyrics-reformat.test.ts
+++ b/src/audio/lyrics-reformat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 
 // Hoisted so the transcriber mock factory (lifted above imports) can use it.
 const fixtures = vi.hoisted(() => ({
@@ -54,7 +54,7 @@ function makeModule(autoFormatLyrics: boolean): AudioModule {
 }
 
 describe('AudioModule.transcribe lyrics reformatting (#234)', () => {
-	let completeSpy: ReturnType<typeof vi.spyOn>;
+	let completeSpy: MockInstance<typeof AIClient.prototype.complete>;
 
 	beforeEach(() => {
 		completeSpy = vi.spyOn(AIClient.prototype, 'complete').mockResolvedValue(REFORMATTED);

--- a/src/audio/post-processor.test.ts
+++ b/src/audio/post-processor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import { PostProcessor } from './post-processor';
 import { AIClient } from '../shared';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
@@ -10,7 +10,7 @@ function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
 }
 
 describe('PostProcessor', () => {
-	let completeSpy: ReturnType<typeof vi.spyOn>;
+	let completeSpy: MockInstance<typeof AIClient.prototype.complete>;
 
 	beforeEach(() => {
 		completeSpy = vi.spyOn(AIClient.prototype, 'complete').mockResolvedValue('processed');

--- a/src/audio/transcriber.test.ts
+++ b/src/audio/transcriber.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { requestUrl } from '../__mocks__/obsidian';
+import { requestUrl, type RequestUrlParam } from '../__mocks__/obsidian';
 import { Transcriber, buildMultipartBody, GEMINI_MAX_INLINE_AUDIO_BYTES } from './transcriber';
 import { SynapseSettings, DEFAULT_SETTINGS } from '../settings';
 
@@ -9,13 +9,19 @@ function makeSettings(overrides?: Partial<SynapseSettings>): SynapseSettings {
 
 const mockRequestUrl = vi.mocked(requestUrl);
 
+/** The slice of the Gemini generateContent request body the tests assert on. */
+interface GeminiRequestBody {
+	contents: Array<{ role: string; parts: Array<{ inline_data: { mime_type: string; data: string } }> }>;
+	system_instruction: { parts: Array<{ text: string }> };
+}
+
 describe('buildMultipartBody', () => {
 	it('produces valid multipart body with text fields and a file', () => {
 		const fields = [
 			{ name: 'model', value: 'whisper-1' },
 			{ name: 'response_format', value: 'verbose_json' },
 		];
-		const fileData = new TextEncoder().encode('fake audio content').buffer as ArrayBuffer;
+		const fileData = new TextEncoder().encode('fake audio content').buffer;
 		const result = buildMultipartBody(fields, {
 			name: 'test.mp3',
 			fieldName: 'file',
@@ -46,7 +52,7 @@ describe('buildMultipartBody', () => {
 	});
 
 	it('handles empty fields array', () => {
-		const fileData = new Uint8Array([0x01, 0x02]).buffer as ArrayBuffer;
+		const fileData = new Uint8Array([0x01, 0x02]).buffer;
 		const result = buildMultipartBody([], {
 			name: 'audio.wav',
 			fieldName: 'file',
@@ -60,7 +66,7 @@ describe('buildMultipartBody', () => {
 	});
 
 	it('generates unique boundaries per call', () => {
-		const fileData = new Uint8Array([0x00]).buffer as ArrayBuffer;
+		const fileData = new Uint8Array([0x00]).buffer;
 		const r1 = buildMultipartBody([], { name: 'a.mp3', fieldName: 'file', data: fileData });
 		const r2 = buildMultipartBody([], { name: 'b.mp3', fieldName: 'file', data: fileData });
 
@@ -78,7 +84,7 @@ describe('buildMultipartBody', () => {
 		(new TextDecoder().decode(body).match(/\r\n/g) || []).length;
 
 	it('neutralizes CRLF/quote injection in a vault-derived file name', () => {
-		const fileData = new Uint8Array([0x01]).buffer as ArrayBuffer;
+		const fileData = new Uint8Array([0x01]).buffer;
 		// A maliciously named note/audio file trying to break out of the quoted
 		// filename param and inject an extra multipart header/part.
 		const evilName =
@@ -94,7 +100,7 @@ describe('buildMultipartBody', () => {
 	});
 
 	it('strips CRLF from field values so they cannot start a new part', () => {
-		const fileData = new Uint8Array([0x02]).buffer as ArrayBuffer;
+		const fileData = new Uint8Array([0x02]).buffer;
 		const benign = buildMultipartBody(
 			[{ name: 'language', value: 'en' }],
 			{ name: 'a.mp3', fieldName: 'file', data: fileData }
@@ -131,7 +137,8 @@ describe('Transcriber', () => {
 
 	describe('provider dispatch', () => {
 		it('throws for unsupported provider', async () => {
-			settings.audio.transcriptionProvider = 'unknown' as any;
+			settings.audio.transcriptionProvider =
+				'unknown' as unknown as SynapseSettings['audio']['transcriptionProvider'];
 			await expect(transcriber.transcribe(new ArrayBuffer(8), 'test.mp3'))
 				.rejects.toThrow('Unsupported transcription provider: unknown');
 		});
@@ -164,8 +171,8 @@ describe('Transcriber', () => {
 
 			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
-			expect(callArgs.headers.Authorization).toBe('Bearer sk-shared-key');
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
+			expect(callArgs.headers?.['Authorization']).toBe('Bearer sk-shared-key');
 		});
 
 		it('sends multipart request to Whisper API via requestUrl', async () => {
@@ -181,17 +188,17 @@ describe('Transcriber', () => {
 				headers: {},
 			});
 
-			const audioData = new Uint8Array([0xff, 0xfb, 0x90]).buffer as ArrayBuffer;
+			const audioData = new Uint8Array([0xff, 0xfb, 0x90]).buffer;
 			const result = await transcriber.transcribe(audioData, 'recording.mp3');
 
 			// Verify requestUrl was called (not native fetch)
 			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(callArgs.url).toBe('https://api.openai.com/v1/audio/transcriptions');
 			expect(callArgs.method).toBe('POST');
-			expect(callArgs.headers.Authorization).toBe('Bearer sk-whisper-key');
-			expect(callArgs.headers['Content-Type']).toMatch(/^multipart\/form-data; boundary=/);
+			expect(callArgs.headers?.['Authorization']).toBe('Bearer sk-whisper-key');
+			expect(callArgs.headers?.['Content-Type']).toMatch(/^multipart\/form-data; boundary=/);
 			expect(callArgs.body).toBeInstanceOf(ArrayBuffer);
 			expect(callArgs.throw).toBe(false);
 
@@ -215,8 +222,8 @@ describe('Transcriber', () => {
 
 			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
-			const body = new TextDecoder().decode(callArgs.body);
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
+			const body = new TextDecoder().decode(callArgs.body as ArrayBuffer);
 			expect(body).toContain('name="language"');
 			expect(body).toContain('fr');
 		});
@@ -312,18 +319,18 @@ describe('Transcriber', () => {
 				headers: {},
 			});
 
-			const audioData = new Uint8Array([0x01, 0x02, 0x03]).buffer as ArrayBuffer;
+			const audioData = new Uint8Array([0x01, 0x02, 0x03]).buffer;
 			const result = await transcriber.transcribe(audioData, 'audio.wav');
 
 			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(callArgs.url).toContain('https://api.deepgram.com/v1/listen');
 			expect(callArgs.url).toContain('punctuate=true');
 			expect(callArgs.url).toContain('paragraphs=true');
 			expect(callArgs.method).toBe('POST');
-			expect(callArgs.headers.Authorization).toBe('Token dg-test-key');
-			expect(callArgs.headers['Content-Type']).toBe('audio/*');
+			expect(callArgs.headers?.['Authorization']).toBe('Token dg-test-key');
+			expect(callArgs.headers?.['Content-Type']).toBe('audio/*');
 			expect(callArgs.body).toBe(audioData);
 			expect(callArgs.throw).toBe(false);
 
@@ -351,7 +358,7 @@ describe('Transcriber', () => {
 
 			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(callArgs.url).toContain('language=de');
 		});
 
@@ -445,28 +452,28 @@ describe('Transcriber', () => {
 
 			await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
-			expect(callArgs.headers['x-goog-api-key']).toBe('AIza-shared-key');
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
+			expect(callArgs.headers?.['x-goog-api-key']).toBe('AIza-shared-key');
 		});
 
 		it('sends base64 inline audio in a JSON body to generateContent', async () => {
 			mockRequestUrl.mockResolvedValue(geminiResponse('transcribed words'));
 
-			const audioData = new Uint8Array([0x01, 0x02, 0x03]).buffer as ArrayBuffer;
+			const audioData = new Uint8Array([0x01, 0x02, 0x03]).buffer;
 			const result = await transcriber.transcribe(audioData, 'recording.mp3');
 
 			expect(mockRequestUrl).toHaveBeenCalledTimes(1);
 
-			const callArgs = mockRequestUrl.mock.calls[0][0] as any;
+			const callArgs = mockRequestUrl.mock.calls[0][0] as RequestUrlParam;
 			expect(callArgs.url).toMatch(
 				/^https:\/\/generativelanguage\.googleapis\.com\/v1beta\/models\/[\w.-]+:generateContent$/
 			);
 			expect(callArgs.method).toBe('POST');
-			expect(callArgs.headers['x-goog-api-key']).toBe('AIza-test-key');
-			expect(callArgs.headers['Content-Type']).toBe('application/json');
+			expect(callArgs.headers?.['x-goog-api-key']).toBe('AIza-test-key');
+			expect(callArgs.headers?.['Content-Type']).toBe('application/json');
 			expect(callArgs.throw).toBe(false);
 
-			const body = JSON.parse(callArgs.body);
+			const body = JSON.parse(callArgs.body as string) as GeminiRequestBody;
 			expect(body.contents).toHaveLength(1);
 			expect(body.contents[0].role).toBe('user');
 			// The transcription instruction rides in system_instruction (not the
@@ -493,7 +500,9 @@ describe('Transcriber', () => {
 
 			await transcriber.transcribe(new ArrayBuffer(8), 'meeting.wav');
 
-			const body = JSON.parse((mockRequestUrl.mock.calls[0][0] as any).body);
+			const body = JSON.parse(
+				(mockRequestUrl.mock.calls[0][0] as RequestUrlParam).body as string,
+			) as GeminiRequestBody;
 			expect(body.contents[0].parts[0].inline_data.mime_type).toBe('audio/wav');
 		});
 
@@ -503,7 +512,9 @@ describe('Transcriber', () => {
 
 			const result = await transcriber.transcribe(new ArrayBuffer(8), 'test.mp3');
 
-			const body = JSON.parse((mockRequestUrl.mock.calls[0][0] as any).body);
+			const body = JSON.parse(
+				(mockRequestUrl.mock.calls[0][0] as RequestUrlParam).body as string,
+			) as GeminiRequestBody;
 			expect(body.system_instruction.parts[0].text).toContain('"fr"');
 			expect(result.language).toBe('fr');
 		});

--- a/src/image/extractor.test.ts
+++ b/src/image/extractor.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ImageExtractor } from './extractor';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import type {
+	NotificationManager,
+	ChatMessage,
+	ContentBlock,
+	ImageContentBlock,
+	TextContentBlock,
+} from '../shared';
 
-const mockChat = vi.fn().mockResolvedValue('Extracted text from image');
+const mockChat = vi
+	.fn<(messages: ChatMessage[]) => Promise<string>>()
+	.mockResolvedValue('Extracted text from image');
 
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {
@@ -28,7 +37,7 @@ describe('ImageExtractor', () => {
 		mockChat.mockClear();
 		mockChat.mockResolvedValue('Extracted text from image');
 		settings = makeSettings();
-		extractor = new ImageExtractor(() => settings, { info: vi.fn() } as any);
+		extractor = new ImageExtractor(() => settings, { info: vi.fn() } as unknown as NotificationManager);
 	});
 
 	afterEach(() => {
@@ -49,14 +58,14 @@ describe('ImageExtractor', () => {
 
 		// User message should have ContentBlock[] with image and text blocks
 		expect(messages[1].role).toBe('user');
-		const content = messages[1].content;
+		const content = messages[1].content as ContentBlock[];
 		expect(Array.isArray(content)).toBe(true);
 		expect(content).toHaveLength(2);
 		expect(content[0].type).toBe('image');
-		expect(content[0].mediaType).toBe('image/png');
-		expect(typeof content[0].data).toBe('string'); // base64
+		expect((content[0] as ImageContentBlock).mediaType).toBe('image/png');
+		expect(typeof (content[0] as ImageContentBlock).data).toBe('string'); // base64
 		expect(content[1].type).toBe('text');
-		expect(content[1].text).toContain('Extract all visible text');
+		expect((content[1] as TextContentBlock).text).toContain('Extract all visible text');
 	});
 
 	it('returns OCR result with text and source name', async () => {
@@ -103,32 +112,32 @@ describe('ImageExtractor', () => {
 		const buffer = makeImageBuffer();
 		await extractor.extract(buffer, 'photo.jpeg');
 
-		const content = mockChat.mock.calls[0][0][1].content;
-		expect(content[0].mediaType).toBe('image/jpeg');
+		const content = mockChat.mock.calls[0][0][1].content as ContentBlock[];
+		expect((content[0] as ImageContentBlock).mediaType).toBe('image/jpeg');
 	});
 
 	it('maps jpg extension to correct media type', async () => {
 		const buffer = makeImageBuffer();
 		await extractor.extract(buffer, 'photo.jpg');
 
-		const content = mockChat.mock.calls[0][0][1].content;
-		expect(content[0].mediaType).toBe('image/jpeg');
+		const content = mockChat.mock.calls[0][0][1].content as ContentBlock[];
+		expect((content[0] as ImageContentBlock).mediaType).toBe('image/jpeg');
 	});
 
 	it('maps webp extension to correct media type', async () => {
 		const buffer = makeImageBuffer();
 		await extractor.extract(buffer, 'photo.webp');
 
-		const content = mockChat.mock.calls[0][0][1].content;
-		expect(content[0].mediaType).toBe('image/webp');
+		const content = mockChat.mock.calls[0][0][1].content as ContentBlock[];
+		expect((content[0] as ImageContentBlock).mediaType).toBe('image/webp');
 	});
 
 	it('defaults to image/png for unknown extensions', async () => {
 		const buffer = makeImageBuffer();
 		await extractor.extract(buffer, 'photo.xyz');
 
-		const content = mockChat.mock.calls[0][0][1].content;
-		expect(content[0].mediaType).toBe('image/png');
+		const content = mockChat.mock.calls[0][0][1].content as ContentBlock[];
+		expect((content[0] as ImageContentBlock).mediaType).toBe('image/png');
 	});
 
 	it('restores model even if chat throws', async () => {

--- a/src/image/index.test.ts
+++ b/src/image/index.test.ts
@@ -1,14 +1,22 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock, type MockInstance } from 'vitest';
 import { ImageModule } from './index';
 import { ImageExtractor } from './extractor';
-import { ImageEmbed } from './types';
+import { ImageEmbed, OCRResult } from './types';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { createMockApp, mockFile as rawFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
-import type { Plugin } from 'obsidian';
+import type { Plugin, TFile as ObsidianTFile } from 'obsidian';
+import type { NotificationManager, CheckpointManager, Checkpoint } from '../shared';
 
-// Mock TFile vs the real obsidian TFile type differ structurally; tests only
-// need the runtime instance, so widen to `any` at the boundary.
-const mockFile = (path: string): any => rawFile(path);
+/** The notification-manager surface the module touches in these tests. */
+interface MockNotifications {
+	info: ReturnType<typeof vi.fn>;
+	notifyError: ReturnType<typeof vi.fn>;
+	startOperation: ReturnType<typeof vi.fn>;
+}
+
+// Mock TFile bridges to the real obsidian TFile the module signatures expect via
+// a single boundary cast (the mock's loose `vault` blocks strict assignability).
+const mockFile = (path: string): ObsidianTFile => rawFile(path) as unknown as ObsidianTFile;
 
 function makeSettings(): SynapseSettings {
 	return structuredClone(DEFAULT_SETTINGS);
@@ -27,15 +35,19 @@ function makeOp(cancelled = false) {
 describe('ImageModule', () => {
 	let app: ReturnType<typeof createMockApp>;
 	let plugin: Plugin;
-	let notifications: any;
+	let notifications: MockNotifications;
 	let checkpointManager: ReturnType<typeof createMockCheckpointManager>;
 	let op: ReturnType<typeof makeOp>;
-	let extractSpy: ReturnType<typeof vi.spyOn>;
+	let extractSpy: MockInstance<typeof ImageExtractor.prototype.extract>;
+	let getActiveFile: Mock<() => ObsidianTFile | null>;
 	let module: ImageModule;
 
 	beforeEach(() => {
 		app = createMockApp();
-		(app.workspace as any).getActiveFile = vi.fn().mockReturnValue(null);
+		// getActiveFile isn't on the base mock workspace; attach the spy the module reads.
+		getActiveFile = vi.fn<() => ObsidianTFile | null>().mockReturnValue(null);
+		(app.workspace as unknown as { getActiveFile: typeof getActiveFile }).getActiveFile =
+			getActiveFile;
 		plugin = { app } as unknown as Plugin;
 		op = makeOp();
 		notifications = {
@@ -47,15 +59,20 @@ describe('ImageModule', () => {
 		extractSpy = vi.spyOn(ImageExtractor.prototype, 'extract').mockResolvedValue({
 			text: 'extracted text',
 			fileName: 'img.png',
-		} as any);
-		module = new ImageModule(plugin, () => makeSettings(), notifications, checkpointManager as any);
+		} as OCRResult);
+		module = new ImageModule(
+			plugin,
+			() => makeSettings(),
+			notifications as unknown as NotificationManager,
+			checkpointManager as unknown as CheckpointManager,
+		);
 	});
 
 	afterEach(() => vi.restoreAllMocks());
 
 	describe('extractFromFile', () => {
 		it('shows an info notice and does nothing when no note is active', async () => {
-			(app.workspace as any).getActiveFile.mockReturnValue(null);
+			getActiveFile.mockReturnValue(null);
 
 			await module.extractFromFile(mockFile('images/img.png'));
 
@@ -67,7 +84,7 @@ describe('ImageModule', () => {
 
 		it('extracts OCR text and appends an OCR callout to the active note', async () => {
 			const active = mockFile('notes/Active.md');
-			(app.workspace as any).getActiveFile.mockReturnValue(active);
+			getActiveFile.mockReturnValue(active);
 			app.vault.read.mockResolvedValue('existing body');
 			const onComplete = vi.fn();
 			module.onExtractionComplete = onComplete;
@@ -86,7 +103,7 @@ describe('ImageModule', () => {
 
 		it('reports an error notice when extraction throws', async () => {
 			const active = mockFile('notes/Active.md');
-			(app.workspace as any).getActiveFile.mockReturnValue(active);
+			getActiveFile.mockReturnValue(active);
 			app.vault.read.mockResolvedValue('body');
 			extractSpy.mockRejectedValue(new Error('vision API down'));
 
@@ -154,7 +171,10 @@ describe('ImageModule', () => {
 
 	describe('resumeFromCheckpoint', () => {
 		it('informs the user and discards the checkpoint', async () => {
-			const checkpoint = { id: 'cp-1', remainingItems: [{ id: 'x' }, { id: 'y' }] } as any;
+			const checkpoint = {
+				id: 'cp-1',
+				remainingItems: [{ id: 'x' }, { id: 'y' }],
+			} as unknown as Checkpoint;
 
 			await module.resumeFromCheckpoint(checkpoint);
 

--- a/src/video/audio-extractor.test.ts
+++ b/src/video/audio-extractor.test.ts
@@ -8,7 +8,9 @@ import { DEFAULT_SETTINGS } from '../settings';
 // lazily resolves its node deps through a private `_node` field, so we inject a
 // stub execFile directly (a runtime require() of 'child_process' is not
 // intercepted by vi.mock).
-const execFileMock = vi.fn();
+const execFileMock = vi.fn<
+	(cmd: string, args: string[], opts: unknown, cb: (e: unknown, o: string, s: string) => void) => void
+>();
 
 describe('AudioExtractor.concatAudio', () => {
 	beforeEach(() => {
@@ -38,7 +40,7 @@ describe('AudioExtractor.concatAudio', () => {
 		expect(cmd).toBe('ffmpeg');
 
 		// One -i per input file, each input present.
-		expect((args as string[]).filter((a) => a === '-i')).toHaveLength(3);
+		expect(args.filter((a) => a === '-i')).toHaveLength(3);
 		expect(args).toContain('/a/one.mp3');
 		expect(args).toContain('/b/two.wav');
 		expect(args).toContain('/c/three.m4a');
@@ -48,7 +50,7 @@ describe('AudioExtractor.concatAudio', () => {
 		const ex = makeExtractor();
 		await ex.concatAudio(['/a/one.mp3', '/b/two.wav']);
 
-		const args = execFileMock.mock.calls[0][1] as string[];
+		const args = execFileMock.mock.calls[0][1];
 		const fcIdx = args.indexOf('-filter_complex');
 		expect(fcIdx).toBeGreaterThan(-1);
 		expect(args[fcIdx + 1]).toBe('[0:a][1:a]concat=n=2:v=0:a=1[out]');
@@ -67,7 +69,7 @@ describe('AudioExtractor.concatAudio', () => {
 		const ex = makeExtractor();
 		await ex.concatAudio(['/1.mp3', '/2.mp3', '/3.ogg', '/4.flac']);
 
-		const args = execFileMock.mock.calls[0][1] as string[];
+		const args = execFileMock.mock.calls[0][1];
 		const filter = args[args.indexOf('-filter_complex') + 1];
 		expect(filter).toBe('[0:a][1:a][2:a][3:a]concat=n=4:v=0:a=1[out]');
 	});
@@ -140,7 +142,7 @@ describe('AudioExtractor.runCommand error classification', () => {
 		expect((thrown as DependencyMissingError).tool).toBe('yt-dlp');
 		// A missing binary must NOT trigger the looser-format retry (only the
 		// metadata dump + the single failed extraction attempt ran).
-		expect(execFileMock.mock.calls.filter((c) => !(c[1] as string[]).includes('--dump-json')))
+		expect(execFileMock.mock.calls.filter((c) => !c[1].includes('--dump-json')))
 			.toHaveLength(1);
 	});
 
@@ -263,7 +265,7 @@ describe('AudioExtractor.extractFromUrl ffmpeg-location & fallback', () => {
 
 	function extractCalls(): unknown[][] {
 		return execFileMock.mock.calls.filter(
-			(c) => !(c[1] as string[]).includes('--dump-json')
+			(c) => !c[1].includes('--dump-json')
 		);
 	}
 

--- a/src/video/index.test.ts
+++ b/src/video/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -17,7 +17,7 @@ import type { VideoMetadata } from './types';
 const VIDEO_BYTES = Buffer.from('fake-mp4-payload-bytes');
 
 interface VaultStub {
-	createBinary: ReturnType<typeof vi.fn>;
+	createBinary: Mock<(path: string, data: ArrayBuffer) => Promise<TFile>>;
 	getAbstractFileByPath: ReturnType<typeof vi.fn>;
 	createFolder: ReturnType<typeof vi.fn>;
 	adapter: { writeBinary: ReturnType<typeof vi.fn> };
@@ -100,7 +100,7 @@ describe('VideoModule.downloadVideoToVault', () => {
 
 		// Exact-bytes assertion: proves the pool-backed-Buffer slice is correct.
 		expect(writtenData).toBeInstanceOf(ArrayBuffer);
-		expect(Buffer.from(writtenData as ArrayBuffer).equals(VIDEO_BYTES)).toBe(true);
+		expect(Buffer.from(writtenData).equals(VIDEO_BYTES)).toBe(true);
 	});
 
 	it('cleans up the temp download file after writing', async () => {
@@ -181,7 +181,7 @@ describe('VideoModule.processUrl dependency-error preservation (#382)', () => {
 		);
 		(mod as unknown as { extractor: { extractFromUrl: ReturnType<typeof vi.fn> } }).extractor = {
 			extractFromUrl,
-		} as never;
+		};
 		return mod;
 	}
 

--- a/src/video/mobile-safety.test.ts
+++ b/src/video/mobile-safety.test.ts
@@ -28,7 +28,7 @@ describe('mobile safety — no top-level Node.js requires', () => {
 			if (nodeBuiltins.includes(id)) {
 				trapped.push(id);
 			}
-			return originalRequire(id);
+			return originalRequire(id) as unknown;
 		}) as NodeRequire;
 		// Copy properties (cache, resolve, …) from the original require.
 		Object.assign(wrappedRequire, originalRequire);

--- a/src/video/settings-section.test.ts
+++ b/src/video/settings-section.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createEl, ToggleComponent, ButtonComponent, Notice } from '../__mocks__/obsidian';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { createEl, ToggleComponent, ButtonComponent, Notice, type StubEl } from '../__mocks__/obsidian';
 import { createSettingsSectionContext, NotificationManager } from '../shared';
 import { renderVideoSettings } from './settings-section';
 import { DEFAULT_SETTINGS } from '../settings';
@@ -24,21 +24,21 @@ const FFMPEG_CMDS = [
 const ALL_CMDS = [...YT_DLP_CMDS, ...FFMPEG_CMDS];
 
 // ── Stub-tree introspection helpers (mirror feature-chip-select.test.ts) ──
-function walk(el: any, out: any[] = []): any[] {
-	for (const c of el?.children ?? []) {
+function walk(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const c of el.children as unknown as StubEl[]) {
 		out.push(c);
 		walk(c, out);
 	}
 	return out;
 }
-function byClass(root: any, cls: string): any[] {
-	return walk(root).filter((e) => e.classList?.contains(cls));
+function byClass(root: StubEl, cls: string): StubEl[] {
+	return walk(root).filter((e) => e.classList.contains(cls));
 }
-function classTexts(root: any, cls: string): string[] {
+function classTexts(root: StubEl, cls: string): (string | null)[] {
 	return byClass(root, cls).map((e) => e.textContent);
 }
 
-let writeText: ReturnType<typeof vi.fn>;
+let writeText: Mock<(text: string) => Promise<void>>;
 
 function makeCtx(mutate?: (s: SynapseSettings) => void) {
 	const settings = structuredClone(DEFAULT_SETTINGS);


### PR DESCRIPTION
Type-safety cleanup of the test files under `src/audio/`, `src/video/`, and `src/image/`: drop now-unnecessary `any` casts in favor of the typed mock helpers (`StubEl`, `RequestUrlParam`, `MockInstance`, etc.) and type ad-hoc per-test mocks so the six type-safety rules pass — no runtime or test behavior change.

closes #424

Part of #321

## Verification
- Bucket gate (`no-unsafe-*` + `no-unnecessary-type-assertion`, forced to error across the three dirs): **187 → 0** findings.
- Full CI green: `tsc --noEmit --skipLibCheck` clean, `npm run lint` clean, `check-top-level-requires` clean, `version-bump --check` consistent, `esbuild production` builds.
- Test suite unchanged: **1823 passed** (136 files).

## Notes
- Stacked on #423 (PR #432); base branch is `refactor/issue-423-typesafe-summarize`, so GitHub's `closingIssuesReferences` will be empty until #423 merges to `main` — expected for a stacked PR.
- No changes outside test files under the three dirs (no shipped code, foundation mocks, or the `eslint.config.mjs` test override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK8VZVGAu257HacqAVPATi
