### PR TITLE
refactor: type-safety cleanup of elaboration/views test files (#425)

### DIFF
--- a/src/elaboration/auto-accept.test.ts
+++ b/src/elaboration/auto-accept.test.ts
@@ -4,9 +4,12 @@ import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { NotificationManager } from '../shared';
 import { mockFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { TFile } from 'obsidian';
 
 // The proposer uses AIClient under the hood; stub it so no network is hit.
-const sharedCompleteMock = vi.fn().mockResolvedValue('AI-generated elaboration content');
+const sharedCompleteMock = vi
+	.fn<(...args: unknown[]) => Promise<string>>()
+	.mockResolvedValue('AI-generated elaboration content');
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {
 		constructor(_getSettings: unknown) {}
@@ -56,14 +59,15 @@ function createMemoryAdapter() {
 
 function createMockPlugin(noteContent: string, adapter: ReturnType<typeof createMemoryAdapter>) {
 	const noteFile = mockFile('notes/topic.md');
-	const vault: any = {
-		read: vi.fn().mockResolvedValue(noteContent),
+	const read = vi.fn<(file: TFile) => Promise<string>>().mockResolvedValue(noteContent);
+	const vault = {
+		read,
 		cachedRead: vi.fn().mockResolvedValue(noteContent),
 		modify: vi.fn().mockResolvedValue(undefined),
 		// Atomic read -> transform -> write; the callback's return value is the
 		// written content (mirrors Obsidian's Vault.process).
-		process: vi.fn(async (file: any, fn: (data: string) => string) =>
-			fn(await vault.read(file))
+		process: vi.fn(async (file: TFile, fn: (data: string) => string) =>
+			fn(await read(file))
 		),
 		create: vi.fn(),
 		createFolder: vi.fn().mockResolvedValue(undefined),
@@ -122,7 +126,7 @@ describe('ElaborationModule auto-accept (#228)', () => {
 			() => settings,
 			notifications,
 			createMockCheckpointManager() as never,
-			new CommandRegistrar(mockPlugin as never),
+			new CommandRegistrar(mockPlugin),
 			shouldAutoAccept
 		);
 	}

--- a/src/elaboration/dedup.test.ts
+++ b/src/elaboration/dedup.test.ts
@@ -5,11 +5,14 @@ import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { NotificationManager } from '../shared';
 import { mockFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { TFile } from 'obsidian';
 import { Proposal } from './types';
 
 // The proposer uses AIClient under the hood; stub it so no network is hit and
 // we can count how many times the model is actually invoked.
-const sharedCompleteMock = vi.fn().mockResolvedValue('AI-generated elaboration content');
+const sharedCompleteMock = vi
+	.fn<(...args: unknown[]) => Promise<string>>()
+	.mockResolvedValue('AI-generated elaboration content');
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {
 		constructor(_getSettings: unknown) {}
@@ -57,11 +60,12 @@ function createMemoryAdapter() {
 
 function createMockPlugin(noteContent: string, adapter: ReturnType<typeof createMemoryAdapter>) {
 	const noteFile = mockFile('notes/topic.md');
-	const vault: any = {
-		read: vi.fn().mockResolvedValue(noteContent),
+	const read = vi.fn<(file: TFile) => Promise<string>>().mockResolvedValue(noteContent);
+	const vault = {
+		read,
 		cachedRead: vi.fn().mockResolvedValue(noteContent),
 		modify: vi.fn().mockResolvedValue(undefined),
-		process: vi.fn(async (file: any, fn: (data: string) => string) => fn(await vault.read(file))),
+		process: vi.fn(async (file: TFile, fn: (data: string) => string) => fn(await read(file))),
 		create: vi.fn(),
 		createFolder: vi.fn().mockResolvedValue(undefined),
 		getAbstractFileByPath: vi.fn((path: string) => (path === 'notes/topic.md' ? noteFile : null)),
@@ -137,7 +141,7 @@ describe('ElaborationModule proposal idempotency (#395)', () => {
 			() => settings,
 			notifications,
 			createMockCheckpointManager() as never,
-			new CommandRegistrar(mockPlugin as never),
+			new CommandRegistrar(mockPlugin),
 			() => settings.autoAccept.elaboration
 		);
 	}

--- a/src/elaboration/image-analyzer.test.ts
+++ b/src/elaboration/image-analyzer.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { TFile } from '../__mocks__/obsidian';
 import { ImageAnalyzer, MAX_IMAGES_PER_NOTE } from './image-analyzer';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
+import type { App } from 'obsidian';
+import type { NotificationManager } from '../shared';
+import type { ChatMessage, ContentBlock, ImageContentBlock, TextContentBlock } from '../shared/types';
 
-const mockChat = vi.fn().mockResolvedValue(
-	'DESCRIPTION: A sunset over mountains\n\nLOCATION: Rocky Mountain range, Colorado\n\nMETADATA: Taken during golden hour, approximately 6pm'
-);
+const mockChat = vi
+	.fn<(messages: ChatMessage[], opts?: unknown) => Promise<string>>()
+	.mockResolvedValue(
+		'DESCRIPTION: A sunset over mountains\n\nLOCATION: Rocky Mountain range, Colorado\n\nMETADATA: Taken during golden hour, approximately 6pm'
+	);
 
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {
@@ -22,6 +27,12 @@ function makeImageBuffer(): ArrayBuffer {
 	return data.buffer;
 }
 
+/** The slice of `App` the analyzer reads; mocked members stay spy-typed. */
+interface MockImageApp {
+	vault: { readBinary: Mock<(...args: unknown[]) => Promise<ArrayBuffer>> };
+	metadataCache: { getFirstLinkpathDest: Mock<(...args: unknown[]) => TFile | null> };
+}
+
 describe('ImageAnalyzer.findImageReferences', () => {
 	let analyzer: ImageAnalyzer;
 
@@ -31,7 +42,11 @@ describe('ImageAnalyzer.findImageReferences', () => {
 			vault: { readBinary: vi.fn() },
 			metadataCache: { getFirstLinkpathDest: vi.fn() },
 		};
-		analyzer = new ImageAnalyzer(mockApp as any, () => settings, { info: vi.fn() } as any);
+		analyzer = new ImageAnalyzer(
+			mockApp as unknown as App,
+			() => settings,
+			{ info: vi.fn() } as unknown as NotificationManager
+		);
 	});
 
 	it('finds wiki-link images', () => {
@@ -139,7 +154,11 @@ describe('ImageAnalyzer.parseAnalysisResponse', () => {
 			vault: { readBinary: vi.fn() },
 			metadataCache: { getFirstLinkpathDest: vi.fn() },
 		};
-		analyzer = new ImageAnalyzer(mockApp as any, () => settings, { info: vi.fn() } as any);
+		analyzer = new ImageAnalyzer(
+			mockApp as unknown as App,
+			() => settings,
+			{ info: vi.fn() } as unknown as NotificationManager
+		);
 	});
 
 	it('parses well-formed DESCRIPTION/LOCATION/METADATA response', () => {
@@ -192,7 +211,7 @@ describe('ImageAnalyzer.parseAnalysisResponse', () => {
 describe('ImageAnalyzer.analyzeImagesInNote', () => {
 	let analyzer: ImageAnalyzer;
 	let settings: SynapseSettings;
-	let mockApp: any;
+	let mockApp: MockImageApp;
 
 	beforeEach(() => {
 		mockChat.mockClear();
@@ -213,7 +232,11 @@ describe('ImageAnalyzer.analyzeImagesInNote', () => {
 			},
 		};
 
-		analyzer = new ImageAnalyzer(mockApp as any, () => settings, { info: vi.fn() } as any);
+		analyzer = new ImageAnalyzer(
+			mockApp as unknown as App,
+			() => settings,
+			{ info: vi.fn() } as unknown as NotificationManager
+		);
 	});
 
 	afterEach(() => {
@@ -260,15 +283,15 @@ describe('ImageAnalyzer.analyzeImagesInNote', () => {
 		expect(messages[0].role).toBe('system');
 		expect(messages[0].content).toContain('image analysis assistant');
 
-		const content = messages[1].content;
+		const content = messages[1].content as ContentBlock[];
 		expect(Array.isArray(content)).toBe(true);
 		expect(content).toHaveLength(2);
 		expect(content[0].type).toBe('image');
-		expect(content[0].mediaType).toBe('image/png');
+		expect((content[0] as ImageContentBlock).mediaType).toBe('image/png');
 		expect(content[1].type).toBe('text');
-		expect(content[1].text).toContain('DESCRIPTION');
-		expect(content[1].text).toContain('LOCATION');
-		expect(content[1].text).toContain('METADATA');
+		expect((content[1] as TextContentBlock).text).toContain('DESCRIPTION');
+		expect((content[1] as TextContentBlock).text).toContain('LOCATION');
+		expect((content[1] as TextContentBlock).text).toContain('METADATA');
 	});
 
 	it('skips images that cannot be resolved', async () => {

--- a/src/elaboration/proposal-store.test.ts
+++ b/src/elaboration/proposal-store.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { App } from 'obsidian';
 import { ProposalStore } from './proposal-store';
 import { Proposal } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
+
+/** The DataAdapter subset ProposalStore exercises; members stay spy-typed. */
+interface MockAdapter {
+	read: Mock<(path: string) => Promise<string>>;
+	write: Mock<(path: string, content: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+	remove: Mock<(path: string) => Promise<void>>;
+	list: Mock<(path: string) => Promise<{ files: string[]; folders: string[] }>>;
+}
 
 function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
 	return {
@@ -19,7 +29,7 @@ function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
 
 describe('ProposalStore', () => {
 	let store: ProposalStore;
-	let mockAdapter: any;
+	let mockAdapter: MockAdapter;
 
 	beforeEach(() => {
 		mockAdapter = {
@@ -36,7 +46,7 @@ describe('ProposalStore', () => {
 				createFolder: vi.fn().mockResolvedValue(undefined),
 				getAbstractFileByPath: vi.fn().mockReturnValue(null),
 			},
-		} as any;
+		} as unknown as App;
 
 		const getSettings = () => ({ ...DEFAULT_SETTINGS });
 		store = new ProposalStore(app, getSettings);
@@ -61,7 +71,7 @@ describe('ProposalStore', () => {
 				// Return null so ensureFolder thinks the folder doesn't exist
 				getAbstractFileByPath: vi.fn().mockReturnValue(null),
 			},
-		} as any;
+		} as unknown as App;
 
 		const freshStore = new ProposalStore(app, () => ({ ...DEFAULT_SETTINGS }));
 		await freshStore.save(makeProposal());
@@ -177,7 +187,7 @@ describe('ProposalStore', () => {
 		await store.updateStatus('update-me', 'accepted');
 
 		expect(mockAdapter.write).toHaveBeenCalled();
-		const written = JSON.parse(mockAdapter.write.mock.calls[0][1]);
+		const written = JSON.parse(mockAdapter.write.mock.calls[0][1]) as Proposal;
 		expect(written.status).toBe('accepted');
 	});
 

--- a/src/elaboration/proposer.test.ts
+++ b/src/elaboration/proposer.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { TFile, requestUrl } from '../__mocks__/obsidian';
 import { ProposalGenerator, proposalContentKey } from './proposer';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { DetectionResult } from './types';
+import type { App } from 'obsidian';
 import type { NotificationManager } from '../shared';
 
-const mockComplete = vi.fn().mockResolvedValue('Expanded content here.');
+const mockComplete = vi
+	.fn<(prompt: string, systemPrompt?: string, opts?: unknown) => Promise<string>>()
+	.mockResolvedValue('Expanded content here.');
 const mockChat = vi.fn().mockResolvedValue(
 	'DESCRIPTION: A photo of mountains\n\nLOCATION: Rocky Mountains\n\nMETADATA: No metadata observations.'
 );
@@ -46,8 +49,8 @@ function makeSettings(): SynapseSettings {
  */
 function makeNotifications() {
 	return { info: vi.fn(), error: vi.fn() } as unknown as NotificationManager & {
-		info: ReturnType<typeof vi.fn>;
-		error: ReturnType<typeof vi.fn>;
+		info: Mock<(message: string) => void>;
+		error: Mock<(message: string) => void>;
 	};
 }
 
@@ -76,7 +79,7 @@ describe('ProposalGenerator -- image embed preservation (no images)', () => {
 		settings.elaboration.proposal.includeSourceContext = false;
 		// Disable image analysis so these tests stay focused on original behavior
 		settings.image.enabled = false;
-		generator = new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+		generator = new ProposalGenerator(mockApp as unknown as App, () => settings, makeNotifications());
 	});
 
 	afterEach(() => {
@@ -146,7 +149,7 @@ describe('ProposalGenerator -- image analysis integration', () => {
 		settings = makeSettings();
 		settings.elaboration.proposal.includeSourceContext = false;
 		settings.image.enabled = true;
-		generator = new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+		generator = new ProposalGenerator(mockApp as unknown as App, () => settings, makeNotifications());
 	});
 
 	afterEach(() => {
@@ -212,7 +215,7 @@ describe('ProposalGenerator -- image analysis integration', () => {
 			},
 		};
 
-		const noImageGenerator = new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+		const noImageGenerator = new ProposalGenerator(mockApp as unknown as App, () => settings, makeNotifications());
 
 		const detection: DetectionResult = {
 			notePath: 'notes/plain.md',
@@ -306,14 +309,14 @@ describe('ProposalGenerator -- Twitter URL external context', () => {
 		const settings = makeSettings();
 		settings.elaboration.proposal.includeSourceContext = false;
 		settings.image.enabled = false;
-		generator = new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+		generator = new ProposalGenerator(mockApp as unknown as App, () => settings, makeNotifications());
 
 		mockRequestUrl.mockResolvedValue({
 			text: JSON.stringify({
 				html: '<blockquote class="twitter-tweet"><p lang="en" dir="ltr">This is the tweet text</p></blockquote>',
 				author_name: 'elonmusk',
 			}),
-		} as never);
+		});
 	});
 
 	afterEach(() => {
@@ -374,7 +377,7 @@ describe('ProposalGenerator -- article URL external context', () => {
 		settings.image.enabled = false;
 		const notifications = makeNotifications();
 		return {
-			generator: new ProposalGenerator(mockApp as any, () => settings, notifications),
+			generator: new ProposalGenerator(mockApp as unknown as App, () => settings, notifications),
 			notifications,
 		};
 	}
@@ -490,7 +493,7 @@ describe('ProposalGenerator -- Reddit URL external context', () => {
 		settings.image.enabled = false;
 		const notifications = makeNotifications();
 		return {
-			generator: new ProposalGenerator(mockApp as any, () => settings, notifications),
+			generator: new ProposalGenerator(mockApp as unknown as App, () => settings, notifications),
 			notifications,
 		};
 	}
@@ -518,7 +521,7 @@ describe('ProposalGenerator -- Reddit URL external context', () => {
 				'<title>Immich backup tips</title>' +
 				'<content type="html">&lt;p&gt;Use the CLI for bulk uploads.&lt;/p&gt;</content>' +
 				'</entry></feed>',
-		} as never);
+		});
 
 		const { generator } = makeGenerator(
 			'# Notes\n\nSaw this: https://www.reddit.com/r/immich/comments/abc123/title/'
@@ -586,7 +589,7 @@ describe('ProposalGenerator -- link-dominated notes (anti-fabrication)', () => {
 		settings.image.enabled = false;
 		const notifications = makeNotifications();
 		return {
-			generator: new ProposalGenerator(mockApp as any, () => settings, notifications),
+			generator: new ProposalGenerator(mockApp as unknown as App, () => settings, notifications),
 			notifications,
 		};
 	}
@@ -611,7 +614,7 @@ describe('ProposalGenerator -- link-dominated notes (anti-fabrication)', () => {
 				'<title>What is rcon.ip and rcon.port used for?</title>' +
 				'<content type="html">&lt;p&gt;Running RustDedicated on Ubuntu in a VM.&lt;/p&gt;</content>' +
 				'</entry></feed>',
-		} as never);
+		});
 
 		const { generator } = makeGenerator(REDDIT_URL);
 		const proposal = await generator.generate({
@@ -702,7 +705,7 @@ describe('ProposalGenerator -- note title as elaboration signal (#387)', () => {
 		settings.image.enabled = false;
 		const notifications = makeNotifications();
 		return {
-			generator: new ProposalGenerator(mockApp as any, () => settings, notifications),
+			generator: new ProposalGenerator(mockApp as unknown as App, () => settings, notifications),
 			notifications,
 		};
 	}
@@ -862,7 +865,7 @@ describe('ProposalGenerator -- deterministic id (#395)', () => {
 		const settings = makeSettings();
 		settings.elaboration.proposal.includeSourceContext = false;
 		settings.image.enabled = false;
-		generator = new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+		generator = new ProposalGenerator(mockApp as unknown as App, () => settings, makeNotifications());
 	});
 
 	afterEach(() => {
@@ -905,7 +908,7 @@ describe('ProposalGenerator -- prompt-injection gating for fetched content (#398
 		const settings = makeSettings();
 		settings.elaboration.proposal.includeSourceContext = false;
 		settings.image.enabled = false;
-		return new ProposalGenerator(mockApp as any, () => settings, makeNotifications());
+		return new ProposalGenerator(mockApp as unknown as App, () => settings, makeNotifications());
 	}
 
 	beforeEach(() => {

--- a/src/elaboration/review-toast.test.ts
+++ b/src/elaboration/review-toast.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import type { Plugin } from 'obsidian';
+import type { NoticeAction } from '../shared';
 import type { DetectionResult, Proposal } from './types';
 
 // Detector flags the note as a stub; proposer returns a concrete proposal — the
@@ -43,7 +44,13 @@ vi.mock('./proposer', () => ({
 }));
 
 function makeOp(cancelled = false) {
-	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+	return {
+		progress: vi.fn(),
+		update: vi.fn(),
+		finish: vi.fn<(message?: string, action?: NoticeAction) => void>(),
+		error: vi.fn(),
+		cancelled,
+	};
 }
 
 describe('ElaborationModule Review toast action (#366)', () => {
@@ -109,7 +116,7 @@ describe('ElaborationModule Review toast action (#366)', () => {
 			'Proposal generated',
 			expect.objectContaining({ label: 'Review' })
 		);
-		op.finish.mock.calls.at(-1)![1].onClick();
+		op.finish.mock.calls.at(-1)![1]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/elaboration/scan-note.test.ts
+++ b/src/elaboration/scan-note.test.ts
@@ -5,18 +5,22 @@ import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { NotificationManager } from '../shared';
 import { mockFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import { requestUrl } from '../__mocks__/obsidian';
-import { DetectionResult } from './types';
+import type { App, Plugin, TFile } from 'obsidian';
+import type { CheckpointManager } from '../shared';
+import { DetectionResult, Proposal } from './types';
 
 // Shared mock function that all MockAIClient instances delegate to.
 // Tests can swap this to capture prompts or change responses.
-const sharedCompleteMock = vi.fn().mockResolvedValue('AI-generated elaboration content');
+const sharedCompleteMock = vi
+	.fn<(...args: unknown[]) => Promise<string>>()
+	.mockResolvedValue('AI-generated elaboration content');
 
 // Mock the shared module's AIClient (used by ProposalGenerator).
 // Must be a real class so that `new AIClient(...)` works in ProposalGenerator.
 vi.mock('../shared/ai-client', () => ({
 	AIClient: class MockAIClient {
-		constructor(_getSettings: any) {}
-		complete(...args: any[]) {
+		constructor(_getSettings: unknown) {}
+		complete(...args: unknown[]) {
 			return sharedCompleteMock(...args);
 		}
 	},
@@ -88,11 +92,11 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 		notifications = new NotificationManager();
 
 		module = new ElaborationModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
 			notifications,
-			createMockCheckpointManager() as any,
-			new CommandRegistrar(mockPlugin as any)
+			createMockCheckpointManager() as unknown as CheckpointManager,
+			new CommandRegistrar(mockPlugin)
 		);
 	});
 
@@ -107,7 +111,7 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 		mockPlugin.app.vault.cachedRead.mockResolvedValue(longContent);
 
 		const file = mockFile('notes/architecture.md');
-		await module.scanNote(file as any);
+		await module.scanNote(file as unknown as TFile);
 
 		// The proposer should have been called (cachedRead is called by proposer.generate)
 		expect(mockPlugin.app.vault.cachedRead).toHaveBeenCalledWith(
@@ -117,9 +121,9 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 
 	it('creates a synthetic detection result with user-requested reason', async () => {
 		// Spy on the proposal store to capture what gets saved
-		const savedProposals: any[] = [];
+		const savedProposals: Proposal[] = [];
 		mockPlugin.app.vault.adapter.write.mockImplementation(async (_path: string, content: string) => {
-			try { savedProposals.push(JSON.parse(content)); } catch { /* not JSON */ }
+			try { savedProposals.push(JSON.parse(content) as Proposal); } catch { /* not JSON */ }
 		});
 
 		const longContent = '# Well-Written Note\n\n' + 'Comprehensive content here. '.repeat(20);
@@ -127,7 +131,7 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 		mockPlugin.app.vault.cachedRead.mockResolvedValue(longContent);
 
 		const file = mockFile('notes/complete.md');
-		await module.scanNote(file as any);
+		await module.scanNote(file as unknown as TFile);
 
 		// A proposal should have been saved
 		expect(savedProposals.length).toBe(1);
@@ -141,18 +145,18 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 		mockPlugin.app.vault.read.mockResolvedValue(shortContent);
 		mockPlugin.app.vault.cachedRead.mockResolvedValue(shortContent);
 
-		const savedProposals: any[] = [];
+		const savedProposals: Proposal[] = [];
 		mockPlugin.app.vault.adapter.write.mockImplementation(async (_path: string, content: string) => {
-			try { savedProposals.push(JSON.parse(content)); } catch { /* not JSON */ }
+			try { savedProposals.push(JSON.parse(content) as Proposal); } catch { /* not JSON */ }
 		});
 
 		const file = mockFile('notes/stub.md');
-		await module.scanNote(file as any);
+		await module.scanNote(file as unknown as TFile);
 
 		expect(savedProposals.length).toBe(1);
 		// Should contain the actual detector reasons, not user-requested
 		const reasons = savedProposals[0].detectionReasons;
-		const reasonTypes = reasons.map((r: any) => r.type);
+		const reasonTypes = reasons.map((r) => r.type);
 		expect(reasonTypes).not.toContain('user-requested');
 		// Should have real detection reasons like short-note or todo-marker
 		expect(reasonTypes.length).toBeGreaterThan(0);
@@ -165,7 +169,7 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 
 		const file = mockFile('notes/complete.md');
 		// Explicitly pass userInvoked = false (simulating auto-scan behavior)
-		await module.scanNote(file as any, false);
+		await module.scanNote(file as unknown as TFile, false);
 
 		// The proposer should NOT have been called since detector found nothing
 		// and userInvoked is false
@@ -179,7 +183,7 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 
 		const file = mockFile('notes/full.md');
 		// Call without second argument — should default to userInvoked=true
-		await module.scanNote(file as any);
+		await module.scanNote(file as unknown as TFile);
 
 		// Should still generate because userInvoked defaults to true
 		expect(mockPlugin.app.vault.cachedRead).toHaveBeenCalledWith(
@@ -194,13 +198,13 @@ describe('ElaborationModule.scanNote — user-invoked elaboration', () => {
 		mockPlugin.app.vault.cachedRead.mockResolvedValue(urlOnly);
 		vi.mocked(requestUrl).mockRejectedValue(new Error('Too Many Requests'));
 
-		const savedProposals: any[] = [];
+		const savedProposals: Proposal[] = [];
 		mockPlugin.app.vault.adapter.write.mockImplementation(async (_path: string, content: string) => {
-			try { savedProposals.push(JSON.parse(content)); } catch { /* not JSON */ }
+			try { savedProposals.push(JSON.parse(content) as Proposal); } catch { /* not JSON */ }
 		});
 
 		const file = mockFile('notes/link-only.md');
-		await module.scanNote(file as any);
+		await module.scanNote(file as unknown as TFile);
 
 		// generate() returns null -> scanNote must NOT save an invented proposal.
 		expect(savedProposals.length).toBe(0);
@@ -234,7 +238,7 @@ describe('ProposalGenerator — user-requested reason handling', () => {
 		};
 
 		const settings = structuredClone(DEFAULT_SETTINGS);
-		const generator = new ProposalGenerator(mockApp as any, () => settings, { info: vi.fn() } as unknown as NotificationManager);
+		const generator = new ProposalGenerator(mockApp as unknown as App, () => settings, { info: vi.fn() } as unknown as NotificationManager);
 
 		const detection: DetectionResult = {
 			notePath: 'notes/test.md',
@@ -267,7 +271,7 @@ describe('ProposalGenerator — user-requested reason handling', () => {
 		// Disable context gathering to simplify the test
 		settings.elaboration.proposal.includeSourceContext = false;
 
-		const generator = new ProposalGenerator(mockApp as any, () => settings, { info: vi.fn() } as unknown as NotificationManager);
+		const generator = new ProposalGenerator(mockApp as unknown as App, () => settings, { info: vi.fn() } as unknown as NotificationManager);
 
 		const userDetection: DetectionResult = {
 			notePath: 'notes/user.md',

--- a/src/elaboration/startup-flow.test.ts
+++ b/src/elaboration/startup-flow.test.ts
@@ -21,6 +21,8 @@ vi.mock('./proposer', () => ({ ProposalGenerator: class {} }));
 import { ElaborationModule } from './index';
 import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
+import type { Plugin } from 'obsidian';
+import type { NotificationManager, CheckpointManager } from '../shared';
 
 describe('ElaborationModule — startup flow gate', () => {
 	let settings: typeof DEFAULT_SETTINGS;
@@ -48,8 +50,14 @@ describe('ElaborationModule — startup flow gate', () => {
 	});
 
 	function makeModule(): ElaborationModule {
-		const plugin = { app: {} } as any;
-		return new ElaborationModule(plugin, () => settings, {} as any, {} as any, new CommandRegistrar(plugin as any));
+		const plugin = { app: {} } as unknown as Plugin;
+		return new ElaborationModule(
+			plugin,
+			() => settings,
+			{} as unknown as NotificationManager,
+			{} as unknown as CheckpointManager,
+			new CommandRegistrar(plugin)
+		);
 	}
 
 	it('schedules the startup + interval scans when scan-vault is in the startup flow', async () => {

--- a/src/views/synapse-actions-view.test.ts
+++ b/src/views/synapse-actions-view.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createEl } from '../__mocks__/obsidian';
+import { createEl, type StubEl } from '../__mocks__/obsidian';
 import { SynapseActionsView, SynapseActionsCallbacks } from './synapse-actions-view';
+import type { WorkspaceLeaf } from 'obsidian';
 import type { CommandDefinition } from '../commands';
+
+/** A `<button>` stub: the view stamps `.disabled` on real button elements. */
+type StubButton = StubEl & { disabled?: boolean };
 
 // --- Helpers ----------------------------------------------------------------
 
 /** Stub WorkspaceLeaf that satisfies the ItemView constructor. */
-function mockLeaf(): any {
-	return { view: {} };
+function mockLeaf(): WorkspaceLeaf {
+	return { view: {} } as unknown as WorkspaceLeaf;
 }
 
 /**
@@ -34,15 +38,15 @@ function makeView(overrides: Partial<SynapseActionsCallbacks> = {}) {
 	const view = new SynapseActionsView(mockLeaf(), callbacks);
 	// Mock ItemView.contentEl is a bare no-op stub; swap in the tracking stub el.
 	const contentEl = createEl();
-	(view as unknown as { contentEl: any }).contentEl = contentEl;
+	(view as unknown as { contentEl: StubEl }).contentEl = contentEl;
 	return { view, callbacks, contentEl };
 }
 
 /** Recursively collect all <button> descendants of a stub element. */
-function buttons(el: any): any[] {
-	const out: any[] = [];
-	const walk = (node: any) => {
-		for (const child of node.children ?? []) {
+function buttons(el: StubEl): StubButton[] {
+	const out: StubButton[] = [];
+	const walk = (node: StubEl) => {
+		for (const child of node.children as unknown as StubEl[]) {
 			if (child.tagName === 'BUTTON') out.push(child);
 			walk(child);
 		}
@@ -52,16 +56,16 @@ function buttons(el: any): any[] {
 }
 
 /** Find the action <button> whose text reads `label`. */
-function findButton(el: any, label: string): any {
+function findButton(el: StubEl, label: string): StubButton | undefined {
 	return buttons(el).find((b) => b.textContent === label);
 }
 
 /** Recursively collect text of all descendants carrying `cls`. */
-function textsByClass(el: any, cls: string): string[] {
-	const out: string[] = [];
-	const walk = (node: any) => {
-		for (const child of node.children ?? []) {
-			if (child.classList?.contains?.(cls)) out.push(child.textContent);
+function textsByClass(el: StubEl, cls: string): (string | null)[] {
+	const out: (string | null)[] = [];
+	const walk = (node: StubEl) => {
+		for (const child of node.children as unknown as StubEl[]) {
+			if (child.classList.contains(cls)) out.push(child.textContent);
 			walk(child);
 		}
 	};
@@ -70,11 +74,11 @@ function textsByClass(el: any, cls: string): string[] {
 }
 
 /** The resolved glyph names stamped on each group heading icon (`data-icon`), in order. */
-function groupIcons(el: any): (string | null)[] {
+function groupIcons(el: StubEl): (string | null)[] {
 	const out: (string | null)[] = [];
-	const walk = (node: any) => {
-		for (const child of node.children ?? []) {
-			if (child.classList?.contains?.('synapse-actions-group-icon')) out.push(child.getAttribute('data-icon'));
+	const walk = (node: StubEl) => {
+		for (const child of node.children as unknown as StubEl[]) {
+			if (child.classList.contains('synapse-actions-group-icon')) out.push(child.getAttribute('data-icon'));
 			walk(child);
 		}
 	};
@@ -123,9 +127,9 @@ describe('SynapseActionsView', () => {
 		await view.onOpen();
 
 		const noteButton = findButton(contentEl, 'Enrich current note');
-		expect(noteButton.disabled).toBe(true);
+		expect(noteButton!.disabled).toBe(true);
 		// A disabled button has no handler, so dispatching a click is a no-op.
-		noteButton.dispatchEvent({ type: 'click' });
+		noteButton!.dispatchEvent({ type: 'click' });
 		expect(runAction).not.toHaveBeenCalled();
 	});
 
@@ -135,8 +139,8 @@ describe('SynapseActionsView', () => {
 		await view.onOpen();
 
 		const vaultButton = findButton(contentEl, 'Scan folder for enrichment');
-		expect(vaultButton.disabled).toBeFalsy();
-		vaultButton.dispatchEvent({ type: 'click' });
+		expect(vaultButton!.disabled).toBeFalsy();
+		vaultButton!.dispatchEvent({ type: 'click' });
 		expect(runAction).toHaveBeenCalledWith('scan-vault-enrichment');
 	});
 
@@ -145,7 +149,7 @@ describe('SynapseActionsView', () => {
 		const { view, contentEl } = makeView({ isNoteActive: () => true, runAction });
 		await view.onOpen();
 
-		findButton(contentEl, 'Enrich current note').dispatchEvent({ type: 'click' });
+		findButton(contentEl, 'Enrich current note')!.dispatchEvent({ type: 'click' });
 		expect(runAction).toHaveBeenCalledWith('enrich-current-note');
 	});
 
@@ -153,11 +157,11 @@ describe('SynapseActionsView', () => {
 		let noteActive = false;
 		const { view, contentEl } = makeView({ isNoteActive: () => noteActive });
 		await view.onOpen();
-		expect(findButton(contentEl, 'Enrich current note').disabled).toBe(true);
+		expect(findButton(contentEl, 'Enrich current note')!.disabled).toBe(true);
 
 		noteActive = true;
 		view.refresh();
-		expect(findButton(contentEl, 'Enrich current note').disabled).toBeFalsy();
+		expect(findButton(contentEl, 'Enrich current note')!.disabled).toBeFalsy();
 	});
 
 	it('shows an empty-state message and no buttons when nothing is registered', async () => {

--- a/src/views/unified-proposal-view.test.ts
+++ b/src/views/unified-proposal-view.test.ts
@@ -1,18 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UnifiedProposalView, UnifiedItem, UnifiedViewCallbacks } from './unified-proposal-view';
 import { NotificationManager } from '../shared/notifications';
-import type { Proposal } from '../elaboration';
-import type { EnrichmentProposal } from '../enrichment';
-import type { OrganizeProposal } from '../organize';
-import type { DeepDiveProposal } from '../deep-dive';
 import type { TitleProposal } from '../title';
-import { createEl } from '../__mocks__/obsidian';
+import { createEl, type StubEl } from '../__mocks__/obsidian';
+import type { WorkspaceLeaf } from 'obsidian';
+
+/**
+ * The private surface of {@link UnifiedProposalView} these tests reach into via
+ * a boundary cast (real instance, internal methods/fields exercised directly).
+ */
+interface ViewInternals {
+	items: UnifiedItem[];
+	rejectAllInProgress: boolean;
+	acceptAllInProgress: boolean;
+	contentEl: StubEl;
+	rejectSingleItem(item: UnifiedItem): Promise<void>;
+	rejectAll(): Promise<void>;
+	acceptAll(): Promise<void>;
+	renderTitleCard(container: StubEl, proposal: TitleProposal): void;
+	renderTitleReview(proposal: TitleProposal): void;
+}
 
 // --- Helpers ----------------------------------------------------------------
 
 /** Stub WorkspaceLeaf that satisfies ItemView constructor. */
-function mockLeaf(): any {
-	return { view: {} };
+function mockLeaf(): WorkspaceLeaf {
+	return { view: {} } as unknown as WorkspaceLeaf;
 }
 
 /** Create a stub callbacks object with all methods as spies. */
@@ -48,7 +61,7 @@ function makeElaborationItem(id = 'elab-1'): UnifiedItem {
 			proposedAdditions: 'additions',
 			insertionPoint: 'append',
 			status: 'pending',
-		} as Proposal,
+		},
 	};
 }
 
@@ -68,7 +81,7 @@ function makeEnrichmentItem(id = 'enrich-1'): UnifiedItem {
 				frontmatter: [],
 			},
 			status: 'pending',
-		} as EnrichmentProposal,
+		},
 	};
 }
 
@@ -83,7 +96,7 @@ function makeOrganizeItem(id = 'org-1'): UnifiedItem {
 			reasoning: 'fits better here',
 			createdAt: '2024-01-01T00:00:00Z',
 			status: 'pending',
-		} as OrganizeProposal,
+		},
 	};
 }
 
@@ -103,7 +116,7 @@ function makeDeepDiveItem(id = 'dd-1'): UnifiedItem {
 			childProposalIds: [],
 			createdAt: '2024-01-01T00:00:00Z',
 			status: 'pending',
-		} as DeepDiveProposal,
+		},
 	};
 }
 
@@ -128,8 +141,8 @@ function makeTitleProposal(conflictsWith?: string): TitleProposal {
 // Notice — the inner-element gotcha does not apply).
 
 /** Recursively collect every element in a createEl() stub tree. */
-function walkEls(el: any, out: any[] = []): any[] {
-	for (const child of el?.children ?? []) {
+function walkEls(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const child of el.children as unknown as StubEl[]) {
 		out.push(child);
 		walkEls(child, out);
 	}
@@ -139,19 +152,19 @@ function walkEls(el: any, out: any[] = []): any[] {
 // a multi-class `cls` string (e.g. "synapse-badge synapse-badge--conflict") as a
 // single combined entry, so contains() of an individual token misses. className
 // rejoins+splits cleanly and works for single- and multi-class elements alike.
-const elsWithClass = (root: any, cls: string): any[] =>
-	walkEls(root).filter((e) => String(e.className ?? '').split(/\s+/).includes(cls));
-const elsWithTag = (root: any, tag: string): any[] =>
+const elsWithClass = (root: StubEl, cls: string): StubEl[] =>
+	walkEls(root).filter((e) => e.className.split(/\s+/).includes(cls));
+const elsWithTag = (root: StubEl, tag: string): StubEl[] =>
 	walkEls(root).filter((e) => e.tagName === tag);
 /** Concatenate an element's own text with all descendant text. */
-const textOf = (el: any): string =>
-	[el?.textContent ?? '', ...walkEls(el).map((c) => c.textContent ?? '')].join(' ');
+const textOf = (el: StubEl): string =>
+	[el.textContent ?? '', ...walkEls(el).map((c) => c.textContent ?? '')].join(' ');
 
 // --- Tests ------------------------------------------------------------------
 
 /** Create a deeply-recursive stub DOM element that supports all Obsidian HTML methods. */
-function stubEl(): any {
-	const el: any = {
+function stubEl(): StubEl {
+	const el = {
 		style: {},
 		disabled: false,
 		value: '',
@@ -165,16 +178,20 @@ function stubEl(): any {
 		createEl: vi.fn().mockImplementation(() => stubEl()),
 		createDiv: vi.fn().mockImplementation(() => stubEl()),
 	};
-	return el;
+	return el as unknown as StubEl;
 }
 
 describe('UnifiedProposalView reject-all', () => {
-	let view: any; // cast to any to access private methods
+	let view: ViewInternals; // boundary cast to reach private methods
 	let callbacks: UnifiedViewCallbacks;
 
 	beforeEach(() => {
 		callbacks = mockCallbacks();
-		view = new UnifiedProposalView(mockLeaf(), callbacks, new NotificationManager());
+		view = new UnifiedProposalView(
+			mockLeaf(),
+			callbacks,
+			new NotificationManager()
+		) as unknown as ViewInternals;
 		// Stub contentEl with a recursive mock so render calls don't throw
 		view.contentEl = stubEl();
 	});
@@ -225,11 +242,11 @@ describe('UnifiedProposalView reject-all', () => {
 
 		it('calls reject callbacks in presentation order', async () => {
 			const callOrder: string[] = [];
-			(callbacks.onElaborationReject as any).mockImplementation((id: string) => {
+			vi.mocked(callbacks.onElaborationReject).mockImplementation((id: string) => {
 				callOrder.push(`elab-${id}`);
 				return Promise.resolve();
 			});
-			(callbacks.onEnrichmentReject as any).mockImplementation((id: string) => {
+			vi.mocked(callbacks.onEnrichmentReject).mockImplementation((id: string) => {
 				callOrder.push(`enrich-${id}`);
 				return Promise.resolve();
 			});
@@ -246,7 +263,7 @@ describe('UnifiedProposalView reject-all', () => {
 		});
 
 		it('stops on first failure and reports partial progress', async () => {
-			(callbacks.onEnrichmentReject as any).mockRejectedValue(new Error('network'));
+			vi.mocked(callbacks.onEnrichmentReject).mockRejectedValue(new Error('network'));
 
 			view.items = [
 				makeElaborationItem('e1'),
@@ -291,7 +308,7 @@ describe('UnifiedProposalView reject-all', () => {
 		});
 
 		it('resets rejectAllInProgress flag after failure', async () => {
-			(callbacks.onElaborationReject as any).mockRejectedValue(new Error('fail'));
+			vi.mocked(callbacks.onElaborationReject).mockRejectedValue(new Error('fail'));
 			view.items = [makeElaborationItem('e1')];
 
 			await view.rejectAll();
@@ -323,9 +340,13 @@ describe('UnifiedProposalView reject-all', () => {
 });
 
 describe('UnifiedProposalView title collision UI (#414)', () => {
-	/** Fresh view; cast to any to reach the private render methods. */
-	function makeView(): any {
-		return new UnifiedProposalView(mockLeaf(), mockCallbacks(), new NotificationManager());
+	/** Fresh view; boundary cast to reach the private render methods. */
+	function makeView(): ViewInternals {
+		return new UnifiedProposalView(
+			mockLeaf(),
+			mockCallbacks(),
+			new NotificationManager()
+		) as unknown as ViewInternals;
 	}
 
 	describe('renderTitleCard', () => {


### PR DESCRIPTION
Type-safety cleanup of the test files under `src/elaboration/` and `src/views/`: drop now-unnecessary `any` casts in favor of the typed mock helpers and type ad-hoc per-test mocks so the six type-safety rules pass for these directories. No runtime/test behavior change.

closes #425

Part of #321. Stacked on #424 (PR #433) — base is `refactor/issue-424-typesafe-media`, not `main`.

## What changed
- Imported mock classes / `StubEl` / `createEl` from `../__mocks__/obsidian`; walk DOM via `el.children as unknown as StubEl[]` (mirrors feature-chip-select / settings-section).
- Typed ad-hoc per-test mocks: `vi.fn<…>()` signatures, `vi.mocked(fn)` for spies, small named interfaces (`MockAdapter`, `MockImageApp`, `ViewInternals`) + `as unknown as <RealType>` boundary casts.
- Mock `TFile` → real `TFile`, mock app/plugin → real types via single `as unknown as` at fixture boundaries.
- ContentBlock union access cast to the specific member after narrowing.
- Dropped genuinely-redundant `as <Proposal>` assertions (and their now-unused imports) and stale `as never` casts.
- 63 `any` tokens removed, 0 added.

## Verification
- Bucket gate (the six rules forced as errors over `src/elaboration src/views`): **296 → 0**.
- Full CI green: `tsc --noEmit --skipLibCheck` exit 0; `npm run lint` exit 0; `check-top-level-requires.mjs` exit 0; `npm test` **1823 passed**; `version-bump.mjs --check` exit 0; `esbuild.config.mjs production` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yfToVSmGYJDLXg2j8GZms
