### PR TITLE
refactor: type-safety cleanup of enrichment/rem test files (#426)

### DIFF
--- a/src/enrichment/auto-accept.test.ts
+++ b/src/enrichment/auto-accept.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { NotificationManager } from '../shared';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { EnrichmentProposal, AcceptedItems } from './types';
 
 // Deterministic enrichment result: one tag, one internal link, one frontmatter key.
 vi.mock('./vault-analyzer', () => ({
@@ -57,7 +58,9 @@ vi.mock('./prompt-builder', () => ({
 }));
 
 // The applier is the side effect we assert on for auto-accept.
-const applySpy = vi.fn().mockResolvedValue(undefined);
+const applySpy = vi
+	.fn<(proposal: EnrichmentProposal, accepted: AcceptedItems) => Promise<void>>()
+	.mockResolvedValue(undefined);
 vi.mock('./enrichment-applier', () => ({
 	EnrichmentApplier: class MockEnrichmentApplier {
 		constructor(_app: unknown, _getSettings: unknown) {}

--- a/src/enrichment/enrichment-applier.test.ts
+++ b/src/enrichment/enrichment-applier.test.ts
@@ -52,7 +52,10 @@ describe('EnrichmentApplier', () => {
 		app.vault.getAbstractFileByPath.mockReturnValue(file);
 		app.vault.read.mockResolvedValue(content);
 		await applier.apply(proposal, accepted);
-		return app.vault.process.mock.results[0].value as Promise<string> as unknown as string;
+		// `process` is the atomic read->transform->write mock; its first call's
+		// result value is the written content (vitest types it as `any`).
+		const written = (await app.vault.process.mock.results[0].value) as unknown as string;
+		return written;
 	}
 
 	describe('apply', () => {

--- a/src/enrichment/enrichment-store.test.ts
+++ b/src/enrichment/enrichment-store.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { EnrichmentStore } from './enrichment-store';
 import { EnrichmentProposal } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
+import type { App } from 'obsidian';
+
+/** Spy-backed stand-in for the vault DataAdapter the store persists through. */
+interface MockAdapter {
+	read: Mock<(path: string) => Promise<string>>;
+	write: Mock<(path: string, data: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+	remove: Mock<(path: string) => Promise<void>>;
+	list: Mock<(path: string) => Promise<{ files: string[]; folders: string[] }>>;
+}
 
 function makeProposal(overrides: Partial<EnrichmentProposal> = {}): EnrichmentProposal {
 	return {
@@ -22,7 +32,7 @@ function makeProposal(overrides: Partial<EnrichmentProposal> = {}): EnrichmentPr
 
 describe('EnrichmentStore', () => {
 	let store: EnrichmentStore;
-	let mockAdapter: any;
+	let mockAdapter: MockAdapter;
 
 	beforeEach(() => {
 		mockAdapter = {
@@ -39,7 +49,7 @@ describe('EnrichmentStore', () => {
 				createFolder: vi.fn().mockResolvedValue(undefined),
 				getAbstractFileByPath: vi.fn().mockReturnValue(null),
 			},
-		} as any;
+		} as unknown as App;
 
 		const getSettings = () => ({ ...DEFAULT_SETTINGS });
 		store = new EnrichmentStore(app, getSettings);
@@ -124,9 +134,9 @@ describe('EnrichmentStore', () => {
 		});
 
 		expect(mockAdapter.write).toHaveBeenCalled();
-		const written = JSON.parse(mockAdapter.write.mock.calls[0][1]);
+		const written = JSON.parse(mockAdapter.write.mock.calls[0][1]) as EnrichmentProposal;
 		expect(written.status).toBe('accepted');
-		expect(written.acceptedItems.tags).toEqual(['#test']);
+		expect(written.acceptedItems!.tags).toEqual(['#test']);
 	});
 
 	it('deletes a proposal by id', async () => {

--- a/src/enrichment/link-resolver.test.ts
+++ b/src/enrichment/link-resolver.test.ts
@@ -3,10 +3,13 @@ import { LinkResolver } from './link-resolver';
 import { InternalLinkCandidate } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
 import { mockFile as rawFile } from '../__test-utils__/mock-factories';
+import type { App, TFile } from 'obsidian';
+import type { VaultAnalyzer } from './vault-analyzer';
 
-// Mock TFile vs the real obsidian TFile type differ structurally; tests only
-// need the runtime instance, so widen to `any` at the boundary.
-const mockFile = (path: string): any => rawFile(path);
+// The mock TFile (from __test-utils__) and obsidian's real TFile differ
+// structurally; tests only need the runtime instance, so cross the boundary
+// once here with a typed cast.
+const mockFile = (path: string): TFile => rawFile(path) as unknown as TFile;
 
 vi.mock('./weight-calculator', () => ({
 	computeProximityWeight: () => 0.8,
@@ -20,9 +23,9 @@ function makeSettings(overrides?: Partial<typeof DEFAULT_SETTINGS.enrichment>) {
 }
 
 function makeMockApp(files: Array<{ path: string }> = []) {
-	const TFile = class {};
-	const fileInstances = files.map(f => {
-		const inst = Object.create(TFile.prototype);
+	const LocalTFile = class {};
+	const fileInstances = files.map((f) => {
+		const inst = Object.create(LocalTFile.prototype) as { path: string };
 		inst.path = f.path;
 		return inst;
 	});
@@ -31,16 +34,16 @@ function makeMockApp(files: Array<{ path: string }> = []) {
 		vault: {
 			getMarkdownFiles: () => fileInstances,
 			getAbstractFileByPath: (path: string) =>
-				fileInstances.find((f: any) => f.path === path) ?? null,
+				fileInstances.find((f) => f.path === path) ?? null,
 		},
 		metadataCache: {
-			fileToLinktext: (file: any, _source: string) => {
+			fileToLinktext: (file: { path: string }, _source: string) => {
 				const basename = file.path.replace(/.*\//, '').replace(/\.md$/, '');
 				return basename;
 			},
 		},
-		_TFile: TFile,
-	} as any;
+		_TFile: LocalTFile,
+	} as unknown as App;
 }
 
 function makeMockAnalyzer(opts: {
@@ -56,7 +59,7 @@ function makeMockAnalyzer(opts: {
 		}),
 		getOutgoingLinks: (path: string) => opts.outgoing?.get(path) ?? [],
 		getIncomingLinks: (path: string) => opts.incoming?.get(path) ?? [],
-	} as any;
+	} as unknown as VaultAnalyzer;
 }
 
 // ── mergeTopicCandidates ──
@@ -158,9 +161,9 @@ function makeTFileApp(markdownPaths: string[] = []) {
 			getAbstractFileByPath: (path: string) => mockFile(path),
 		},
 		metadataCache: {
-			fileToLinktext: (file: any) => file.basename,
+			fileToLinktext: (file: TFile) => file.basename,
 		},
-	} as any;
+	} as unknown as App;
 }
 
 describe('LinkResolver.findInternalLinks', () => {

--- a/src/enrichment/prompt-builder.test.ts
+++ b/src/enrichment/prompt-builder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import { PromptBuilder } from './prompt-builder';
 import { AIClient } from '../shared';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
@@ -11,7 +11,7 @@ function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
 
 describe('PromptBuilder', () => {
 	let settings: SynapseSettings;
-	let completeSpy: ReturnType<typeof vi.spyOn>;
+	let completeSpy: MockInstance<typeof AIClient.prototype.complete>;
 	let builder: PromptBuilder;
 
 	beforeEach(() => {
@@ -90,7 +90,7 @@ describe('PromptBuilder', () => {
 			completeSpy.mockResolvedValue('[]');
 
 			await builder.suggestExternalLinks('text', ['https://existing.com']);
-			const prompt = completeSpy.mock.calls[0][0] as string;
+			const prompt = completeSpy.mock.calls[0][0];
 			expect(prompt).toContain('https://existing.com');
 		});
 

--- a/src/enrichment/review-toast.test.ts
+++ b/src/enrichment/review-toast.test.ts
@@ -5,10 +5,17 @@ import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import type { Plugin } from 'obsidian';
+import type { NoticeAction } from '../shared';
 import type { EnrichmentProposal } from './types';
 
 function makeOp(cancelled = false) {
-	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+	return {
+		progress: vi.fn(),
+		update: vi.fn(),
+		finish: vi.fn<(message?: string, action?: NoticeAction) => void>(),
+		error: vi.fn(),
+		cancelled,
+	};
 }
 
 /** A pending proposal with an empty-but-valid result, for the auto-accept path. */
@@ -89,7 +96,7 @@ describe('EnrichmentModule Review toast action (#366)', () => {
 			'Enrichment proposal created',
 			expect.objectContaining({ label: 'Review' })
 		);
-		op.finish.mock.calls.at(-1)![1].onClick();
+		op.finish.mock.calls.at(-1)![1]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/enrichment/vault-analyzer.test.ts
+++ b/src/enrichment/vault-analyzer.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VaultAnalyzer } from './vault-analyzer';
 import { TFile } from '../__mocks__/obsidian';
+import type { App, TFile as ObsidianTFile } from 'obsidian';
+import type { SynapseSettings } from '../settings';
 
-const noExclusions = () => ({ exclusions: [] }) as any;
-const settingsWith = (exclusions: unknown[]) => () => ({ exclusions }) as any;
+const noExclusions = () => ({ exclusions: [] }) as unknown as SynapseSettings;
+const settingsWith = (exclusions: unknown[]) => () =>
+	({ exclusions }) as unknown as SynapseSettings;
 
-function createMockApp(files: TFile[], caches: Map<string, any>, resolvedLinks: Record<string, Record<string, number>> = {}) {
+/** The slice of Obsidian's `CachedMetadata` these tests stub for tag extraction. */
+type TestFileCache = { tags?: Array<{ tag: string }> };
+
+function createMockApp(files: TFile[], caches: Map<string, TestFileCache>, resolvedLinks: Record<string, Record<string, number>> = {}) {
 	return {
 		vault: {
 			getMarkdownFiles: vi.fn().mockReturnValue(files),
@@ -14,7 +20,7 @@ function createMockApp(files: TFile[], caches: Map<string, any>, resolvedLinks: 
 			getFileCache: vi.fn().mockImplementation((file: TFile) => caches.get(file.path) || null),
 			resolvedLinks,
 		},
-	} as any;
+	} as unknown as App;
 }
 
 describe('VaultAnalyzer', () => {
@@ -23,7 +29,7 @@ describe('VaultAnalyzer', () => {
 			const file1 = new TFile('notes/a.md');
 			const file2 = new TFile('notes/b.md');
 
-			const caches = new Map();
+			const caches = new Map<string, TestFileCache>();
 			caches.set('notes/a.md', {
 				tags: [{ tag: '#python' }, { tag: '#ml' }],
 			});
@@ -52,7 +58,7 @@ describe('VaultAnalyzer', () => {
 		it('omits files in folders excluded for enrichment (#323)', () => {
 			const included = new TFile('notes/a.md');
 			const excluded = new TFile('Templates/t.md');
-			const caches = new Map();
+			const caches = new Map<string, TestFileCache>();
 			caches.set('notes/a.md', { tags: [{ tag: '#python' }] });
 			caches.set('Templates/t.md', { tags: [{ tag: '#tpl' }] });
 
@@ -69,7 +75,7 @@ describe('VaultAnalyzer', () => {
 
 		it('returns empty index for vault with no tags', () => {
 			const file = new TFile('empty.md');
-			const caches = new Map();
+			const caches = new Map<string, TestFileCache>();
 			caches.set('empty.md', {});
 
 			const app = createMockApp([file], caches);
@@ -81,7 +87,7 @@ describe('VaultAnalyzer', () => {
 
 		it('caches results and invalidates on call', () => {
 			const file = new TFile('note.md');
-			const caches = new Map();
+			const caches = new Map<string, TestFileCache>();
 			caches.set('note.md', { tags: [{ tag: '#test' }] });
 
 			const app = createMockApp([file], caches);
@@ -104,7 +110,7 @@ describe('VaultAnalyzer', () => {
 				'b.md': { 'c.md': 1 },
 			};
 
-			const app = createMockApp([], new Map(), resolvedLinks);
+			const app = createMockApp([], new Map<string, TestFileCache>(), resolvedLinks);
 			const analyzer = new VaultAnalyzer(app, noExclusions);
 			const graph = analyzer.buildLinkGraph();
 
@@ -118,7 +124,7 @@ describe('VaultAnalyzer', () => {
 		});
 
 		it('handles empty resolved links', () => {
-			const app = createMockApp([], new Map(), {});
+			const app = createMockApp([], new Map<string, TestFileCache>(), {});
 			const analyzer = new VaultAnalyzer(app, noExclusions);
 			const graph = analyzer.buildLinkGraph();
 
@@ -130,7 +136,7 @@ describe('VaultAnalyzer', () => {
 	describe('getFileTags', () => {
 		it('returns normalized tags for a file', () => {
 			const file = new TFile('note.md');
-			const caches = new Map();
+			const caches = new Map<string, TestFileCache>();
 			caches.set('note.md', {
 				tags: [{ tag: '#Python' }, { tag: '#ML' }],
 			});
@@ -138,15 +144,15 @@ describe('VaultAnalyzer', () => {
 			const app = createMockApp([file], caches);
 			const analyzer = new VaultAnalyzer(app, noExclusions);
 
-			expect(analyzer.getFileTags(file as any)).toEqual(['#python', '#ml']);
+			expect(analyzer.getFileTags(file as unknown as ObsidianTFile)).toEqual(['#python', '#ml']);
 		});
 
 		it('returns empty array for file with no cache', () => {
 			const file = new TFile('uncached.md');
-			const app = createMockApp([file], new Map());
+			const app = createMockApp([file], new Map<string, TestFileCache>());
 			const analyzer = new VaultAnalyzer(app, noExclusions);
 
-			expect(analyzer.getFileTags(file as any)).toEqual([]);
+			expect(analyzer.getFileTags(file as unknown as ObsidianTFile)).toEqual([]);
 		});
 	});
 
@@ -157,7 +163,7 @@ describe('VaultAnalyzer', () => {
 				'b.md': { 'a.md': 1, 'c.md': 1 },
 			};
 
-			const app = createMockApp([], new Map(), resolvedLinks);
+			const app = createMockApp([], new Map<string, TestFileCache>(), resolvedLinks);
 			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			expect(analyzer.getOutgoingLinks('a.md')).toEqual(['b.md']);
@@ -166,7 +172,7 @@ describe('VaultAnalyzer', () => {
 		});
 
 		it('returns empty for unknown files', () => {
-			const app = createMockApp([], new Map(), {});
+			const app = createMockApp([], new Map<string, TestFileCache>(), {});
 			const analyzer = new VaultAnalyzer(app, noExclusions);
 
 			expect(analyzer.getOutgoingLinks('unknown.md')).toEqual([]);

--- a/src/rem/auto-accept.test.ts
+++ b/src/rem/auto-accept.test.ts
@@ -80,10 +80,12 @@ describe('RemModule auto-accept (#228)', () => {
 		adapter = createMemoryAdapter();
 		settings = structuredClone(DEFAULT_SETTINGS);
 		notifications = new NotificationManager();
-		const readSpy = vi.fn().mockResolvedValue('# ML\n\nThis note is about backpropagation in depth.');
+		const readSpy = vi
+			.fn<(file: unknown) => Promise<string>>()
+			.mockResolvedValue('# ML\n\nThis note is about backpropagation in depth.');
 		// Atomic read -> transform -> write; the callback's return value is the
 		// written content (mirrors Obsidian's Vault.process).
-		processSpy = vi.fn(async (file: any, fn: (data: string) => string) =>
+		processSpy = vi.fn(async (file: unknown, fn: (data: string) => string) =>
 			fn(await readSpy(file))
 		);
 		sourceFile = new TFile('notes/ml.md');

--- a/src/rem/index.test.ts
+++ b/src/rem/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock, type MockInstance } from 'vitest';
 import { RemModule } from './index';
 import { RemStore } from './rem-store';
 import { MentionScanner } from './mention-scanner';
@@ -6,11 +6,14 @@ import { SemanticMatcher } from './semantic-matcher';
 import { RemProposal, RemLinkCandidate } from './types';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { createMockApp, mockFile as rawFile, createMockCheckpointManager } from '../__test-utils__/mock-factories';
-import type { Plugin } from 'obsidian';
+import type { Plugin, TFile } from 'obsidian';
+import type { CheckpointManager, NotificationManager, NoticeAction, Checkpoint } from '../shared';
+import type { CommandRegistrar } from '../commands';
 
-// Mock TFile vs the real obsidian TFile type differ structurally; tests only
-// need the runtime instance, so widen to `any` at the boundary.
-const mockFile = (path: string): any => rawFile(path);
+// The mock TFile (from __test-utils__) and obsidian's real TFile differ
+// structurally; tests only need the runtime instance, so cross the boundary
+// once here with a typed cast.
+const mockFile = (path: string): TFile => rawFile(path) as unknown as TFile;
 
 function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
 	const s = structuredClone(DEFAULT_SETTINGS);
@@ -19,7 +22,25 @@ function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
 }
 
 function makeOp(cancelled = false) {
-	return { progress: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+	return {
+		progress: vi.fn<(current: number, total: number, label?: string) => void>(),
+		finish: vi.fn<(message?: string, action?: NoticeAction) => void>(),
+		error: vi.fn<(message: string) => void>(),
+		cancelled,
+	};
+}
+
+/** Spy-backed stand-in for the NotificationManager surface the module calls. */
+interface MockNotifications {
+	info: Mock<(message: string, duration?: number, action?: NoticeAction) => void>;
+	success: Mock<(message: string, duration?: number, action?: NoticeAction) => void>;
+	notifyError: Mock<(context: string, error: unknown) => void>;
+	startOperation: Mock<(label: string, id?: string) => ReturnType<typeof makeOp>>;
+}
+
+/** Spy-backed stand-in for the CommandRegistrar the module registers against. */
+interface MockRegistrar {
+	register: Mock<(id: string, userEnabled: boolean, spec: unknown) => void>;
 }
 
 function candidate(matchedText: string, line = 0): RemLinkCandidate {
@@ -36,23 +57,23 @@ function candidate(matchedText: string, line = 0): RemLinkCandidate {
 describe('RemModule', () => {
 	let app: ReturnType<typeof createMockApp>;
 	let plugin: Plugin;
-	let notifications: any;
+	let notifications: MockNotifications;
 	let checkpointManager: ReturnType<typeof createMockCheckpointManager>;
-	let registrar: any;
+	let registrar: MockRegistrar;
 	let settings: SynapseSettings;
 
 	// Collaborator spies
-	let initSpy: ReturnType<typeof vi.spyOn>;
-	let saveSpy: ReturnType<typeof vi.spyOn>;
-	let loadSpy: ReturnType<typeof vi.spyOn>;
-	let updateStatusSpy: ReturnType<typeof vi.spyOn>;
-	let scanSpy: ReturnType<typeof vi.spyOn>;
-	let matchSpy: ReturnType<typeof vi.spyOn>;
-	let loadPendingSpy: ReturnType<typeof vi.spyOn>;
+	let initSpy: MockInstance<typeof RemStore.prototype.init>;
+	let saveSpy: MockInstance<typeof RemStore.prototype.save>;
+	let loadSpy: MockInstance<typeof RemStore.prototype.load>;
+	let updateStatusSpy: MockInstance<typeof RemStore.prototype.updateStatus>;
+	let scanSpy: MockInstance<typeof MentionScanner.prototype.scan>;
+	let matchSpy: MockInstance<typeof SemanticMatcher.prototype.match>;
+	let loadPendingSpy: MockInstance<typeof RemStore.prototype.loadPending>;
 
 	beforeEach(() => {
 		app = createMockApp();
-		(app.metadataCache as any).getFileCache = vi.fn().mockReturnValue(null);
+		app.metadataCache.getFileCache = vi.fn().mockReturnValue(null);
 		plugin = { app } as unknown as Plugin;
 		settings = makeSettings();
 		notifications = {
@@ -79,9 +100,9 @@ describe('RemModule', () => {
 		const module = new RemModule(
 			plugin,
 			() => settings,
-			notifications,
-			checkpointManager as any,
-			registrar,
+			notifications as unknown as NotificationManager,
+			checkpointManager as unknown as CheckpointManager,
+			registrar as unknown as CommandRegistrar,
 			shouldAutoAccept
 		);
 		await module.onload();
@@ -92,7 +113,7 @@ describe('RemModule', () => {
 		it('initializes the store and registers both REM commands', async () => {
 			await loadedModule();
 			expect(initSpy).toHaveBeenCalled();
-			const ids = registrar.register.mock.calls.map((c: any[]) => c[0]);
+			const ids = registrar.register.mock.calls.map((c) => c[0]);
 			expect(ids).toContain('rem-current-note');
 			expect(ids).toContain('rem-directory');
 		});
@@ -299,7 +320,7 @@ describe('RemModule', () => {
 			);
 			// The action opens the unified proposal view.
 			const action = notifications.success.mock.calls[0][2];
-			action.onClick();
+			action!.onClick();
 			expect(openSpy).toHaveBeenCalledTimes(1);
 		});
 
@@ -319,7 +340,7 @@ describe('RemModule', () => {
 				expect.stringContaining('REM scan complete'),
 				expect.objectContaining({ label: 'Review' })
 			);
-			op.finish.mock.calls.at(-1)![1].onClick();
+			op.finish.mock.calls.at(-1)![1]!.onClick();
 			expect(openSpy).toHaveBeenCalledTimes(1);
 		});
 
@@ -441,7 +462,7 @@ describe('RemModule', () => {
 	});
 
 	describe('resumeFromCheckpoint', () => {
-		const checkpointWith = (filePaths: string[]): any => ({
+		const checkpointWith = (filePaths: string[]): Checkpoint => ({
 			id: 'cp1',
 			module: 'rem',
 			operationLabel: 'REM scan',
@@ -483,7 +504,7 @@ describe('RemModule', () => {
 
 	describe('getPendingProposals', () => {
 		it('delegates to the store', async () => {
-			const pending = [{ id: 'p1' }] as any;
+			const pending = [{ id: 'p1' }] as unknown as RemProposal[];
 			loadPendingSpy.mockResolvedValue(pending);
 			const module = await loadedModule();
 
@@ -495,7 +516,7 @@ describe('RemModule', () => {
 		it('excludes a note carrying an excluded frontmatter tag', async () => {
 			settings.enrichment.excludeTags = ['#private'];
 			app.vault.getAbstractFileByPath.mockReturnValue(mockFile('notes/Secret.md'));
-			(app.metadataCache as any).getFileCache.mockReturnValue({
+			app.metadataCache.getFileCache.mockReturnValue({
 				frontmatter: { tags: ['private'] },
 			});
 			const module = await loadedModule();

--- a/src/rem/mention-scanner.test.ts
+++ b/src/rem/mention-scanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MentionScanner } from './mention-scanner';
-import type { TFile, CachedMetadata } from 'obsidian';
+import type { App, TFile, CachedMetadata } from 'obsidian';
+import type { SynapseSettings } from '../settings';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -21,11 +22,12 @@ function makeApp(files: TFile[], cacheMap: Map<string, Partial<CachedMetadata>> 
 		metadataCache: {
 			getFileCache: (file: TFile) => cacheMap.get(file.path) ?? null,
 		},
-	} as any;
+	} as unknown as App;
 }
 
-const noExclusions = () => ({ exclusions: [] }) as any;
-const settingsWith = (exclusions: unknown[]) => () => ({ exclusions }) as any;
+const noExclusions = () => ({ exclusions: [] }) as unknown as SynapseSettings;
+const settingsWith = (exclusions: unknown[]) => () =>
+	({ exclusions }) as unknown as SynapseSettings;
 
 // ── Tests ────────────────────────────────────────────────────
 

--- a/src/rem/review-toast.test.ts
+++ b/src/rem/review-toast.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { RemModule } from './index';
 import { RemStore } from './rem-store';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import type { Plugin } from 'obsidian';
+import type { NoticeAction } from '../shared';
 import type { RemLinkCandidate } from './types';
 
 function candidate(): RemLinkCandidate {
@@ -24,7 +25,7 @@ describe('RemModule Review toast action (#366)', () => {
 	let settings: SynapseSettings;
 	let notifications: {
 		info: ReturnType<typeof vi.fn>;
-		success: ReturnType<typeof vi.fn>;
+		success: Mock<(message: string, duration?: number, action?: NoticeAction) => void>;
 		notifyError: ReturnType<typeof vi.fn>;
 		startOperation: ReturnType<typeof vi.fn>;
 	};
@@ -86,7 +87,7 @@ describe('RemModule Review toast action (#366)', () => {
 			undefined,
 			expect.objectContaining({ label: 'Review' })
 		);
-		notifications.success.mock.calls.at(-1)![2].onClick();
+		notifications.success.mock.calls.at(-1)![2]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/rem/semantic-matcher.test.ts
+++ b/src/rem/semantic-matcher.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import { SemanticMatcher } from './semantic-matcher';
 import { AIClient } from '../shared';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { createMockApp, mockFile as rawFile } from '../__test-utils__/mock-factories';
-import type { App } from 'obsidian';
+import type { App, TFile } from 'obsidian';
 
-// Mock TFile vs the real obsidian TFile type differ structurally; tests only
-// need the runtime instance, so widen to `any` at the boundary.
-const mockFile = (path: string): any => rawFile(path);
+// The mock TFile (from __test-utils__) and obsidian's real TFile differ
+// structurally; tests only need the runtime instance, so cross the boundary
+// once here with a typed cast.
+const mockFile = (path: string): TFile => rawFile(path) as unknown as TFile;
 
 function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
 	const s = structuredClone(DEFAULT_SETTINGS);
@@ -18,7 +19,7 @@ function makeSettings(mutate?: (s: SynapseSettings) => void): SynapseSettings {
 describe('SemanticMatcher', () => {
 	let app: ReturnType<typeof createMockApp>;
 	let settings: SynapseSettings;
-	let completeSpy: ReturnType<typeof vi.spyOn>;
+	let completeSpy: MockInstance<typeof AIClient.prototype.complete>;
 
 	beforeEach(() => {
 		app = createMockApp();
@@ -55,7 +56,7 @@ describe('SemanticMatcher', () => {
 
 		await makeMatcher().match(source, 'about deep learning', new Set(['notes/Already.md']), 10);
 
-		const userPrompt = completeSpy.mock.calls[0][0] as string;
+		const userPrompt = completeSpy.mock.calls[0][0];
 		expect(userPrompt).toContain('Neural Networks');
 		expect(userPrompt).not.toContain('Already');
 		expect(userPrompt).not.toContain('Source');


### PR DESCRIPTION
Drives the six type-safety rules (`no-unsafe-assignment/call/member-access/argument/return`, `no-unnecessary-type-assertion`) to **0 findings** across the test files under `src/enrichment/` and `src/rem/`, replacing `any`-casts with the typed mock helpers from the foundation (#421) and typing ad-hoc per-test mocks.

closes #426

Part of #321

### Approach
- `mockFile` helpers now return real `TFile` via a single `as unknown as TFile` boundary cast.
- `vi.spyOn` spies typed `MockInstance<typeof X.prototype.method>`; ad-hoc spies typed `vi.fn<(…)=>…>()`.
- Hand-rolled `App`/analyzer/adapter/notification mocks given small named interfaces + boundary casts (`as unknown as App` / `VaultAnalyzer` / `NotificationManager` / `CommandRegistrar`).
- Surfaced nullability handled with `!` (e.g. toast-action `onClick`); domain casts on `JSON.parse(...)` results.
- No runtime/test behavior change.

### Verification
- Bucket gate (forced six rules over `src/enrichment src/rem`): **323 → 0**.
- `tsc --noEmit --skipLibCheck`: clean. `npm run lint`: clean. `check-top-level-requires`: clean. `version-bump --check`: consistent at 1.0.8. `esbuild production`: ok.
- `npm test`: **1823 passed** (136 files) — unchanged.

Stacked on #425 (PR #434); base is `refactor/issue-425-typesafe-elaboration-views`.
