### PR TITLE
refactor: type-safety cleanup of tidy/organize/intake/title/misc test files (#427)

### DIFF
--- a/src/changelog-modal.test.ts
+++ b/src/changelog-modal.test.ts
@@ -20,20 +20,20 @@ vi.mock('../CHANGELOG.md', () => ({
 `,
 }));
 
-import { createEl } from './__mocks__/obsidian';
+import { createEl, type StubEl } from './__mocks__/obsidian';
 import { ChangelogModal } from './changelog-modal';
 
 /** Recursively collect every element in a stub tree. */
-function walkEls(el: any, out: any[] = []): any[] {
-	for (const child of el?.children ?? []) {
+function walkEls(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const child of el.children as unknown as StubEl[]) {
 		out.push(child);
 		walkEls(child, out);
 	}
 	return out;
 }
-const elsWithClass = (root: any, cls: string): any[] =>
-	walkEls(root).filter((e) => e.classList?.contains(cls));
-const elsWithTag = (root: any, tag: string): any[] =>
+const elsWithClass = (root: StubEl, cls: string): StubEl[] =>
+	walkEls(root).filter((e) => e.classList.contains(cls));
+const elsWithTag = (root: StubEl, tag: string): StubEl[] =>
 	walkEls(root).filter((e) => e.tagName === tag);
 
 function openModal(version = '1.0.6') {
@@ -48,14 +48,14 @@ function openModal(version = '1.0.6') {
 describe('ChangelogModal', () => {
 	it('renders a title heading', () => {
 		const modal = openModal();
-		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		const contentEl = (modal as unknown as { contentEl: StubEl }).contentEl;
 		const headings = elsWithTag(contentEl, 'H2').map((e) => e.textContent);
 		expect(headings).toContain("What's new in Synapse");
 	});
 
 	it('renders the parsed changelog entries (version headings + items)', () => {
 		const modal = openModal();
-		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		const contentEl = (modal as unknown as { contentEl: StubEl }).contentEl;
 
 		const versions = elsWithClass(contentEl, 'synapse-changelog-version').map(
 			(e) => e.textContent,
@@ -70,7 +70,7 @@ describe('ChangelogModal', () => {
 
 	it('highlights the entry matching the installed version', () => {
 		const modal = openModal('1.0.6');
-		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		const contentEl = (modal as unknown as { contentEl: StubEl }).contentEl;
 		const highlighted = elsWithClass(contentEl, 'synapse-changelog-entry--current');
 		expect(highlighted).toHaveLength(1);
 		const version = elsWithClass(highlighted[0], 'synapse-changelog-version')[0];
@@ -79,7 +79,7 @@ describe('ChangelogModal', () => {
 
 	it('adds the synapse-changelog hook class to the content element', () => {
 		const modal = openModal();
-		const contentEl = (modal as unknown as { contentEl: any }).contentEl;
+		const contentEl = (modal as unknown as { contentEl: StubEl }).contentEl;
 		expect(contentEl.classList.contains('synapse-changelog')).toBe(true);
 	});
 });

--- a/src/changelog.test.ts
+++ b/src/changelog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createEl } from './__mocks__/obsidian';
+import { createEl, type StubEl } from './__mocks__/obsidian';
 import {
 	parseChangelog,
 	renderChangelog,
@@ -31,17 +31,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 `;
 
 /** Recursively collect every element in a stub tree. */
-function walkEls(el: any, out: any[] = []): any[] {
-	for (const child of el?.children ?? []) {
+function walkEls(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const child of el.children as unknown as StubEl[]) {
 		out.push(child);
 		walkEls(child, out);
 	}
 	return out;
 }
-const elsWithTag = (root: any, tag: string): any[] =>
+const elsWithTag = (root: StubEl, tag: string): StubEl[] =>
 	walkEls(root).filter((e) => e.tagName === tag);
-const elsWithClass = (root: any, cls: string): any[] =>
-	walkEls(root).filter((e) => e.classList?.contains(cls));
+const elsWithClass = (root: StubEl, cls: string): StubEl[] =>
+	walkEls(root).filter((e) => e.classList.contains(cls));
 
 describe('stripInlineMarkdown', () => {
 	it('unwraps bold, code, and links to their visible text', () => {

--- a/src/commands/registrar.test.ts
+++ b/src/commands/registrar.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { Command } from 'obsidian';
 
 // Mock the registry so we can exercise every status/flow combination
 // (the real registry ships everything active + palette).
@@ -16,13 +17,13 @@ vi.mock('./registry', () => {
 import { CommandRegistrar } from './registrar';
 
 describe('CommandRegistrar', () => {
-	let host: { addCommand: ReturnType<typeof vi.fn> };
+	let host: { addCommand: Mock<(command: Command) => unknown> };
 	let registrar: CommandRegistrar;
 	const spec = { callback: () => {} };
 
 	beforeEach(() => {
 		host = { addCommand: vi.fn() };
-		registrar = new CommandRegistrar(host as any);
+		registrar = new CommandRegistrar(host);
 	});
 
 	it('registers an active palette command with its feature-default icon when enabled', () => {

--- a/src/intake/intake-dispatcher.test.ts
+++ b/src/intake/intake-dispatcher.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { IntakeDispatcher } from './intake-dispatcher';
 import { parseFrontmatter } from '../shared';
 import { TFile } from '../__mocks__/obsidian';
+import type { TFile as ObsidianTFile } from 'obsidian';
 
 /**
  * Routing policy is pure: it depends only on the parsed body, so these tests
@@ -9,7 +10,7 @@ import { TFile } from '../__mocks__/obsidian';
  */
 describe('IntakeDispatcher.route', () => {
 	let dispatcher: IntakeDispatcher;
-	const file = new TFile('Inbox/capture.md') as any;
+	const file = new TFile('Inbox/capture.md') as unknown as ObsidianTFile;
 
 	beforeEach(() => {
 		dispatcher = new IntakeDispatcher();

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -2,6 +2,26 @@ import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vite
 import { IntakeModule } from './index';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile, TFolder } from '../__mocks__/obsidian';
+import type { Plugin, TFile as ObsidianTFile } from 'obsidian';
+import type { NotificationManager } from '../shared';
+
+/** Spy-backed stand-ins for the in-memory vault/fileManager/Plugin surfaces. */
+interface MockVault {
+	on: Mock<(event: string, cb: (file: ObsidianTFile) => void) => { event: string }>;
+	read: Mock<(file: ObsidianTFile) => Promise<string>>;
+	modify: Mock<(file: ObsidianTFile, content: string) => Promise<void>>;
+	process: Mock<(file: ObsidianTFile, fn: (data: string) => string) => Promise<string>>;
+	create: Mock<(path: string, content: string) => Promise<ObsidianTFile>>;
+	createFolder: Mock<(path: string) => Promise<void>>;
+	getAbstractFileByPath: Mock<(path: string) => ObsidianTFile | null>;
+}
+interface MockFileManager {
+	renameFile: Mock<(file: ObsidianTFile, newPath: string) => Promise<void>>;
+}
+interface MockPlugin {
+	app: { vault: MockVault; fileManager: MockFileManager };
+	registerEvent: Mock<(ref: unknown) => void>;
+}
 
 // Mock only the article fetcher from shared; everything else (parseFrontmatter,
 // serializeFrontmatter, ensureFolder, classifyUrl, extractUrls) uses the real
@@ -41,31 +61,31 @@ function createMockNotifications() {
  * Build a TFile whose `.parent` is a real TFolder, mirroring how Obsidian
  * populates events. extension/name/basename are derived by the mock TFile ctor.
  */
-function makeFile(path: string): TFile {
+function makeFile(path: string): ObsidianTFile {
 	const file = new TFile(path);
 	const slash = path.lastIndexOf('/');
 	if (slash >= 0) {
 		file.parent = new TFolder(path.slice(0, slash));
 	}
-	return file;
+	return file as unknown as ObsidianTFile;
 }
 
 describe('IntakeModule', () => {
 	let module: IntakeModule;
-	let plugin: any;
+	let plugin: MockPlugin;
 	let notifications: ReturnType<typeof createMockNotifications>;
 	let settings: SynapseSettings;
 	let deps: {
 		// Typed with their real Promise-returning signatures (mirroring IntakeDeps)
 		// so `mockImplementation` accepts async bodies — an untyped `vi.fn()` infers
 		// a `void` return, which trips `@typescript-eslint/no-misused-promises`.
-		fireOnFile: Mock<(file: any) => Promise<void>>;
+		fireOnFile: Mock<(file: ObsidianTFile) => Promise<void>>;
 		transcribeUrlToNote: Mock<
-			(url: string, mediaType: 'video' | 'audio', file: any) => Promise<void>
+			(url: string, mediaType: 'video' | 'audio', file: ObsidianTFile) => Promise<void>
 		>;
 	};
 	/** Captured vault event handlers, keyed by event name. */
-	let handlers: Record<string, (file: any) => void>;
+	let handlers: Record<string, (file: ObsidianTFile) => void>;
 	/** In-memory file content, keyed by path. */
 	let store: Map<string, string>;
 
@@ -87,18 +107,18 @@ describe('IntakeModule', () => {
 		handlers = {};
 		store = new Map();
 
-		const vault = {
-			on: vi.fn((event: string, cb: (file: any) => void) => {
+		const vault: MockVault = {
+			on: vi.fn((event: string, cb: (file: ObsidianTFile) => void) => {
 				handlers[event] = cb;
 				return { event };
 			}),
-			read: vi.fn(async (file: any) => store.get(file.path) ?? ''),
-			modify: vi.fn(async (file: any, content: string) => {
+			read: vi.fn(async (file: ObsidianTFile) => store.get(file.path) ?? ''),
+			modify: vi.fn(async (file: ObsidianTFile, content: string) => {
 				store.set(file.path, content);
 			}),
 			// Atomic read -> transform -> write against the in-memory store
 			// (mirrors Obsidian's Vault.process).
-			process: vi.fn(async (file: any, fn: (data: string) => string) => {
+			process: vi.fn(async (file: ObsidianTFile, fn: (data: string) => string) => {
 				const result = fn(store.get(file.path) ?? '');
 				store.set(file.path, result);
 				return result;
@@ -114,8 +134,8 @@ describe('IntakeModule', () => {
 			}),
 		};
 
-		const fileManager = {
-			renameFile: vi.fn(async (file: any, newPath: string) => {
+		const fileManager: MockFileManager = {
+			renameFile: vi.fn(async (file: ObsidianTFile, newPath: string) => {
 				const content = store.get(file.path);
 				store.delete(file.path);
 				if (content !== undefined) store.set(newPath, content);
@@ -134,9 +154,14 @@ describe('IntakeModule', () => {
 			transcribeUrlToNote: vi.fn().mockResolvedValue(undefined),
 		};
 
-		module = new IntakeModule(plugin, () => settings, notifications as any, deps as any);
-		(fetchArticleContent as any).mockClear();
-		(fetchArticleContent as any).mockResolvedValue('FETCHED ARTICLE BODY');
+		module = new IntakeModule(
+			plugin as unknown as Plugin,
+			() => settings,
+			notifications as unknown as NotificationManager,
+			deps,
+		);
+		vi.mocked(fetchArticleContent).mockClear();
+		vi.mocked(fetchArticleContent).mockResolvedValue('FETCHED ARTICLE BODY');
 	});
 
 	afterEach(() => {
@@ -165,7 +190,7 @@ describe('IntakeModule', () => {
 	 * place (low confidence → proposal / no-op) — content/path are untouched.
 	 */
 	function organizeMovesTo(newPath: string | null) {
-		deps.fireOnFile.mockImplementation(async (file: any) => {
+		deps.fireOnFile.mockImplementation(async (file: ObsidianTFile) => {
 			if (newPath === null || newPath === file.path) return;
 			const content = store.get(file.path);
 			store.delete(file.path);
@@ -339,7 +364,7 @@ describe('IntakeModule', () => {
 		it('falls back to a sane window when settleSeconds is invalid', async () => {
 			// A malformed setting (0 / NaN / undefined) must not disable the
 			// watcher — it falls back to DEBOUNCE_MS (5000ms).
-			(settings.intake as any).settleSeconds = 0;
+			settings.intake.settleSeconds = 0;
 			const path = 'Inbox/fallback.md';
 			store.set(path, 'hello prose');
 			handlers['create'](makeFile(path));
@@ -473,13 +498,13 @@ describe('IntakeModule', () => {
 			settings.intake.moveWhenDone = 'Processed';
 			const order: string[] = [];
 
-			plugin.app.vault.process.mockImplementation(async (file: any, fn: (data: string) => string) => {
+			plugin.app.vault.process.mockImplementation(async (file: ObsidianTFile, fn: (data: string) => string) => {
 				const content = fn(store.get(file.path) ?? '');
 				if (content.includes('synapse-processed: true')) order.push('stamp');
 				store.set(file.path, content);
 				return content;
 			});
-			plugin.app.fileManager.renameFile.mockImplementation(async (file: any, newPath: string) => {
+			plugin.app.fileManager.renameFile.mockImplementation(async (file: ObsidianTFile, newPath: string) => {
 				order.push('move');
 				const content = store.get(file.path);
 				store.delete(file.path);

--- a/src/intake/intake-organize-e2e.test.ts
+++ b/src/intake/intake-organize-e2e.test.ts
@@ -1,10 +1,34 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { IntakeModule } from './index';
 import { OrganizeModule } from '../organize';
 import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile, TFolder } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+import type { Plugin, TFile as ObsidianTFile } from 'obsidian';
+
+/** Spy-backed stand-ins for the in-memory vault/adapter/fileManager surfaces. */
+interface MockAdapter {
+	read: Mock<(path: string) => Promise<string>>;
+	write: Mock<(path: string, content: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+	remove: Mock<(path: string) => Promise<void>>;
+	list: Mock<(folder: string) => Promise<{ files: string[]; folders: string[] }>>;
+}
+interface MockVault {
+	on: Mock<(event: string, cb: (file: ObsidianTFile) => void) => { event: string }>;
+	read: Mock<(file: ObsidianTFile) => Promise<string>>;
+	process: Mock<(file: ObsidianTFile, fn: (data: string) => string) => Promise<string>>;
+	create: Mock<(path: string, content: string) => Promise<ObsidianTFile>>;
+	createFolder: Mock<(path: string) => Promise<void>>;
+	getRoot: () => TFolder;
+	getAbstractFileByPath: Mock<(path: string) => ObsidianTFile | null>;
+	rename: Mock<(file: ObsidianTFile, newPath: string) => Promise<void>>;
+	adapter: MockAdapter;
+}
+interface MockFileManager {
+	renameFile: Mock<(file: ObsidianTFile, newPath: string) => Promise<void>>;
+}
 
 /**
  * Integration test for the intake → organize handshake (#227).
@@ -50,13 +74,13 @@ vi.mock('../organize/content-analyzer', () => ({
 
 const SETTLE_MS = 5000;
 
-function makeFile(path: string): TFile {
+function makeFile(path: string): ObsidianTFile {
 	const file = new TFile(path);
 	const slash = path.lastIndexOf('/');
 	if (slash >= 0) {
 		file.parent = new TFolder(path.slice(0, slash));
 	}
-	return file;
+	return file as unknown as ObsidianTFile;
 }
 
 /** Build a TFolder tree (for vault.getRoot) from flat directory paths. */
@@ -102,9 +126,9 @@ describe('intake → real organize handshake (#227)', () => {
 	let settings: SynapseSettings;
 	let store: Map<string, string>;
 	let adapterFiles: Map<string, string>;
-	let handlers: Record<string, (file: any) => void>;
-	let vault: any;
-	let fileManager: any;
+	let handlers: Record<string, (file: ObsidianTFile) => void>;
+	let vault: MockVault;
+	let fileManager: MockFileManager;
 	let organize: OrganizeModule;
 	let intake: IntakeModule;
 	let deps: {
@@ -171,7 +195,7 @@ describe('intake → real organize handshake (#227)', () => {
 			})),
 		};
 
-		const moveInPlace = (file: any, newPath: string) => {
+		const moveInPlace = (file: ObsidianTFile, newPath: string) => {
 			const content = store.get(file.path);
 			store.delete(file.path);
 			if (content !== undefined) store.set(newPath, content);
@@ -182,12 +206,12 @@ describe('intake → real organize handshake (#227)', () => {
 		};
 
 		vault = {
-			on: vi.fn((event: string, cb: (file: any) => void) => {
+			on: vi.fn((event: string, cb: (file: ObsidianTFile) => void) => {
 				handlers[event] = cb;
 				return { event };
 			}),
-			read: vi.fn(async (file: any) => store.get(file.path) ?? ''),
-			process: vi.fn(async (file: any, fn: (data: string) => string) => {
+			read: vi.fn(async (file: ObsidianTFile) => store.get(file.path) ?? ''),
+			process: vi.fn(async (file: ObsidianTFile, fn: (data: string) => string) => {
 				const result = fn(store.get(file.path) ?? '');
 				store.set(file.path, result);
 				return result;
@@ -202,13 +226,13 @@ describe('intake → real organize handshake (#227)', () => {
 				store.has(path) ? makeFile(path) : null,
 			),
 			// Organize's primary mover.
-			rename: vi.fn(async (file: any, newPath: string) => moveInPlace(file, newPath)),
+			rename: vi.fn(async (file: ObsidianTFile, newPath: string) => moveInPlace(file, newPath)),
 			adapter,
 		};
 
 		fileManager = {
 			// Intake's fallback mover.
-			renameFile: vi.fn(async (file: any, newPath: string) => moveInPlace(file, newPath)),
+			renameFile: vi.fn(async (file: ObsidianTFile, newPath: string) => moveInPlace(file, newPath)),
 		};
 
 		const metadataCache = {
@@ -216,14 +240,14 @@ describe('intake → real organize handshake (#227)', () => {
 			getFirstLinkpathDest: vi.fn().mockReturnValue(null),
 		};
 
-		const plugin: any = {
+		const plugin = {
 			app: { vault, fileManager, metadataCache },
 			registerEvent: vi.fn(),
 			addCommand: vi.fn(),
 		};
 
 		organize = new OrganizeModule(
-			plugin,
+			plugin as unknown as Plugin,
 			() => settings,
 			createMockNotifications() as never,
 			createMockCheckpointManager() as never,
@@ -234,17 +258,17 @@ describe('intake → real organize handshake (#227)', () => {
 
 		deps = {
 			// THE handshake: intake's pipeline phase IS the real organize module.
-			fireOnFile: vi.fn(async (file: any) => {
+			fireOnFile: vi.fn(async (file: ObsidianTFile) => {
 				await organize.organizeNote(file);
 			}),
 			transcribeUrlToNote: vi.fn().mockResolvedValue(undefined),
 		};
 
-		intake = new IntakeModule(plugin, () => settings, createMockNotifications() as never, deps as never);
+		intake = new IntakeModule(plugin as unknown as Plugin, () => settings, createMockNotifications() as never, deps as never);
 		await intake.onload();
 	}
 
-	function emit(event: string, path: string, content = ''): TFile {
+	function emit(event: string, path: string, content = ''): ObsidianTFile {
 		store.set(path, content);
 		const file = makeFile(path);
 		handlers[event](file);
@@ -359,7 +383,7 @@ describe('intake → real organize handshake (#227)', () => {
 			const file = makeFile('Inbox/note.md');
 			const originalPath = file.path; // exactly how intake snapshots it pre-pipeline
 
-			await organize.organizeNote(file as never);
+			await organize.organizeNote(file);
 
 			// The real module mutated this very object — so intake's
 			// `originalPath !== file.path` detection holds against production code.
@@ -377,7 +401,7 @@ describe('intake → real organize handshake (#227)', () => {
 			store.set('Inbox/keep.md', 'unstructured notes');
 			const file = makeFile('Inbox/keep.md');
 
-			await organize.organizeNote(file as never);
+			await organize.organizeNote(file);
 
 			expect(file.path).toBe('Inbox/keep.md'); // unchanged
 			expect(vault.rename).not.toHaveBeenCalled();

--- a/src/organize/content-analyzer.test.ts
+++ b/src/organize/content-analyzer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContentAnalyzer } from './content-analyzer';
 import { createMockApp } from '../__test-utils__/mock-factories';
 import { DEFAULT_SETTINGS } from '../settings';
+import type { App } from 'obsidian';
 
 const mockComplete = vi.fn().mockResolvedValue('[{"label": "test", "confidence": 0.5}]');
 
@@ -18,7 +19,7 @@ vi.mock('../shared/ai-client', () => ({
  */
 describe('ContentAnalyzer', () => {
 	function makeAnalyzer() {
-		const app = createMockApp() as any;
+		const app = createMockApp() as unknown as App;
 		const getSettings = () => structuredClone(DEFAULT_SETTINGS);
 		return new ContentAnalyzer(app, getSettings);
 	}

--- a/src/organize/directory-matcher.test.ts
+++ b/src/organize/directory-matcher.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { DirectoryMatcher } from './directory-matcher';
 import { ContentAnalysis } from './types';
 import { TFolder } from '../__mocks__/obsidian';
+import type { App } from 'obsidian';
 
 function makeMockApp(directories: string[]) {
 	// Build a folder tree from flat paths
@@ -32,7 +33,7 @@ function makeMockApp(directories: string[]) {
 		vault: {
 			getRoot: () => root,
 		},
-	} as any;
+	} as unknown as App;
 }
 
 function makeAnalysis(overrides: Partial<ContentAnalysis> = {}): ContentAnalysis {

--- a/src/organize/organize-store.test.ts
+++ b/src/organize/organize-store.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { OrganizeStore } from './organize-store';
 import { OrganizeProposal, OrganizeSnapshot } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
+import type { App } from 'obsidian';
+
+/** Spy-backed stand-in for the Vault adapter surface the store reads/writes through. */
+interface MockAdapter {
+	read: Mock<(path: string) => Promise<string>>;
+	write: Mock<(path: string, data: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+	remove: Mock<(path: string) => Promise<void>>;
+	list: Mock<(path: string) => Promise<{ files: string[]; folders: string[] }>>;
+}
 
 function makeProposal(overrides: Partial<OrganizeProposal> = {}): OrganizeProposal {
 	return {
@@ -27,7 +37,7 @@ function makeSnapshot(overrides: Partial<OrganizeSnapshot> = {}): OrganizeSnapsh
 
 describe('OrganizeStore', () => {
 	let store: OrganizeStore;
-	let mockAdapter: any;
+	let mockAdapter: MockAdapter;
 
 	beforeEach(() => {
 		mockAdapter = {
@@ -44,7 +54,7 @@ describe('OrganizeStore', () => {
 				createFolder: vi.fn().mockResolvedValue(undefined),
 				getAbstractFileByPath: vi.fn().mockReturnValue(null),
 			},
-		} as any;
+		} as unknown as App;
 
 		const getSettings = () => structuredClone(DEFAULT_SETTINGS);
 		store = new OrganizeStore(app, getSettings);
@@ -110,7 +120,7 @@ describe('OrganizeStore', () => {
 			await store.updateProposalStatus('update-me', 'accepted');
 
 			expect(mockAdapter.write).toHaveBeenCalled();
-			const written = JSON.parse(mockAdapter.write.mock.calls[0][1]);
+			const written = JSON.parse(mockAdapter.write.mock.calls[0][1]) as OrganizeProposal;
 			expect(written.status).toBe('accepted');
 		});
 

--- a/src/organize/review-toast.test.ts
+++ b/src/organize/review-toast.test.ts
@@ -5,7 +5,7 @@ import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
 import { createMockApp, createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import type { Plugin } from 'obsidian';
-import type { OrganizeProposal } from './types';
+import type { NoticeAction } from '../shared';
 
 // Analyzer finds a topic; matcher proposes a NEW directory — the only path that
 // creates an organize proposal (a reviewable item).
@@ -34,7 +34,13 @@ vi.mock('./directory-matcher', () => ({
 }));
 
 function makeOp(cancelled = false) {
-	return { progress: vi.fn(), update: vi.fn(), finish: vi.fn(), error: vi.fn(), cancelled };
+	return {
+		progress: vi.fn<(current: number, total: number, label?: string) => void>(),
+		update: vi.fn<(message: string) => void>(),
+		finish: vi.fn<(message?: string, action?: NoticeAction) => void>(),
+		error: vi.fn<(message: string) => void>(),
+		cancelled,
+	};
 }
 
 describe('OrganizeModule Review toast action (#340)', () => {
@@ -94,7 +100,7 @@ describe('OrganizeModule Review toast action (#340)', () => {
 					reasoning: 'Note is about machine learning',
 					createdAt: '2026-06-11T00:00:00.000Z',
 					status: 'pending',
-				}) as OrganizeProposal
+				})
 		);
 	});
 
@@ -126,7 +132,7 @@ describe('OrganizeModule Review toast action (#340)', () => {
 			expect.objectContaining({ label: 'Review' })
 		);
 		// The action opens the unified proposal view.
-		genOp.finish.mock.calls.at(-1)![1].onClick();
+		genOp.finish.mock.calls.at(-1)![1]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 	});
 
@@ -160,7 +166,7 @@ describe('OrganizeModule Review toast action (#340)', () => {
 			'Proposal created for new directory',
 			expect.objectContaining({ label: 'Review' })
 		);
-		scanOp.finish.mock.calls.at(-1)![1].onClick();
+		scanOp.finish.mock.calls.at(-1)![1]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 		// Nothing moved — the proposal is left pending for review.
 		expect((app.vault as unknown as { rename: ReturnType<typeof vi.fn> }).rename).not.toHaveBeenCalled();

--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createEl, ToggleComponent, Setting } from './__mocks__/obsidian';
+import { createEl, ToggleComponent, Setting, type StubEl } from './__mocks__/obsidian';
 
 // Mock the changelog modal so this suite never resolves the real CHANGELOG.md
 // import (a build-time `.md` text import that Vitest can't transform), and so
@@ -67,8 +67,8 @@ function lastSetDisabledArg(row: Setting): boolean {
 }
 
 /** Recursively collect all anchor elements rendered into a stub element tree. */
-function findAnchors(el: any, out: any[] = []): any[] {
-	for (const child of el?.children ?? []) {
+function findAnchors(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const child of el.children as unknown as StubEl[]) {
 		if (child.tagName === 'A') out.push(child);
 		findAnchors(child, out);
 	}
@@ -80,8 +80,8 @@ function findAnchors(el: any, out: any[] = []): any[] {
  * `textContent` is per-element (it does not aggregate descendants), so a match is
  * the element that was created with that text — not an ancestor.
  */
-function findByText(el: any, needle: string, out: any[] = []): any[] {
-	for (const child of el?.children ?? []) {
+function findByText(el: StubEl, needle: string, out: StubEl[] = []): StubEl[] {
+	for (const child of el.children as unknown as StubEl[]) {
 		if (typeof child.textContent === 'string' && child.textContent.includes(needle)) {
 			out.push(child);
 		}
@@ -198,7 +198,7 @@ describe('SynapseSettingTab — About support links (#274)', () => {
 		const { tab } = makeTab();
 		tab.display();
 
-		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+		const containerEl = (tab as unknown as { containerEl: StubEl }).containerEl;
 		const anchors = findAnchors(containerEl);
 		const byHref = new Map(
 			anchors.map((a) => [a.getAttribute('href'), a.textContent]),
@@ -222,7 +222,7 @@ describe('SynapseSettingTab — About "What\'s new" changelog link (#375)', () =
 		const { tab } = makeTab();
 		tab.display();
 
-		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+		const containerEl = (tab as unknown as { containerEl: StubEl }).containerEl;
 		const link = findAnchors(containerEl).find((a) => a.textContent === "What's new");
 		expect(link).toBeDefined();
 
@@ -236,17 +236,17 @@ describe('SynapseSettingTab — About "What\'s new" changelog link (#375)', () =
 });
 
 /** Recursively collect every element in a stub tree. */
-function walkEls(el: any, out: any[] = []): any[] {
-	for (const child of el?.children ?? []) {
+function walkEls(el: StubEl, out: StubEl[] = []): StubEl[] {
+	for (const child of el.children as unknown as StubEl[]) {
 		out.push(child);
 		walkEls(child, out);
 	}
 	return out;
 }
-function elsWithClass(root: any, cls: string): any[] {
-	return walkEls(root).filter((e) => e.classList?.contains(cls));
+function elsWithClass(root: StubEl, cls: string): StubEl[] {
+	return walkEls(root).filter((e) => e.classList.contains(cls));
 }
-function elsWithTag(root: any, tag: string): any[] {
+function elsWithTag(root: StubEl, tag: string): StubEl[] {
 	return walkEls(root).filter((e) => e.tagName === tag);
 }
 
@@ -256,11 +256,11 @@ describe('SynapseSettingTab — Exclusions chip multi-select (#328)', () => {
 	 * add-folder and add-pattern scope pickers. (The mocked `Setting` rows are not
 	 * appended to the container, so only these chip divs are introspectable.)
 	 */
-	function chipContainers(tab: SynapseSettingTab): any[] {
-		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+	function chipContainers(tab: SynapseSettingTab): StubEl[] {
+		const containerEl = (tab as unknown as { containerEl: StubEl }).containerEl;
 		return elsWithClass(containerEl, 'synapse-exclusion-chips');
 	}
-	const chipLabels = (container: any): string[] =>
+	const chipLabels = (container: StubEl): (string | null)[] =>
 		elsWithClass(container, 'synapse-chip-label').map((e) => e.textContent);
 
 	/**
@@ -270,14 +270,14 @@ describe('SynapseSettingTab — Exclusions chip multi-select (#328)', () => {
 	 * the chip div.
 	 */
 	function assertChipsNestedInSettingItem(tab: SynapseSettingTab): void {
-		const containerEl = (tab as unknown as { containerEl: any }).containerEl;
+		const containerEl = (tab as unknown as { containerEl: StubEl }).containerEl;
 		const hosts = walkEls(containerEl).filter(
 			(e) =>
-				e.classList?.contains('setting-item') &&
-				e.classList?.contains('synapse-setting--has-helper'),
+				e.classList.contains('setting-item') &&
+				e.classList.contains('synapse-setting--has-helper'),
 		);
 		for (const chip of chipContainers(tab)) {
-			const host = hosts.find((h) => h.children.includes(chip));
+			const host = hosts.find((h) => (h.children as unknown as StubEl[]).includes(chip));
 			expect(host).toBeDefined();
 		}
 	}
@@ -326,7 +326,7 @@ describe('SynapseSettingTab — Exclusions chip multi-select (#328)', () => {
 		const removeBtn = elsWithClass(chipContainers(tab)[0], 'synapse-chip-remove').find(
 			(b) => b.getAttribute('aria-label') === 'Remove Organize',
 		);
-		removeBtn.dispatchEvent({ type: 'click' });
+		removeBtn!.dispatchEvent({ type: 'click' });
 
 		expect(plugin.settings.exclusions[0].features).toEqual(['summarize']);
 		expect(plugin.saveSettings).toHaveBeenCalled();
@@ -466,8 +466,8 @@ describe('SynapseSettingTab — no-subscription note in AI Configuration (#364)'
 		ToggleComponent.instances.length = 0;
 	});
 
-	function subscriptionNotes(tab: SynapseSettingTab): any[] {
-		const container = (tab as unknown as { containerEl: any }).containerEl;
+	function subscriptionNotes(tab: SynapseSettingTab): StubEl[] {
+		const container = (tab as unknown as { containerEl: StubEl }).containerEl;
 		return findByText(container, 'Subscriptions');
 	}
 

--- a/src/tidy/tidy-module.test.ts
+++ b/src/tidy/tidy-module.test.ts
@@ -1,8 +1,45 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { TidyModule } from './index';
 import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
+import type { Plugin, Command, TFile as ObsidianTFile } from 'obsidian';
+import type { NotificationManager } from '../shared';
+
+/** The mock TFile and obsidian's real TFile differ structurally; tests only need
+ *  the runtime instance, so cross the boundary once here. */
+const tfile = (path: string): ObsidianTFile => new TFile(path) as unknown as ObsidianTFile;
+
+/** Reach TidyModule's private undo path without widening to `any`. */
+function internals(m: TidyModule): { undoTidy(file: ObsidianTFile): Promise<void> } {
+	return m as unknown as { undoTidy(file: ObsidianTFile): Promise<void> };
+}
+
+/** Spy-backed stand-ins for the Vault/adapter/FileManager/Plugin surfaces TidyModule uses. */
+interface MockAdapter {
+	write: Mock<(path: string, data: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+}
+interface MockVault {
+	read: Mock<(file: ObsidianTFile) => Promise<string>>;
+	modify: Mock<(file: ObsidianTFile, data: string) => Promise<void>>;
+	// Default stub returns the transformed content (string); one test overrides it
+	// to a bare order-tracking resolve — `unknown` accommodates both at the boundary.
+	process: Mock<(file: ObsidianTFile, fn: (data: string) => string) => Promise<unknown>>;
+	create: Mock<(path: string, data: string) => Promise<TFile>>;
+	createFolder: Mock<(path: string) => Promise<void>>;
+	getAbstractFileByPath: Mock<(path: string) => TFile | null>;
+	getMarkdownFiles?: Mock<() => TFile[]>;
+	adapter: MockAdapter;
+}
+interface MockFileManager {
+	trashFile: Mock<(file: ObsidianTFile) => Promise<void>>;
+}
+interface MockPlugin {
+	app: { vault: MockVault; fileManager: MockFileManager };
+	addCommand: Mock<(command: Command) => unknown>;
+	registerEvent: Mock<(ref: unknown) => void>;
+}
 
 // Mock the AI client
 vi.mock('../shared/ai-client', () => ({
@@ -37,7 +74,7 @@ function createMockNotifications() {
 
 describe('TidyModule', () => {
 	let module: TidyModule;
-	let mockPlugin: any;
+	let mockPlugin: MockPlugin;
 	let mockNotifications: ReturnType<typeof createMockNotifications>;
 	let settings: typeof DEFAULT_SETTINGS;
 
@@ -49,12 +86,12 @@ describe('TidyModule', () => {
 			exists: vi.fn().mockResolvedValue(true),
 		};
 
-		const vault: any = {
+		const vault: MockVault = {
 			read: vi.fn().mockResolvedValue('# Test\n\nSome contnt with typos.'),
 			modify: vi.fn().mockResolvedValue(undefined),
 			// Atomic read -> transform -> write; the callback's return value is
 			// the written content (mirrors Obsidian's Vault.process).
-			process: vi.fn(async (file: any, fn: (data: string) => string) =>
+			process: vi.fn(async (file: ObsidianTFile, fn: (data: string) => string) =>
 				fn(await vault.read(file))
 			),
 			create: vi.fn().mockResolvedValue(new TFile()),
@@ -65,7 +102,7 @@ describe('TidyModule', () => {
 
 		// Snapshot cleanup goes through FileManager.trashFile (recoverable),
 		// not vault.delete (permanent).
-		const fileManager: any = {
+		const fileManager: MockFileManager = {
 			trashFile: vi.fn().mockResolvedValue(undefined),
 		};
 
@@ -77,10 +114,10 @@ describe('TidyModule', () => {
 
 		mockNotifications = createMockNotifications();
 		module = new TidyModule(
-			mockPlugin as any,
+			mockPlugin as unknown as Plugin,
 			() => settings,
-			mockNotifications as any,
-			new CommandRegistrar(mockPlugin as any)
+			mockNotifications as unknown as NotificationManager,
+			new CommandRegistrar(mockPlugin)
 		);
 	});
 
@@ -91,7 +128,7 @@ describe('TidyModule', () => {
 			// `undo-tidy` ships as `status: 'disabled'` in COMMAND_REGISTRY, so
 			// the registrar gates it out — only the active tidy command registers.
 			expect(mockPlugin.addCommand).toHaveBeenCalledTimes(1);
-			const commands = mockPlugin.addCommand.mock.calls.map((c: any) => c[0].id);
+			const commands = mockPlugin.addCommand.mock.calls.map((c) => c[0].id);
 			expect(commands).toContain('tidy-current-note');
 			expect(commands).not.toContain('undo-tidy');
 		});
@@ -99,7 +136,7 @@ describe('TidyModule', () => {
 
 	describe('tidy', () => {
 		it('reads note, calls AI, and writes tidied content', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			await module.tidy(file);
 
 			expect(mockPlugin.app.vault.process).toHaveBeenCalledWith(
@@ -111,7 +148,7 @@ describe('TidyModule', () => {
 		});
 
 		it('saves a snapshot before modifying', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			const writeOrder: string[] = [];
 
 			mockPlugin.app.vault.adapter.write.mockImplementation(() => {
@@ -133,7 +170,7 @@ describe('TidyModule', () => {
 			const body = 'Some contnt.';
 			mockPlugin.app.vault.read.mockResolvedValue(frontmatter + body);
 
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			await module.tidy(file);
 
 			const written = await mockPlugin.app.vault.process.mock.results[0].value as string;
@@ -144,7 +181,7 @@ describe('TidyModule', () => {
 		it('finishes early for empty notes', async () => {
 			mockPlugin.app.vault.read.mockResolvedValue('---\ntitle: Empty\n---\n');
 
-			const file = new TFile('notes/empty.md') as any;
+			const file = tfile('notes/empty.md');
 			await module.tidy(file);
 
 			expect(mockNotifications._handle.finish).toHaveBeenCalledWith(
@@ -155,11 +192,11 @@ describe('TidyModule', () => {
 
 		it('strips code fences from AI response', async () => {
 			// Access the AIClient instance through the module internals
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 
 			// Override the AI response for this test via withRetry mock
 			const { withRetry } = await import('../shared/api-utils');
-			(withRetry as any).mockImplementationOnce(() =>
+			vi.mocked(withRetry).mockImplementationOnce(() =>
 				Promise.resolve('```markdown\n# Clean content\n\nFixed text.\n```')
 			);
 
@@ -171,10 +208,10 @@ describe('TidyModule', () => {
 		});
 
 		it('reports error on AI failure', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 
 			const { withRetry } = await import('../shared/api-utils');
-			(withRetry as any).mockImplementationOnce(() =>
+			vi.mocked(withRetry).mockImplementationOnce(() =>
 				Promise.reject(new Error('API error (500): Internal server error'))
 			);
 
@@ -186,7 +223,7 @@ describe('TidyModule', () => {
 		});
 
 		it('shows progress updates during operation', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			await module.tidy(file);
 
 			expect(mockNotifications.startOperation).toHaveBeenCalledWith(
@@ -208,11 +245,11 @@ describe('TidyModule', () => {
 			mockPlugin.app.vault.getMarkdownFiles = vi.fn().mockReturnValue([a, b, c]);
 
 			const tidied: string[] = [];
-			vi.spyOn(module, 'tidy').mockImplementation(async (f: any) => {
+			vi.spyOn(module, 'tidy').mockImplementation(async (f: ObsidianTFile) => {
 				tidied.push(f.path);
 			});
 
-			const count = await module.scanVault('Inbox', true, b as any);
+			const count = await module.scanVault('Inbox', true, b as unknown as ObsidianTFile);
 
 			expect(count).toBe(1);
 			expect(tidied).toEqual(['Inbox/b.md']);
@@ -224,7 +261,7 @@ describe('TidyModule', () => {
 			mockPlugin.app.vault.getMarkdownFiles = vi.fn().mockReturnValue([a, b]);
 
 			const tidied: string[] = [];
-			vi.spyOn(module, 'tidy').mockImplementation(async (f: any) => {
+			vi.spyOn(module, 'tidy').mockImplementation(async (f: ObsidianTFile) => {
 				tidied.push(f.path);
 			});
 
@@ -237,7 +274,7 @@ describe('TidyModule', () => {
 
 	describe('undoTidy', () => {
 		it('restores original content from snapshot', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			const snapshot = {
 				id: 'snap-1',
 				filePath: 'notes/test.md',
@@ -253,7 +290,7 @@ describe('TidyModule', () => {
 			// undo-tidy is gated off as a palette command (registry master switch), so
 			// invoke the still-present undo logic directly.
 			await module.onload();
-			await (module as any).undoTidy(file);
+			await internals(module).undoTidy(file);
 
 			expect(mockPlugin.app.vault.process).toHaveBeenCalledWith(
 				file,
@@ -265,11 +302,11 @@ describe('TidyModule', () => {
 		});
 
 		it('informs user when no snapshot exists', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
 
 			await module.onload();
-			await (module as any).undoTidy(file);
+			await internals(module).undoTidy(file);
 
 			expect(mockNotifications.info).toHaveBeenCalledWith(
 				'No tidy to undo for this note'
@@ -278,7 +315,7 @@ describe('TidyModule', () => {
 		});
 
 		it('removes snapshot after undo', async () => {
-			const file = new TFile('notes/test.md') as any;
+			const file = tfile('notes/test.md');
 			const snapshot = {
 				id: 'snap-1',
 				filePath: 'notes/test.md',
@@ -291,7 +328,7 @@ describe('TidyModule', () => {
 			mockPlugin.app.vault.read.mockResolvedValue(JSON.stringify(snapshot));
 
 			await module.onload();
-			await (module as any).undoTidy(file);
+			await internals(module).undoTidy(file);
 
 			expect(mockPlugin.app.fileManager.trashFile).toHaveBeenCalled();
 		});

--- a/src/tidy/tidy-store.test.ts
+++ b/src/tidy/tidy-store.test.ts
@@ -1,8 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { TidyStore } from './tidy-store';
 import { TidySnapshot } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
 import { TFile } from '../__mocks__/obsidian';
+import type { App } from 'obsidian';
+
+/** Spy-backed stand-ins for the Vault/adapter/FileManager surfaces TidyStore uses. */
+interface MockAdapter {
+	write: Mock<(path: string, data: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+}
+interface MockVault {
+	adapter: MockAdapter;
+	createFolder: Mock<(path: string) => Promise<void>>;
+	getAbstractFileByPath: Mock<(path: string) => TFile | null>;
+	read: Mock<(file: TFile) => Promise<string>>;
+}
+interface MockFileManager {
+	trashFile: Mock<(file: TFile) => Promise<void>>;
+}
 
 function makeSnapshot(overrides: Partial<TidySnapshot> = {}): TidySnapshot {
 	return {
@@ -16,9 +32,9 @@ function makeSnapshot(overrides: Partial<TidySnapshot> = {}): TidySnapshot {
 
 describe('TidyStore', () => {
 	let store: TidyStore;
-	let mockAdapter: any;
-	let mockVault: any;
-	let mockFileManager: any;
+	let mockAdapter: MockAdapter;
+	let mockVault: MockVault;
+	let mockFileManager: MockFileManager;
 
 	beforeEach(() => {
 		mockAdapter = {
@@ -39,7 +55,7 @@ describe('TidyStore', () => {
 			trashFile: vi.fn().mockResolvedValue(undefined),
 		};
 
-		const app = { vault: mockVault, fileManager: mockFileManager } as any;
+		const app = { vault: mockVault, fileManager: mockFileManager } as unknown as App;
 		const getSettings = () => ({ ...DEFAULT_SETTINGS });
 		store = new TidyStore(app, getSettings);
 	});
@@ -63,11 +79,11 @@ describe('TidyStore', () => {
 		await store.save(snap2);
 
 		// Both writes go to the same path
-		const paths = mockAdapter.write.mock.calls.map((c: any) => c[0]);
+		const paths = mockAdapter.write.mock.calls.map((c) => c[0]);
 		expect(paths[0]).toBe(paths[1]);
 
 		// Second write has the updated content
-		const written = JSON.parse(mockAdapter.write.mock.calls[1][1]);
+		const written = JSON.parse(mockAdapter.write.mock.calls[1][1]) as TidySnapshot;
 		expect(written.id).toBe('second');
 		expect(written.originalContent).toBe('v2');
 	});
@@ -125,7 +141,7 @@ describe('TidyStore', () => {
 
 	it('sanitizes slashes in file paths for snapshot filename', async () => {
 		await store.save(makeSnapshot({ filePath: 'deep/nested/path/note.md' }));
-		const path = mockAdapter.write.mock.calls[0][0] as string;
+		const path = mockAdapter.write.mock.calls[0][0];
 		const fileName = path.split('/').pop()!;
 		// No slashes in the filename itself
 		expect(fileName).not.toContain('/');

--- a/src/title/review-toast.test.ts
+++ b/src/title/review-toast.test.ts
@@ -1,7 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { TitleModule } from './index';
 import { DEFAULT_SETTINGS, SynapseSettings } from '../settings';
 import { TFile, TFolder } from '../__mocks__/obsidian';
+import type { NoticeAction } from '../shared';
+
+/** Spy-backed stand-in for the NotificationManager surface the module calls. */
+interface MockNotifications {
+	info: Mock<(message: string, duration?: number, action?: NoticeAction) => void>;
+	success: Mock<(message: string, duration?: number, action?: NoticeAction) => void>;
+	notifyError: Mock<(context: string, error: unknown) => void>;
+}
 
 // Stub the title suggester so checkUntitled produces a deterministic proposal
 // without any AI/network call.
@@ -54,7 +62,7 @@ describe('TitleModule Review toast action (#340)', () => {
 	let adapter: ReturnType<typeof createMemoryAdapter>;
 	let mockPlugin: { app: { vault: Record<string, unknown>; metadataCache: Record<string, unknown> } };
 	let settings: SynapseSettings;
-	let notifications: { info: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn>; notifyError: ReturnType<typeof vi.fn> };
+	let notifications: MockNotifications;
 	let untitledFile: TFile;
 
 	beforeEach(() => {
@@ -107,7 +115,7 @@ describe('TitleModule Review toast action (#340)', () => {
 			expect.objectContaining({ label: 'Review' })
 		);
 		// The action opens the unified proposal view.
-		notifications.success.mock.calls[0][2].onClick();
+		notifications.success.mock.calls[0][2]!.onClick();
 		expect(openSpy).toHaveBeenCalledTimes(1);
 
 		// Nothing was renamed (proposal left pending for review).

--- a/src/title/title-store.test.ts
+++ b/src/title/title-store.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { TitleProposalStore } from './title-store';
 import { TitleProposal } from './types';
 import { DEFAULT_SETTINGS } from '../settings';
+import type { App } from 'obsidian';
+
+/** Spy-backed stand-in for the Vault adapter surface the store reads/writes through. */
+interface MockAdapter {
+	read: Mock<(path: string) => Promise<string>>;
+	write: Mock<(path: string, data: string) => Promise<void>>;
+	exists: Mock<(path: string) => Promise<boolean>>;
+	remove: Mock<(path: string) => Promise<void>>;
+	list: Mock<(path: string) => Promise<{ files: string[]; folders: string[] }>>;
+}
 
 function makeProposal(overrides: Partial<TitleProposal> = {}): TitleProposal {
 	return {
@@ -19,7 +29,7 @@ function makeProposal(overrides: Partial<TitleProposal> = {}): TitleProposal {
 
 describe('TitleProposalStore', () => {
 	let store: TitleProposalStore;
-	let mockAdapter: any;
+	let mockAdapter: MockAdapter;
 
 	beforeEach(() => {
 		mockAdapter = {
@@ -36,7 +46,7 @@ describe('TitleProposalStore', () => {
 				createFolder: vi.fn().mockResolvedValue(undefined),
 				getAbstractFileByPath: vi.fn().mockReturnValue(null),
 			},
-		} as any;
+		} as unknown as App;
 
 		const getSettings = () => ({ ...DEFAULT_SETTINGS });
 		store = new TitleProposalStore(app, getSettings);
@@ -116,7 +126,7 @@ describe('TitleProposalStore', () => {
 		await store.updateStatus('update-me', 'accepted');
 
 		expect(mockAdapter.write).toHaveBeenCalled();
-		const written = JSON.parse(mockAdapter.write.mock.calls[0][1]);
+		const written = JSON.parse(mockAdapter.write.mock.calls[0][1]) as TitleProposal;
 		expect(written.status).toBe('accepted');
 	});
 

--- a/src/title/title-suggester.test.ts
+++ b/src/title/title-suggester.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { TitleSuggester } from './title-suggester';
+import type { AIClient } from '../shared';
 
 describe('TitleSuggester', () => {
 	let suggester: TitleSuggester;
-	let mockComplete: ReturnType<typeof vi.fn>;
+	let mockComplete: Mock<AIClient['complete']>;
 
 	beforeEach(() => {
 		mockComplete = vi.fn();
-		const mockAIClient = { complete: mockComplete } as any;
+		const mockAIClient = { complete: mockComplete } as unknown as AIClient;
 		suggester = new TitleSuggester(mockAIClient);
 	});
 


### PR DESCRIPTION
Drops now-unnecessary `any` casts in favor of the typed mock helpers and types ad-hoc per-test mocks so the six type-safety rules pass across the test files under `src/tidy/`, `src/organize/`, `src/intake/`, `src/title/`, `src/commands/` plus the root `settings-tab.test.ts`, `changelog.test.ts`, and `changelog-modal.test.ts`. No runtime/test behavior change.

closes #427

Part of #321

## Verification
- Bucket gate (the six rules forced to `error` across all in-scope files): **448 → 0**.
- Full CI green: `tsc --noEmit --skipLibCheck` exit 0; `npm run lint` exit 0; `check-top-level-requires.mjs` exit 0; `version-bump.mjs --check` consistent; `esbuild.config.mjs production` exit 0; **1823 tests pass** (16 files changed, all in scope).

## Notes
- Stacked on #426 (PR #435) — base is `refactor/issue-426-typesafe-enrichment-rem`, not `main`.
- Convention (from #422–#426): typed mock surfaces via small named interfaces + `as unknown as <RealType>` boundary casts; mock `TFile` → real `TFile` once at fixtures; `vi.mocked(fn)` for module-mock spies; `StubEl` for DOM-walk helpers; JSON.parse results cast to the domain type; pre-existing `as never` casts left untouched (not flagged by the six rules).