### PR TITLE
chore: remove test-file ESLint override to enforce type-safety rules repo-wide (#428)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,20 +144,4 @@ export default tseslint.config(
 			],
 		},
 	},
-	{
-		// Test infra is exempt from no-unsafe-* / unnecessary-assertion — tracked in #321.
-		// Mocks, factories, and test files lean on deliberately loose `any`-typed
-		// stubs (spy objects, `mockResolvedValue`, the Obsidian DOM mock), so the
-		// type-safety family adds churn without protecting shipped code. The
-		// promise rules and `no-duplicate-type-constituents` stay ON here.
-		files: ['**/*.test.ts', 'src/__mocks__/**', 'src/__test-utils__/**'],
-		rules: {
-			'@typescript-eslint/no-unsafe-assignment': 'off',
-			'@typescript-eslint/no-unsafe-call': 'off',
-			'@typescript-eslint/no-unsafe-member-access': 'off',
-			'@typescript-eslint/no-unsafe-argument': 'off',
-			'@typescript-eslint/no-unsafe-return': 'off',
-			'@typescript-eslint/no-unnecessary-type-assertion': 'off',
-		},
-	},
 );


### PR DESCRIPTION
Removes the test-infra ESLint override so the six type-safety rules (`no-unsafe-assignment/-call/-member-access/-argument/-return`, `no-unnecessary-type-assertion`) enforce repo-wide via `eslint src`.

closes #428
Part of #321

## What changed
Deleted the last config object in `eslint.config.mjs` — the `files: ['**/*.test.ts', 'src/__mocks__/**', 'src/__test-utils__/**']` block that turned all six rules `off`. With #421–#427 landed, every test-infra file is clean, so `npm run lint` now enforces these rules everywhere — closing the gap between shipped-code and test enforcement. No other rules were touched: the promise rules and `no-duplicate-type-constituents` were already ON for tests and stay ON, and the six rules were already `error` in the main `src/**/*.ts` block, which test files now inherit.

## Verification
- `npm run lint` (= `eslint src`) is globally green — exits **0** with the override removed. All 138 test-infra files pass the six rules under normal config.
- The forced-rule sweep (`npx eslint src --rule '{…six: error}'`) now also reports **0**, matching `npm run lint` — both at 0.
- Rest of CI green: `tsc --noEmit --skipLibCheck` → 0, `check-top-level-requires.mjs` → 0, `version-bump.mjs --check` → 0, `esbuild.config.mjs production` → 0, and **1823 tests passed** (136 files).

## Stack
Final PR of the #421 → #428 stack. Stacked on #427 (PR #436) — base is `refactor/issue-427-typesafe-tidy-misc`. Merge after the rest of the chain.
