### PR TITLE
feat: add per-section and global reset-to-defaults settings controls

### DIFF
--- a/src/settings-tab.test.ts
+++ b/src/settings-tab.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createEl, ToggleComponent, Setting, type StubEl } from './__mocks__/obsidian';
+import { createEl, ToggleComponent, ButtonComponent, Setting, type StubEl } from './__mocks__/obsidian';
 
 // Mock the changelog modal so this suite never resolves the real CHANGELOG.md
 // import (a build-time `.md` text import that Vitest can't transform), and so
@@ -13,7 +13,19 @@ vi.mock('./changelog-modal', () => ({
 	}),
 }));
 
+// Mock the confirm modal (used by both the per-section reset and the global
+// reset-all) so its confirm/cancel outcome is controllable via `confirmResult`
+// without opening a real modal (#420). Mocking the leaf module also covers the
+// `./shared` barrel re-export that settings-tab imports.
+const { confirmResult } = vi.hoisted(() => ({ confirmResult: vi.fn() }));
+vi.mock('./shared/confirm-modal', () => ({
+	ConfirmModal: vi.fn(function (this: { openAndConfirm: () => Promise<boolean> }) {
+		this.openAndConfirm = confirmResult;
+	}),
+}));
+
 import { ChangelogModal } from './changelog-modal';
+import { ConfirmModal } from './shared/confirm-modal';
 import { SynapseSettingTab } from './settings-tab';
 import { DEFAULT_SETTINGS } from './settings';
 import type { SynapseSettings } from './settings';
@@ -488,5 +500,166 @@ describe('SynapseSettingTab — no-subscription note in AI Configuration (#364)'
 		});
 		tab.display();
 		expect(subscriptionNotes(tab)).toHaveLength(0);
+	});
+});
+
+/** Drain pending microtasks so a floating `void onReset()` handler completes. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('SynapseSettingTab — per-section reset controls (#420)', () => {
+	beforeEach(() => {
+		ToggleComponent.instances.length = 0;
+		(ConfirmModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+		confirmResult.mockReset();
+	});
+
+	/** All accordion section wrappers, in DOM order. */
+	function accordions(tab: SynapseSettingTab): StubEl[] {
+		const container = (tab as unknown as { containerEl: StubEl }).containerEl;
+		return elsWithClass(container, 'synapse-accordion');
+	}
+
+	/** The accordion whose header title matches `title`. */
+	function sectionByTitle(tab: SynapseSettingTab, title: string): StubEl | undefined {
+		return accordions(tab).find((acc) =>
+			elsWithClass(acc, 'synapse-accordion-title').some((t) => t.textContent === title),
+		);
+	}
+
+	/** The reset icon button within a section (located by class, never by icon). */
+	function resetBtn(section: StubEl): StubEl | undefined {
+		return elsWithClass(section, 'synapse-accordion-reset')[0];
+	}
+
+	it('renders a reset control (data-icon rotate-ccw) in feature and config section headers', () => {
+		const { tab } = makeTab();
+		tab.display();
+
+		const elaboration = sectionByTitle(tab, 'Note elaboration');
+		const ai = sectionByTitle(tab, 'AI configuration');
+		expect(resetBtn(elaboration!)?.getAttribute('data-icon')).toBe('rotate-ccw');
+		expect(resetBtn(ai!)?.getAttribute('data-icon')).toBe('rotate-ccw');
+	});
+
+	it('does not render a reset control in the About section', () => {
+		const { tab } = makeTab();
+		tab.display();
+
+		const about = sectionByTitle(tab, 'About');
+		expect(about).toBeDefined();
+		expect(resetBtn(about!)).toBeUndefined();
+	});
+
+	it('restores the section subtree, saves, and re-renders when confirmed', async () => {
+		confirmResult.mockResolvedValue(true);
+		const { tab, plugin } = makeTab((s) => {
+			s.elaboration.enabled = false;
+			s.elaboration.proposalFolderPath = 'custom/path';
+		});
+		const displaySpy = vi.spyOn(tab, 'display');
+		tab.display();
+
+		const btn = resetBtn(sectionByTitle(tab, 'Note elaboration')!)!;
+		btn.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+		await flush();
+
+		expect(plugin.settings.elaboration).toEqual(DEFAULT_SETTINGS.elaboration);
+		expect(plugin.saveSettings).toHaveBeenCalled();
+		// Initial render + the post-reset re-render.
+		expect(displaySpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('leaves settings untouched (no save) when the confirmation is cancelled', async () => {
+		confirmResult.mockResolvedValue(false);
+		const { tab, plugin } = makeTab((s) => {
+			s.elaboration.enabled = false;
+		});
+		tab.display();
+
+		const btn = resetBtn(sectionByTitle(tab, 'Note elaboration')!)!;
+		btn.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+		await flush();
+
+		expect(plugin.settings.elaboration.enabled).toBe(false);
+		expect(plugin.saveSettings).not.toHaveBeenCalled();
+	});
+
+	it('scopes the Audio section reset so transcription credentials survive', async () => {
+		confirmResult.mockResolvedValue(true);
+		const { tab, plugin } = makeTab((s) => {
+			s.audio.enabled = false;
+			s.audio.language = 'es';
+			s.audio.deepgramApiKey = 'dg-key';
+			s.audio.whisperApiKey = 'sk-whisper';
+		});
+		tab.display();
+
+		const btn = resetBtn(sectionByTitle(tab, 'Audio transcription')!)!;
+		btn.dispatchEvent({ type: 'click', stopPropagation: vi.fn() });
+		await flush();
+
+		// Behavior restored…
+		expect(plugin.settings.audio.enabled).toBe(DEFAULT_SETTINGS.audio.enabled);
+		expect(plugin.settings.audio.language).toBe(DEFAULT_SETTINGS.audio.language);
+		// …credentials preserved.
+		expect(plugin.settings.audio.deepgramApiKey).toBe('dg-key');
+		expect(plugin.settings.audio.whisperApiKey).toBe('sk-whisper');
+	});
+});
+
+describe('SynapseSettingTab — global reset all (#420)', () => {
+	beforeEach(() => {
+		ButtonComponent.instances.length = 0;
+		(ConfirmModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+		confirmResult.mockReset();
+	});
+
+	function resetAllButton(): ButtonComponent | undefined {
+		return ButtonComponent.instances.find((b) => b.buttonText === 'Reset all settings');
+	}
+
+	it('renders a "Reset all settings" warning button in About', () => {
+		const { tab } = makeTab();
+		tab.display();
+
+		const btn = resetAllButton();
+		expect(btn).toBeDefined();
+		expect(btn!.setWarning).toHaveBeenCalled();
+	});
+
+	it('restores all settings and preserves bookkeeping when confirmed', async () => {
+		confirmResult.mockResolvedValue(true);
+		const { tab, plugin } = makeTab((s) => {
+			s.ai.apiKey = 'sk';
+			s.elaboration.enabled = false;
+			s.onboarding.hasSeenWelcome = true;
+			s.ui.collapsedSections = { audio: true };
+			s.settingsVersion = 3;
+		});
+		tab.display();
+
+		await resetAllButton()!._click();
+
+		// Everything reset to defaults…
+		expect(plugin.settings.ai.apiKey).toBe('');
+		expect(plugin.settings.elaboration.enabled).toBe(true);
+		// …except the preserved install bookkeeping.
+		expect(plugin.settings.onboarding.hasSeenWelcome).toBe(true);
+		expect(plugin.settings.ui.collapsedSections).toEqual({ audio: true });
+		expect(plugin.settings.settingsVersion).toBe(3);
+		expect(plugin.saveSettings).toHaveBeenCalled();
+	});
+
+	it('does nothing when the reset-all confirmation is cancelled', async () => {
+		confirmResult.mockResolvedValue(false);
+		const { tab, plugin } = makeTab((s) => {
+			s.ai.apiKey = 'sk';
+		});
+		tab.display();
+
+		await resetAllButton()!._click();
+
+		expect(plugin.settings.ai.apiKey).toBe('sk');
+		expect(plugin.saveSettings).not.toHaveBeenCalled();
 	});
 });

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -11,6 +11,8 @@ import {
 	PROVIDER_METADATA,
 	aiProviderToCredential,
 	decorateCredentialField,
+	ConfirmModal,
+	applyResetAll,
 } from './shared';
 import type {
 	SettingsSectionContext,
@@ -682,5 +684,34 @@ export class SynapseSettingTab extends PluginSettingTab {
 			evt.preventDefault();
 			new ChangelogModal(this.app, this.plugin).open();
 		});
+
+		// ── Reset all settings (#420) ──
+		// The global counterpart to the per-section reset icon. Gated behind a
+		// confirmation modal; preserves install bookkeeping (see applyResetAll).
+		new Setting(aboutBody)
+			.setName('Reset all settings')
+			.setDesc(
+				'Restore every Synapse setting to its shipped defaults, including your ' +
+				'API keys. This cannot be undone. Your notes and proposals are not affected.',
+			)
+			.addButton((btn) =>
+				btn
+					.setButtonText('Reset all settings')
+					.setWarning()
+					.onClick(async () => {
+						const confirmed = await new ConfirmModal(this.app, {
+							title: 'Reset all settings?',
+							message:
+								'This restores every Synapse setting to its defaults, including ' +
+								'your API keys, and cannot be undone. Your notes and proposals ' +
+								'are not affected.',
+							confirmLabel: 'Reset all settings',
+						}).openAndConfirm();
+						if (!confirmed) return;
+						this.plugin.settings = applyResetAll(this.plugin.settings);
+						await this.plugin.saveSettings();
+						ctx.rerender();
+					}),
+			);
 	}
 }

--- a/src/shared/collapsible-section.test.ts
+++ b/src/shared/collapsible-section.test.ts
@@ -251,4 +251,64 @@ describe('addCollapsibleSection', () => {
 			expect(onCollapseChange).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('reset button', () => {
+		it('does not render a reset button when onReset is omitted', () => {
+			const section = addCollapsibleSection(container, { title: 'X' });
+			expect(findByClass(section.headerEl, 'synapse-accordion-reset')).toBeUndefined();
+		});
+
+		it('renders a reset button (with a locatable data-icon) when onReset is provided', () => {
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				onReset: vi.fn(),
+			});
+			const btn = findByClass(section.headerEl, 'synapse-accordion-reset');
+			expect(btn).toBeDefined();
+			// setIcon is a no-op in the mock, so tests locate the button by data-icon.
+			expect(btn?.getAttribute('data-icon')).toBe('rotate-ccw');
+		});
+
+		it('uses the provided resetTooltip as the aria-label', () => {
+			const section = addCollapsibleSection(container, {
+				title: 'Audio',
+				onReset: vi.fn(),
+				resetTooltip: 'Reset Audio to defaults',
+			});
+			const btn = findByClass(section.headerEl, 'synapse-accordion-reset');
+			expect(btn?.getAttribute('aria-label')).toBe('Reset Audio to defaults');
+		});
+
+		it('falls back to a default aria-label when resetTooltip is omitted', () => {
+			const section = addCollapsibleSection(container, {
+				title: 'X',
+				onReset: vi.fn(),
+			});
+			const btn = findByClass(section.headerEl, 'synapse-accordion-reset');
+			expect(btn?.getAttribute('aria-label')).toBe('Reset to defaults');
+		});
+
+		it('invokes onReset and stops propagation on click, without folding the section', () => {
+			const onReset = vi.fn();
+			const section = addCollapsibleSection(container, { title: 'X', onReset });
+			const btn = findByClass(section.headerEl, 'synapse-accordion-reset');
+			const stopPropagation = vi.fn();
+
+			fire(btn!, { type: 'click', stopPropagation });
+
+			expect(onReset).toHaveBeenCalledTimes(1);
+			// stopPropagation keeps the click off the header's fold handler.
+			expect(stopPropagation).toHaveBeenCalledTimes(1);
+			expect(section.isCollapsed()).toBe(false);
+		});
+
+		it('renders the reset button for a toggle-less config section too', () => {
+			const section = addCollapsibleSection(container, {
+				title: 'AI config',
+				onReset: vi.fn(),
+			});
+			expect(section.toggle).toBeUndefined();
+			expect(findByClass(section.headerEl, 'synapse-accordion-reset')).toBeDefined();
+		});
+	});
 });

--- a/src/shared/collapsible-section.ts
+++ b/src/shared/collapsible-section.ts
@@ -1,4 +1,4 @@
-import { Setting } from 'obsidian';
+import { setIcon, Setting } from 'obsidian';
 import type { ToggleComponent } from 'obsidian';
 
 /**
@@ -37,6 +37,18 @@ export interface CollapsibleSectionOptions {
 	 * Optional aria-label for the header toggle (falls back to `title`).
 	 */
 	toggleAriaLabel?: string;
+	/**
+	 * When provided, a small "reset to defaults" icon button is rendered in the
+	 * header (before the enable toggle, if any). Clicking it invokes this handler
+	 * without folding/unfolding the section. Use it to restore just this section's
+	 * settings to their shipped defaults.
+	 */
+	onReset?: () => void | Promise<void>;
+	/**
+	 * Optional aria-label/tooltip for the reset button (falls back to
+	 * `Reset to defaults`). Only used when {@link onReset} is provided.
+	 */
+	resetTooltip?: string;
 }
 
 /**
@@ -98,6 +110,8 @@ export function addCollapsibleSection(
 		onToggle,
 		onCollapseChange,
 		toggleAriaLabel,
+		onReset,
+		resetTooltip,
 	} = options;
 
 	const hasToggle = enabled !== undefined;
@@ -118,6 +132,28 @@ export function addCollapsibleSection(
 
 	// Spacer pushes the toggle to the trailing edge of the header row.
 	const controlEl = headerEl.createDiv({ cls: 'synapse-accordion-control' });
+
+	if (onReset) {
+		// Raw button matches the header's raw-DOM style (mirrors the video
+		// settings copy button). `data-icon` + aria-label make it locatable in
+		// tests, where `setIcon` is a no-op.
+		const resetBtn = controlEl.createEl('button', {
+			cls: 'synapse-accordion-reset',
+			attr: {
+				type: 'button',
+				'aria-label': resetTooltip ?? 'Reset to defaults',
+				'data-icon': 'rotate-ccw',
+			},
+		});
+		setIcon(resetBtn, 'rotate-ccw');
+		// stopPropagation is REQUIRED: config sections have no toggle, so the
+		// header's own fold handler would otherwise fire on this click (the
+		// controlEl stop-guard below only exists for toggle sections).
+		resetBtn.addEventListener('click', (evt) => {
+			evt.stopPropagation();
+			void onReset();
+		});
+	}
 
 	let toggle: ToggleComponent | undefined;
 	if (hasToggle) {

--- a/src/shared/confirm-modal.test.ts
+++ b/src/shared/confirm-modal.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConfirmModal } from './confirm-modal';
+
+// No vi.mock('obsidian') here: the vitest.config alias already resolves
+// 'obsidian' to the manual mock (src/__mocks__/obsidian.ts), which gives Modal
+// real `open`/`close` instance methods. Auto-mocking would strip those, breaking
+// openAndConfirm()/settle().
+
+/**
+ * Reach into the modal's confirm internals the button callbacks drive. Mirrors
+ * the DepthSelectorModal test: `onOpen` isn't exercised (the Modal mock's
+ * `contentEl` is a bare stub), so the confirm/cancel paths are driven through
+ * the private `settle` and the public `onClose`.
+ */
+function internals(modal: ConfirmModal): {
+	resolved: boolean;
+	resolve: (confirmed: boolean) => void;
+	settle: (confirmed: boolean) => void;
+} {
+	return modal as unknown as {
+		resolved: boolean;
+		resolve: (confirmed: boolean) => void;
+		settle: (confirmed: boolean) => void;
+	};
+}
+
+describe('ConfirmModal', () => {
+	const mockApp = {} as ConstructorParameters<typeof ConfirmModal>[0];
+	const opts = { title: 'Reset audio transcription?', message: 'Are you sure?' };
+
+	it('resolves true when the confirm action settles', async () => {
+		const modal = new ConfirmModal(mockApp, opts);
+		const promise = modal.openAndConfirm();
+
+		internals(modal).settle(true);
+
+		await expect(promise).resolves.toBe(true);
+	});
+
+	it('resolves false when the cancel action settles', async () => {
+		const modal = new ConfirmModal(mockApp, opts);
+		const promise = modal.openAndConfirm();
+
+		internals(modal).settle(false);
+
+		await expect(promise).resolves.toBe(false);
+	});
+
+	it('resolves false when dismissed without choosing (onClose)', async () => {
+		const modal = new ConfirmModal(mockApp, opts);
+		const promise = modal.openAndConfirm();
+
+		modal.onClose();
+
+		await expect(promise).resolves.toBe(false);
+	});
+
+	it('does not double-resolve when closed after a confirm', () => {
+		const modal = new ConfirmModal(mockApp, opts);
+		const resolve = vi.fn();
+		internals(modal).resolve = resolve;
+
+		internals(modal).settle(true);
+		modal.onClose();
+
+		expect(resolve).toHaveBeenCalledTimes(1);
+		expect(resolve).toHaveBeenCalledWith(true);
+	});
+
+	it('closes the modal once a choice is made', () => {
+		const modal = new ConfirmModal(mockApp, opts);
+
+		internals(modal).settle(true);
+
+		expect(modal.close as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/shared/confirm-modal.ts
+++ b/src/shared/confirm-modal.ts
@@ -1,0 +1,80 @@
+import { App, Modal, Setting } from 'obsidian';
+
+/** Copy for a {@link ConfirmModal}. */
+export interface ConfirmModalOptions {
+	/** Heading shown at the top of the modal. */
+	title: string;
+	/** Body text explaining what will happen. */
+	message: string;
+	/** Label for the confirm (warning) button. Defaults to `Reset`. */
+	confirmLabel?: string;
+}
+
+/**
+ * Reusable yes/no confirmation modal (#420).
+ *
+ * Modeled on {@link DepthSelectorModal}: it keeps a `resolved` flag plus the
+ * pending promise `resolve` so a dismiss (Escape / click-away → `onClose`)
+ * settles as "cancelled" exactly once, and the button callbacks settle it
+ * eagerly. Used to gate destructive resets behind an explicit confirmation
+ * rather than the transient snackbar.
+ */
+export class ConfirmModal extends Modal {
+	private opts: ConfirmModalOptions;
+	private resolved = false;
+	private resolve: (confirmed: boolean) => void = () => {};
+
+	constructor(app: App, opts: ConfirmModalOptions) {
+		super(app);
+		this.opts = opts;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('synapse-confirm-modal');
+
+		contentEl.createEl('h3', { text: this.opts.title });
+		contentEl.createEl('p', {
+			cls: 'synapse-confirm-message',
+			text: this.opts.message,
+		});
+
+		new Setting(contentEl)
+			.addButton((btn) => {
+				btn.setButtonText('Cancel').onClick(() => this.settle(false));
+			})
+			.addButton((btn) => {
+				btn
+					.setButtonText(this.opts.confirmLabel ?? 'Reset')
+					.setWarning()
+					.onClick(() => this.settle(true));
+			});
+	}
+
+	onClose(): void {
+		this.contentEl?.empty();
+		// A dismiss (Escape / click-away) that never hit a button counts as cancel.
+		if (!this.resolved) {
+			this.resolve(false);
+		}
+	}
+
+	/** Settle the pending promise once and close the modal. */
+	private settle(confirmed: boolean): void {
+		this.resolved = true;
+		this.resolve(confirmed);
+		this.close();
+	}
+
+	/**
+	 * Open the modal and resolve to the user's choice: `true` on confirm, `false`
+	 * on cancel or dismiss.
+	 */
+	openAndConfirm(): Promise<boolean> {
+		return new Promise((resolve) => {
+			this.resolve = resolve;
+			this.open();
+		});
+	}
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -97,6 +97,13 @@ export type {
 	SettingsSectionContext,
 	SettingsSectionContextOptions,
 } from './settings-section';
+export { ConfirmModal } from './confirm-modal';
+export type { ConfirmModalOptions } from './confirm-modal';
+export {
+	sectionHasReset,
+	applySectionReset,
+	applyResetAll,
+} from './settings-reset';
 export {
 	findMatchingRule,
 	isPathExcluded,

--- a/src/shared/settings-reset.test.ts
+++ b/src/shared/settings-reset.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+import { sectionHasReset, applySectionReset, applyResetAll } from './settings-reset';
+
+/** A fresh, independent copy of shipped defaults to mutate per test. */
+function freshSettings(): SynapseSettings {
+	return structuredClone(DEFAULT_SETTINGS);
+}
+
+describe('sectionHasReset', () => {
+	it('is true for every section key except about', () => {
+		const withReset = [
+			'ai', 'autoAccept', 'exclusions', 'general', 'elaboration', 'intake',
+			'image', 'audio', 'video', 'enrichment', 'summarize', 'tidy', 'organize',
+			'deepDive', 'title', 'rem',
+		];
+		for (const key of withReset) {
+			expect(sectionHasReset(key)).toBe(true);
+		}
+	});
+
+	it('is false for the about section (it hosts the global reset instead)', () => {
+		expect(sectionHasReset('about')).toBe(false);
+	});
+});
+
+describe('applySectionReset — 1:1 top-level subtrees', () => {
+	it('restores a feature subtree wholesale (elaboration)', () => {
+		const s = freshSettings();
+		s.elaboration.enabled = false;
+		s.elaboration.proposalFolderPath = 'custom/path';
+		s.elaboration.detection.minWordThreshold = 999;
+
+		applySectionReset(s, 'elaboration');
+
+		expect(s.elaboration).toEqual(DEFAULT_SETTINGS.elaboration);
+	});
+
+	it('maps the deepDive key to the deepDive subtree', () => {
+		const s = freshSettings();
+		s.deepDive.maxDepth = 99;
+		s.deepDive.nestingMode = 'flat';
+
+		applySectionReset(s, 'deepDive');
+
+		expect(s.deepDive).toEqual(DEFAULT_SETTINGS.deepDive);
+	});
+
+	it('restores the global config subtrees (autoAccept, exclusions)', () => {
+		const s = freshSettings();
+		s.autoAccept.rem = true;
+		s.exclusions = [{ pattern: 'Archive/**', features: 'all' }];
+
+		applySectionReset(s, 'autoAccept');
+		applySectionReset(s, 'exclusions');
+
+		expect(s.autoAccept).toEqual(DEFAULT_SETTINGS.autoAccept);
+		expect(s.exclusions).toEqual(DEFAULT_SETTINGS.exclusions);
+	});
+
+	it('does not alias DEFAULT_SETTINGS (mutating a reset result is safe)', () => {
+		const s = freshSettings();
+		s.elaboration.enabled = false;
+
+		applySectionReset(s, 'elaboration');
+		// Mutate the freshly-restored subtree in place…
+		s.elaboration.detection.excludeTags.push('mutated');
+		s.elaboration.enabled = false;
+
+		// …the shared DEFAULT_SETTINGS constant is untouched.
+		expect(DEFAULT_SETTINGS.elaboration.detection.excludeTags).toEqual(['no-elaborate']);
+		expect(DEFAULT_SETTINGS.elaboration.enabled).toBe(true);
+	});
+});
+
+describe('applySectionReset — audio (scoped: keep credentials)', () => {
+	it('restores the four behavior fields but PRESERVES the six credential/provider fields', () => {
+		const s = freshSettings();
+		// Behavior customizations (owned by the Audio section)…
+		s.audio.enabled = false;
+		s.audio.language = 'es';
+		s.audio.autoFormatLyrics = false;
+		s.audio.postProcessing.removeFiller = false;
+		// …and credential/provider customizations (owned by AI configuration).
+		s.audio.transcriptionProvider = 'deepgram';
+		s.audio.whisperApiKey = 'sk-whisper';
+		s.audio.deepgramApiKey = 'dg-key';
+		s.audio.geminiApiKey = 'gm-key';
+		s.audio.whisperModel = 'whisper-large';
+		s.audio.localWhisperPath = '/opt/whisper';
+
+		applySectionReset(s, 'audio');
+
+		// Behavior restored to defaults…
+		expect(s.audio.enabled).toBe(DEFAULT_SETTINGS.audio.enabled);
+		expect(s.audio.language).toBe(DEFAULT_SETTINGS.audio.language);
+		expect(s.audio.autoFormatLyrics).toBe(DEFAULT_SETTINGS.audio.autoFormatLyrics);
+		expect(s.audio.postProcessing).toEqual(DEFAULT_SETTINGS.audio.postProcessing);
+		// …credentials/provider left exactly as the user set them.
+		expect(s.audio.transcriptionProvider).toBe('deepgram');
+		expect(s.audio.whisperApiKey).toBe('sk-whisper');
+		expect(s.audio.deepgramApiKey).toBe('dg-key');
+		expect(s.audio.geminiApiKey).toBe('gm-key');
+		expect(s.audio.whisperModel).toBe('whisper-large');
+		expect(s.audio.localWhisperPath).toBe('/opt/whisper');
+	});
+
+	it('clones postProcessing so the reset result does not alias DEFAULT_SETTINGS', () => {
+		const s = freshSettings();
+		s.audio.postProcessing.customPrompt = 'x';
+
+		applySectionReset(s, 'audio');
+		s.audio.postProcessing.customPrompt = 'mutated';
+
+		expect(DEFAULT_SETTINGS.audio.postProcessing.customPrompt).toBe('');
+	});
+});
+
+describe('applySectionReset — ai (restores ai + audio credentials)', () => {
+	it('restores the ai group and the six audio credential/provider fields', () => {
+		const s = freshSettings();
+		s.ai.provider = 'anthropic';
+		s.ai.apiKey = 'sk-ai';
+		s.ai.temperature = 0.1;
+		s.audio.transcriptionProvider = 'deepgram';
+		s.audio.whisperApiKey = 'sk-whisper';
+		s.audio.deepgramApiKey = 'dg-key';
+		s.audio.geminiApiKey = 'gm-key';
+		s.audio.whisperModel = 'whisper-large';
+		s.audio.localWhisperPath = '/opt/whisper';
+		// A behavior field the AI reset must NOT touch.
+		s.audio.language = 'es';
+
+		applySectionReset(s, 'ai');
+
+		expect(s.ai).toEqual(DEFAULT_SETTINGS.ai);
+		expect(s.audio.transcriptionProvider).toBe(DEFAULT_SETTINGS.audio.transcriptionProvider);
+		expect(s.audio.whisperApiKey).toBe('');
+		expect(s.audio.deepgramApiKey).toBe('');
+		expect(s.audio.geminiApiKey).toBe('');
+		expect(s.audio.whisperModel).toBe(DEFAULT_SETTINGS.audio.whisperModel);
+		expect(s.audio.localWhisperPath).toBe('');
+		// Audio behavior is out of scope for an AI reset.
+		expect(s.audio.language).toBe('es');
+	});
+
+	it('does not alias DEFAULT_SETTINGS.ai', () => {
+		const s = freshSettings();
+		applySectionReset(s, 'ai');
+		s.ai.apiKey = 'mutated';
+		expect(DEFAULT_SETTINGS.ai.apiKey).toBe('');
+	});
+});
+
+describe('applySectionReset — general (two cross-cutting fields only)', () => {
+	it('restores autoFoldProperties and enableUpdateNotifications, nothing else', () => {
+		const s = freshSettings();
+		s.ui.autoFoldProperties = true;
+		s.updates.enableUpdateNotifications = false;
+		// Bookkeeping the general reset must leave alone.
+		s.ui.collapsedSections = { audio: true };
+		s.updates.lastUpdateCheck = 12345;
+		s.updates.dismissedUpdateVersion = '9.9.9';
+
+		applySectionReset(s, 'general');
+
+		expect(s.ui.autoFoldProperties).toBe(DEFAULT_SETTINGS.ui.autoFoldProperties);
+		expect(s.updates.enableUpdateNotifications).toBe(
+			DEFAULT_SETTINGS.updates.enableUpdateNotifications,
+		);
+		// Untouched:
+		expect(s.ui.collapsedSections).toEqual({ audio: true });
+		expect(s.updates.lastUpdateCheck).toBe(12345);
+		expect(s.updates.dismissedUpdateVersion).toBe('9.9.9');
+	});
+});
+
+describe('applyResetAll', () => {
+	it('restores every subtree to defaults', () => {
+		const s = freshSettings();
+		s.ai.apiKey = 'sk';
+		s.elaboration.enabled = false;
+		s.audio.deepgramApiKey = 'dg';
+		s.exclusions = [];
+
+		const result = applyResetAll(s);
+
+		expect(result.ai).toEqual(DEFAULT_SETTINGS.ai);
+		expect(result.elaboration).toEqual(DEFAULT_SETTINGS.elaboration);
+		expect(result.audio).toEqual(DEFAULT_SETTINGS.audio);
+		expect(result.exclusions).toEqual(DEFAULT_SETTINGS.exclusions);
+	});
+
+	it('preserves the five install-bookkeeping fields', () => {
+		const s = freshSettings();
+		s.settingsVersion = 3;
+		s.onboarding.hasSeenWelcome = true;
+		s.ui.collapsedSections = { audio: true, ai: false };
+		s.updates.lastUpdateCheck = 999;
+		s.updates.dismissedUpdateVersion = '2.0.0';
+		// A non-bookkeeping updates field that must be reset.
+		s.updates.enableUpdateNotifications = false;
+
+		const result = applyResetAll(s);
+
+		expect(result.settingsVersion).toBe(3);
+		expect(result.onboarding.hasSeenWelcome).toBe(true);
+		expect(result.ui.collapsedSections).toEqual({ audio: true, ai: false });
+		expect(result.updates.lastUpdateCheck).toBe(999);
+		expect(result.updates.dismissedUpdateVersion).toBe('2.0.0');
+		expect(result.updates.enableUpdateNotifications).toBe(
+			DEFAULT_SETTINGS.updates.enableUpdateNotifications,
+		);
+	});
+
+	it('omits the optional updates fields when the source lacks them', () => {
+		// DEFAULT_SETTINGS.updates omits lastUpdateCheck / dismissedUpdateVersion.
+		const result = applyResetAll(freshSettings());
+		expect(result.updates.lastUpdateCheck).toBeUndefined();
+		expect(result.updates.dismissedUpdateVersion).toBeUndefined();
+	});
+
+	it('does not mutate the source settings', () => {
+		const s = freshSettings();
+		s.ai.apiKey = 'sk';
+		applyResetAll(s);
+		expect(s.ai.apiKey).toBe('sk');
+	});
+
+	it('does not alias DEFAULT_SETTINGS', () => {
+		const result = applyResetAll(freshSettings());
+		result.ai.apiKey = 'mutated';
+		result.ui.collapsedSections['x'] = true;
+		expect(DEFAULT_SETTINGS.ai.apiKey).toBe('');
+		expect(DEFAULT_SETTINGS.ui.collapsedSections).toEqual({});
+	});
+
+	it('clones collapsedSections so later edits do not reach the source', () => {
+		const s = freshSettings();
+		s.ui.collapsedSections = { audio: true };
+		const result = applyResetAll(s);
+		result.ui.collapsedSections['audio'] = false;
+		expect(s.ui.collapsedSections).toEqual({ audio: true });
+	});
+});

--- a/src/shared/settings-reset.ts
+++ b/src/shared/settings-reset.ts
@@ -1,0 +1,123 @@
+import { DEFAULT_SETTINGS } from '../settings';
+import type { SynapseSettings } from '../settings';
+
+/**
+ * Reset-to-defaults logic for the settings tab (#420).
+ *
+ * Pure, DOM-free helpers so the reset math is unit-testable in isolation from the
+ * accordion UI and the confirmation modal. Two scopes:
+ *  - {@link applySectionReset} restores a single section's subtree in place.
+ *  - {@link applyResetAll} rebuilds the whole settings object, preserving a small
+ *    set of install bookkeeping fields.
+ *
+ * ALIASING GUARD: `main.ts`'s `deepMerge` is not a deep clone, so on a fresh
+ * install `settings.<key>` can be the SAME object reference as
+ * `DEFAULT_SETTINGS.<key>`. Every object restored here therefore goes through
+ * `structuredClone` so a later edit never mutates the shared `DEFAULT_SETTINGS`
+ * constant.
+ */
+
+/**
+ * Whether a settings section exposes a per-section "reset to defaults" control.
+ * Every section does EXCEPT `about`, which hosts the global reset-all control
+ * instead of resetting a settings subtree of its own.
+ */
+export function sectionHasReset(key: string): boolean {
+	return key !== 'about';
+}
+
+/**
+ * Restore one top-level settings group to its default (deep-cloned) value.
+ * Generic over the key so the source and destination stay correlated — a plain
+ * `settings[key] = clone(DEFAULT[key])` with a union `key` doesn't type-check.
+ */
+function restoreGroup<K extends keyof SynapseSettings>(
+	settings: SynapseSettings,
+	key: K,
+): void {
+	settings[key] = structuredClone(DEFAULT_SETTINGS[key]);
+}
+
+/**
+ * Restore a single section's settings subtree to shipped defaults, mutating
+ * `settings` in place. The section KEY identifies the subtree.
+ *
+ * Most sections map 1:1 to a top-level settings group and are restored
+ * wholesale. Three keys are special:
+ *  - `general` — a cross-cutting section that owns only `ui.autoFoldProperties`
+ *    and `updates.enableUpdateNotifications` (not the whole `ui`/`updates` group).
+ *  - `ai` — restores the `ai` group plus the six audio credential/provider fields
+ *    that render under AI configuration.
+ *  - `audio` — restores ONLY the four audio behavior fields, preserving the
+ *    credential/provider fields owned by AI configuration.
+ *
+ * Does NOT touch `ui.collapsedSections[key]`: a section's collapse state is UI
+ * bookkeeping, not a user setting.
+ */
+export function applySectionReset(settings: SynapseSettings, key: string): void {
+	switch (key) {
+		case 'general':
+			// Primitives — no aliasing concern, direct copy from defaults.
+			settings.ui.autoFoldProperties = DEFAULT_SETTINGS.ui.autoFoldProperties;
+			settings.updates.enableUpdateNotifications =
+				DEFAULT_SETTINGS.updates.enableUpdateNotifications;
+			return;
+		case 'ai':
+			settings.ai = structuredClone(DEFAULT_SETTINGS.ai);
+			// The six audio credential/provider fields render under AI configuration,
+			// so restore them here alongside `ai`. All string primitives (or a string
+			// literal union) — direct copy is safe, no clone needed.
+			settings.audio.transcriptionProvider = DEFAULT_SETTINGS.audio.transcriptionProvider;
+			settings.audio.whisperApiKey = DEFAULT_SETTINGS.audio.whisperApiKey;
+			settings.audio.deepgramApiKey = DEFAULT_SETTINGS.audio.deepgramApiKey;
+			settings.audio.geminiApiKey = DEFAULT_SETTINGS.audio.geminiApiKey;
+			settings.audio.whisperModel = DEFAULT_SETTINGS.audio.whisperModel;
+			settings.audio.localWhisperPath = DEFAULT_SETTINGS.audio.localWhisperPath;
+			return;
+		case 'audio':
+			// Behavior fields only — leave the credential/provider fields (owned by
+			// AI configuration) exactly as the user left them.
+			settings.audio.enabled = DEFAULT_SETTINGS.audio.enabled;
+			settings.audio.language = DEFAULT_SETTINGS.audio.language;
+			settings.audio.autoFormatLyrics = DEFAULT_SETTINGS.audio.autoFormatLyrics;
+			settings.audio.postProcessing = structuredClone(
+				DEFAULT_SETTINGS.audio.postProcessing,
+			);
+			return;
+		default:
+			// Every remaining section key names a 1:1 top-level settings subtree.
+			// restoreGroup deep-clones so the fresh values never alias DEFAULT_SETTINGS.
+			restoreGroup(settings, key as keyof SynapseSettings);
+	}
+}
+
+/**
+ * Build a fresh settings object at shipped defaults for a global "reset all",
+ * copying back the small set of install-bookkeeping fields that must survive a
+ * reset:
+ *  - `settingsVersion` — schema version stamp;
+ *  - `onboarding.hasSeenWelcome` — so the first-run welcome never re-fires;
+ *  - `updates.lastUpdateCheck` / `updates.dismissedUpdateVersion` — update-check
+ *    rate-limit + dedupe state (optional; only copied when present, since
+ *    `DEFAULT_SETTINGS.updates` omits them);
+ *  - `ui.collapsedSections` — the accordion collapse state.
+ *
+ * Returns a new object (the caller reassigns `plugin.settings`); `current` is
+ * not mutated.
+ */
+export function applyResetAll(current: SynapseSettings): SynapseSettings {
+	const fresh = structuredClone(DEFAULT_SETTINGS);
+
+	fresh.settingsVersion = current.settingsVersion;
+	fresh.onboarding.hasSeenWelcome = current.onboarding.hasSeenWelcome;
+	fresh.ui.collapsedSections = structuredClone(current.ui.collapsedSections);
+
+	if (current.updates.lastUpdateCheck !== undefined) {
+		fresh.updates.lastUpdateCheck = current.updates.lastUpdateCheck;
+	}
+	if (current.updates.dismissedUpdateVersion !== undefined) {
+		fresh.updates.dismissedUpdateVersion = current.updates.dismissedUpdateVersion;
+	}
+
+	return fresh;
+}

--- a/src/shared/settings-section.ts
+++ b/src/shared/settings-section.ts
@@ -1,5 +1,7 @@
 import type SynapsePlugin from '../main';
 import { addCollapsibleSection } from './collapsible-section';
+import { ConfirmModal } from './confirm-modal';
+import { applySectionReset, sectionHasReset } from './settings-reset';
 
 /**
  * Shared accordion plumbing for the settings tab (#243).
@@ -99,6 +101,30 @@ export function createSettingsSectionContext(
 	options: SettingsSectionContextOptions,
 ): SettingsSectionContext {
 	const { containerEl, plugin, onFeatureToggle, rerender } = options;
+	const doRerender = rerender ?? (() => {});
+
+	/**
+	 * Build the per-section reset handler for a section KEY, or `undefined` when
+	 * the section has no reset control (e.g. `about`). Confirmed via a modal, the
+	 * handler restores just this section's subtree, persists, and re-renders.
+	 */
+	function makeSectionReset(
+		key: string,
+		title: string,
+	): (() => Promise<void>) | undefined {
+		if (!sectionHasReset(key)) return undefined;
+		return async () => {
+			const confirmed = await new ConfirmModal(plugin.app, {
+				title: `Reset ${title}?`,
+				message: `This restores the ${title} settings to their defaults. Your other settings are left unchanged.`,
+				confirmLabel: 'Reset',
+			}).openAndConfirm();
+			if (!confirmed) return;
+			applySectionReset(plugin.settings, key);
+			await plugin.saveSettings();
+			doRerender();
+		};
+	}
 
 	function featureSection(
 		key: string,
@@ -113,6 +139,8 @@ export function createSettingsSectionContext(
 			enabled,
 			collapsed: isSectionCollapsed(plugin, key, enabled),
 			toggleAriaLabel: toggleDesc ?? `Enable ${title}`,
+			onReset: makeSectionReset(key, title),
+			resetTooltip: `Reset ${title} to defaults`,
 			onToggle: async (value) => {
 				setEnabled(value);
 				await plugin.saveSettings();
@@ -133,6 +161,8 @@ export function createSettingsSectionContext(
 		const { bodyEl } = addCollapsibleSection(containerEl, {
 			title,
 			collapsed: isSectionCollapsed(plugin, key, null),
+			onReset: makeSectionReset(key, title),
+			resetTooltip: `Reset ${title} to defaults`,
 			onCollapseChange: async (collapsed) => {
 				await persistCollapse(plugin, key, collapsed);
 			},
@@ -145,6 +175,6 @@ export function createSettingsSectionContext(
 		plugin,
 		featureSection,
 		configSection,
-		rerender: rerender ?? (() => {}),
+		rerender: doRerender,
 	};
 }

--- a/styles.css
+++ b/styles.css
@@ -383,6 +383,46 @@
 }
 
 /*
+ * Per-section "reset to defaults" icon button (#420). Sits in the header control
+ * area, before the enable toggle. Muted by default so it reads as a secondary
+ * affordance; brightens on hover/focus. Mirrors the .synapse-install-copy
+ * icon-button idiom.
+ */
+.synapse-accordion-reset {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  margin-right: 4px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: color 150ms ease, background-color 150ms ease, opacity 150ms ease;
+}
+
+.synapse-accordion-reset:hover {
+  color: var(--text-normal);
+  background: var(--background-modifier-hover);
+  opacity: 1;
+}
+
+.synapse-accordion-reset:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: -2px;
+  opacity: 1;
+}
+
+/* Match the injected lucide icon to the header's scale. */
+.synapse-accordion-reset svg {
+  width: 16px;
+  height: 16px;
+}
+
+/*
  * The enable toggle lives inside a borderless Setting so we reuse the native
  * ToggleComponent. Strip the Setting's default block layout/border/padding so
  * it sits inline in the header next to the title.


### PR DESCRIPTION
## Summary

Adds two reset affordances to the Synapse settings tab (#420):

- **Per-section reset** — a small `rotate-ccw` icon button in every accordion header that restores just that section's settings. It is auto-wired from the section key inside the shared `featureSection`/`configSection` helpers, so the 13 feature render sites need zero changes.
- **Global "Reset all settings"** — a warning button in the About section that restores everything while preserving install bookkeeping.

Both are gated behind a reusable `ConfirmModal` (modeled on the proven `DepthSelectorModal` pattern), not the transient snackbar.

## Scoping & policies

- **Audio reset is scoped**: it restores only the four behavior fields (`enabled`, `language`, `autoFormatLyrics`, `postProcessing`) and leaves the six transcription credential/provider fields untouched — those render under AI configuration, whose own reset restores `ai` plus those six fields.
- **General** resets only its two cross-cutting fields (`ui.autoFoldProperties`, `updates.enableUpdateNotifications`).
- **Reset-all preserves** `settingsVersion`, `onboarding.hasSeenWelcome`, `updates.lastUpdateCheck`, `updates.dismissedUpdateVersion`, and `ui.collapsedSections`.
- Per-section reset does not touch `ui.collapsedSections`.
- Every reset routes through `structuredClone` so a fresh-install alias can never mutate the shared `DEFAULT_SETTINGS` constant.

## Files

- New: `src/shared/settings-reset.ts` (pure logic), `src/shared/confirm-modal.ts` (reusable modal), plus their tests.
- Modified: `src/shared/collapsible-section.ts` (optional reset button), `src/shared/settings-section.ts` (auto-wire per-section reset), `src/shared/index.ts` (barrel exports), `src/settings-tab.ts` (global reset in About), `styles.css` (reset button styles), and the two extended test suites.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck`
- [x] `npm test` (138 files, 1859 tests)
- [x] `node esbuild.config.mjs production`
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `npm run lint`
- [x] `node scripts/version-bump.mjs --check` (no version change)

closes #420

Co-Authored-By: bot <bot@wafflenet.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5mKX5iZvcunpDhCy9iy2e