### PR TITLE
chore: triage Obsidian v1.0.11 automated review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,11 @@ These are the only services Synapse contacts, what each one is used for, and wha
 - **Audio and video transcription use privileged desktop access.** To work with `yt-dlp`, `ffmpeg`, and `ffprobe`, the desktop build reaches outside the vault in two ways, both gated to desktop only (mobile never runs this code):
   - **Direct filesystem access.** Synapse writes scratch files -- downloaded media, extracted audio, clipped or concatenated segments -- to your operating system's temp directory (`os.tmpdir()`), never inside your vault. These temp files are removed when the operation finishes, on both success and failure. The finished video, if you opt to keep it, is the only artifact saved into the vault (in your configured download folder).
   - **Local shell execution.** Synapse runs the external tools as child processes with `execFile` and an explicit argument array -- never a shell command string -- so there is no shell interpolation of URLs, paths, or titles. URLs and file paths are sanitized first (`sanitizeUrl` / `sanitizePath`), the subprocess inherits a narrowed environment (essentially just an augmented `PATH` plus `HOME`), and the binaries that run are exactly the `yt-dlp path` and `ffmpeg path` you set in settings.
+- **The clipboard is written, never read.** Synapse copies text to the clipboard in exactly two places -- a redacted error string when you dismiss an error toast, and an install command in the video settings -- and never reads clipboard contents.
 
 Synapse proposes, you decide -- and that holds for the network too: nothing is requested until you ask for it.
+
+For the reviewer-facing counterpart to this section -- the desktop-only Node usage declaration, the wontfix rationale for the `node-loader` require pattern and the `:has()` toast selectors, and the rebuttals for the automated review's false positives -- see [`docs/automated-review-notes.md`](docs/automated-review-notes.md).
 
 ## FAQ
 

--- a/docs/automated-review-notes.md
+++ b/docs/automated-review-notes.md
@@ -1,0 +1,135 @@
+# Automated plugin-review notes
+
+Reviewer-facing companion to [`audit-community-guidelines.md`](./audit-community-guidelines.md).
+That file maps Synapse to Obsidian's *written* guidelines; this file triages the
+**automated** lint/behavior review that runs on every GitHub release, and collects
+the justifications a community-directory reviewer (#389) most commonly asks for.
+
+Every finding falls into one of four buckets: **fix**, **document-as-intended**,
+**rebut (false positive)**, or **artifact of untyped analysis**. In-code comments
+are the source of truth for the design decisions below — this file links to them
+rather than restating them.
+
+---
+
+## 1. Declared desktop-only Node usage
+
+Synapse ships `isDesktopOnly: false` (`manifest.json`) so the bundle must load on
+Obsidian mobile, yet the transcription pipeline needs privileged desktop access to
+drive `yt-dlp` / `ffmpeg` / `ffprobe`. Every Node builtin is reached through one
+sanctioned layer — `src/shared/node-loader.ts` — never a top-level import:
+
+- **Lazy, function-body-only builtin access.** `loadNodeModules()`
+  (`src/shared/node-loader.ts:65`) resolves `os` / `path` / `fs` /
+  `child_process` inside the function body, behind `assertDesktop()`
+  (`src/shared/node-loader.ts:45`, `Platform.isDesktop`). A top-level import would
+  evaluate at module load and crash on mobile before any guard could run. The
+  `scripts/check-top-level-requires.mjs` CI gate enforces that no such top-level
+  access re-enters, and esbuild marks the builtins `external`.
+
+- **Temp-file filesystem I/O, cleaned up in `finally`.** All scratch media
+  (downloaded video, extracted/clipped/combined audio, probe inputs) is written
+  under `os.tmpdir()` only — never inside the vault — and removed on both success
+  and failure. See the temp paths at `src/video/audio-extractor.ts:174` and the
+  cleanup at `src/audio/index.ts:464` (`finally { … fs.promises.unlink … }`) and
+  `src/transcription/duration-detector.ts:107`. All *vault* file access elsewhere
+  goes through the Obsidian Vault API.
+
+- **Subprocess execution is `execFile`-only.** Tools are spawned with `execFile`
+  and an explicit **argument array** (`src/video/audio-extractor.ts:436`,
+  `src/transcription/duration-detector.ts:94` and `:145`) — never a shell command
+  string, and never `shell: true`. There is no shell interpolation of URLs, paths,
+  or titles. URLs and paths are sanitized first via `sanitizeUrl`
+  (`src/shared/validation.ts:10`) / `sanitizePath` (`src/shared/validation.ts:50`),
+  and the binaries that run are exactly the `yt-dlp path` / `ffmpeg path` set in
+  settings.
+
+- **Narrowed subprocess environment.** `shellEnv()`
+  (`src/shared/node-loader.ts:96`) builds an **allowlist** — an augmented `PATH`,
+  plus `HOME`, `TMPDIR`, and proxy vars only when present — and deliberately does
+  **not** spread `process.env` into the child. Subprocesses inherit only what they
+  need to locate and run the tools (and to work behind a corporate proxy).
+
+- **Clipboard is write-only.** Synapse never *reads* the clipboard. The only
+  clipboard calls are `navigator.clipboard.writeText`: copying a redacted error
+  string on error-toast dismiss (`src/shared/notifications.ts:505`) and copying an
+  install command from the video settings (`src/video/settings-section.ts:70`).
+
+- **No system-identity reads.** No `os.hostname()`, `os.userInfo()`, or
+  `os.networkInterfaces()` anywhere in `src`; the only `os.*` call is
+  `os.tmpdir()`. (See the rebuttal in §3.)
+
+The user-facing summary of this access lives in the README "Privacy and network
+use" section; this list is the reviewer-facing counterpart.
+
+---
+
+## 2. Documented-as-intended (wontfix)
+
+- **`require()` of `os` / `path` / `fs` / `child_process`
+  (`src/shared/node-loader.ts:72`–`75`).** This *is* the mobile-safety design, not
+  an oversight: lazy, function-body-only, `assertDesktop()`-gated, and CI-enforced
+  by `scripts/check-top-level-requires.mjs`. Converting to top-level ESM imports
+  would crash the mobile bundle. Rationale in full at the file header
+  (`src/shared/node-loader.ts:1`–`17`) and the inline disable justification at
+  `:67`.
+
+- **`:has()` CSS selectors (`styles.css:502`–`519`, `:588`–`592`).** Obsidian
+  places the plugin's `synapse-notice*` classes on the **inner** `.notice-message`
+  element, not the outer `.notice` (mechanism from #361). Each toast rule therefore
+  needs a `.notice:has(.synapse-notice…)` branch to style the real `.notice`
+  container at (0,2,0) specificity — beating core padding/background without
+  `!important`. The selectors scope to a handful of `.notice` elements, not a broad
+  document match, so the invalidation cost is negligible. Removing them regresses
+  toast styling. Rationale in full at `styles.css:490`–`501`.
+
+---
+
+## 3. Rebuttals (false positives)
+
+- **"Reads system identity information (hostname, user info, environment
+  variables)."** Verifiable by grep: `src` contains no `os.hostname()`,
+  `os.userInfo()`, or `os.networkInterfaces()` call. The sole `os.*` usage is
+  `os.tmpdir()` (temp scratch paths). Every `hostname` occurrence in `src` is
+  `URL.hostname` — localhost/loopback checks for AI endpoints (e.g.
+  `src/shared/ai-client.ts:552`, `src/shared/provider-metadata.ts:65`) and platform
+  host matching, not machine identity. Environment access is the narrowed
+  `shellEnv()` allowlist (§1), never a bulk `process.env` read for fingerprinting.
+
+- **`globalThis` warnings.** All `globalThis` usage in `src` is confined to
+  `src/__test-utils__/setup.ts` (vitest scaffolding that mirrors Obsidian's
+  window-scoped globals for the Node test environment) and to `*.test.ts` files.
+  None of it is shipped: the esbuild entry point is `src/main.ts`
+  (`esbuild.config.mjs`), which never imports test infrastructure, and the repo's
+  own `obsidianmd/*` lint scope explicitly ignores `**/*.test.ts` and
+  `src/__test-utils__/**` (`eslint.config.mjs`). Shipped code uses `window` /
+  `activeWindow` throughout.
+
+---
+
+## 4. `no-unsafe-*` cascade — artifact of untyped analysis
+
+The bulk of the source-code review (all `@typescript-eslint/no-unsafe-assignment`
+/ `-call` / `-member-access` / `-argument` / `-return`, the "unnecessary
+assertion" hits in `node-loader.ts`, and "`error` type acts as `any`") does **not**
+reproduce under type-aware analysis. `npm run lint` — the repo's own type-aware
+config (`eslint.config.mjs`, `projectService` + `tsconfigRootDir`) with the entire
+`no-unsafe-*` family already at `error` (#296/#321) — exits **0** on `main`.
+
+The findings appear only when the review harness analyzes without the repo's type
+information: Node builtin handles from `require()` then resolve to TypeScript's
+intrinsic `error` type and cascade `any`-unsafety through every downstream consumer
+of `node-loader` / ffmpeg / yt-dlp output. Under type-aware analysis those same
+expressions are fully typed (e.g. the `as typeof import('os')` handles in
+`node-loader.ts`, `asYtDlpDumpJson()` in `src/video/audio-extractor.ts`, and the
+`isRecord` / `parseJson` guards in `src/shared/json-utils.ts`).
+
+A reproduction of the harness (the full `eslint-plugin-obsidianmd` recommended
+preset, including its bundled `typescript-eslint` type-checked layer, run once with
+and once without the repo's type info) and the per-rule enumeration is recorded in
+the issue-comment triage on #454. Bottom line: after excluding untyped-analysis
+artifacts (all `no-unsafe-*`), test-only findings (`globalThis`), and the one
+genuine fix (`querySelectorAll` → Obsidian's typed `findAll`, `src/summarize/index.ts`),
+the only review findings that survive a correctly-scoped, type-aware pass of
+shipped code are the intentional builtin `require()`s at `src/shared/node-loader.ts:72`–`75`
+documented in §2.

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -206,6 +206,25 @@ function createStubEl(tag = 'div'): StubEl {
 			return true;
 		},
 		closest: vi.fn().mockReturnValue(null),
+		/**
+		 * Obsidian's `HTMLElement.findAll` augmentation, absent from jsdom-less
+		 * vitest. Minimal recursive matcher over the tracked `children` tree
+		 * supporting the selector shapes shipped code uses: a single class
+		 * (`.foo`) or a tag name (`div`). Returns a real array so callers can
+		 * `.find()`/`.map()` on it as they would in Obsidian.
+		 */
+		findAll: (selector: string): StubEl[] => {
+			const matches = (node: StubEl): boolean =>
+				selector.startsWith('.')
+					? node.classList.contains(selector.slice(1))
+					: node.tagName === selector.toUpperCase();
+			const walk = (nodes: StubEl[]): StubEl[] =>
+				nodes.flatMap((n) => [
+					...(matches(n) ? [n] : []),
+					...walk((n.children as unknown as StubEl[]) ?? []),
+				]);
+			return walk(children);
+		},
 		style: {},
 	} as unknown as StubEl;
 	return el;

--- a/src/summarize/index.ts
+++ b/src/summarize/index.ts
@@ -863,14 +863,16 @@ export class SummarizeModule {
 			: undefined;
 
 		// Best-effort scroll of the Video section into view once the tab paints.
-		// The section is already expanded above, so this is pure polish; guard for
-		// the test environment where containerEl has no querySelectorAll.
+		// The section is already expanded above, so this is pure polish. `findAll`
+		// is an Obsidian HTMLElement augmentation returning a typed array (no
+		// `Array.from` needed); feature-detect it so the vitest environment — where
+		// containerEl only gains `findAll` via the obsidian mock — no-ops cleanly.
 		const containerEl = tab?.containerEl;
-		if (containerEl && typeof containerEl.querySelectorAll === 'function') {
+		if (containerEl && typeof containerEl.findAll === 'function') {
 			window.setTimeout(() => {
-				const title = Array.from(
-					containerEl.querySelectorAll<HTMLElement>('.synapse-accordion-title'),
-				).find((el) => el.textContent === 'Video transcription');
+				const title = containerEl
+					.findAll('.synapse-accordion-title')
+					.find((el) => el.textContent === 'Video transcription');
 				title?.closest('.synapse-accordion')?.scrollIntoView({ block: 'start' });
 			}, 0);
 		}

--- a/src/summarize/video-dependency-notice.test.ts
+++ b/src/summarize/video-dependency-notice.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { SummarizeModule, TranscribeUrlFn } from './index';
 import { CommandRegistrar } from '../commands';
 import { DEFAULT_SETTINGS } from '../settings';
-import { TFile } from '../__mocks__/obsidian';
+import { TFile, createEl } from '../__mocks__/obsidian';
 import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
 import type { Plugin } from 'obsidian';
 import type { NotificationManager, CheckpointManager } from '../shared';
@@ -234,6 +234,36 @@ describe('SummarizeModule video-dependency onboarding (#382)', () => {
 		// Video accordion expanded + persisted so the tab renders it open.
 		expect(settings.ui.collapsedSections['video']).toBe(false);
 		expect(saveSettings).toHaveBeenCalled();
+	});
+
+	it('scrolls the expanded Video section into view once the settings tab paints', async () => {
+		// Build a stub settings-tab container holding the Video accordion so the
+		// reveal path's `containerEl.findAll('.synapse-accordion-title')` resolves
+		// to it. `findAll` is an Obsidian HTMLElement augmentation supplied only by
+		// the obsidian mock — this is the test that exercises that changed path.
+		const scrollIntoView = vi.fn();
+		const container = createEl('div');
+		const accordion = container.createDiv({ cls: 'synapse-accordion' });
+		const title = accordion.createEl('div', {
+			cls: 'synapse-accordion-title',
+			text: 'Video transcription',
+		});
+		accordion.scrollIntoView = scrollIntoView;
+		(title.closest as unknown as Mock).mockReturnValue(accordion);
+		openTabById.mockReturnValue({ containerEl: container });
+
+		module = build(vi.fn().mockRejectedValue(
+			depError('yt-dlp', 'yt-dlp not found — install it or set the full path in settings')
+		));
+
+		await runSummarize();
+
+		const action = notifications.info.mock.calls.find((c) => c[2] !== undefined)![2] as NoticeAction;
+		action.onClick();
+		// The scroll is deferred to a macrotask (window.setTimeout(…, 0)); flush it.
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start' });
 	});
 
 	it('the action degrades to a no-op when the undocumented app.setting API is absent', async () => {


### PR DESCRIPTION
Triages the v1.0.11 Obsidian automated plugin-review dump into four buckets, fixes the one genuinely actionable item, and documents the rest for the pending community-directory submission (#389).

## Triage buckets

1. **Artifact of untyped analysis — verified resolved.** All `@typescript-eslint/no-unsafe-*` (415), the `no-unnecessary-type-assertion` hits in `node-loader.ts` (6), and "`error` type acts as `any`" reproduce **only** without the repo's type info. `npm run lint` (type-aware, `no-unsafe-*` at `error` via #296/#321) exits 0 on this branch. Full harness reproduction + per-rule enumeration: [issue comment](https://github.com/dustinkeeton/obsidian-synapse/issues/454#issuecomment-4879224720).

2. **Intentional / load-bearing — documented, not changed.** The `require()` of `os`/`path`/`fs`/`child_process` at `src/shared/node-loader.ts:72–75` (the `assertDesktop()`-gated, CI-guarded desktop-only Node layer) and the `:has()` toast selectors in `styles.css` (Obsidian puts plugin classes on the inner `.notice-message` — #361). Rationale lives in the existing in-code comments; the docs reference them.

3. **False positive — rebutted.** "Reads system identity" (no `os.hostname()`/`os.userInfo()`/`os.networkInterfaces()` in `src`; only `os.tmpdir()`; every `hostname` hit is `URL.hostname`) and the `globalThis` warnings (test-only `src/__test-utils__/setup.ts` + `*.test.ts`, never bundled — esbuild entry is `src/main.ts`, and the `obsidianmd/*` gate ignores test infra). Each claim grep-verified.

4. **Genuinely actionable — fixed here.** `src/summarize/index.ts` deprecated `querySelectorAll` + `Array.from().find()` → Obsidian's typed `containerEl.findAll()`, feature-detected so the vitest env no-ops. Added a recursive `findAll` stub to the obsidian mock and a test that exercises the scroll-reveal path.

## Changes

- `src/summarize/index.ts` — `findAll` replaces `querySelectorAll`.
- `src/__mocks__/obsidian.ts` — `findAll` stub on the DOM stub element.
- `src/summarize/video-dependency-notice.test.ts` — covers the reveal/scroll path (6 tests, all green).
- `docs/automated-review-notes.md` — reviewer-facing declaration (desktop-only Node usage: temp-file fs under `os.tmpdir` with `finally` cleanup, `execFile`-only subprocesses with arg arrays + sanitized args, the `shellEnv()` env allowlist, write-only clipboard), plus the wontfix rationale and false-positive rebuttals, reusable for #389.
- `README.md` — declares the clipboard is write-only; links the reviewer doc.

## Verification (full CI guard set, all pass)

`node scripts/check-top-level-requires.mjs` · `node scripts/version-bump.mjs --check` · `npm run lint` · `npx tsc --noEmit --skipLibCheck` · `npm test` (1872 passed) · `node esbuild.config.mjs production`. `package.json` / `package-lock.json` untouched; `CHANGELOG.md` untouched.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
