### PR TITLE
feat: mobile URL transcription via caption-first tier routing

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,23 @@ Decisions listed in reverse chronological order.
 
 ---
 
+## 2026-07-14: URL transcription ships as a transcript-level strategy router, not #180's MediaExtractor (#184/#112/#455)
+
+**Context**: Mobile video transcription (Android-first) finally lands. The 2026-03-19 "revised hybrid" entry below sketched a caption-first tier cascade but was never built; issue #180 proposed abstracting extraction behind a `MediaExtractor` interface whose unit of exchange is *extracted audio*. The caption tier, however, never produces audio — it goes straight from URL to transcript — so an audio-returning interface cannot host it.
+
+**Decision**: Introduce `UrlTranscriptionRouter` + `UrlTranscriptionStrategy` (`src/transcription/url-transcription.ts`), whose unit of exchange is a **transcript** (`UrlTranscript`). Tier 1 `CaptionStrategy` fetches YouTube captions over HTTP (`youtube-captions.ts`: watch-page parse, Innertube ANDROID fallback, json3 cleanup) and post-processes them through `AudioModule.processTranscriptText` — the same pipeline (and lyrics-schema callouts) as audio transcriptions. Tier 2 `LocalExtractionStrategy` wraps the existing desktop `VideoModule.processUrl` via an injected callback. Contract: `canHandle` is a cheap gate; `transcribe` returns `null` to fall through (captionless video) and **throws only on real failures** so `DependencyMissingError` keeps its #382 onboarding UX; exhaustion throws a platform-aware `NoTranscriptionPathError`. The router serves summarize, the unified modal (via `insertUrlTranscript`), and the intake media-URL branch (#112) — which now also runs the full pipeline and, on failure, leaves the note **un-stamped so a synced desktop vault retries it** (the honest mobile-TikTok story until the #181 server extractor exists). Companion decisions: `video.captionsFirst` (default on — captioned YouTube no longer auto-downloads on desktop; the toggle restores it) and opt-in `intake.adoptSharedCaptures` (#455) which adopts root-level bare-URL creations into the intake folder for share-sheet captures.
+
+**Alternatives considered**:
+- **Implement #180's `MediaExtractor` as specced** — rejected; the caption tier has no audio to return, and the phase-2 `ServerExtractionStrategy` (#181) slots into the transcript-level seam as just a third array element.
+- **Deepgram URL input for mobile (#112 as written)** — rejected as unworkable; Deepgram's `/v1/listen` URL mode needs a *direct media file URL*, not a YouTube/TikTok page URL.
+- **Silent notice (status quo stub) on mobile misses** — rejected; an un-stamped note plus an explanatory error makes the desktop-sync handoff a designed behavior instead of an accident.
+
+**Rationale**: The lightest seam that hosts today's two tiers and Phase 2's server tier without rework, keeps the module-boundary rule (strategies reach feature modules through injected callbacks), and reuses the existing post-processing, callout, exclusion, and onboarding machinery instead of duplicating any of it.
+
+**Impact**: New `src/transcription/{url-transcription,youtube-captions,caption-strategy,local-extraction-strategy,insert-url-transcript}.ts` (+ tests); `AudioModule.processTranscriptText`; `main.ts` wiring (summarize callback, intake branch, modal, ribbon/command ungating); `video.captionsFirst` + mobile-aware video settings; `intake.adoptSharedCaptures` + root-create adoption; docs. Supersedes the #112 stub. #180 closes as superseded by this seam.
+
+---
+
 ## 2026-07-03: The console-sink redaction contract is now lint-enforced (`synapse/no-unredacted-console`, #418)
 
 **Context**: Three successive audit passes (2026-06-25, 2026-06-29, 2026-07-02) each found and patched console sinks that logged unredacted values — the contract "every error console sink routes through `redactError`/`redactSecrets`" was held only by convention, and nothing stopped a new `console.error('…', err)` from silently reopening the hole. The sinks listed in #418 were already fixed by the 2026-07-02 pass; the remaining deliverable was an enforcement guard.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Scans your vault for stub notes (short content, TODO markers, empty sections) an
 ### Audio Transcription
 Transcribes audio files embedded in your notes using OpenAI Whisper API, Deepgram, or a local Whisper installation. Includes AI post-processing to remove filler words, add structure, and extract key points.
 
-### Video Transcription (desktop only)
-Downloads and transcribes YouTube and TikTok videos using yt-dlp and ffmpeg. Extracts the audio track and feeds it through the audio transcription pipeline. Not available on mobile.
+### Video Transcription
+Transcribes YouTube, TikTok, and Instagram videos. YouTube videos are transcribed caption-first: the caption track is fetched over plain HTTP -- free, near-instant, no external tools -- and works **on mobile** as well as desktop. Videos without captions, plus TikTok and Instagram, fall back to the desktop pipeline, which downloads the video with yt-dlp, extracts the audio with ffmpeg, and feeds it through the audio transcription pipeline. Share a video link into the intake folder on your phone and a synced desktop vault will even finish the ones mobile can't (see [docs/intake-folder.md](docs/intake-folder.md)).
 
 ### Enrichment
 Analyzes note content to suggest metadata tags (from a configurable vocabulary), internal links to related notes, topic links, and external references. Uses proximity-weighted scoring to find the most relevant connections in your vault. Runs automatically after elaboration, transcription, or summarization when configured.
@@ -137,14 +137,16 @@ These are the only services Synapse contacts, what each one is used for, and wha
 | Deepgram -- `api.deepgram.com` | Audio transcription | The audio you transcribe | API key required |
 | Twitter / X -- `publish.twitter.com` (fxtwitter, vxtwitter as fallbacks) | Tweet context during enrichment and summarize | The tweet URL found in your note | None |
 | Web pages -- any `http(s)` URL in your notes | Article context during elaboration, enrichment, and summarize | A request to that URL, to read the page | None |
-| YouTube / TikTok and others -- via `yt-dlp` (desktop) | Video transcription | The video URL you transcribe | None |
+| YouTube -- `www.youtube.com` | Caption-first video transcription | The video ID of the YouTube URL you transcribe, to fetch its caption track | None |
+| YouTube / TikTok and others -- via `yt-dlp` (desktop) | Video transcription (extraction fallback) | The video URL you transcribe | None |
 
 ### What this means for you
 
 - **Cloud AI and transcription require an account.** OpenAI, Anthropic, Google Gemini, and Deepgram each need an API key you supply in **Settings > Synapse**. The note content or audio you act on is sent to the one provider you selected so it can do the work, and to no one else.
 - **Two paths stay offline.** Selected as your AI provider, **Ollama** sends note content only to the local endpoint you set (default `http://localhost:11434`) -- no account, no key, nothing leaving your machine. For transcription, the **local Whisper** option is designed to run entirely on-device for the same reason. Use these if you want Synapse to work without sending anything out.
 - **Content you link is fetched from third-party sites.** When a note references a tweet or a web page and you run elaboration, enrichment, or summarize, Synapse requests that URL to read its content -- from Twitter/X (falling back to the fxtwitter and vxtwitter mirrors) or from the site itself. To avoid this, don't run those features on notes whose links you would rather not request, or turn the feature off in settings.
-- **Video transcription downloads the video.** On desktop, video transcription invokes `yt-dlp` to download the source from YouTube, TikTok, or another platform, then extracts and transcribes the audio locally.
+- **YouTube captions are fetched over plain HTTP.** Caption-first transcription requests the video's public watch page and caption track from `www.youtube.com` (no account, no download). Only when captions are unavailable — or for other platforms — does the flow fall to the desktop extraction pipeline below.
+- **Video transcription downloads the video (extraction fallback).** On desktop, the fallback invokes `yt-dlp` to download the source from YouTube, TikTok, or another platform, then extracts and transcribes the audio locally.
 - **Audio and video transcription use privileged desktop access.** To work with `yt-dlp`, `ffmpeg`, and `ffprobe`, the desktop build reaches outside the vault in two ways, both gated to desktop only (mobile never runs this code):
   - **Direct filesystem access.** Synapse writes scratch files -- downloaded media, extracted audio, clipped or concatenated segments -- to your operating system's temp directory (`os.tmpdir()`), never inside your vault. These temp files are removed when the operation finishes, on both success and failure. The finished video, if you opt to keep it, is the only artifact saved into the vault (in your configured download folder).
   - **Local shell execution.** Synapse runs the external tools as child processes with `execFile` and an explicit argument array -- never a shell command string -- so there is no shell interpolation of URLs, paths, or titles. URLs and file paths are sanitized first (`sanitizeUrl` / `sanitizePath`), the subprocess inherits a narrowed environment (essentially just an augmented `PATH` plus `HOME`), and the binaries that run are exactly the `yt-dlp path` and `ffmpeg path` you set in settings.
@@ -278,15 +280,16 @@ way (see DECISIONS.md).
 | Post-processing | Clean up transcriptions with AI | On |
 | Remove filler words | Strip filler words from transcripts | On |
 
-### Video Transcription (desktop only)
+### Video Transcription
 
 | Setting | Description | Default |
 |---------|-------------|---------|
 | Enable video | Toggle video transcription | On |
-| yt-dlp path | Path to yt-dlp binary | `yt-dlp` |
-| ffmpeg path | Path to ffmpeg binary | `ffmpeg` |
-| Download folder | Where to save downloaded video files | `Media` |
-| Embed in note | Add an embed link to the downloaded video | On |
+| Prefer YouTube captions | Transcribe YouTube from its captions when available (free, works on mobile); off = always download + transcribe | On |
+| yt-dlp path (desktop) | Path to yt-dlp binary | `yt-dlp` |
+| ffmpeg path (desktop) | Path to ffmpeg binary | `ffmpeg` |
+| Download folder (desktop) | Where to save downloaded video files | `Media` |
+| Embed in note (desktop) | Add an embed link to the downloaded video | On |
 
 ### Enrichment
 

--- a/docs/intake-folder.md
+++ b/docs/intake-folder.md
@@ -32,10 +32,18 @@ Synapse picks it up and processes it automatically.
 The shared note only gets processed if it ends up *inside* the intake folder. Use whichever of these fits your setup:
 
 - **(a) Set a default location.** In Obsidian: **Settings → Files & Links → Default location for new notes** → point it at your intake folder (e.g. `Inbox`). Every new/shared note then lands there automatically -- the smoothest option.
-- **(b) Pick the folder in the share dialog**, where Obsidian's share UI lets you choose a destination.
-- **(c) Move the note** into the intake folder after it's created; the move is detected just like a fresh note.
+- **(b) Turn on "Adopt shared captures"** (Settings → Synapse → Intake folder). Synapse then also watches newly created notes at the vault *root* -- where shares land when your default new-note location is the vault root -- and moves any note that is just a single video/audio/article link into the intake folder for you. Off by default because it relocates root notes.
+- **(c) Pick the folder in the share dialog**, where Obsidian's share UI lets you choose a destination.
+- **(d) Move the note** into the intake folder after it's created; the move is detected just like a fresh note.
 
-> Tip: Option (a) makes mobile capture truly one-tap -- Share → Obsidian, done.
+> Tip: Option (a) makes mobile capture truly one-tap -- Share → Obsidian, done. Option (b) is for when you want new notes to keep landing somewhere else by default.
+
+### Sharing a video (YouTube, TikTok...)
+
+Share a video link into the intake folder and Synapse transcribes it:
+
+- **YouTube** links are transcribed from the video's captions -- free, fast, and it works **on mobile** too.
+- **TikTok / Instagram / caption-less YouTube** need the desktop app (yt-dlp + ffmpeg). Captured on your phone in a synced vault? No problem: the note stays un-stamped in the intake folder, and your desktop vault's watcher picks it up and finishes the transcription next time it sees the note change.
 
 ---
 
@@ -58,6 +66,7 @@ All settings live under **Settings → Synapse → Intake Folder** (see issue #1
 |---------|------|---------|--------------|
 | **Enable intake processing** | toggle | on | Master switch. When off, the folder is not watched and nothing is auto-processed. |
 | **Intake folder** | text | `Inbox` | The folder Synapse watches. Notes here (and in its subfolders) are processed; everything else is ignored. Leaving it blank watches *nothing* -- Synapse never falls back to scanning the whole vault. |
+| **Adopt shared captures** | toggle | off | Also watch newly *created* notes at the vault root and move any whose body is a single video/audio/article link into the intake folder (#455). Catches mobile share-sheet captures when the default new-note location isn't the intake folder. |
 | **Mark processed in frontmatter** | toggle | on | Stamps `synapse-processed: true` on each note after handling so it is never reprocessed. See [Idempotency](#idempotency). |
 | **Move when done (optional)** | text | *(blank)* | Destination folder to move a note into after processing. Blank = leave it where it is. The folder is created if it doesn't exist, and inbound links are preserved on the move. |
 
@@ -73,8 +82,9 @@ If the note body is essentially a single URL (the URL, modulo surrounding whites
 
 | URL type | Examples | What Synapse does |
 |----------|----------|-------------------|
-| **Video / audio** | YouTube, TikTok, Spotify, Apple Podcasts, SoundCloud, podcast RSS feeds | **Not yet available.** Synapse shows a "coming soon" notice and leaves the note for you. See [Current limitation](#current-limitation-video--audio) below. |
-| **Article** | Medium, Substack, Wikipedia, or any other web page | Fetches the readable article content into the note, then runs **Elaboration** on the now-fleshed-out note. |
+| **Video** | YouTube, TikTok, Instagram | Transcribes the video and appends the transcript, then runs the full pipeline on the note. YouTube goes caption-first (all platforms, including mobile); TikTok/Instagram and caption-less videos use the desktop yt-dlp pipeline. See [Video / audio URLs](#video--audio-urls) below. |
+| **Audio** | Spotify, Apple Podcasts, SoundCloud | **Not yet supported** -- the note is left un-stamped with an error notice. |
+| **Article** | Medium, Substack, Wikipedia, or any other web page | Fetches the readable article content into the note, then runs the full pipeline on the now-fleshed-out note. |
 | **Unrecognized URL** | anything `sanitizeUrl` can't accept (e.g. some parenthesized Wikipedia titles) | Treated as general content (below). |
 
 ### Everything else
@@ -102,11 +112,16 @@ This means edits, re-syncs, or the move itself won't trigger a second pass. The 
 
 ---
 
-## Current Limitation: Video / Audio
+## Video / Audio URLs
 
-Routing a bare video or audio URL to real transcription is **not part of this release**. For now, a video/audio link in the intake folder produces a "coming soon" notice and the note is left in place. Full URL-to-transcription routing is tracked in **#112**.
+A bare **video URL** in the intake folder is transcribed through tiered routing (#112/#184):
 
-Article links and general text/idea notes are fully supported today.
+1. **YouTube captions** (all platforms, including mobile) -- the video's caption track is fetched over HTTP, cleaned, and post-processed. Free and near-instant. Controlled by the **Prefer YouTube captions** toggle in the Video transcription settings.
+2. **Local extraction** (desktop only) -- the existing yt-dlp + ffmpeg pipeline downloads the video and transcribes its audio. Covers TikTok, Instagram, and YouTube videos without captions.
+
+When neither tier applies -- e.g. a TikTok link captured **on mobile** -- the note gets an error notice and stays **un-stamped** in the intake folder. In a synced vault this is a feature: the desktop app's intake watcher retries the note when the vault syncs, so phone-captured TikToks are transcribed by your desktop. A future self-hosted extractor service (#181) will close this gap for mobile-only setups.
+
+Bare **audio URLs** (Spotify, podcasts) are not transcribable yet -- no tier handles them, so they behave like the mobile-TikTok case above.
 
 ---
 

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -94,6 +94,31 @@ export class AudioModule {
 	}
 
 	/**
+	 * Run an already-textual transcript through the same post-processing
+	 * pipeline as {@link transcribe} (sanitize → cleanup → optional schema
+	 * reformat, #234), without needing audio bytes. Used by the caption tier of
+	 * URL transcription (#184) so caption-sourced transcripts get identical
+	 * treatment — and identical callout types — to extraction-sourced ones.
+	 * Post-processing failures propagate, mirroring {@link transcribe}; callers
+	 * that prefer degrading to the raw text catch and fall back themselves.
+	 */
+	async processTranscriptText(
+		raw: string
+	): Promise<{ text: string; reformatted?: boolean; schemaId?: string }> {
+		const result: TranscriptionResult = {
+			raw: sanitizeAIResponse(raw),
+			sourceName: '',
+		};
+		result.processed = await this.postProcessor.process(result.raw);
+		await this.maybeReformatBySchema(result);
+		return {
+			text: result.processed || result.raw,
+			reformatted: result.reformatted,
+			schemaId: result.schemaId,
+		};
+	}
+
+	/**
 	 * Content-schema reformat (#234): if a transcription-stage schema (e.g.
 	 * lyrics) matches and auto-formatting is enabled, reformat the transcript in
 	 * place — preserving it rather than condensing it. The reformatted text is

--- a/src/audio/process-transcript-text.test.ts
+++ b/src/audio/process-transcript-text.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The post-processor is mocked at the module boundary (same pattern as
+// lyrics-reformat.test.ts); schema reformat stays inert because the text
+// below never matches the lyrics schema.
+vi.mock('./post-processor', () => ({
+	PostProcessor: class {
+		process = vi.fn(async (t: string) => (t.includes('fail') ? Promise.reject(new Error('no AI key')) : `cleaned: ${t}`));
+	},
+}));
+
+import { AudioModule } from './index';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+function makeModule(): AudioModule {
+	return new AudioModule(
+		{} as never,
+		() => ({ audio: { autoFormatLyrics: false, transcriptionProvider: 'whisper-api' } }) as never,
+		{ info: vi.fn() } as never,
+		createMockCheckpointManager() as never,
+		undefined
+	);
+}
+
+describe('AudioModule.processTranscriptText (#184)', () => {
+	it('runs a transcript string through the post-processing pipeline', async () => {
+		const result = await makeModule().processTranscriptText('caption text');
+		expect(result.text).toBe('cleaned: caption text');
+		expect(result.reformatted).toBeUndefined();
+	});
+
+	it('propagates post-processing failures (callers choose the fallback)', async () => {
+		await expect(makeModule().processTranscriptText('this will fail')).rejects.toThrow('no AI key');
+	});
+});

--- a/src/intake/index.ts
+++ b/src/intake/index.ts
@@ -3,6 +3,7 @@ import type { TAbstractFile } from 'obsidian';
 import { SynapseSettings } from '../settings';
 import {
 	NotificationManager,
+	classifyUrl,
 	ensureFolder,
 	fetchArticleContent,
 	isPathExcluded,
@@ -83,10 +84,10 @@ export class IntakeModule {
 		}
 
 		this.plugin.registerEvent(
-			this.plugin.app.vault.on('create', (file) => this.handleEvent(file)),
+			this.plugin.app.vault.on('create', (file) => this.handleEvent(file, 'create')),
 		);
 		this.plugin.registerEvent(
-			this.plugin.app.vault.on('modify', (file) => this.handleEvent(file)),
+			this.plugin.app.vault.on('modify', (file) => this.handleEvent(file, 'modify')),
 		);
 	}
 
@@ -103,8 +104,14 @@ export class IntakeModule {
 	 * Cheap synchronous gatekeeper run on every vault event, before any async
 	 * work. Order is deliberately cheapest-first. Anything that passes is
 	 * debounced; everything else is ignored outright.
+	 *
+	 * Two kinds of paths get through: notes inside the intake folder (create or
+	 * modify), and — when `adoptSharedCaptures` is on (#455) — newly CREATED
+	 * root-level notes, which is where Obsidian's mobile share receiver drops
+	 * captures when "Default location for new notes" is the vault root. The
+	 * flush step decides whether a root note is actually a bare-URL capture.
 	 */
-	private handleEvent(file: TAbstractFile): void {
+	private handleEvent(file: TAbstractFile, kind: 'create' | 'modify'): void {
 		if (!(file instanceof TFile) || file.extension !== 'md') {
 			return;
 		}
@@ -115,7 +122,9 @@ export class IntakeModule {
 		}
 
 		if (!this.isInIntakeFolder(file.path, settings.intakeFolder)) {
-			return;
+			if (!this.isAdoptionCandidate(file.path, kind)) {
+				return;
+			}
 		}
 
 		// Path exclusion (#307): never auto-process a watched note that an
@@ -131,6 +140,23 @@ export class IntakeModule {
 		}
 
 		this.scheduleFlush(file.path);
+	}
+
+	/**
+	 * True when a path outside the intake folder may still enter the pipeline
+	 * as a shared capture (#455): the feature is on, an intake folder is
+	 * configured to adopt INTO, the event is a `create` (never a modify — we
+	 * don't chase edits to existing root notes), and the note sits at the vault
+	 * root (no `/`). Content checks happen later in {@link maybeAdoptCapture}.
+	 */
+	private isAdoptionCandidate(path: string, kind: 'create' | 'modify'): boolean {
+		const settings = this.getSettings().intake;
+		return (
+			settings.adoptSharedCaptures === true &&
+			kind === 'create' &&
+			!path.includes('/') &&
+			settings.intakeFolder.trim().length > 0
+		);
 	}
 
 	/**
@@ -228,6 +254,13 @@ export class IntakeModule {
 			return;
 		}
 
+		// A settled path OUTSIDE the intake folder can only have been scheduled
+		// as an adoption candidate (#455): adopt-or-ignore, never process here.
+		if (!this.isInIntakeFolder(path, this.getSettings().intake.intakeFolder)) {
+			await this.maybeAdoptCapture(file);
+			return;
+		}
+
 		this.inFlight.add(path);
 		try {
 			const content = await this.plugin.app.vault.read(file);
@@ -248,6 +281,45 @@ export class IntakeModule {
 			);
 		} finally {
 			this.inFlight.delete(path);
+		}
+	}
+
+	/**
+	 * Adopt a shared capture (#455): move a settled root-level note into the
+	 * intake folder when its body is a bare, classifiable URL — the exact shape
+	 * Obsidian's mobile share receiver produces — then re-schedule it so the
+	 * normal watcher/debounce path processes it from its new home. Anything
+	 * else (prose, multiple URLs, an unclassifiable link, an already-stamped
+	 * note) is left untouched where the user created it.
+	 */
+	private async maybeAdoptCapture(file: TFile): Promise<void> {
+		const settings = this.getSettings().intake;
+		if (!settings.adoptSharedCaptures) {
+			return;
+		}
+
+		try {
+			const content = await this.plugin.app.vault.read(file);
+			const parsed = parseFrontmatter(content);
+			if (this.isProcessed(parsed.frontmatter)) {
+				return;
+			}
+
+			const url = this.dispatcher.bareUrl(parsed.body);
+			if (url === null || classifyUrl(url).type === 'unknown') {
+				return;
+			}
+
+			await this.moveNote(file, settings.intakeFolder.trim());
+			// renameFile mutates file.path in place; hand the note to the normal
+			// intake debounce from its new path (a rename fires no create/modify
+			// event, so without this the adopted note would sit unprocessed).
+			this.scheduleFlush(file.path);
+		} catch (error) {
+			this.notifications.notifyError(
+				`Could not adopt shared capture ${file.basename}`,
+				error,
+			);
 		}
 	}
 
@@ -283,12 +355,12 @@ export class IntakeModule {
 
 		switch (route.kind) {
 			case 'transcription':
-				// #112 — STUB. Surfaces a "coming soon" notice and no-ops. A
-				// content-less URL note has nothing for organize to analyse; once
-				// #112 produces a transcript this branch should also end in
-				// `await this.deps.fireOnFile(file)` so the note is enriched and
-				// organized like the others.
+				// #112/#184 — tiered URL transcription appends the transcript to
+				// the note (throws when no tier can handle it, leaving the note
+				// un-stamped/retriable), then the full pipeline enriches and
+				// organizes the now-content-bearing note like the article branch.
 				await this.deps.transcribeUrlToNote(route.url, route.mediaType, file);
+				await this.deps.fireOnFile(file);
 				break;
 
 			case 'article': {

--- a/src/intake/intake-dispatcher.ts
+++ b/src/intake/intake-dispatcher.ts
@@ -51,8 +51,11 @@ export class IntakeDispatcher {
 	 * whitespace remains (i.e. the body IS the URL modulo trailing/leading
 	 * whitespace). Returns null otherwise — including when there are zero or
 	 * multiple URLs, or the URL is surrounded by other prose.
+	 *
+	 * Public because the adopt-shared-captures flow (#455) reuses the exact
+	 * same "is this note just a captured link?" test on root-level notes.
 	 */
-	private bareUrl(body: string): string | null {
+	bareUrl(body: string): string | null {
 		const urls = extractUrls(body);
 		if (urls.length !== 1) {
 			return null;

--- a/src/intake/intake-module.test.ts
+++ b/src/intake/intake-module.test.ts
@@ -433,7 +433,7 @@ describe('IntakeModule', () => {
 			await module.onload();
 		});
 
-		it('bare video URL → transcription stub (no fire, no fetch)', async () => {
+		it('bare video URL → transcription, then the full pipeline (#112/#184)', async () => {
 			emit('create', 'Inbox/vid.md', 'https://www.youtube.com/watch?v=abc');
 			await flushDebounce();
 			expect(deps.transcribeUrlToNote).toHaveBeenCalledWith(
@@ -441,8 +441,18 @@ describe('IntakeModule', () => {
 				'video',
 				expect.anything()
 			);
-			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			expect(deps.fireOnFile).toHaveBeenCalledTimes(1);
 			expect(fetchArticleContent).not.toHaveBeenCalled();
+			expect(store.get('Inbox/vid.md')).toContain('synapse-processed');
+		});
+
+		it('failed URL transcription leaves the note un-stamped and skips the pipeline', async () => {
+			deps.transcribeUrlToNote.mockRejectedValueOnce(new Error('no transcription path'));
+			emit('create', 'Inbox/vid.md', 'https://www.youtube.com/watch?v=abc');
+			await flushDebounce();
+			expect(deps.fireOnFile).not.toHaveBeenCalled();
+			expect(store.get('Inbox/vid.md')).not.toContain('synapse-processed');
+			expect(notifications.notifyError).toHaveBeenCalled();
 		});
 
 		it('bare audio URL → transcription stub with mediaType audio', async () => {
@@ -797,6 +807,73 @@ describe('IntakeModule', () => {
 			handlers['create'](makeFile(path)); // never seeded into store
 			await flushDebounce();
 			expect(deps.fireOnFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('adopt shared captures (#455)', () => {
+		beforeEach(async () => {
+			settings.intake.adoptSharedCaptures = true;
+			await module.onload();
+		});
+
+		it('moves a created root-level bare-URL note into the intake folder and processes it', async () => {
+			emit('create', 'shared.md', 'https://www.youtube.com/watch?v=abc');
+			// First settle adopts (move + re-schedule), second settle processes.
+			await flushDebounce();
+			expect(plugin.app.fileManager.renameFile).toHaveBeenCalled();
+			expect(store.has('shared.md')).toBe(false);
+			expect(store.has('Inbox/shared.md')).toBe(true);
+
+			await flushDebounce();
+			expect(deps.transcribeUrlToNote).toHaveBeenCalledWith(
+				'https://www.youtube.com/watch?v=abc',
+				'video',
+				expect.anything()
+			);
+		});
+
+		it('ignores root notes when the toggle is off', async () => {
+			settings.intake.adoptSharedCaptures = false;
+			emit('create', 'shared.md', 'https://www.youtube.com/watch?v=abc');
+			await flushDebounce();
+			await flushDebounce();
+			expect(store.has('shared.md')).toBe(true);
+			expect(deps.transcribeUrlToNote).not.toHaveBeenCalled();
+		});
+
+		it('ignores modify events outside the intake folder', async () => {
+			store.set('shared.md', 'https://www.youtube.com/watch?v=abc');
+			handlers['modify'](makeFile('shared.md'));
+			await flushDebounce();
+			expect(store.has('shared.md')).toBe(true);
+			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
+		});
+
+		it('ignores non-root creations outside the intake folder', async () => {
+			emit('create', 'Projects/shared.md', 'https://www.youtube.com/watch?v=abc');
+			await flushDebounce();
+			expect(store.has('Projects/shared.md')).toBe(true);
+			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
+		});
+
+		it('leaves prose and unclassifiable-URL root notes untouched', async () => {
+			emit('create', 'ideas.md', 'some prose with https://example.com inside');
+			emit('create', 'weird.md', 'ftp://example.com/file');
+			await flushDebounce();
+			expect(store.has('ideas.md')).toBe(true);
+			expect(store.has('weird.md')).toBe(true);
+			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
+		});
+
+		it('never re-adopts an already-stamped note', async () => {
+			emit(
+				'create',
+				'done.md',
+				'---\nsynapse-processed: true\n---\nhttps://www.youtube.com/watch?v=abc'
+			);
+			await flushDebounce();
+			expect(store.has('done.md')).toBe(true);
+			expect(plugin.app.fileManager.renameFile).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/intake/settings-section.ts
+++ b/src/intake/settings-section.ts
@@ -49,6 +49,24 @@ export function renderIntakeSettings(ctx: SettingsSectionContext): void {
 		);
 
 	new Setting(intakeBody)
+		.setName('Adopt shared captures')
+		.setDesc(
+			'Also watch newly created notes at the vault ROOT and move any whose ' +
+			'body is a single video/audio/article link into the intake folder. ' +
+			'Catches captures from the mobile share sheet when "Default location ' +
+			'for new notes" is not the intake folder. Off by default because it ' +
+			'relocates root notes.'
+		)
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.intake.adoptSharedCaptures)
+				.onChange(async (value) => {
+					plugin.settings.intake.adoptSharedCaptures = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	new Setting(intakeBody)
 		.setName('Mark processed in frontmatter')
 		.setDesc('Stamp `synapse-processed: true` on a note once handled so it is not reprocessed')
 		.addToggle((toggle) =>

--- a/src/intake/types.ts
+++ b/src/intake/types.ts
@@ -19,8 +19,8 @@ export const SYNAPSE_PROCESSED_AT_FLAG = 'synapse-processed-at';
 export type IntakeRoute =
 	/**
 	 * The note is essentially a single video/audio URL. Carries the URL and
-	 * which media type it is so the (stubbed, #112) transcription branch can
-	 * route it. NOT implemented yet — see IntakeDeps.transcribeUrlToNote.
+	 * which media type it is so the transcription branch (#112/#184) can route
+	 * it — see IntakeDeps.transcribeUrlToNote.
 	 */
 	| { kind: 'transcription'; url: string; mediaType: 'video' | 'audio' }
 	/**
@@ -52,8 +52,11 @@ export interface IntakeDeps {
 	 */
 	fireOnFile(file: TFile): Promise<void>;
 	/**
-	 * Transcription branch (#112) — STUB. For now this just surfaces a
-	 * "coming soon" notice and no-ops; real URL transcription is out of scope.
+	 * Transcription branch (#112/#184): transcribe a bare media URL through the
+	 * tiered URL-transcription router and append the transcript to the note.
+	 * MUST throw when transcription fails or no tier can handle the URL (e.g.
+	 * TikTok on mobile), so the note stays un-stamped and a synced desktop
+	 * vault's watcher can retry it.
 	 */
 	transcribeUrlToNote(
 		url: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,16 @@ import { SynapseRunner } from './pipeline';
 import type { PipelineModuleMap } from './pipeline';
 import { openScanFolderPicker, NotificationManager, CheckpointManager, UpdateChecker, fireAndForget, migrateSettings, readSettingsVersion, CURRENT_SETTINGS_VERSION, redactError } from './shared';
 import type { DeferredTask } from './shared';
-import { UnifiedTranscriptionModal, NoteMediaModal } from './transcription';
+import {
+	UnifiedTranscriptionModal,
+	NoteMediaModal,
+	UrlTranscriptionRouter,
+	CaptionStrategy,
+	LocalExtractionStrategy,
+	buildUrlTranscriptBlock,
+	insertUrlTranscript,
+} from './transcription';
+import type { UrlTranscriptionStrategy } from './transcription';
 import { findAudioEmbeds } from './audio';
 import { findVideoUrls } from './video';
 import { findImageEmbeds } from './image';
@@ -61,6 +70,8 @@ export default class SynapsePlugin extends Plugin {
 	private rem!: RemModule;
 	private intake!: IntakeModule;
 	private audioExtractor: AudioExtractor | undefined;
+	/** Tiered URL transcription router (#184) — built in onload, used by the unified modal. */
+	private urlTranscription!: UrlTranscriptionRouter;
 	private ffmpegAvailable: boolean | null = null;
 	private startupTimeout: number | null = null;
 	/**
@@ -125,11 +136,36 @@ export default class SynapsePlugin extends Plugin {
 		}
 		this.image = new ImageModule(this, getSettings, this.notifications, this.checkpointManager);
 		this.enrichment = new EnrichmentModule(this, getSettings, this.notifications, this.checkpointManager, registrar, () => this.settings.autoAccept.enrichment);
+
+		// URL transcription router (#184): ordered tiers behind one seam.
+		// Captions work on every platform; the yt-dlp/ffmpeg extraction tier
+		// joins only where VideoModule exists (desktop). Both tiers reach their
+		// feature modules through injected callbacks, mirroring the other
+		// cross-module callback bundles.
+		const urlStrategies: UrlTranscriptionStrategy[] = [
+			new CaptionStrategy(getSettings, (raw) => this.audio.processTranscriptText(raw)),
+		];
+		const video = this.video;
+		if (video) {
+			urlStrategies.push(new LocalExtractionStrategy((url, opts) =>
+				video.processUrl(
+					url,
+					{ insertMode: false, timeRange: opts.timeRange },
+					opts.update ? { update: opts.update } : undefined
+				)
+			));
+		}
+		const urlTranscription = new UrlTranscriptionRouter(urlStrategies);
+		this.urlTranscription = urlTranscription;
+
 		this.summarize = new SummarizeModule(
 			this, getSettings, this.notifications, this.checkpointManager, registrar,
-			this.video
-				? (url, parentOp) => this.video!.transcribeUrl(url, parentOp)
-				: async () => { throw new Error('Video transcription is not available on mobile'); },
+			async (url, parentOp) => {
+				const result = await urlTranscription.transcribe(url, {
+					update: parentOp ? (msg) => parentOp.update(msg) : undefined,
+				});
+				return result.text;
+			},
 			async (audioFile) => {
 				const data = await this.app.vault.readBinary(audioFile);
 				const result = await this.audio.transcribe(data, audioFile.name);
@@ -342,14 +378,13 @@ export default class SynapsePlugin extends Plugin {
 			fireAndForget(this.activateUnifiedView(), 'Open proposal review', { notifications: this.notifications });
 		});
 
-		// Unified transcription ribbon (desktop only — transcribe implies video
-		// support). Uses the bespoke 'synapse-transcribe' mark (#349), the same
-		// glyph the transcribe action carries, so the set stays coherent.
-		if (Platform.isDesktop) {
-			this.addRibbonIcon('synapse-transcribe', 'Transcribe media', () => {
-				this.openUnifiedModal();
-			});
-		}
+		// Unified transcription ribbon. Available on every platform since #184:
+		// mobile transcribes audio files and YouTube URLs (captions). Uses the
+		// bespoke 'synapse-transcribe' mark (#349), the same glyph the
+		// transcribe action carries, so the set stays coherent.
+		this.addRibbonIcon('synapse-transcribe', 'Transcribe media', () => {
+			this.openUnifiedModal();
+		});
 
 		// Opener for the Synapse actions sidebar (#289). Unconditional so it
 		// appears on mobile, where the command palette is hardest to reach. Uses
@@ -374,9 +409,10 @@ export default class SynapsePlugin extends Plugin {
 		// on the toggle and the once/day rate limit.
 		this.updateCheckTimeout = window.setTimeout(() => { void this.updateChecker.maybeCheck(); }, 5000);
 
-		// Unified transcription commands (audio on any platform, video on desktop only, image OCR).
-		// Always attempted so the registry audit sees them; userEnabled gates actual registration.
-		const hasTranscription = this.settings.audio.enabled || (this.settings.video.enabled && this.video) || this.settings.image.enabled;
+		// Unified transcription commands (audio + URL transcription on any
+		// platform since #184, image OCR). Always attempted so the registry
+		// audit sees them; userEnabled gates actual registration.
+		const hasTranscription = this.settings.audio.enabled || this.settings.video.enabled || this.settings.image.enabled;
 		registrar.register('transcribe-media', !!hasTranscription, {
 			callback: () => this.openUnifiedModal(),
 		});
@@ -408,13 +444,33 @@ export default class SynapsePlugin extends Plugin {
 		//   - general notes  -> run the whole pipeline on the one note
 		//   - article URLs    -> fetch+append, then the whole pipeline (#223);
 		//                        the pipeline's organize phase relocates the note
-		//   - media URLs      -> #112 transcription STUB (notice only)
+		//   - media URLs      -> tiered URL transcription (#112/#184), then the
+		//                        whole pipeline like the article branch
 		// fireOnFile runs elaboration as its first phase, so no separate
 		// elaborate-only callback is needed anymore (#223).
 		this.intake = new IntakeModule(this, getSettings, this.notifications, {
 			fireOnFile: (file) => synapseRunner.fireOnFile(file),
-			transcribeUrlToNote: async (_url, _mediaType, _file) => {
-				this.notifications.info('URL transcription from intake is coming soon (#112)');
+			transcribeUrlToNote: async (url, _mediaType, file) => {
+				const op = this.notifications.startOperation(
+					'Transcribing shared URL...',
+					`intake-url-${file.path}`
+				);
+				try {
+					const result = await urlTranscription.transcribe(url, {
+						update: (msg) => op.update(msg),
+					});
+					const block = buildUrlTranscriptBlock(
+						result, url, this.settings.video.embedInNote
+					);
+					await this.app.vault.process(file, (data) => data + block);
+					op.finish('Transcript added');
+				} catch (error) {
+					const msg = error instanceof Error ? error.message : String(error);
+					op.error(`URL transcription failed -- ${msg}`);
+					// Rethrow so intake leaves the note un-stamped/retriable — in a
+					// synced vault a mobile failure is finished by the desktop watcher.
+					throw error;
+				}
 			},
 		});
 		if (this.settings.intake.enabled) {
@@ -536,13 +592,25 @@ export default class SynapsePlugin extends Plugin {
 			() => this.settings,
 			{
 				audio: this.settings.audio.enabled,
-				video: this.settings.video.enabled && this.video !== null,
+				video: this.settings.video.enabled,
 			},
 			{
 				onTranscribeFile: (file, timeRange) => this.audio.transcribeFileToActiveNote(file, timeRange),
-				onTranscribeUrl: this.video
-					? (url, timeRange) => this.video!.transcribeUrlToActiveNote(url, timeRange)
-					: async () => { /* unreachable: video hidden on mobile */ },
+				// Tier-routed on every platform (#184). A time range forces the
+				// extraction tier, so desktop clipping behaves exactly as before.
+				// Completion reuses the audio module's post-transcription hook
+				// (enrichment + title check) — same kind, same wiring blocks.
+				onTranscribeUrl: (url, timeRange) => insertUrlTranscript(
+					{
+						app: this.app,
+						getSettings: () => this.settings,
+						notifications: this.notifications,
+						router: this.urlTranscription,
+						onComplete: (filePath) => this.audio.onTranscriptionComplete?.(filePath),
+					},
+					url,
+					timeRange
+				),
 			},
 			this.notifications
 		).open();

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,4 +1,4 @@
-import { App, Platform, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, Setting } from 'obsidian';
 import type { ButtonComponent } from 'obsidian';
 import type SynapsePlugin from './main';
 import { MODEL_OPTIONS } from './settings';
@@ -97,18 +97,17 @@ const FEATURE_LABELS: Record<FeatureId, string> = {
 const FEATURE_ORDER = Object.keys(ALL_FEATURE_IDS) as FeatureId[];
 
 /**
- * The ordered list of per-feature section renderers (#243). Video is gated
- * behind `Platform.isDesktop` in {@link SynapseSettingTab.display} and inserted
- * here at render time, preserving the historical section order:
- * Elaboration, Intake, Image, Audio, Video, Enrichment, Summarize, Tidy,
- * Organize, Deep Dive, REM.
+ * The ordered list of per-feature section renderers (#243). Video is inserted
+ * in {@link SynapseSettingTab.display} at render time, preserving the
+ * historical section order: Elaboration, Intake, Image, Audio, Video,
+ * Enrichment, Summarize, Tidy, Organize, Deep Dive, REM.
  */
 const FEATURE_SECTION_RENDERERS: Array<(ctx: SettingsSectionContext) => void> = [
 	renderElaborationSettings,
 	renderIntakeSettings,
 	renderImageSettings,
 	renderAudioSettings,
-	// renderVideoSettings is spliced in after Audio when Platform.isDesktop.
+	// renderVideoSettings is spliced in after Audio (see display()).
 	renderEnrichmentSettings,
 	renderSummarizeSettings,
 	renderTidySettings,
@@ -259,12 +258,13 @@ export class SynapseSettingTab extends PluginSettingTab {
 		// ── General (non-feature, cross-cutting preferences; sits near the top) ──
 		this.renderGeneralSettings(ctx);
 
-		// ── Per-feature sections, in order (Video gated to desktop) ──
+		// ── Per-feature sections, in order ──
 		for (const render of FEATURE_SECTION_RENDERERS) {
 			render(ctx);
-			// Video Transcription slots in after Audio (desktop only — requires
-			// yt-dlp + ffmpeg). Splicing here keeps the historical section order.
-			if (render === renderAudioSettings && Platform.isDesktop) {
+			// Video Transcription slots in after Audio on every platform since
+			// #184; the section renderer itself hides the desktop-only binary
+			// settings on mobile. Splicing keeps the historical section order.
+			if (render === renderAudioSettings) {
 				renderVideoSettings(ctx);
 			}
 		}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -118,6 +118,13 @@ export interface VideoSettings {
 	tempFolder: string;
 	downloadFolder: string;
 	embedInNote: boolean;
+	/**
+	 * Prefer YouTube caption extraction over download+transcribe (#184). The
+	 * caption tier is free, near-instant, and the only URL-transcription path
+	 * available on mobile; turning this off restores the old always-download
+	 * desktop behavior (including the vault video download/embed).
+	 */
+	captionsFirst: boolean;
 	frameExtraction: FrameExtractionSettings;
 }
 
@@ -257,6 +264,14 @@ export interface IntakeSettings {
 	 * breadcrumbs are never re-ingested.
 	 */
 	captureLogFolder: string;
+	/**
+	 * Adopt shared captures (#455): also watch newly created ROOT-level notes
+	 * whose body is a bare media/article URL and move them into the intake
+	 * folder. Covers Obsidian's mobile share-sheet receiver, which creates the
+	 * note at "Default location for new notes" — a location plugins cannot
+	 * influence. Opt-in (default off) because it relocates root notes.
+	 */
+	adoptSharedCaptures: boolean;
 }
 
 /**
@@ -418,6 +433,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		tempFolder: '.synapse/temp',
 		downloadFolder: 'Media',
 		embedInNote: true,
+		captionsFirst: true,
 		frameExtraction: {
 			enabled: false,
 			intervalSeconds: 30,
@@ -513,6 +529,7 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		settleSeconds: 5,
 		captureLog: true,
 		captureLogFolder: '_captured',
+		adoptSharedCaptures: false,
 	},
 	ui: {
 		collapsedSections: {},

--- a/src/transcription/caption-strategy.test.ts
+++ b/src/transcription/caption-strategy.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CaptionStrategy } from './caption-strategy';
+import { DEFAULT_SETTINGS } from '../settings';
+import { makeSettings } from '../__test-utils__/mock-factories';
+import * as youtubeCaptions from './youtube-captions';
+
+const YOUTUBE_URL = 'https://www.youtube.com/watch?v=abc123xyz00';
+const TIKTOK_URL = 'https://www.tiktok.com/@user/video/123';
+
+const fetchTranscript = vi.spyOn(youtubeCaptions, 'fetchYouTubeTranscript');
+
+function makeStrategy(
+	settingsOverrides: {
+		captionsFirst?: boolean;
+		language?: string;
+	} = {},
+	postProcess = vi.fn((raw: string) => Promise.resolve({ text: `processed: ${raw}` }))
+) {
+	const settings = makeSettings(DEFAULT_SETTINGS);
+	settings.video.captionsFirst = settingsOverrides.captionsFirst ?? true;
+	settings.audio.language = settingsOverrides.language ?? '';
+	return {
+		strategy: new CaptionStrategy(() => settings, postProcess),
+		postProcess,
+	};
+}
+
+beforeEach(() => {
+	fetchTranscript.mockReset();
+});
+
+describe('CaptionStrategy.canHandle', () => {
+	it('accepts a YouTube URL with captionsFirst on and no time range', () => {
+		const { strategy } = makeStrategy();
+		expect(strategy.canHandle(YOUTUBE_URL, {})).toBe(true);
+	});
+
+	it('declines non-YouTube URLs', () => {
+		const { strategy } = makeStrategy();
+		expect(strategy.canHandle(TIKTOK_URL, {})).toBe(false);
+	});
+
+	it('declines when a time range is requested (captions cannot clip)', () => {
+		const { strategy } = makeStrategy();
+		expect(
+			strategy.canHandle(YOUTUBE_URL, { timeRange: { startSeconds: 0, endSeconds: 5 } })
+		).toBe(false);
+	});
+
+	it('declines when captionsFirst is off', () => {
+		const { strategy } = makeStrategy({ captionsFirst: false });
+		expect(strategy.canHandle(YOUTUBE_URL, {})).toBe(false);
+	});
+});
+
+describe('CaptionStrategy.transcribe', () => {
+	it('post-processes fetched captions into a caption-sourced transcript', async () => {
+		fetchTranscript.mockResolvedValue({
+			text: 'caption text',
+			language: 'en',
+			auto: true,
+			title: 'A Video',
+		});
+		const { strategy, postProcess } = makeStrategy();
+
+		const result = await strategy.transcribe(YOUTUBE_URL, {});
+
+		expect(postProcess).toHaveBeenCalledWith('caption text');
+		expect(result).toEqual({
+			text: 'processed: caption text',
+			raw: 'caption text',
+			source: 'captions',
+			title: 'A Video',
+			language: 'en',
+			reformatted: undefined,
+			schemaId: undefined,
+		});
+	});
+
+	it('prefers the configured audio language, then English', async () => {
+		fetchTranscript.mockResolvedValue(null);
+		const { strategy } = makeStrategy({ language: 'de' });
+
+		await strategy.transcribe(YOUTUBE_URL, {});
+
+		expect(fetchTranscript).toHaveBeenCalledWith(YOUTUBE_URL, ['de', 'en']);
+	});
+
+	it('returns null (fall through) when the video has no captions', async () => {
+		fetchTranscript.mockResolvedValue(null);
+		const { strategy, postProcess } = makeStrategy();
+
+		expect(await strategy.transcribe(YOUTUBE_URL, {})).toBeNull();
+		expect(postProcess).not.toHaveBeenCalled();
+	});
+
+	it('degrades to raw captions when post-processing fails', async () => {
+		fetchTranscript.mockResolvedValue({ text: 'caption text', language: 'en', auto: true });
+		const { strategy } = makeStrategy(
+			{},
+			vi.fn(() => Promise.reject(new Error('no AI key')))
+		);
+
+		const result = await strategy.transcribe(YOUTUBE_URL, {});
+
+		expect(result?.text).toBe('caption text');
+		expect(result?.source).toBe('captions');
+	});
+
+	it('carries schema-reformat flags through (lyrics callout, #234)', async () => {
+		fetchTranscript.mockResolvedValue({ text: 'la la la', language: 'en', auto: true });
+		const { strategy } = makeStrategy(
+			{},
+			vi.fn(() => Promise.resolve({ text: '## Verse\nla la la', reformatted: true, schemaId: 'lyrics' }))
+		);
+
+		const result = await strategy.transcribe(YOUTUBE_URL, {});
+
+		expect(result?.reformatted).toBe(true);
+		expect(result?.schemaId).toBe('lyrics');
+	});
+
+	it('reports progress through the update hook', async () => {
+		fetchTranscript.mockResolvedValue({ text: 'caption text', language: 'en', auto: true });
+		const { strategy } = makeStrategy();
+		const update = vi.fn();
+
+		await strategy.transcribe(YOUTUBE_URL, { update });
+
+		expect(update).toHaveBeenCalledWith('Fetching YouTube captions...');
+	});
+});

--- a/src/transcription/caption-strategy.ts
+++ b/src/transcription/caption-strategy.ts
@@ -1,0 +1,77 @@
+import { redactError } from '../shared';
+import { detectPlatform } from '../shared';
+import type { SynapseSettings } from '../settings';
+import { fetchYouTubeTranscript } from './youtube-captions';
+import type { UrlTranscript, UrlTranscriptOptions, UrlTranscriptionStrategy } from './url-transcription';
+
+/**
+ * Result of running a transcript string through the audio module's
+ * post-processing pipeline (cleanup + optional schema reformat, #234).
+ * Matches the return shape of `AudioModule.processTranscriptText`.
+ */
+export interface ProcessedTranscript {
+	text: string;
+	reformatted?: boolean;
+	schemaId?: string;
+}
+
+export type ProcessTranscript = (raw: string) => Promise<ProcessedTranscript>;
+
+/**
+ * Tier 1 of URL transcription (#184): YouTube captions over HTTP. Free, fast,
+ * dependency-less, and the only tier available on mobile in Phase 1.
+ *
+ * The fetched caption text runs through the SAME post-processing pipeline as
+ * audio transcriptions (injected as a callback to keep this module decoupled
+ * from AudioModule), so ASR captions gain punctuation/structure and song
+ * lyrics get the lyrics-schema callout. A post-processing failure (e.g. no AI
+ * key configured) degrades to the raw caption text rather than failing the
+ * transcription — the captions themselves are already useful.
+ */
+export class CaptionStrategy implements UrlTranscriptionStrategy {
+	readonly id = 'captions';
+
+	constructor(
+		private readonly getSettings: () => SynapseSettings,
+		private readonly postProcess: ProcessTranscript
+	) {}
+
+	canHandle(url: string, opts: UrlTranscriptOptions): boolean {
+		// Captions carry no per-second audio, so a clip range forces extraction.
+		if (opts.timeRange) return false;
+		if (!this.getSettings().video.captionsFirst) return false;
+		return detectPlatform(url)?.platform === 'youtube';
+	}
+
+	async transcribe(url: string, opts: UrlTranscriptOptions): Promise<UrlTranscript | null> {
+		opts.update?.('Fetching YouTube captions...');
+		const preferred = [this.getSettings().audio.language, 'en'].filter(
+			(lang) => lang.trim().length > 0
+		);
+		const captions = await fetchYouTubeTranscript(url, preferred);
+		if (!captions) {
+			return null;
+		}
+
+		opts.update?.('Post-processing transcript...');
+		let processed: ProcessedTranscript = { text: captions.text };
+		try {
+			processed = await this.postProcess(captions.text);
+		} catch (error) {
+			console.warn(
+				'[Synapse] Caption post-processing failed; keeping raw captions',
+				redactError(error)
+			);
+		}
+
+		return {
+			text: processed.text || captions.text,
+			raw: captions.text,
+			source: 'captions',
+			title: captions.title,
+			language: captions.language,
+			reformatted: processed.reformatted,
+			schemaId: processed.schemaId,
+		};
+	}
+}

--- a/src/transcription/index.ts
+++ b/src/transcription/index.ts
@@ -11,3 +11,21 @@ export {
 	MIN_SLIDER_DURATION,
 } from './duration-detector';
 export type { DurationResult } from './duration-detector';
+export {
+	UrlTranscriptionRouter,
+	NoTranscriptionPathError,
+	buildUrlTranscriptBlock,
+} from './url-transcription';
+export type {
+	UrlTranscript,
+	UrlTranscriptOptions,
+	UrlTranscriptionStrategy,
+} from './url-transcription';
+export { CaptionStrategy } from './caption-strategy';
+export type { ProcessedTranscript, ProcessTranscript } from './caption-strategy';
+export { LocalExtractionStrategy } from './local-extraction-strategy';
+export type { LocalExtractionDelegate } from './local-extraction-strategy';
+export { fetchYouTubeTranscript } from './youtube-captions';
+export type { YouTubeTranscript } from './youtube-captions';
+export { insertUrlTranscript } from './insert-url-transcript';
+export type { InsertUrlTranscriptDeps } from './insert-url-transcript';

--- a/src/transcription/insert-url-transcript.ts
+++ b/src/transcription/insert-url-transcript.ts
@@ -1,0 +1,69 @@
+import type { App } from 'obsidian';
+import { findMatchingRule } from '../shared';
+import type { NotificationManager, TimeRange } from '../shared';
+import type { SynapseSettings } from '../settings';
+import { buildUrlTranscriptBlock, UrlTranscriptionRouter } from './url-transcription';
+
+/** Wiring for {@link insertUrlTranscript}, injected by main.ts. */
+export interface InsertUrlTranscriptDeps {
+	app: App;
+	getSettings: () => SynapseSettings;
+	notifications: NotificationManager;
+	router: UrlTranscriptionRouter;
+	/** Post-transcription hook (enrichment/title check), same contract as the module `onTranscriptionComplete` callbacks. */
+	onComplete?: (filePath: string) => void;
+}
+
+/**
+ * Transcribe a media URL through the tier router and append the transcript to
+ * the ACTIVE note — the platform-agnostic sibling of the desktop-only
+ * `VideoModule.transcribeUrlToActiveNote`, and the path the unified
+ * transcription modal takes on every platform. Mirrors that method's guards
+ * (active note required, #307 path exclusion) and its output block shape.
+ */
+export async function insertUrlTranscript(
+	deps: InsertUrlTranscriptDeps,
+	url: string,
+	timeRange?: TimeRange
+): Promise<void> {
+	const { app, getSettings, notifications, router } = deps;
+
+	const activeFile = app.workspace.getActiveFile();
+	if (!activeFile) {
+		notifications.info('Open a note first to insert the transcription');
+		return;
+	}
+
+	// Path exclusion (#307): transcription lands in the ACTIVE note. Explicit
+	// command → Notice naming the rule.
+	const rule = findMatchingRule(activeFile.path, 'video', getSettings());
+	if (rule) {
+		notifications.info(
+			`Skipped — "${activeFile.path}" is excluded by rule "${rule.pattern}"`
+		);
+		return;
+	}
+
+	const op = notifications.startOperation(
+		'Processing video URL...',
+		`video-url-${Date.now()}`
+	);
+	try {
+		const result = await router.transcribe(url, {
+			timeRange,
+			update: (message) => op.update(message),
+		});
+		const block = buildUrlTranscriptBlock(
+			result,
+			url,
+			getSettings().video.embedInNote,
+			timeRange
+		);
+		await app.vault.process(activeFile, (data) => data + block);
+		deps.onComplete?.(activeFile.path);
+		op.finish('Transcription added to note');
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		op.error(`URL transcription failed -- ${msg}`);
+	}
+}

--- a/src/transcription/local-extraction-strategy.test.ts
+++ b/src/transcription/local-extraction-strategy.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Platform } from '../__mocks__/obsidian';
+import { LocalExtractionStrategy } from './local-extraction-strategy';
+import type { TranscriptionResult } from '../audio';
+
+const YOUTUBE_URL = 'https://www.youtube.com/watch?v=abc123xyz00';
+const TIKTOK_URL = 'https://www.tiktok.com/@user/video/123';
+
+function extractionResult(
+	overrides: Partial<TranscriptionResult & { videoVaultPath?: string }> = {}
+): TranscriptionResult & { videoVaultPath?: string } {
+	return {
+		raw: 'raw transcript',
+		processed: 'processed transcript',
+		sourceName: 'A Video',
+		language: 'en',
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	Platform.isDesktop = true;
+	Platform.isMobile = false;
+});
+
+describe('LocalExtractionStrategy.canHandle', () => {
+	it('accepts supported URLs on desktop', () => {
+		const strategy = new LocalExtractionStrategy(vi.fn());
+		expect(strategy.canHandle(YOUTUBE_URL)).toBe(true);
+		expect(strategy.canHandle(TIKTOK_URL)).toBe(true);
+	});
+
+	it('declines everything on mobile', () => {
+		Platform.isDesktop = false;
+		Platform.isMobile = true;
+		const strategy = new LocalExtractionStrategy(vi.fn());
+		expect(strategy.canHandle(YOUTUBE_URL)).toBe(false);
+	});
+
+	it('declines unsupported URLs', () => {
+		const strategy = new LocalExtractionStrategy(vi.fn());
+		expect(strategy.canHandle('https://open.spotify.com/track/xyz')).toBe(false);
+	});
+});
+
+describe('LocalExtractionStrategy.transcribe', () => {
+	it('maps the extraction result into an extraction-sourced transcript', async () => {
+		const delegate = vi.fn(() =>
+			Promise.resolve(extractionResult({ videoVaultPath: 'Media/v.mp4', reformatted: true, schemaId: 'lyrics' }))
+		);
+		const strategy = new LocalExtractionStrategy(delegate);
+		const opts = { timeRange: { startSeconds: 1, endSeconds: 2 } };
+
+		const result = await strategy.transcribe(YOUTUBE_URL, opts);
+
+		expect(delegate).toHaveBeenCalledWith(YOUTUBE_URL, opts);
+		expect(result).toEqual({
+			text: 'processed transcript',
+			raw: 'raw transcript',
+			source: 'local-extraction',
+			title: 'A Video',
+			language: 'en',
+			videoVaultPath: 'Media/v.mp4',
+			reformatted: true,
+			schemaId: 'lyrics',
+		});
+	});
+
+	it('falls back to the raw transcript when post-processing is disabled', async () => {
+		const delegate = vi.fn(() => Promise.resolve(extractionResult({ processed: undefined })));
+		const strategy = new LocalExtractionStrategy(delegate);
+
+		const result = await strategy.transcribe(YOUTUBE_URL, {});
+		expect(result.text).toBe('raw transcript');
+	});
+
+	it('propagates delegate failures unchanged', async () => {
+		const boom = new Error('yt-dlp missing');
+		boom.name = 'DependencyMissingError';
+		const strategy = new LocalExtractionStrategy(vi.fn(() => Promise.reject(boom)));
+
+		await expect(strategy.transcribe(YOUTUBE_URL, {})).rejects.toBe(boom);
+	});
+});

--- a/src/transcription/local-extraction-strategy.ts
+++ b/src/transcription/local-extraction-strategy.ts
@@ -1,0 +1,46 @@
+import { Platform } from 'obsidian';
+import { isSupportedUrl } from '../shared';
+import type { TranscriptionResult } from '../audio';
+import type { UrlTranscript, UrlTranscriptOptions, UrlTranscriptionStrategy } from './url-transcription';
+
+/**
+ * The desktop extraction pipeline as a callback — wired by main.ts to
+ * `VideoModule.processUrl` (yt-dlp download → ffmpeg extract → transcribe),
+ * matching the DI style of the other cross-module callbacks so this module
+ * never imports the video feature module.
+ */
+export type LocalExtractionDelegate = (
+	url: string,
+	opts: UrlTranscriptOptions
+) => Promise<TranscriptionResult & { videoVaultPath?: string }>;
+
+/**
+ * Tier 2 of URL transcription (#184): the existing desktop yt-dlp/ffmpeg
+ * pipeline. Handles every supported platform (YouTube, TikTok, Instagram)
+ * and time-range clipping, but only where child processes exist — never on
+ * mobile. Failures propagate unchanged so DependencyMissingError keeps
+ * driving the yt-dlp/ffmpeg onboarding notice (#382).
+ */
+export class LocalExtractionStrategy implements UrlTranscriptionStrategy {
+	readonly id = 'local-extraction';
+
+	constructor(private readonly delegate: LocalExtractionDelegate) {}
+
+	canHandle(url: string): boolean {
+		return Platform.isDesktop && isSupportedUrl(url);
+	}
+
+	async transcribe(url: string, opts: UrlTranscriptOptions): Promise<UrlTranscript> {
+		const result = await this.delegate(url, opts);
+		return {
+			text: result.processed || result.raw,
+			raw: result.raw,
+			source: 'local-extraction',
+			title: result.sourceName || undefined,
+			language: result.language,
+			videoVaultPath: result.videoVaultPath,
+			reformatted: result.reformatted,
+			schemaId: result.schemaId,
+		};
+	}
+}

--- a/src/transcription/unified-modal.test.ts
+++ b/src/transcription/unified-modal.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Platform } from '../__mocks__/obsidian';
+import { UnifiedTranscriptionModal } from './unified-modal';
+import { DEFAULT_SETTINGS } from '../settings';
+import { makeSettings } from '../__test-utils__/mock-factories';
+import type { NotificationManager } from '../shared';
+
+/**
+ * Minimal Modal contentEl stand-in: the mock Modal's contentEl createDiv is a
+ * bare vi.fn(), but the URL section chains `.hide()`/`.setText()` on the
+ * platform badge, so return a badge-shaped stub and record the calls.
+ */
+function makeContentEl() {
+	const createDiv = vi.fn(() => ({ hide: vi.fn(), show: vi.fn(), setText: vi.fn() }));
+	return { empty: vi.fn(), createEl: vi.fn(), createDiv };
+}
+
+function makeModal(enabledModules: { audio: boolean; video: boolean }) {
+	const callbacks = {
+		onTranscribeFile: vi.fn(() => Promise.resolve()),
+		onTranscribeUrl: vi.fn(() => Promise.resolve()),
+	};
+	const app = { vault: { getFiles: () => [] } };
+	const modal = new UnifiedTranscriptionModal(
+		app as never,
+		() => makeSettings(DEFAULT_SETTINGS),
+		enabledModules,
+		callbacks,
+		{ info: vi.fn() } as unknown as NotificationManager
+	);
+	const contentEl = makeContentEl();
+	(modal as unknown as { contentEl: unknown }).contentEl = contentEl;
+	return { modal, callbacks, contentEl };
+}
+
+afterEach(() => {
+	Platform.isDesktop = true;
+	Platform.isMobile = false;
+});
+
+describe('UnifiedTranscriptionModal URL section (#184)', () => {
+	it('renders the URL input on mobile when video is enabled', () => {
+		Platform.isDesktop = false;
+		Platform.isMobile = true;
+		const { modal, contentEl } = makeModal({ audio: true, video: true });
+
+		modal.onOpen();
+
+		expect(contentEl.createDiv).toHaveBeenCalledWith({ cls: 'synapse-platform-badge' });
+	});
+
+	it('does not render the URL input when video is disabled', () => {
+		const { modal, contentEl } = makeModal({ audio: true, video: false });
+
+		modal.onOpen();
+
+		expect(contentEl.createDiv).not.toHaveBeenCalledWith({ cls: 'synapse-platform-badge' });
+	});
+
+	it('dispatches a URL directly (no duration detection) on mobile', async () => {
+		Platform.isDesktop = false;
+		Platform.isMobile = true;
+		const { modal, callbacks } = makeModal({ audio: false, video: true });
+		const url = 'https://www.youtube.com/watch?v=abc123xyz00';
+		(modal as unknown as { url: string }).url = url;
+
+		await (modal as unknown as { handleTranscribe: () => Promise<void> }).handleTranscribe();
+
+		expect(callbacks.onTranscribeUrl).toHaveBeenCalledWith(url);
+	});
+});

--- a/src/transcription/unified-modal.ts
+++ b/src/transcription/unified-modal.ts
@@ -71,8 +71,9 @@ export class UnifiedTranscriptionModal extends Modal {
 				.setDesc(ppStatus);
 		}
 
-		// URL section (desktop only -- video transcription requires yt-dlp + ffmpeg)
-		if (this.enabledModules.video && Platform.isDesktop) {
+		// URL section — every platform since #184: desktop routes through
+		// captions/yt-dlp, mobile through the caption tier (YouTube only).
+		if (this.enabledModules.video) {
 			const platformBadge = contentEl.createDiv({
 				cls: 'synapse-platform-badge',
 			});

--- a/src/transcription/url-transcription.test.ts
+++ b/src/transcription/url-transcription.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Platform } from '../__mocks__/obsidian';
+import {
+	UrlTranscriptionRouter,
+	NoTranscriptionPathError,
+	buildUrlTranscriptBlock,
+} from './url-transcription';
+import type { UrlTranscript, UrlTranscriptionStrategy } from './url-transcription';
+
+const URL = 'https://www.youtube.com/watch?v=abc123xyz00';
+
+function transcript(overrides: Partial<UrlTranscript> = {}): UrlTranscript {
+	return {
+		text: 'processed text',
+		raw: 'raw text',
+		source: 'captions',
+		...overrides,
+	};
+}
+
+function strategy(
+	id: string,
+	behavior: {
+		canHandle?: boolean;
+		result?: UrlTranscript | null;
+		error?: Error;
+	}
+): UrlTranscriptionStrategy & { transcribe: ReturnType<typeof vi.fn> } {
+	return {
+		id,
+		canHandle: () => behavior.canHandle ?? true,
+		transcribe: vi.fn(() =>
+			behavior.error
+				? Promise.reject(behavior.error)
+				: Promise.resolve(behavior.result ?? null)
+		),
+	};
+}
+
+afterEach(() => {
+	Platform.isDesktop = true;
+	Platform.isMobile = false;
+});
+
+describe('UrlTranscriptionRouter', () => {
+	it('returns the first strategy result and never calls later tiers', async () => {
+		const first = strategy('captions', { result: transcript() });
+		const second = strategy('local-extraction', { result: transcript({ source: 'local-extraction' }) });
+		const router = new UrlTranscriptionRouter([first, second]);
+
+		const result = await router.transcribe(URL);
+
+		expect(result.source).toBe('captions');
+		expect(second.transcribe).not.toHaveBeenCalled();
+	});
+
+	it('falls through on null and on canHandle=false', async () => {
+		const inapplicable = strategy('captions', { canHandle: false });
+		const empty = strategy('middle', { result: null });
+		const winner = strategy('local-extraction', { result: transcript({ source: 'local-extraction' }) });
+		const router = new UrlTranscriptionRouter([inapplicable, empty, winner]);
+
+		const result = await router.transcribe(URL);
+
+		expect(result.source).toBe('local-extraction');
+		expect(inapplicable.transcribe).not.toHaveBeenCalled();
+		expect(empty.transcribe).toHaveBeenCalledOnce();
+	});
+
+	it('propagates a strategy throw unchanged (typed errors keep their UX)', async () => {
+		const boom = new Error('yt-dlp not found');
+		boom.name = 'DependencyMissingError';
+		const failing = strategy('local-extraction', { error: boom });
+		const never = strategy('after', { result: transcript() });
+		const router = new UrlTranscriptionRouter([failing, never]);
+
+		await expect(router.transcribe(URL)).rejects.toBe(boom);
+		expect(never.transcribe).not.toHaveBeenCalled();
+	});
+
+	it('throws NoTranscriptionPathError with per-tier attempts when exhausted', async () => {
+		const inapplicable = strategy('captions', { canHandle: false });
+		const empty = strategy('local-extraction', { result: null });
+		const router = new UrlTranscriptionRouter([inapplicable, empty]);
+
+		const error = await router.transcribe(URL).catch((e: unknown) => e);
+
+		expect(error).toBeInstanceOf(NoTranscriptionPathError);
+		const typed = error as NoTranscriptionPathError;
+		expect(typed.url).toBe(URL);
+		expect(typed.attempts).toEqual([
+			'captions: not applicable',
+			'local-extraction: unavailable for this video',
+		]);
+	});
+
+	it('passes options (timeRange, update) through to strategies', async () => {
+		const only = strategy('captions', { result: transcript() });
+		const router = new UrlTranscriptionRouter([only]);
+		const update = vi.fn();
+		const timeRange = { startSeconds: 1, endSeconds: 2 };
+
+		await router.transcribe(URL, { timeRange, update });
+
+		expect(only.transcribe).toHaveBeenCalledWith(URL, { timeRange, update });
+	});
+});
+
+describe('NoTranscriptionPathError', () => {
+	it('names the desktop failure with attempt detail', () => {
+		Platform.isDesktop = true;
+		const error = new NoTranscriptionPathError(URL, ['captions: not applicable']);
+		expect(error.message).toContain('No transcription path available');
+		expect(error.message).toContain(URL);
+		expect(error.message).toContain('captions: not applicable');
+	});
+
+	it('explains the desktop/sync handoff on mobile', () => {
+		Platform.isDesktop = false;
+		Platform.isMobile = true;
+		const error = new NoTranscriptionPathError(URL, []);
+		expect(error.message).toContain('mobile');
+		expect(error.message).toContain('desktop app');
+		expect(error.name).toBe('NoTranscriptionPathError');
+	});
+});
+
+describe('buildUrlTranscriptBlock', () => {
+	it('mirrors the desktop VideoModule block shape (embed + collapsed callout)', () => {
+		const block = buildUrlTranscriptBlock(
+			transcript({ videoVaultPath: 'Media/2026-07-14-video.mp4' }),
+			URL,
+			true
+		);
+
+		expect(block).toBe(
+			'\n![[2026-07-14-video.mp4]]\n\n\n' +
+				`> [!synapse-transcription]- Transcription of ${URL}\n` +
+				'> processed text\n'
+		);
+	});
+
+	it('omits the embed when disabled or when there is no vault video', () => {
+		const withPath = buildUrlTranscriptBlock(
+			transcript({ videoVaultPath: 'Media/x.mp4' }),
+			URL,
+			false
+		);
+		const withoutPath = buildUrlTranscriptBlock(transcript(), URL, true);
+
+		expect(withPath).not.toContain('![[');
+		expect(withoutPath).not.toContain('![[');
+	});
+
+	it('appends the time range to the callout title', () => {
+		const block = buildUrlTranscriptBlock(transcript(), URL, false, {
+			startSeconds: 60,
+			endSeconds: 120,
+		});
+		expect(block).toContain(`Transcription of ${URL} [01:00 – 02:00]`);
+	});
+
+	it('emits the lyrics callout for schema-reformatted transcripts', () => {
+		const block = buildUrlTranscriptBlock(
+			transcript({ reformatted: true, schemaId: 'lyrics' }),
+			URL,
+			false
+		);
+		expect(block).toContain(`> [!synapse-lyrics]- Lyrics of ${URL}`);
+	});
+});

--- a/src/transcription/url-transcription.ts
+++ b/src/transcription/url-transcription.ts
@@ -1,0 +1,146 @@
+import { Platform } from 'obsidian';
+import { buildCallout, calloutForTranscriptionResult, formatTimeRange } from '../shared';
+import type { TimeRange } from '../shared';
+
+/**
+ * URL transcription router (#184) — the platform seam between "transcribe this
+ * video/audio URL" and the tiers that can actually do it:
+ *
+ *   1. captions          — YouTube caption fetch over HTTP (all platforms)
+ *   2. local-extraction  — yt-dlp/ffmpeg download + transcribe (desktop only)
+ *   3. server-extraction — self-hosted extractor endpoint (planned, #181)
+ *
+ * Strategies are tried in order. A strategy returns `null` to mean "not my
+ * video, fall through" (e.g. captionless YouTube); a throw is a REAL failure
+ * (bad credentials, missing yt-dlp) and propagates unchanged so typed errors
+ * like DependencyMissingError keep driving their dedicated UX (#382). When
+ * every tier is exhausted the router throws {@link NoTranscriptionPathError}
+ * with a platform-aware message.
+ *
+ * Deliberately lighter than the `MediaExtractor` interface proposed in #180:
+ * the unit of exchange here is a *transcript*, not extracted audio, so a tier
+ * like captions — which never produces audio — fits naturally.
+ */
+
+export interface UrlTranscriptOptions {
+	/**
+	 * Clip to a time range. Captions cannot clip, so a set range forces the
+	 * extraction tiers (CaptionStrategy declines via canHandle).
+	 */
+	timeRange?: TimeRange;
+	/** Progress hook, same shape as NotificationManager operation updates. */
+	update?: (message: string) => void;
+}
+
+export interface UrlTranscript {
+	/** Final transcript (post-processed when available, else raw). */
+	text: string;
+	/** Unprocessed transcript. */
+	raw: string;
+	/** Which tier produced the transcript. */
+	source: 'captions' | 'local-extraction';
+	/** Video title, when the tier could determine one. */
+	title?: string;
+	/** Language code, when known. */
+	language?: string;
+	/** Vault path of a downloaded video file (local extraction only). */
+	videoVaultPath?: string;
+	/** True when a content schema (#234, e.g. lyrics) reformatted the text. */
+	reformatted?: boolean;
+	/** Id of the content schema that reformatted the text, if any. */
+	schemaId?: string;
+}
+
+export interface UrlTranscriptionStrategy {
+	/** Stable identifier used in diagnostics and error summaries. */
+	readonly id: string;
+	/** Cheap applicability gate — platform/url/settings only, no network. */
+	canHandle(url: string, opts: UrlTranscriptOptions): boolean;
+	/**
+	 * Produce a transcript, or `null` to fall through to the next tier (e.g.
+	 * the video has no captions). Throw only on a real failure.
+	 */
+	transcribe(url: string, opts: UrlTranscriptOptions): Promise<UrlTranscript | null>;
+}
+
+/**
+ * Thrown when no strategy could transcribe a URL. The message is written for
+ * the end user and is platform-aware: on mobile it explains the desktop/sync
+ * handoff (an intake note is left un-stamped, so a synced desktop vault's
+ * watcher picks it up and finishes the job).
+ */
+export class NoTranscriptionPathError extends Error {
+	constructor(
+		public readonly url: string,
+		public readonly attempts: string[]
+	) {
+		super(NoTranscriptionPathError.buildMessage(url, attempts));
+		this.name = 'NoTranscriptionPathError';
+	}
+
+	private static buildMessage(url: string, attempts: string[]): string {
+		const detail = attempts.length > 0 ? ` (${attempts.join('; ')})` : '';
+		if (Platform.isDesktop) {
+			return `No transcription path available for ${url}${detail}`;
+		}
+		return (
+			`Can't transcribe ${url} on mobile yet — TikTok/Instagram and caption-less ` +
+			'videos need the Synapse desktop app (yt-dlp + ffmpeg). In a synced vault, ' +
+			'leave the note in the intake folder and the desktop app will process it.'
+		);
+	}
+}
+
+export class UrlTranscriptionRouter {
+	constructor(private readonly strategies: UrlTranscriptionStrategy[]) {}
+
+	/**
+	 * Try each strategy in order; first transcript wins. Real strategy failures
+	 * propagate unchanged; exhausting every tier throws
+	 * {@link NoTranscriptionPathError}.
+	 */
+	async transcribe(url: string, opts: UrlTranscriptOptions = {}): Promise<UrlTranscript> {
+		const attempts: string[] = [];
+		for (const strategy of this.strategies) {
+			if (!strategy.canHandle(url, opts)) {
+				attempts.push(`${strategy.id}: not applicable`);
+				continue;
+			}
+			const result = await strategy.transcribe(url, opts);
+			if (result) {
+				return result;
+			}
+			attempts.push(`${strategy.id}: unavailable for this video`);
+		}
+		throw new NoTranscriptionPathError(url, attempts);
+	}
+}
+
+/**
+ * Build the note block for a URL transcript — the single place that mirrors
+ * the desktop VideoModule output shape (optional `![[video]]` embed, then a
+ * collapsed transcription/lyrics callout), so caption- and extraction-sourced
+ * transcripts render identically wherever they land.
+ */
+export function buildUrlTranscriptBlock(
+	result: UrlTranscript,
+	url: string,
+	embedInNote: boolean,
+	timeRange?: TimeRange
+): string {
+	const blockLines: string[] = [''];
+
+	if (embedInNote && result.videoVaultPath) {
+		const fileName = result.videoVaultPath.split('/').pop()!;
+		blockLines.push(`![[${fileName}]]`);
+		blockLines.push('');
+	}
+
+	const { type, verb } = calloutForTranscriptionResult(result);
+	const title = timeRange
+		? `${verb} ${url} ${formatTimeRange(timeRange)}`
+		: `${verb} ${url}`;
+	blockLines.push(buildCallout(type, title, result.text, true));
+
+	return blockLines.join('\n');
+}

--- a/src/transcription/youtube-captions.test.ts
+++ b/src/transcription/youtube-captions.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import {
+	fetchYouTubeTranscript,
+	extractJsonAfterMarker,
+	extractCaptionTracks,
+	selectCaptionTrack,
+	collectJson3Text,
+} from './youtube-captions';
+import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from '../__mocks__/obsidian';
+
+/**
+ * The `requestUrl` mock viewed with a precise async signature (same pattern as
+ * src/shared/tweet-fetcher.test.ts): the shared mock is loosely typed, and the
+ * view lets stubs return partial responses with only the fields read here.
+ */
+const mockRequestUrl = vi.mocked(requestUrl) as unknown as Mock<
+	(params: RequestUrlParam | string) => Promise<Partial<RequestUrlResponse>>
+>;
+
+const WATCH_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
+/** Build a player response with the given caption tracks. */
+function playerResponse(
+	tracks: Array<{ baseUrl: string; languageCode: string; kind?: string }>,
+	overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+	return {
+		captions: {
+			playerCaptionsTracklistRenderer: { captionTracks: tracks },
+		},
+		videoDetails: { title: 'Test Video' },
+		playabilityStatus: { status: 'OK' },
+		...overrides,
+	};
+}
+
+/** Wrap a player response in watch-page HTML the way YouTube embeds it. */
+function watchPageHtml(player: Record<string, unknown>): string {
+	return (
+		'<html><head><title>Test</title></head><body>' +
+		`<script>var ytInitialPlayerResponse = ${JSON.stringify(player)};var meta = {};</script>` +
+		'</body></html>'
+	);
+}
+
+/** A minimal json3 timedtext payload. */
+function json3(events: Array<Record<string, unknown>>): string {
+	return JSON.stringify({ wireMagic: 'pb3', events });
+}
+
+const SIMPLE_EVENTS = [
+	{ tStartMs: 0, dDurationMs: 2000, segs: [{ utf8: 'hello' }, { utf8: ' world' }] },
+	{ tStartMs: 2000, aAppend: 1, segs: [{ utf8: ' world' }] },
+	{ tStartMs: 4000, dDurationMs: 1000 },
+	{ tStartMs: 5000, segs: [{ utf8: 'it&#39;s fine' }] },
+];
+
+/** Stub the two requests of a successful Innertube-primary run. */
+function stubInnertubeSuccess(
+	player: Record<string, unknown>,
+	trackBody: string
+): void {
+	mockRequestUrl.mockImplementation((params) => {
+		const url = typeof params === 'string' ? params : params.url;
+		if (url.includes('/youtubei/v1/player')) {
+			return Promise.resolve({ status: 200, text: JSON.stringify(player) });
+		}
+		return Promise.resolve({ status: 200, text: trackBody });
+	});
+}
+
+beforeEach(() => {
+	mockRequestUrl.mockReset();
+});
+
+describe('fetchYouTubeTranscript', () => {
+	it('returns a cleaned transcript via the primary Innertube ANDROID attempt', async () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://www.youtube.com/api/timedtext?v=x&lang=en', languageCode: 'en', kind: 'asr' },
+		]);
+		stubInnertubeSuccess(player, json3(SIMPLE_EVENTS));
+
+		const result = await fetchYouTubeTranscript(WATCH_URL, ['en']);
+
+		expect(result).toEqual({
+			text: "hello world it's fine",
+			language: 'en',
+			auto: true,
+			title: 'Test Video',
+		});
+		const innertubeCall = mockRequestUrl.mock.calls.find(([params]) => {
+			const url = typeof params === 'string' ? params : params.url;
+			return url.includes('/youtubei/v1/player');
+		});
+		const body = JSON.parse((innertubeCall![0] as RequestUrlParam).body as string) as {
+			videoId: string;
+			context: { client: { clientName: string } };
+		};
+		expect(body.videoId).toBe('dQw4w9WgXcQ');
+		expect(body.context.client.clientName).toBe('ANDROID');
+	});
+
+	it('requests the track in json3 format', async () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://www.youtube.com/api/timedtext?v=x&lang=en', languageCode: 'en' },
+		]);
+		stubInnertubeSuccess(player, json3(SIMPLE_EVENTS));
+
+		await fetchYouTubeTranscript(WATCH_URL, ['en']);
+
+		const trackCall = mockRequestUrl.mock.calls
+			.map(([params]) => (typeof params === 'string' ? params : params.url))
+			.find((url) => url.includes('timedtext'));
+		expect(trackCall).toContain('fmt=json3');
+	});
+
+	it('falls back to the watch page when Innertube rejects (retired client version)', async () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://www.youtube.com/api/timedtext?v=x&lang=en', languageCode: 'en' },
+		]);
+		mockRequestUrl.mockImplementation((params) => {
+			const url = typeof params === 'string' ? params : params.url;
+			if (url.includes('/youtubei/v1/player')) {
+				return Promise.reject(new Error('400 FAILED_PRECONDITION'));
+			}
+			if (url.includes('/watch?v=')) {
+				return Promise.resolve({ status: 200, text: watchPageHtml(player) });
+			}
+			return Promise.resolve({ status: 200, text: json3(SIMPLE_EVENTS) });
+		});
+
+		const result = await fetchYouTubeTranscript(WATCH_URL, ['en']);
+		expect(result?.text).toBe("hello world it's fine");
+	});
+
+	it('falls back to the watch page when Innertube returns an error payload without tracks', async () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://www.youtube.com/api/timedtext?v=x&lang=en', languageCode: 'en' },
+		]);
+		mockRequestUrl.mockImplementation((params) => {
+			const url = typeof params === 'string' ? params : params.url;
+			if (url.includes('/youtubei/v1/player')) {
+				return Promise.resolve({ status: 200, text: '{"error":{"code":400}}' });
+			}
+			if (url.includes('/watch?v=')) {
+				return Promise.resolve({ status: 200, text: watchPageHtml(player) });
+			}
+			return Promise.resolve({ status: 200, text: json3(SIMPLE_EVENTS) });
+		});
+
+		const result = await fetchYouTubeTranscript(WATCH_URL, ['en']);
+		expect(result?.text).toBe("hello world it's fine");
+	});
+
+	it('returns null when neither attempt yields caption tracks', async () => {
+		const noTracks = playerResponse([], { playabilityStatus: { status: 'LOGIN_REQUIRED' } });
+		mockRequestUrl.mockImplementation((params) => {
+			const url = typeof params === 'string' ? params : params.url;
+			if (url.includes('/watch?v=')) {
+				return Promise.resolve({ status: 200, text: watchPageHtml(noTracks) });
+			}
+			return Promise.resolve({ status: 200, text: JSON.stringify(noTracks) });
+		});
+
+		expect(await fetchYouTubeTranscript(WATCH_URL, ['en'])).toBeNull();
+	});
+
+	it('returns null on an empty timedtext body (POT enforcement)', async () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://www.youtube.com/api/timedtext?v=x&lang=en', languageCode: 'en' },
+		]);
+		stubInnertubeSuccess(player, '');
+
+		expect(await fetchYouTubeTranscript(WATCH_URL, ['en'])).toBeNull();
+	});
+
+	it('returns null on a malformed timedtext body', async () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://www.youtube.com/api/timedtext?v=x&lang=en', languageCode: 'en' },
+		]);
+		stubInnertubeSuccess(player, '<transcript>not json</transcript>');
+
+		expect(await fetchYouTubeTranscript(WATCH_URL, ['en'])).toBeNull();
+	});
+
+	it('returns null for a non-YouTube URL without any request', async () => {
+		expect(
+			await fetchYouTubeTranscript('https://www.tiktok.com/@user/video/123', ['en'])
+		).toBeNull();
+		expect(mockRequestUrl).not.toHaveBeenCalled();
+	});
+
+	it('throws on a URL rejected by sanitizeUrl', async () => {
+		await expect(fetchYouTubeTranscript('not-a-url', ['en'])).rejects.toThrow();
+	});
+});
+
+describe('extractJsonAfterMarker', () => {
+	it('extracts a nested object with braces and escapes inside strings', () => {
+		const html = 'var ytInitialPlayerResponse = {"a":{"b":"};\\" tricky"},"c":1};var x = 2;';
+		expect(extractJsonAfterMarker(html, 'ytInitialPlayerResponse')).toEqual({
+			a: { b: '};" tricky' },
+			c: 1,
+		});
+	});
+
+	it('returns null when the marker is absent', () => {
+		expect(extractJsonAfterMarker('<html></html>', 'ytInitialPlayerResponse')).toBeNull();
+	});
+
+	it('returns null on an unbalanced object', () => {
+		expect(extractJsonAfterMarker('ytInitialPlayerResponse = {"a": {', 'ytInitialPlayerResponse')).toBeNull();
+	});
+});
+
+describe('extractCaptionTracks', () => {
+	it('reads well-formed tracks and drops malformed entries', () => {
+		const player = playerResponse([
+			{ baseUrl: 'https://x/1', languageCode: 'en', kind: 'asr' },
+		]);
+		const renderer = (player.captions as Record<string, unknown>)
+			.playerCaptionsTracklistRenderer as Record<string, unknown>;
+		(renderer.captionTracks as unknown[]).push({ languageCode: 'de' }, 'junk', null);
+
+		expect(extractCaptionTracks(player)).toEqual([
+			{ baseUrl: 'https://x/1', languageCode: 'en', kind: 'asr' },
+		]);
+	});
+
+	it('returns [] for shapes without captions', () => {
+		expect(extractCaptionTracks(null)).toEqual([]);
+		expect(extractCaptionTracks({})).toEqual([]);
+		expect(extractCaptionTracks({ captions: {} })).toEqual([]);
+	});
+});
+
+describe('selectCaptionTrack', () => {
+	const manualEn = { baseUrl: 'm-en', languageCode: 'en' };
+	const manualDe = { baseUrl: 'm-de', languageCode: 'de' };
+	const asrEn = { baseUrl: 'a-en', languageCode: 'en', kind: 'asr' };
+	const asrEs = { baseUrl: 'a-es', languageCode: 'es', kind: 'asr' };
+
+	it('prefers a manual track in the preferred language', () => {
+		expect(selectCaptionTrack([asrEn, manualDe, manualEn], ['en'])).toBe(manualEn);
+	});
+
+	it('prefers a preferred-language ASR track over a wrong-language manual track', () => {
+		expect(selectCaptionTrack([asrEn, manualDe], ['en'])).toBe(asrEn);
+	});
+
+	it('falls back to any manual track when no language matches', () => {
+		expect(selectCaptionTrack([asrEs, manualDe], ['fr'])).toBe(manualDe);
+	});
+
+	it('falls back to a preferred-language ASR track', () => {
+		expect(selectCaptionTrack([asrEs, asrEn], ['en'])).toBe(asrEn);
+	});
+
+	it('falls back to the first track when nothing matches', () => {
+		expect(selectCaptionTrack([asrEs], ['fr'])).toBe(asrEs);
+	});
+
+	it('matches regional variants in both directions', () => {
+		const enUs = { baseUrl: 'm-en-us', languageCode: 'en-US' };
+		expect(selectCaptionTrack([manualDe, enUs], ['en'])).toBe(enUs);
+		expect(selectCaptionTrack([manualDe, manualEn], ['en-GB'])).toBe(manualEn);
+	});
+
+	it('walks the preference list in order', () => {
+		expect(selectCaptionTrack([manualDe, manualEn], ['', 'de', 'en'])).toBe(manualDe);
+	});
+});
+
+describe('collectJson3Text', () => {
+	it('joins segments, skips append events, and decodes entities', () => {
+		const payload = JSON.parse(json3(SIMPLE_EVENTS)) as unknown;
+		expect(collectJson3Text(payload)).toBe("hello world it's fine");
+	});
+
+	it('collapses whitespace runs and newline segments', () => {
+		const payload = {
+			events: [
+				{ segs: [{ utf8: 'line one\n' }, { utf8: '  line   two ' }] },
+			],
+		};
+		expect(collectJson3Text(payload)).toBe('line one line two');
+	});
+
+	it('returns empty string for non-json3 shapes', () => {
+		expect(collectJson3Text(null)).toBe('');
+		expect(collectJson3Text({})).toBe('');
+		expect(collectJson3Text({ events: 'nope' })).toBe('');
+	});
+});

--- a/src/transcription/youtube-captions.ts
+++ b/src/transcription/youtube-captions.ts
@@ -1,0 +1,406 @@
+import { requestUrl } from 'obsidian';
+import type { RequestUrlParam, RequestUrlResponse } from 'obsidian';
+import { detectPlatform, isRecord, parseJson, redactError, sanitizeUrl } from '../shared';
+
+/**
+ * YouTube caption extraction (#184) — fetch a video's caption/subtitle track
+ * over plain HTTP and clean it into a transcript. Zero external dependencies,
+ * so it works identically on desktop and mobile; this is the Tier-1 strategy
+ * of URL transcription (see url-transcription.ts).
+ *
+ * Two attempts, both parsing the same `playerResponse` shape:
+ *   A. POST the Innertube `/youtubei/v1/player` endpoint with the ANDROID
+ *      client context. This is the PRIMARY attempt: its caption-track URLs
+ *      currently work without the proof-of-origin (POT) tokens, whereas the
+ *      web watch page's track URLs are POT-gated and return empty bodies
+ *      (verified live 2026-07-14).
+ *   B. GET the watch page and extract the embedded `ytInitialPlayerResponse`
+ *      — the fallback when the pinned ANDROID client version is retired
+ *      (YouTube then answers 400 FAILED_PRECONDITION).
+ *
+ * YouTube's internals are an accepted maintenance surface: every failure mode
+ * short of an invalid URL returns `null` (with a console.warn diagnostic) so
+ * callers fall through to the next transcription tier — on desktop the yt-dlp
+ * pipeline takes over invisibly.
+ */
+
+export interface YouTubeTranscript {
+	/** Cleaned caption text (timing stripped, segments merged). */
+	text: string;
+	/** BCP-47 language code of the selected track (e.g. `en`, `en-US`). */
+	language: string;
+	/** True when the track is YouTube's auto-generated (ASR) captions. */
+	auto: boolean;
+	/** Video title from the player response, when present. */
+	title?: string;
+}
+
+/** A caption track as advertised by the player response. */
+interface CaptionTrack {
+	baseUrl: string;
+	languageCode: string;
+	/** `'asr'` marks an auto-generated track; manual tracks omit it. */
+	kind?: string;
+}
+
+/** Hard timeout for each caption-related HTTP request. */
+const CAPTION_FETCH_TIMEOUT_MS = 30_000;
+
+/** Browser-like User-Agent so the watch page returns real HTML. */
+const WATCH_PAGE_USER_AGENT =
+	'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+/**
+ * Consent cookies sent with the watch-page request. In consent-wall regions
+ * (notably the EU) youtube.com otherwise responds with an interstitial that
+ * carries no player response. `requestUrl` has no cookie jar, so the cookies
+ * are sent unconditionally — they are inert where no consent wall exists.
+ */
+const CONSENT_COOKIE = 'CONSENT=YES+cb.20210328-17-p0.en+FX+678; SOCS=CAI';
+
+/**
+ * Pinned Innertube ANDROID client identity — the single place to bump when
+ * YouTube retires this client version (the symptom is a 400
+ * FAILED_PRECONDITION from the player endpoint). The ANDROID client is used
+ * because its caption-track URLs work without proof-of-origin (POT) tokens.
+ */
+export const INNERTUBE_ANDROID_CLIENT = {
+	clientName: 'ANDROID',
+	clientVersion: '20.10.38',
+	androidSdkVersion: 30,
+	userAgent: 'com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip',
+} as const;
+
+/** Innertube player endpoint (attempt B). */
+const INNERTUBE_PLAYER_URL = 'https://www.youtube.com/youtubei/v1/player?prettyPrint=false';
+
+/**
+ * Fetch and clean the caption transcript for a YouTube URL.
+ *
+ * @param url                A YouTube watch/short/embed URL.
+ * @param preferredLanguages Language codes in preference order (e.g. the
+ *                           user's `audio.language` setting, then `'en'`).
+ * @returns The transcript, or `null` when the video has no usable captions or
+ *          any fetch/parse step fails. Throws ONLY when `url` fails
+ *          {@link sanitizeUrl} validation.
+ */
+export async function fetchYouTubeTranscript(
+	url: string,
+	preferredLanguages: string[]
+): Promise<YouTubeTranscript | null> {
+	const validatedUrl = sanitizeUrl(url);
+	const detected = detectPlatform(validatedUrl);
+	if (!detected || detected.platform !== 'youtube') {
+		return null;
+	}
+
+	try {
+		// Attempt A: Innertube ANDROID client (primary — its track URLs are
+		// not POT-gated). Its failure must never block attempt B.
+		let player = await attempt('Innertube player', () =>
+			fetchInnertubePlayer(detected.videoId)
+		);
+		let tracks = extractCaptionTracks(player);
+
+		// Attempt B: watch page. Only useful when A breaks (retired client
+		// version); note its track URLs may be POT-gated and fetch empty.
+		if (tracks.length === 0) {
+			const fallback = await attempt('watch page', () =>
+				fetchWatchPagePlayer(detected.videoId)
+			);
+			const fallbackTracks = extractCaptionTracks(fallback);
+			if (fallbackTracks.length > 0) {
+				player = fallback;
+				tracks = fallbackTracks;
+			}
+		}
+
+		if (tracks.length === 0) {
+			console.warn(
+				`[Synapse] No caption tracks for YouTube video ${detected.videoId}` +
+					playabilityDiagnostic(player)
+			);
+			return null;
+		}
+
+		const track = selectCaptionTrack(tracks, preferredLanguages);
+		const text = await fetchCaptionText(track.baseUrl);
+		if (!text) {
+			// The known POT-enforcement failure mode is a 200 with an empty body.
+			console.warn(`[Synapse] Empty caption track for YouTube video ${detected.videoId}`);
+			return null;
+		}
+
+		return {
+			text,
+			language: track.languageCode,
+			auto: track.kind === 'asr',
+			title: extractVideoTitle(player),
+		};
+	} catch (error) {
+		console.warn('[Synapse] YouTube caption fetch failed:', redactError(error));
+		return null;
+	}
+}
+
+/** Run one fetch attempt, downgrading its failure to a warn + null. */
+async function attempt(
+	label: string,
+	fn: () => Promise<unknown>
+): Promise<unknown> {
+	try {
+		return await fn();
+	} catch (error) {
+		console.warn(`[Synapse] YouTube caption ${label} attempt failed:`, redactError(error));
+		return null;
+	}
+}
+
+/** requestUrl with the shared hard timeout (mirrors content-fetcher.ts). */
+async function fetchWithTimeout(params: RequestUrlParam): Promise<RequestUrlResponse> {
+	const timeout = new Promise<never>((_, reject) =>
+		window.setTimeout(
+			() => reject(new Error('Caption fetch timed out')),
+			CAPTION_FETCH_TIMEOUT_MS
+		)
+	);
+	return Promise.race([requestUrl(params), timeout]);
+}
+
+/** Attempt A: GET the watch page and extract `ytInitialPlayerResponse`. */
+async function fetchWatchPagePlayer(videoId: string): Promise<unknown> {
+	const response = await fetchWithTimeout({
+		url: `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}&hl=en`,
+		method: 'GET',
+		headers: {
+			'User-Agent': WATCH_PAGE_USER_AGENT,
+			'Accept': 'text/html,application/xhtml+xml',
+			'Accept-Language': 'en-US,en;q=0.9',
+			'Cookie': CONSENT_COOKIE,
+		},
+	});
+	return extractJsonAfterMarker(response.text, 'ytInitialPlayerResponse');
+}
+
+/** Attempt B: POST the Innertube player endpoint as the ANDROID client. */
+async function fetchInnertubePlayer(videoId: string): Promise<unknown> {
+	const { clientName, clientVersion, androidSdkVersion, userAgent } = INNERTUBE_ANDROID_CLIENT;
+	const response = await fetchWithTimeout({
+		url: INNERTUBE_PLAYER_URL,
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'User-Agent': userAgent,
+			'X-Youtube-Client-Name': '3',
+			'X-Youtube-Client-Version': clientVersion,
+		},
+		body: JSON.stringify({
+			videoId,
+			context: {
+				client: { clientName, clientVersion, androidSdkVersion, hl: 'en' },
+			},
+			contentCheckOk: true,
+			racyCheckOk: true,
+		}),
+	});
+	return parseJson(response.text);
+}
+
+/**
+ * Extract the JSON object assigned right after `marker` in a script-bearing
+ * HTML page by balanced-brace scanning (string- and escape-aware). A greedy
+ * regex is not safe here: the player response is a huge object with nested
+ * braces and embedded `};` sequences inside string values.
+ */
+export function extractJsonAfterMarker(source: string, marker: string): unknown {
+	const markerIdx = source.indexOf(marker);
+	if (markerIdx === -1) return null;
+	const start = source.indexOf('{', markerIdx);
+	if (start === -1) return null;
+
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let i = start; i < source.length; i++) {
+		const ch = source[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (inString) {
+			if (ch === '\\') escaped = true;
+			else if (ch === '"') inString = false;
+			continue;
+		}
+		if (ch === '"') {
+			inString = true;
+		} else if (ch === '{') {
+			depth++;
+		} else if (ch === '}') {
+			depth--;
+			if (depth === 0) {
+				try {
+					return parseJson(source.slice(start, i + 1));
+				} catch {
+					return null;
+				}
+			}
+		}
+	}
+	return null;
+}
+
+/** Read `captions.playerCaptionsTracklistRenderer.captionTracks` defensively. */
+export function extractCaptionTracks(player: unknown): CaptionTrack[] {
+	if (!isRecord(player)) return [];
+	const captions = player.captions;
+	if (!isRecord(captions)) return [];
+	const renderer = captions.playerCaptionsTracklistRenderer;
+	if (!isRecord(renderer)) return [];
+	const rawTracks: unknown = renderer.captionTracks;
+	if (!Array.isArray(rawTracks)) return [];
+
+	const tracks: CaptionTrack[] = [];
+	for (const raw of rawTracks as unknown[]) {
+		if (!isRecord(raw)) continue;
+		const { baseUrl, languageCode, kind } = raw;
+		if (typeof baseUrl !== 'string' || typeof languageCode !== 'string') continue;
+		tracks.push({
+			baseUrl,
+			languageCode,
+			kind: typeof kind === 'string' ? kind : undefined,
+		});
+	}
+	return tracks;
+}
+
+/** `videoDetails.title`, when the player response carries it. */
+function extractVideoTitle(player: unknown): string | undefined {
+	if (!isRecord(player)) return undefined;
+	const details = player.videoDetails;
+	if (!isRecord(details)) return undefined;
+	return typeof details.title === 'string' ? details.title : undefined;
+}
+
+/**
+ * Human-readable `playabilityStatus` fragment for the no-tracks diagnostic —
+ * e.g. LOGIN_REQUIRED (age restriction) or UNPLAYABLE, which explain why no
+ * captions came back.
+ */
+function playabilityDiagnostic(player: unknown): string {
+	if (!isRecord(player)) return '';
+	const status = player.playabilityStatus;
+	if (!isRecord(status) || typeof status.status !== 'string') return '';
+	return ` (playability: ${status.status})`;
+}
+
+/**
+ * Pick the best track: a manually-authored track in a preferred language,
+ * then an auto-generated (ASR) track in a preferred language, then any manual
+ * track, then any ASR track. Language match outranks manual-ness — an ASR
+ * transcript the user can read beats a manual one they can't. `tracks` must
+ * be non-empty.
+ */
+export function selectCaptionTrack(
+	tracks: CaptionTrack[],
+	preferredLanguages: string[]
+): CaptionTrack {
+	const preferred = preferredLanguages
+		.map((lang) => lang.trim().toLowerCase())
+		.filter((lang) => lang.length > 0);
+	const manual = tracks.filter((t) => t.kind !== 'asr');
+	const asr = tracks.filter((t) => t.kind === 'asr');
+
+	for (const pool of [manual, asr]) {
+		for (const lang of preferred) {
+			const match = pool.find((t) => languageMatches(t.languageCode, lang));
+			if (match) return match;
+		}
+	}
+	return manual[0] ?? asr[0] ?? tracks[0];
+}
+
+/** `en` matches `en`, `en-US`, `en-GB`; `pt-BR` also matches a bare `pt`. */
+function languageMatches(trackLanguage: string, preferred: string): boolean {
+	const track = trackLanguage.toLowerCase();
+	return (
+		track === preferred ||
+		track.startsWith(`${preferred}-`) ||
+		preferred.startsWith(`${track}-`)
+	);
+}
+
+/** Fetch a caption track in json3 format and clean it into transcript text. */
+async function fetchCaptionText(baseUrl: string): Promise<string | null> {
+	const trackUrl = buildTrackUrl(baseUrl);
+	if (!trackUrl) return null;
+
+	const response = await fetchWithTimeout({
+		url: trackUrl,
+		method: 'GET',
+		headers: { 'User-Agent': WATCH_PAGE_USER_AGENT },
+	});
+	if (!response.text || response.text.trim().length === 0) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = parseJson(response.text);
+	} catch {
+		return null;
+	}
+	const text = collectJson3Text(parsed);
+	return text.length > 0 ? text : null;
+}
+
+/** Force `fmt=json3` onto a track URL; tolerate a protocol-relative/path base. */
+function buildTrackUrl(baseUrl: string): string | null {
+	const absolute = baseUrl.startsWith('/')
+		? `https://www.youtube.com${baseUrl}`
+		: baseUrl;
+	try {
+		const url = new URL(absolute);
+		url.searchParams.set('fmt', 'json3');
+		return url.toString();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Flatten a json3 timedtext payload (`events[].segs[].utf8`) into clean text.
+ * Skips `aAppend` continuation events (they duplicate the previous window's
+ * trailing text in rolling ASR captions) and events with no segments.
+ */
+export function collectJson3Text(payload: unknown): string {
+	if (!isRecord(payload) || !Array.isArray(payload.events)) return '';
+
+	const parts: string[] = [];
+	for (const event of payload.events as unknown[]) {
+		if (!isRecord(event)) continue;
+		if (event.aAppend === 1) continue;
+		if (!Array.isArray(event.segs)) continue;
+		let eventText = '';
+		for (const seg of event.segs as unknown[]) {
+			if (isRecord(seg) && typeof seg.utf8 === 'string') {
+				eventText += seg.utf8;
+			}
+		}
+		if (eventText.trim().length > 0) {
+			parts.push(eventText);
+		}
+	}
+	return cleanCaptionText(parts.join(' '));
+}
+
+/** Decode the entities YouTube emits and collapse whitespace runs. */
+function cleanCaptionText(text: string): string {
+	return text
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&nbsp;/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}

--- a/src/video/settings-section.ts
+++ b/src/video/settings-section.ts
@@ -1,4 +1,4 @@
-import { Setting, setIcon } from 'obsidian';
+import { Platform, Setting, setIcon } from 'obsidian';
 import { redactError } from '../shared';
 import type { SettingsSectionContext, NotificationManager } from '../shared';
 
@@ -143,9 +143,11 @@ function addPathSetting(
 /**
  * Render the Video Transcription settings accordion (#243).
  *
- * NOTE: This feature is desktop-only (requires yt-dlp + ffmpeg). The
- * `Platform.isDesktop` gate lives in the orchestrator (`settings-tab.ts`),
- * which only invokes this renderer on desktop — keep it that way.
+ * Rendered on every platform since #184 (mobile transcribes YouTube URLs via
+ * captions). The section is platform-aware itself: the desktop-only settings
+ * — yt-dlp/ffmpeg binary paths and the video download/embed pair, all tied to
+ * the local extraction pipeline — are hidden on mobile, where a short note
+ * explains what works instead.
  */
 export function renderVideoSettings(ctx: SettingsSectionContext): void {
 	const { plugin } = ctx;
@@ -157,6 +159,37 @@ export function renderVideoSettings(ctx: SettingsSectionContext): void {
 		(v) => { plugin.settings.video.enabled = v; },
 		'Enable video transcription',
 	);
+
+	new Setting(videoBody)
+		.setName('Prefer YouTube captions')
+		.setDesc(
+			'Transcribe YouTube videos from their captions when available — free, ' +
+			'near-instant, and the only path on mobile. Turn off to always ' +
+			'download and transcribe the audio (desktop only), which also restores ' +
+			'the video download/embed behavior for captioned videos.'
+		)
+		.addToggle((toggle) =>
+			toggle
+				.setValue(plugin.settings.video.captionsFirst)
+				.onChange(async (value) => {
+					plugin.settings.video.captionsFirst = value;
+					await plugin.saveSettings();
+				})
+		);
+
+	if (!Platform.isDesktop) {
+		// Raw createEl DOM (not a Setting row) so the structure stays
+		// unit-testable under the Obsidian mock.
+		videoBody.createDiv({
+			cls: 'setting-item-description',
+			text:
+				'On mobile, YouTube videos are transcribed from their captions. ' +
+				'TikTok/Instagram and caption-less videos need the desktop app ' +
+				'(yt-dlp + ffmpeg) — in a synced vault, notes left in the intake ' +
+				'folder are picked up by the desktop app automatically.',
+		});
+		return;
+	}
 
 	addPathSetting(videoBody, {
 		name: 'yt-dlp path',


### PR DESCRIPTION
## Summary
- **YouTube transcription now works on mobile (and got free/instant on desktop):** new zero-dependency caption fetcher (`src/transcription/youtube-captions.ts`) pulls the video's caption track over plain HTTP — Innertube ANDROID client as the primary attempt (its track URLs are not POT-gated; verified live 2026-07-14), watch page as fallback — then cleans json3 into a transcript.
- **Tiered `UrlTranscriptionRouter`** (`src/transcription/url-transcription.ts`): captions → local yt-dlp/ffmpeg extraction (desktop), with a `null`-falls-through / throw-propagates contract so `DependencyMissingError` keeps its #382 onboarding UX. Deliberately a *transcript*-level seam rather than #180's audio-returning `MediaExtractor` — the Phase 2 server extractor (#181) slots in as a third strategy. Decision recorded in DECISIONS.md (2026-07-14).
- **Intake media-URL branch is real now** (was the #112 "coming soon" stub): transcribe → append callout → full pipeline (enrich/organize) → stamp. On failure the note stays **un-stamped**, so a synced desktop vault's watcher finishes what mobile can't — the designed mobile-TikTok story until #181 exists.
- **Summarize, unified modal, ribbon, and commands ungated** from `Platform.isDesktop`; a time range still forces the extraction tier so desktop clipping is unchanged. Caption text runs through the same post-processing + lyrics-schema pipeline via new `AudioModule.processTranscriptText`.
- **#455 Android share flow:** opt-in `intake.adoptSharedCaptures` setting moves newly created root-level bare-URL notes (where Obsidian's share receiver drops them) into the intake folder; docs updated with the share→transcribe walkthrough.
- **Settings:** new `video.captionsFirst` toggle (default on — captioned YouTube no longer auto-downloads the video on desktop; turning it off restores that); video section now renders on mobile with binary-path settings hidden; README privacy table documents the youtube.com caption fetch.

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] Types pass (`npx tsc --noEmit --skipLibCheck`)
- [x] Tests pass (`npm test` — 1935 tests, 40+ new across fetcher/router/strategies/intake-adoption/modal)
- [x] CI guards pass (`check-top-level-requires.mjs`, `version-bump.mjs --check`)
- [x] Build passes (`node esbuild.config.mjs production`)
- [x] **Live-verified** caption fetch against real YouTube (Innertube ANDROID end-to-end; confirmed web watch-page track URLs return empty — hence the primary/fallback order)
- [ ] Manual desktop pass: intake note with captioned YouTube URL / captionless → yt-dlp fallback / TikTok / `captionsFirst` off
- [ ] Android device pass via BRAT: share YouTube link → Inbox → transcript; TikTok share → un-stamped note + clear notice → desktop finishes after sync

Closes #184, closes #112, closes #455

Co-Authored-By: Claude <bot@wafflenet.io>

https://claude.ai/code/session_012HVfTic7eKWvFiEYkoJe6m