### PR TITLE
fix: route batch note-media transcription through the caption tier

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -157,6 +157,14 @@ export default class SynapsePlugin extends Plugin {
 		}
 		const urlTranscription = new UrlTranscriptionRouter(urlStrategies);
 		this.urlTranscription = urlTranscription;
+		if (video) {
+			// Batch note-media transcription routes through the same tiers, so
+			// captioned YouTube videos never hit the download/size limits (#184).
+			video.urlTranscriber = (url, parentOp) =>
+				urlTranscription.transcribe(url, {
+					update: parentOp ? (msg) => parentOp.update(msg) : undefined,
+				});
+		}
 
 		this.summarize = new SummarizeModule(
 			this, getSettings, this.notifications, this.checkpointManager, registrar,

--- a/src/transcription/insert-url-transcript.ts
+++ b/src/transcription/insert-url-transcript.ts
@@ -16,10 +16,10 @@ export interface InsertUrlTranscriptDeps {
 
 /**
  * Transcribe a media URL through the tier router and append the transcript to
- * the ACTIVE note — the platform-agnostic sibling of the desktop-only
- * `VideoModule.transcribeUrlToActiveNote`, and the path the unified
- * transcription modal takes on every platform. Mirrors that method's guards
- * (active note required, #307 path exclusion) and its output block shape.
+ * the ACTIVE note — the path the unified transcription modal takes on every
+ * platform (it replaced the desktop-only VideoModule equivalent). Guards:
+ * active note required, #307 path exclusion; output mirrors the standard
+ * transcription block shape.
  */
 export async function insertUrlTranscript(
 	deps: InsertUrlTranscriptDeps,

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -4,16 +4,18 @@ import { CommandRegistrar } from '../commands';
 import { AudioModule, TranscriptionResult } from '../audio';
 import {
 	ensureFolder, NotificationManager, sanitizeUrl, buildCallout, calloutForTranscriptionResult,
-	CheckpointManager, generateId, formatTimeRange, detectPlatform, loadNodeModules,
-	isPathExcluded, findMatchingRule, findAvailableVaultPath,
+	CheckpointManager, generateId, detectPlatform, loadNodeModules,
+	isPathExcluded, findAvailableVaultPath,
 } from '../shared';
-import type { TimeRange } from '../shared';
 import type { Checkpoint, CheckpointWorkItem, DeferredTask } from '../shared';
 import { AudioExtractor, DependencyMissingError } from './audio-extractor';
 import { VideoMetadata, VideoProcessOptions, VideoUrlEmbed } from './types';
+import type { RoutedUrlTranscriber, RoutedUrlTranscript } from './types';
 
 export type {
 	ExtractionResult,
+	RoutedUrlTranscriber,
+	RoutedUrlTranscript,
 	VideoMetadata,
 	VideoProcessOptions,
 	VideoSource,
@@ -29,6 +31,14 @@ export class VideoModule {
 
 	/** Optional callback invoked after video transcription completes. Wired by main.ts for enrichment. */
 	onTranscriptionComplete: ((filePath: string) => void) | null = null;
+
+	/**
+	 * Tier-routed URL transcriber (captions first, then extraction). Wired by
+	 * main.ts so batch note-media transcription (#184) goes through the same
+	 * tier routing as every other URL path; when unset (defensive fallback),
+	 * the batch falls back to direct extraction via {@link processUrl}.
+	 */
+	urlTranscriber: RoutedUrlTranscriber | null = null;
 
 	constructor(
 		private plugin: Plugin,
@@ -53,19 +63,6 @@ export class VideoModule {
 	}
 
 	onunload(): void {}
-
-	/**
-	 * Transcribe a video URL and return the transcript text without creating
-	 * a note. Used by the summarize module to auto-transcribe video URLs
-	 * before summarizing.
-	 */
-	async transcribeUrl(
-		url: string,
-		parentOp?: { update: (msg: string) => void }
-	): Promise<string> {
-		const result = await this.processUrl(url, { insertMode: false }, parentOp);
-		return result.processed || result.raw;
-	}
 
 	async processUrl(
 		url: string,
@@ -146,61 +143,6 @@ export class VideoModule {
 		return { ...result, videoVaultPath };
 	}
 
-	async transcribeUrlToActiveNote(url: string, timeRange?: TimeRange): Promise<void> {
-		const activeFile = this.plugin.app.workspace.getActiveFile();
-		if (!activeFile) {
-			this.notifications.info('Open a note first to insert the transcription');
-			return;
-		}
-
-		// Path exclusion (#307): transcription lands in the ACTIVE note. Explicit
-		// command → Notice naming the rule.
-		const rule = findMatchingRule(activeFile.path, 'video', this.getSettings());
-		if (rule) {
-			this.notifications.info(
-				`Skipped — "${activeFile.path}" is excluded by rule "${rule.pattern}"`
-			);
-			return;
-		}
-
-		const op = this.notifications.startOperation(
-			'Processing video URL...',
-			`video-url-${Date.now()}`
-		);
-		try {
-			const result = await this.processUrl(url, { insertMode: true, timeRange }, op);
-			const text = result.processed || result.raw;
-
-			const blockLines: string[] = [''];
-
-			if (this.getSettings().video.embedInNote && result.videoVaultPath) {
-				const fileName = result.videoVaultPath.split('/').pop()!;
-				blockLines.push(`![[${fileName}]]`);
-				blockLines.push('');
-			}
-
-			const { type, verb } = calloutForTranscriptionResult(result);
-			const title = timeRange
-				? `${verb} ${url} ${formatTimeRange(timeRange)}`
-				: `${verb} ${url}`;
-			const callout = buildCallout(
-				type,
-				title,
-				text,
-				true
-			);
-			blockLines.push(callout);
-
-			const block = blockLines.join('\n');
-			await this.plugin.app.vault.process(activeFile, (data) => data + block);
-			this.onTranscriptionComplete?.(activeFile.path);
-			op.finish('Video transcription added to note');
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : String(error);
-			op.error(`Video transcription failed -- ${msg}`);
-		}
-	}
-
 	/**
 	 * Resume video transcription from a checkpoint (C1).
 	 * The remaining video files are re-processed.
@@ -262,8 +204,22 @@ export class VideoModule {
 			}
 			try {
 				op.progress(completed + 1, total, 'Transcribing video');
-				const result = await this.processUrl(embed.url, { insertMode: true }, op);
-				const text = result.processed || result.raw;
+
+				// Tier-routed (#184): captions first, extraction fallback — the
+				// same routing every other URL path uses. The direct processUrl
+				// branch is a defensive fallback for an unwired transcriber.
+				let result: RoutedUrlTranscript;
+				if (this.urlTranscriber) {
+					result = await this.urlTranscriber(embed.url, op);
+				} else {
+					const extracted = await this.processUrl(embed.url, { insertMode: true }, op);
+					result = {
+						text: extracted.processed || extracted.raw,
+						videoVaultPath: extracted.videoVaultPath,
+						reformatted: extracted.reformatted,
+						schemaId: extracted.schemaId,
+					};
+				}
 
 				const blockLines: string[] = [''];
 
@@ -278,7 +234,7 @@ export class VideoModule {
 				const callout = buildCallout(
 					type,
 					`${verb} ${embed.url}`,
-					text,
+					result.text,
 					true
 				);
 				blockLines.push(callout);

--- a/src/video/transcribe-and-insert.test.ts
+++ b/src/video/transcribe-and-insert.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { TFile } from '../__mocks__/obsidian';
+import { VideoModule } from './index';
+import type { VideoUrlEmbed } from './types';
+import { createMockCheckpointManager } from '../__test-utils__/mock-factories';
+
+/**
+ * Batch note-media transcription goes through the injected tier-routed
+ * transcriber (#184) — captioned YouTube must never be forced through the
+ * download/extract pipeline (the pre-#184 behavior that hit provider size
+ * limits on long videos).
+ */
+
+const URL = 'https://www.youtube.com/watch?v=abc123xyz00';
+
+function makeOperation() {
+	return {
+		update: vi.fn(),
+		progress: vi.fn(),
+		finish: vi.fn(),
+		error: vi.fn(),
+		cancelled: false,
+	};
+}
+
+function makeModule() {
+	const store = new Map<string, string>();
+	const noteFile = new TFile('Notes/video-note.md');
+	store.set(noteFile.path, 'line0\nhttps://www.youtube.com/watch?v=abc123xyz00\nline2');
+
+	const vault = {
+		process: vi.fn(async (file: TFile, fn: (data: string) => string) => {
+			const result = fn(store.get(file.path) ?? '');
+			store.set(file.path, result);
+			return result;
+		}),
+	};
+	const notifications = {
+		startOperation: vi.fn().mockReturnValue(makeOperation()),
+		info: vi.fn(),
+		notifyError: vi.fn(),
+	};
+	const getSettings = () =>
+		({
+			video: { enabled: true, embedInNote: true, downloadFolder: 'Media' },
+			exclusions: [],
+		}) as never;
+	const plugin = { app: { vault } } as never;
+
+	const mod = new VideoModule(
+		plugin,
+		getSettings,
+		{} as never,
+		notifications as never,
+		createMockCheckpointManager() as never,
+		{} as never
+	);
+	const processUrl = vi.spyOn(mod, 'processUrl');
+	return { mod, store, noteFile, notifications, processUrl };
+}
+
+function embed(line: number): VideoUrlEmbed {
+	return { url: URL, platform: 'youtube', line };
+}
+
+beforeEach(() => {
+	vi.stubGlobal('window', globalThis);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('VideoModule.transcribeAndInsert tier routing (#184)', () => {
+	it('uses the injected tier-routed transcriber, never direct extraction', async () => {
+		const { mod, store, noteFile, processUrl } = makeModule();
+		mod.urlTranscriber = vi.fn().mockResolvedValue({ text: 'caption transcript' });
+
+		await mod.transcribeAndInsert(noteFile as never, [embed(1)]);
+
+		expect(mod.urlTranscriber).toHaveBeenCalledWith(URL, expect.anything());
+		expect(processUrl).not.toHaveBeenCalled();
+		const content = store.get(noteFile.path)!;
+		expect(content).toContain('> [!synapse-transcription]- Transcription of');
+		expect(content).toContain('> caption transcript');
+	});
+
+	it('embeds the downloaded video when the routed result carries a vault path', async () => {
+		const { mod, store, noteFile } = makeModule();
+		mod.urlTranscriber = vi.fn().mockResolvedValue({
+			text: 'extracted transcript',
+			videoVaultPath: 'Media/2026-07-15-video.mp4',
+		});
+
+		await mod.transcribeAndInsert(noteFile as never, [embed(1)]);
+
+		expect(store.get(noteFile.path)).toContain('![[2026-07-15-video.mp4]]');
+	});
+
+	it('surfaces a routed failure per embed without inserting anything', async () => {
+		const { mod, store, noteFile, notifications } = makeModule();
+		const before = store.get(noteFile.path);
+		mod.urlTranscriber = vi.fn().mockRejectedValue(new Error('no transcription path'));
+
+		await mod.transcribeAndInsert(noteFile as never, [embed(1)]);
+
+		expect(notifications.notifyError).toHaveBeenCalled();
+		expect(store.get(noteFile.path)).toBe(before);
+	});
+
+	it('falls back to direct extraction when no transcriber is wired', async () => {
+		const { mod, store, noteFile, processUrl } = makeModule();
+		(processUrl as Mock).mockResolvedValue({
+			raw: 'raw',
+			processed: 'extracted transcript',
+			sourceName: 'v',
+		});
+
+		await mod.transcribeAndInsert(noteFile as never, [embed(1)]);
+
+		expect(processUrl).toHaveBeenCalledWith(URL, { insertMode: true }, expect.anything());
+		expect(store.get(noteFile.path)).toContain('> extracted transcript');
+	});
+});

--- a/src/video/types.ts
+++ b/src/video/types.ts
@@ -42,3 +42,25 @@ export interface VideoUrlEmbed {
 	platform: Platform;
 	line: number;
 }
+
+/**
+ * Result of the tier-routed URL transcriber injected by main.ts —
+ * structurally compatible with `UrlTranscript` from `src/transcription`
+ * (declared here so the video module never imports the transcription module,
+ * whose barrel imports this one).
+ */
+export interface RoutedUrlTranscript {
+	text: string;
+	videoVaultPath?: string;
+	reformatted?: boolean;
+	schemaId?: string;
+}
+
+/**
+ * Tier-routed URL transcription callback (captions first, then extraction).
+ * Throws on failure — including when no tier can handle the URL.
+ */
+export type RoutedUrlTranscriber = (
+	url: string,
+	parentOp?: { update: (message: string) => void }
+) => Promise<RoutedUrlTranscript>;


### PR DESCRIPTION
## Summary
- **Bug (found in live desktop testing right after #461 merged):** the "Transcribe media" note flow (`VideoModule.transcribeAndInsert`) still called `processUrl` directly, bypassing the tier router — so a captioned YouTube video was forced through yt-dlp + Whisper and long videos failed with `Whisper API request failed (status 413)` even with "Prefer YouTube captions" on. The intake, summarize, and URL-modal paths were already tier-routed; this was the one path left out.
- **Fix:** main.ts injects the `UrlTranscriptionRouter` into `VideoModule` (`urlTranscriber`, same setter style as `onTranscriptionComplete`), and the batch loop routes each embed through it — captions first, extraction fallback. Direct `processUrl` remains only as a defensive fallback when no transcriber is wired.
- **Dead code removed:** `VideoModule.transcribeUrl` and `transcribeUrlToActiveNote` had no remaining callers (the router took over the summarize and modal paths in #461).
- New `src/video/transcribe-and-insert.test.ts` covers: routed-transcriber-only (no `processUrl`), embed from a routed vault path, per-embed failure without insertion, and the unwired fallback.

## Test plan
- [x] Lint / types / tests (1939) / CI guards / production build all pass
- [ ] Manual: "Transcribe media" on a note with the long captioned YouTube URL that previously 413'd — should insert a caption transcript near-instantly

Co-Authored-By: Claude <bot@wafflenet.io>

https://claude.ai/code/session_012HVfTic7eKWvFiEYkoJe6m