### PR TITLE
fix: post-processing token guard + filler-removal off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ way (see DECISIONS.md).
 | Enable audio | Toggle audio transcription | On |
 | Transcription provider | Whisper API, Deepgram, or Local Whisper (desktop only) | Whisper API |
 | Post-processing | Clean up transcriptions with AI | On |
-| Remove filler words | Strip filler words from transcripts | On |
+| Remove filler words | Strip filler words from transcripts (best for voice memos; alters quoted speech) | Off |
 
 ### Video Transcription
 

--- a/src/audio/post-processor.test.ts
+++ b/src/audio/post-processor.test.ts
@@ -44,6 +44,31 @@ describe('PostProcessor', () => {
 		expect(completeSpy).not.toHaveBeenCalled();
 	});
 
+	it('skips the AI pass when the transcript exceeds the output-token budget (#466)', async () => {
+		const settings = makeSettings((s) => {
+			s.ai.maxTokens = 100; // budget: ~400 chars
+		});
+		const pp = new PostProcessor(() => settings);
+		const longTranscript = 'word '.repeat(200); // 1000 chars ≈ 250 tokens
+
+		const result = await pp.process(longTranscript);
+
+		expect(result).toBe(longTranscript);
+		expect(completeSpy).not.toHaveBeenCalled();
+	});
+
+	it('still post-processes a transcript that fits the output-token budget', async () => {
+		const settings = makeSettings((s) => {
+			s.ai.maxTokens = 100;
+		});
+		const pp = new PostProcessor(() => settings);
+
+		const result = await pp.process('short transcript');
+
+		expect(result).toBe('processed');
+		expect(completeSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it('builds an instruction list from the enabled toggles and sends it to the AI', async () => {
 		const settings = makeSettings((s) => {
 			s.audio.postProcessing.enabled = true;

--- a/src/audio/post-processor.ts
+++ b/src/audio/post-processor.ts
@@ -1,6 +1,12 @@
 import { SynapseSettings } from '../settings';
 import { AIClient, sanitizeAIResponse } from '../shared';
 
+/**
+ * Rough chars-per-token estimate for English text, used by the output-budget
+ * guard below. Deliberately conservative (real ratios are usually higher).
+ */
+const CHARS_PER_TOKEN = 4;
+
 export class PostProcessor {
 	private aiClient: AIClient;
 
@@ -34,6 +40,24 @@ export class PostProcessor {
 		}
 
 		if (instructions.length === 0) return rawTranscript;
+
+		// Output-budget guard (#466): post-processing REWRITES the transcript,
+		// so the response needs roughly as many tokens as the input. Every
+		// provider dispatch caps responses at ai.maxTokens; past that the model
+		// silently truncates and the cut-off text would land in `processed`,
+		// which every consumer prefers over `raw`. A raw-but-complete
+		// transcript beats a clean-but-truncated one, so skip the AI pass for
+		// transcripts that clearly exceed the budget. Chunked processing for
+		// long transcripts is #467.
+		const estimatedTokens = Math.ceil(rawTranscript.length / CHARS_PER_TOKEN);
+		const { maxTokens } = this.getSettings().ai;
+		if (estimatedTokens > maxTokens) {
+			console.warn(
+				`[Synapse] Transcript needs ~${estimatedTokens} output tokens but the AI max tokens setting is ${maxTokens}; ` +
+				'skipping post-processing to avoid truncation (raise Max tokens in AI settings to post-process long transcripts)'
+			);
+			return rawTranscript;
+		}
 
 		const systemPrompt =
 			'You are a transcription editor. Process the following raw transcript according to the instructions. ' +

--- a/src/audio/settings-section.ts
+++ b/src/audio/settings-section.ts
@@ -81,6 +81,11 @@ export function renderAudioSettings(ctx: SettingsSectionContext): void {
 
 	new Setting(audioBody)
 		.setName('Remove filler words')
+		.setDesc(
+			'Strip "um", "uh", and false starts during post-processing. Best for ' +
+			'voice memos — it rewords quoted speech, so leave it off for ' +
+			'interviews, talks, and video transcripts you want verbatim.'
+		)
 		.addToggle((toggle) =>
 			toggle
 				.setValue(plugin.settings.audio.postProcessing.removeFiller)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -420,7 +420,10 @@ export const DEFAULT_SETTINGS: SynapseSettings = {
 		autoFormatLyrics: true,
 		postProcessing: {
 			enabled: true,
-			removeFiller: true,
+			// Off by default: stripping filler is a per-content-type call (great
+			// for voice memos, wrong for interviews/quotes) that users forget
+			// is on. Opt in per vault; possibly moving to tidy (#465).
+			removeFiller: false,
 			addStructure: true,
 			extractKeyPoints: false,
 			customPrompt: '',


### PR DESCRIPTION
## Summary
Two related post-processing fixes found while testing caption transcription of a 70-minute video:

- **Silent truncation guard (closes #466):** `PostProcessor.process` sends the whole transcript through one AI call capped at `ai.maxTokens` (default 2048). Post-processing rewrites the transcript, so anything past ~1,500 words came back truncated — and the truncated text landed in `processed`, which every consumer prefers over `raw`. The guard estimates the output budget (`chars / 4`) and keeps the complete raw transcript (with a console diagnostic naming the remedy) when it exceeds `maxTokens`. Raw-but-complete beats clean-but-truncated. Chunked processing for long transcripts is #467.
- **"Remove filler words" defaults off:** stripping filler is a per-content-type call — right for voice memos, wrong for interviews/talks/video transcripts wanted verbatim — and an always-on default silently rewords content users never asked to change. New installs get it off; existing vaults keep their saved value (flip the toggle to adopt). The toggle now carries a description explaining the trade-off. Whether filler-removal belongs in tidy instead is on the #465 UX review.

## Test plan
- [x] Lint / types / tests (1937, 2 new) / CI guards / production build pass
- [ ] Manual: transcribe a long captioned YouTube video — full transcript (raw) with the skip diagnostic in console; short video still post-processes; filler toggle shows the new description

Closes #466

Co-Authored-By: Claude <bot@wafflenet.io>

https://claude.ai/code/session_012HVfTic7eKWvFiEYkoJe6m