### PR TITLE
feat: deterministic caption formatting — speaker turns, chapters, pauses

### DIFF
--- a/src/transcription/caption-strategy.test.ts
+++ b/src/transcription/caption-strategy.test.ts
@@ -54,12 +54,30 @@ describe('CaptionStrategy.canHandle', () => {
 });
 
 describe('CaptionStrategy.transcribe', () => {
+	it('skips AI post-processing for deterministically structured transcripts', async () => {
+		fetchTranscript.mockResolvedValue({
+			text: '### [Intro](https://youtube/t=0)\n\nHi everyone.\n\nGlad to be here.',
+			language: 'en',
+			auto: true,
+			title: 'A Video',
+			structured: true,
+		});
+		const { strategy, postProcess } = makeStrategy();
+
+		const result = await strategy.transcribe(YOUTUBE_URL, {});
+
+		expect(postProcess).not.toHaveBeenCalled();
+		expect(result?.text).toContain('### [Intro]');
+		expect(result?.source).toBe('captions');
+	});
+
 	it('post-processes fetched captions into a caption-sourced transcript', async () => {
 		fetchTranscript.mockResolvedValue({
 			text: 'caption text',
 			language: 'en',
 			auto: true,
 			title: 'A Video',
+			structured: false,
 		});
 		const { strategy, postProcess } = makeStrategy();
 
@@ -95,7 +113,7 @@ describe('CaptionStrategy.transcribe', () => {
 	});
 
 	it('degrades to raw captions when post-processing fails', async () => {
-		fetchTranscript.mockResolvedValue({ text: 'caption text', language: 'en', auto: true });
+		fetchTranscript.mockResolvedValue({ text: 'caption text', language: 'en', auto: true, structured: false });
 		const { strategy } = makeStrategy(
 			{},
 			vi.fn(() => Promise.reject(new Error('no AI key')))
@@ -108,7 +126,7 @@ describe('CaptionStrategy.transcribe', () => {
 	});
 
 	it('carries schema-reformat flags through (lyrics callout, #234)', async () => {
-		fetchTranscript.mockResolvedValue({ text: 'la la la', language: 'en', auto: true });
+		fetchTranscript.mockResolvedValue({ text: 'la la la', language: 'en', auto: true, structured: false });
 		const { strategy } = makeStrategy(
 			{},
 			vi.fn(() => Promise.resolve({ text: '## Verse\nla la la', reformatted: true, schemaId: 'lyrics' }))
@@ -121,7 +139,7 @@ describe('CaptionStrategy.transcribe', () => {
 	});
 
 	it('reports progress through the update hook', async () => {
-		fetchTranscript.mockResolvedValue({ text: 'caption text', language: 'en', auto: true });
+		fetchTranscript.mockResolvedValue({ text: 'caption text', language: 'en', auto: true, structured: false });
 		const { strategy } = makeStrategy();
 		const update = vi.fn();
 

--- a/src/transcription/caption-strategy.ts
+++ b/src/transcription/caption-strategy.ts
@@ -53,6 +53,20 @@ export class CaptionStrategy implements UrlTranscriptionStrategy {
 			return null;
 		}
 
+		// Deterministically structured transcripts (speaker turns / chapter
+		// headings) are finished markdown — an AI rewrite would only flatten
+		// the structure the caption stream itself declared. Only weakly
+		// structured (plain ASR) text goes through the post-processing pass.
+		if (captions.structured) {
+			return {
+				text: captions.text,
+				raw: captions.text,
+				source: 'captions',
+				title: captions.title,
+				language: captions.language,
+			};
+		}
+
 		opts.update?.('Post-processing transcript...');
 		let processed: ProcessedTranscript = { text: captions.text };
 		try {

--- a/src/transcription/youtube-captions.test.ts
+++ b/src/transcription/youtube-captions.test.ts
@@ -4,8 +4,11 @@ import {
 	extractJsonAfterMarker,
 	extractCaptionTracks,
 	selectCaptionTrack,
-	collectJson3Text,
+	collectJson3Cues,
+	parseChaptersFromDescription,
+	formatCaptionTranscript,
 } from './youtube-captions';
+import type { CaptionCue } from './youtube-captions';
 import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from '../__mocks__/obsidian';
 
 /**
@@ -82,11 +85,13 @@ describe('fetchYouTubeTranscript', () => {
 
 		const result = await fetchYouTubeTranscript(WATCH_URL, ['en']);
 
+		// The 3s silence between the cues becomes a paragraph break.
 		expect(result).toEqual({
-			text: "hello world it's fine",
+			text: "hello world\n\nit's fine",
 			language: 'en',
 			auto: true,
 			title: 'Test Video',
+			structured: false,
 		});
 		const innertubeCall = mockRequestUrl.mock.calls.find(([params]) => {
 			const url = typeof params === 'string' ? params : params.url;
@@ -130,7 +135,7 @@ describe('fetchYouTubeTranscript', () => {
 		});
 
 		const result = await fetchYouTubeTranscript(WATCH_URL, ['en']);
-		expect(result?.text).toBe("hello world it's fine");
+		expect(result?.text).toBe("hello world\n\nit's fine");
 	});
 
 	it('falls back to the watch page when Innertube returns an error payload without tracks', async () => {
@@ -149,7 +154,7 @@ describe('fetchYouTubeTranscript', () => {
 		});
 
 		const result = await fetchYouTubeTranscript(WATCH_URL, ['en']);
-		expect(result?.text).toBe("hello world it's fine");
+		expect(result?.text).toBe("hello world\n\nit's fine");
 	});
 
 	it('returns null when neither attempt yields caption tracks', async () => {
@@ -271,24 +276,126 @@ describe('selectCaptionTrack', () => {
 	});
 });
 
-describe('collectJson3Text', () => {
-	it('joins segments, skips append events, and decodes entities', () => {
+describe('collectJson3Cues', () => {
+	it('produces timed cues, skipping append and blank filler events', () => {
 		const payload = JSON.parse(json3(SIMPLE_EVENTS)) as unknown;
-		expect(collectJson3Text(payload)).toBe("hello world it's fine");
+		expect(collectJson3Cues(payload)).toEqual([
+			{ startMs: 0, endMs: 2000, text: 'hello world' },
+			{ startMs: 5000, endMs: 5000, text: "it's fine" },
+		]);
 	});
 
-	it('collapses whitespace runs and newline segments', () => {
+	it('decodes entities and collapses whitespace/newline segments', () => {
 		const payload = {
 			events: [
-				{ segs: [{ utf8: 'line one\n' }, { utf8: '  line   two ' }] },
+				{ tStartMs: 10, dDurationMs: 5, segs: [{ utf8: 'line one\n' }, { utf8: '  line &amp; two ' }] },
+				{ tStartMs: 20, dDurationMs: 5, segs: [{ utf8: '\n' }] },
 			],
 		};
-		expect(collectJson3Text(payload)).toBe('line one line two');
+		expect(collectJson3Cues(payload)).toEqual([
+			{ startMs: 10, endMs: 15, text: 'line one line & two' },
+		]);
 	});
 
-	it('returns empty string for non-json3 shapes', () => {
-		expect(collectJson3Text(null)).toBe('');
-		expect(collectJson3Text({})).toBe('');
-		expect(collectJson3Text({ events: 'nope' })).toBe('');
+	it('returns [] for non-json3 shapes', () => {
+		expect(collectJson3Cues(null)).toEqual([]);
+		expect(collectJson3Cues({})).toEqual([]);
+		expect(collectJson3Cues({ events: 'nope' })).toEqual([]);
+	});
+});
+
+describe('parseChaptersFromDescription', () => {
+	const DESCRIPTION = [
+		'Kara and Scott discuss the week.',
+		'',
+		'00:00 Intro',
+		'05:11 First Topic',
+		'1:01:30 - Late Topic',
+		'',
+		'Follow us at https://example.com',
+	].join('\n');
+
+	it('parses MM:SS and H:MM:SS chapter lines', () => {
+		expect(parseChaptersFromDescription(DESCRIPTION)).toEqual([
+			{ title: 'Intro', startMs: 0 },
+			{ title: 'First Topic', startMs: 311_000 },
+			{ title: 'Late Topic', startMs: 3_690_000 },
+		]);
+	});
+
+	it('requires at least two chapters', () => {
+		expect(parseChaptersFromDescription('00:00 Only one')).toEqual([]);
+		expect(parseChaptersFromDescription('no chapters here')).toEqual([]);
+	});
+
+	it('rejects non-ascending timestamps (not a chapter list)', () => {
+		expect(
+			parseChaptersFromDescription('05:00 Later\n00:30 Earlier')
+		).toEqual([]);
+	});
+});
+
+describe('formatCaptionTranscript', () => {
+	const VIDEO_ID = 'dQw4w9WgXcQ';
+
+	function cue(startMs: number, text: string, durationMs = 1000): CaptionCue {
+		return { startMs, endMs: startMs + durationMs, text };
+	}
+
+	it('splits >> speaker markers into turn paragraphs (structured)', () => {
+		const cues = [
+			cue(0, "This isn't a story about Mitch McConnell."),
+			cue(2000, '>> Hi everyone, this is Pivot. >> And'),
+			cue(4000, "I'm Scott Galloway."),
+		];
+		const { text, structured } = formatCaptionTranscript(cues, [], VIDEO_ID);
+		expect(structured).toBe(true);
+		expect(text).toBe(
+			"This isn't a story about Mitch McConnell.\n\n" +
+				'Hi everyone, this is Pivot.\n\n' +
+				"And I'm Scott Galloway."
+		);
+	});
+
+	it('weaves chapter headings in as timestamp links', () => {
+		const cues = [
+			cue(0, '>> Welcome back. >> Glad to be here.'),
+			cue(310_000, '>> Now the big story.'),
+		];
+		const chapters = [
+			{ title: 'Intro', startMs: 0 },
+			{ title: 'Big [Story]', startMs: 305_000 },
+		];
+		const { text, structured } = formatCaptionTranscript(cues, chapters, VIDEO_ID);
+		expect(structured).toBe(true);
+		expect(text).toContain('### [Intro](https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=0)');
+		expect(text).toContain('### [Big Story](https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=305)');
+		expect(text.indexOf('Big Story')).toBeGreaterThan(text.indexOf('Glad to be here.'));
+		expect(text.indexOf('Now the big story.')).toBeGreaterThan(text.indexOf('Big Story'));
+	});
+
+	it('paragraphs marker-less ASR at pauses (not structured)', () => {
+		const cues = [
+			cue(0, 'first thought', 2000),
+			cue(2100, 'continues here', 1000),
+			cue(6000, 'after a long pause'),
+		];
+		const { text, structured } = formatCaptionTranscript(cues, [], VIDEO_ID);
+		expect(structured).toBe(false);
+		expect(text).toBe('first thought continues here\n\nafter a long pause');
+	});
+
+	it('force-breaks unreadably long marker-less paragraphs at a cue boundary', () => {
+		const long = 'x'.repeat(400);
+		const cues = [cue(0, long), cue(1100, long), cue(2200, 'tail')];
+		const { text } = formatCaptionTranscript(cues, [], VIDEO_ID);
+		expect(text.split('\n\n').length).toBe(2);
+		expect(text.endsWith('tail')).toBe(true);
+	});
+
+	it('a single stray >> is not treated as dialogue', () => {
+		const cues = [cue(0, 'plain text >> once only')];
+		const { structured } = formatCaptionTranscript(cues, [], VIDEO_ID);
+		expect(structured).toBe(false);
 	});
 });

--- a/src/transcription/youtube-captions.ts
+++ b/src/transcription/youtube-captions.ts
@@ -25,7 +25,12 @@ import { detectPlatform, isRecord, parseJson, redactError, sanitizeUrl } from '.
  */
 
 export interface YouTubeTranscript {
-	/** Cleaned caption text (timing stripped, segments merged). */
+	/**
+	 * Cleaned transcript, deterministically structured from the caption
+	 * stream's own signals (see {@link formatCaptionTranscript}): speaker-turn
+	 * paragraphs from `>>` markers, chapter headings from the video
+	 * description, and pause-based paragraph breaks from cue timing.
+	 */
 	text: string;
 	/** BCP-47 language code of the selected track (e.g. `en`, `en-US`). */
 	language: string;
@@ -33,6 +38,26 @@ export interface YouTubeTranscript {
 	auto: boolean;
 	/** Video title from the player response, when present. */
 	title?: string;
+	/**
+	 * True when STRONG deterministic structure was found (speaker turns or
+	 * chapters) — the text is finished markdown, and AI restructuring would
+	 * only degrade it. Weakly-structured transcripts (pause-paragraphed ASR)
+	 * still benefit from the AI post-processing pass.
+	 */
+	structured: boolean;
+}
+
+/** One caption cue: a timed slice of transcript text. */
+export interface CaptionCue {
+	startMs: number;
+	endMs: number;
+	text: string;
+}
+
+/** A chapter declared in the video description (`MM:SS Title` lines). */
+export interface VideoChapter {
+	title: string;
+	startMs: number;
 }
 
 /** A caption track as advertised by the player response. */
@@ -124,18 +149,22 @@ export async function fetchYouTubeTranscript(
 		}
 
 		const track = selectCaptionTrack(tracks, preferredLanguages);
-		const text = await fetchCaptionText(track.baseUrl);
-		if (!text) {
+		const cues = await fetchCaptionCues(track.baseUrl);
+		if (cues.length === 0) {
 			// The known POT-enforcement failure mode is a 200 with an empty body.
 			console.warn(`[Synapse] Empty caption track for YouTube video ${detected.videoId}`);
 			return null;
 		}
+
+		const chapters = parseChaptersFromDescription(extractVideoDescription(player));
+		const { text, structured } = formatCaptionTranscript(cues, chapters, detected.videoId);
 
 		return {
 			text,
 			language: track.languageCode,
 			auto: track.kind === 'asr',
 			title: extractVideoTitle(player),
+			structured,
 		};
 	} catch (error) {
 		console.warn('[Synapse] YouTube caption fetch failed:', redactError(error));
@@ -282,6 +311,14 @@ function extractVideoTitle(player: unknown): string | undefined {
 	return typeof details.title === 'string' ? details.title : undefined;
 }
 
+/** `videoDetails.shortDescription` — where creators declare chapters. */
+function extractVideoDescription(player: unknown): string {
+	if (!isRecord(player)) return '';
+	const details = player.videoDetails;
+	if (!isRecord(details)) return '';
+	return typeof details.shortDescription === 'string' ? details.shortDescription : '';
+}
+
 /**
  * Human-readable `playabilityStatus` fragment for the no-tracks diagnostic —
  * e.g. LOGIN_REQUIRED (age restriction) or UNPLAYABLE, which explain why no
@@ -330,26 +367,25 @@ function languageMatches(trackLanguage: string, preferred: string): boolean {
 	);
 }
 
-/** Fetch a caption track in json3 format and clean it into transcript text. */
-async function fetchCaptionText(baseUrl: string): Promise<string | null> {
+/** Fetch a caption track in json3 format and parse it into timed cues. */
+async function fetchCaptionCues(baseUrl: string): Promise<CaptionCue[]> {
 	const trackUrl = buildTrackUrl(baseUrl);
-	if (!trackUrl) return null;
+	if (!trackUrl) return [];
 
 	const response = await fetchWithTimeout({
 		url: trackUrl,
 		method: 'GET',
 		headers: { 'User-Agent': WATCH_PAGE_USER_AGENT },
 	});
-	if (!response.text || response.text.trim().length === 0) return null;
+	if (!response.text || response.text.trim().length === 0) return [];
 
 	let parsed: unknown;
 	try {
 		parsed = parseJson(response.text);
 	} catch {
-		return null;
+		return [];
 	}
-	const text = collectJson3Text(parsed);
-	return text.length > 0 ? text : null;
+	return collectJson3Cues(parsed);
 }
 
 /** Force `fmt=json3` onto a track URL; tolerate a protocol-relative/path base. */
@@ -367,14 +403,15 @@ function buildTrackUrl(baseUrl: string): string | null {
 }
 
 /**
- * Flatten a json3 timedtext payload (`events[].segs[].utf8`) into clean text.
+ * Parse a json3 timedtext payload (`events[].segs[].utf8`) into timed cues.
  * Skips `aAppend` continuation events (they duplicate the previous window's
- * trailing text in rolling ASR captions) and events with no segments.
+ * trailing text in rolling ASR captions), events with no segments, and
+ * blank/newline-only filler cues.
  */
-export function collectJson3Text(payload: unknown): string {
-	if (!isRecord(payload) || !Array.isArray(payload.events)) return '';
+export function collectJson3Cues(payload: unknown): CaptionCue[] {
+	if (!isRecord(payload) || !Array.isArray(payload.events)) return [];
 
-	const parts: string[] = [];
+	const cues: CaptionCue[] = [];
 	for (const event of payload.events as unknown[]) {
 		if (!isRecord(event)) continue;
 		if (event.aAppend === 1) continue;
@@ -385,11 +422,13 @@ export function collectJson3Text(payload: unknown): string {
 				eventText += seg.utf8;
 			}
 		}
-		if (eventText.trim().length > 0) {
-			parts.push(eventText);
-		}
+		const text = cleanCaptionText(eventText);
+		if (text.length === 0) continue;
+		const startMs = typeof event.tStartMs === 'number' ? event.tStartMs : 0;
+		const durationMs = typeof event.dDurationMs === 'number' ? event.dDurationMs : 0;
+		cues.push({ startMs, endMs: startMs + durationMs, text });
 	}
-	return cleanCaptionText(parts.join(' '));
+	return cues;
 }
 
 /** Decode the entities YouTube emits and collapse whitespace runs. */
@@ -403,4 +442,151 @@ function cleanCaptionText(text: string): string {
 		.replace(/&nbsp;/g, ' ')
 		.replace(/\s+/g, ' ')
 		.trim();
+}
+
+/* ── Deterministic transcript formatting ──
+ *
+ * The caption stream carries its own structure — no AI required:
+ *   - `>>` is the broadcast-captioning convention for a speaker change;
+ *     each turn becomes its own paragraph.
+ *   - Creators declare chapters as `MM:SS Title` lines in the description;
+ *     each becomes a heading linked to that timestamp in the video.
+ *   - Cue timing exposes real pauses; long gaps become paragraph breaks in
+ *     marker-less (plain ASR) transcripts.
+ */
+
+/** Minimum silence between cues that starts a new paragraph (marker-less mode). */
+const PARAGRAPH_GAP_MS = 2500;
+
+/** Force a paragraph break at the next cue once one grows past this length. */
+const PARAGRAPH_MAX_CHARS = 700;
+
+/** Chapter line: leading `H:MM:SS` or `MM:SS`, then the title. */
+const CHAPTER_LINE_REGEX = /^\s*(?:(\d{1,2}):)?(\d{1,2}):(\d{2})\s*[-–—:.]?\s+(\S.*)$/;
+
+/**
+ * Parse `MM:SS Title` chapter lines out of a video description. Returns []
+ * unless at least two chapters exist in strictly ascending order — the same
+ * shape YouTube itself requires before it renders chapter markers.
+ */
+export function parseChaptersFromDescription(description: string): VideoChapter[] {
+	const chapters: VideoChapter[] = [];
+	for (const line of description.split('\n')) {
+		const match = line.match(CHAPTER_LINE_REGEX);
+		if (!match) continue;
+		const [, hours, minutes, seconds, title] = match;
+		const startMs =
+			((hours ? parseInt(hours, 10) : 0) * 3600 +
+				parseInt(minutes, 10) * 60 +
+				parseInt(seconds, 10)) * 1000;
+		chapters.push({ title: title.trim(), startMs });
+	}
+
+	if (chapters.length < 2) return [];
+	for (let i = 1; i < chapters.length; i++) {
+		if (chapters[i].startMs <= chapters[i - 1].startMs) return [];
+	}
+	return chapters;
+}
+
+/** A timed block of output text (one speaker turn or one paragraph). */
+interface TranscriptBlock {
+	startMs: number;
+	text: string;
+}
+
+/**
+ * Split cues into speaker turns at `>>` markers. A marker can land anywhere
+ * inside a cue, so each cue's text is split and the fragments after the
+ * first each open a new turn stamped with that cue's start time.
+ */
+function splitDialogueTurns(cues: CaptionCue[]): TranscriptBlock[] {
+	const turns: TranscriptBlock[] = [];
+	let current: TranscriptBlock = { startMs: cues[0]?.startMs ?? 0, text: '' };
+
+	for (const cue of cues) {
+		const fragments = cue.text.split(/\s*>{2,}\s*/);
+		if (fragments[0]) {
+			current.text += (current.text ? ' ' : '') + fragments[0];
+		}
+		for (let i = 1; i < fragments.length; i++) {
+			if (current.text.trim()) turns.push(current);
+			current = { startMs: cue.startMs, text: fragments[i] };
+		}
+	}
+	if (current.text.trim()) turns.push(current);
+	return turns;
+}
+
+/**
+ * Group marker-less cues into paragraphs at real pauses (and force a break
+ * once a paragraph gets unreadably long).
+ */
+function paragraphsByGaps(cues: CaptionCue[]): TranscriptBlock[] {
+	const paragraphs: TranscriptBlock[] = [];
+	let current: TranscriptBlock | null = null;
+	let previousEndMs = 0;
+
+	for (const cue of cues) {
+		const isPause = current !== null && cue.startMs - previousEndMs >= PARAGRAPH_GAP_MS;
+		const isOverlong = current !== null && current.text.length >= PARAGRAPH_MAX_CHARS;
+		if (current === null || isPause || isOverlong) {
+			if (current) paragraphs.push(current);
+			current = { startMs: cue.startMs, text: cue.text };
+		} else {
+			current.text += ' ' + cue.text;
+		}
+		previousEndMs = Math.max(previousEndMs, cue.endMs);
+	}
+	if (current) paragraphs.push(current);
+	return paragraphs;
+}
+
+/**
+ * Assemble the final transcript: blocks become paragraphs, and each chapter
+ * becomes a `###` heading (linked to its timestamp in the video) inserted
+ * before the first block that starts at or after it.
+ *
+ * `structured` is true only for STRONG structure (speaker turns or chapters);
+ * pause-based paragraphs alone still leave ASR text unpunctuated, so those
+ * transcripts keep going through the AI post-processing pass.
+ */
+export function formatCaptionTranscript(
+	cues: CaptionCue[],
+	chapters: VideoChapter[],
+	videoId: string
+): { text: string; structured: boolean } {
+	const markerCount = cues.reduce(
+		(count, cue) => count + (cue.text.match(/>{2,}/g)?.length ?? 0),
+		0
+	);
+	const hasDialogue = markerCount >= 2;
+	const blocks = hasDialogue ? splitDialogueTurns(cues) : paragraphsByGaps(cues);
+
+	const lines: string[] = [];
+	let chapterIdx = 0;
+	for (const block of blocks) {
+		while (chapterIdx < chapters.length && chapters[chapterIdx].startMs <= block.startMs) {
+			lines.push(chapterHeading(chapters[chapterIdx], videoId));
+			chapterIdx++;
+		}
+		lines.push(block.text);
+	}
+	// Trailing chapters with no caption text after them (e.g. an outro card).
+	while (chapterIdx < chapters.length) {
+		lines.push(chapterHeading(chapters[chapterIdx], videoId));
+		chapterIdx++;
+	}
+
+	return {
+		text: lines.join('\n\n'),
+		structured: hasDialogue || chapters.length > 0,
+	};
+}
+
+/** `### [Title](watch?v=…&t=…)` — a heading that jumps to the chapter. */
+function chapterHeading(chapter: VideoChapter, videoId: string): string {
+	const title = chapter.title.replace(/[[\]]/g, '');
+	const seconds = Math.floor(chapter.startMs / 1000);
+	return `### [${title}](https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}&t=${seconds})`;
 }


### PR DESCRIPTION
## Summary
Caption transcripts rendered as a wall of text. The caption stream carries its own structure — all deterministic, no AI calls:

- **Speaker turns:** `>>` is the standard broadcast-captioning marker for a speaker change. Each turn becomes its own paragraph (the test video has 252 of them).
- **Chapter headings:** creators declare chapters as `MM:SS Title` lines in the video description (available in the player response). Each becomes a `###` heading **linked to that timestamp** in the video — click a chapter in your note, land there in the video. Chapter parsing mirrors YouTube's own rules (≥2 entries, ascending).
- **Pause paragraphs:** the json3 parser now keeps per-cue timing; for marker-less ASR transcripts, silences ≥2.5s become paragraph breaks, with a force-break so no paragraph grows unreadable.
- **Post-processing interplay:** strongly structured output (turns or chapters) is finished markdown and skips the AI post-processing pass — a rewrite would only flatten structure the stream itself declared. Plain ASR keeps the existing AI path (with the #468 token guard).

Verified live on the 70-minute Pivot episode: 7 linked chapter headings, 260 dialogue paragraphs, zero leftover `>>` markers, formatted in under a second at zero AI cost.

## Test plan
- [x] Lint / types / tests (1944 — cue parsing, chapter parsing incl. rejection rules, turn splitting, chapter weaving, pause/force-break paragraphing, strategy skip) / CI guards / production build pass
- [x] Live-verified formatting quality on the real video
- [ ] Manual: re-transcribe the Pivot episode — chapters + dialogue paragraphs in the note; a plain ASR video still post-processes

Co-Authored-By: Claude <bot@wafflenet.io>

https://claude.ai/code/session_012HVfTic7eKWvFiEYkoJe6m