### PR TITLE
fix: remediate backlinks on title rename, preserving display text

### DIFF
--- a/src/title/AGENTS.md
+++ b/src/title/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-last-updated: 2026-07-02
+last-updated: 2026-08-11
 ---
 
 # title module
@@ -57,6 +57,7 @@ type TitleAcceptOutcome =
 | `title-suggester.ts` | `TitleSuggester` | AI title suggestion and mismatch detection |
 | `title-store.ts` | `TitleProposalStore` | JSON persistence in `settings.title.proposalFolderPath` |
 | `content-key.ts` | `titleContentKey` | Deterministic input-keyed dedup hash for proposals (#408) |
+| `backlink-remediation.ts` | `collectInboundLinks`, `rewriteLinkText`, `rewriteContent` | Inbound-link snapshot + display-text-preserving rewrite for accepted renames (#485) |
 | `settings-section.ts` | `renderTitleSettings` | Title settings accordion (enabled toggle + duplicate-handling dropdown) (#408) |
 | `title-detector.ts` | re-exports `isUntitled` | Thin re-export of `isUntitled` through the `../shared` barrel (never the internal `shared/title-detector` file, per the shared-import rule); canonical home is `shared/title-detector.ts` |
 | `types.ts` | -- | All title types |
@@ -145,13 +146,21 @@ acceptProposal(id, options?)  -> TitleAcceptOutcome
   --> guard: { status:'skipped' } if proposal.status !== 'pending'
   --> if source note no longer a TFile: info notice, updateStatus 'rejected', refreshView, { status:'skipped' }
   --> targetPath = computeTargetPath(file, proposedTitle); collision = a different file occupies targetPath  [live recheck #408]
-  --> no collision: vault.rename(file, targetPath), accepted, announce --> { status:'renamed', path }
+  --> snapshot inbound links: collectInboundLinks(app, file) BEFORE any rename/merge (#485)
+  --> no collision: vault.rename(file, targetPath), remediateBacklinks, accepted, announce --> { status:'renamed', path }
   --> collision: resolution = options.resolution ?? (shouldAutoAccept() ? settings.title.duplicateHandling : undefined)
         --> no resolution (plain manual accept): persist conflictsWith, info 'choose Add suffix or Merge', stay pending --> { status:'conflict', target }
-        --> 'merge' & target is TFile: mergeNotes(file, existing), accepted, announce --> { status:'merged', into }
-        --> 'merge' & target not a TFile: info 'Nothing to merge into — renamed instead', rename, accepted --> { status:'renamed', path }
-        --> 'iterate': findAvailableVaultPath(targetPath), rename to free suffixed path, accepted --> { status:'renamed', path }
+        --> 'merge' & target is TFile: mergeNotes(file, existing), remediateBacklinks(-> existing.path), accepted, announce --> { status:'merged', into }
+        --> 'merge' & target not a TFile: info 'Nothing to merge into — renamed instead', rename, remediateBacklinks, accepted --> { status:'renamed', path }
+        --> 'iterate': findAvailableVaultPath(targetPath), rename to free suffixed path, remediateBacklinks, accepted --> { status:'renamed', path }
   --> on rename/process throw: notifyError, rethrow Error('Rename failed: ...')
+
+remediateBacklinks(refs, oldPath, newPath)  [private, #485]
+  --> group refs by sourcePath (a self-link's source remaps to newPath — its content moved)
+  --> per referencing note: vault.process(refFile, c => rewriteContent(c, originals, oldPath, newPath))
+      [[Old]] -> [[New|Old]]; [[Old|Custom]] -> [[New|Custom]]; [[Old#H]] -> [[New#H|Old]];
+      [t](Old%20.md) -> path-only; ![[Old]] -> ![[New]] (no alias) — display text byte-identical
+  --> per-file failure: console.warn + skip (never corrupts, never fails the accept)
 
 mergeNotes(source, target)  [private]
   --> read source; vault.process(target): union frontmatter (target wins scalar conflicts; tags+aliases unioned),
@@ -223,6 +232,7 @@ Out: consumed by `main.ts` (TitleModule, checkTitle), `views/` (TitleProposal, T
 - Reject-loop dedup (#408): both check methods skip when an existing proposal has the same `contentKey` and `status !== 'accepted'`. Editing the note changes the content hash → key → a new proposal is allowed; an `accepted` proposal never blocks.
 - `contentKey` is computed from inputs BEFORE the AI call (temperature>0 output would otherwise vary every run).
 - Auto-accept for title RENAMES (or MERGES) the file; the notice reflects the REAL outcome (suffixed name / merge target), not the originally proposed title (#408).
+- Renames use `vault.rename` (NOT `fileManager.renameFile`) on purpose: Obsidian's automatic link update would rewrite the visible prose of referencing notes. Instead every resolving accept branch snapshots inbound links first (`collectInboundLinks`, feature-detected `metadataCache.getBacklinksForFile` — no-op if absent) and rewrites them afterwards with display text preserved byte-for-byte; embeds retarget without an alias (#485). Merge retargets links from the trashed source title to the surviving note.
 - `checkTitle` is silent: no notifications until a proposal is confirmed or auto-accepted. The Review toast is gated through `reviewAction()` and suppressed for `postOp` invocations (#366) and when auto-accept is on.
 - `checkMismatch` skips notes that are already untitled (let `checkUntitled` handle those).
 - Both check methods skip if any pending proposal already exists for the note.
@@ -250,5 +260,6 @@ Out: consumed by `main.ts` (TitleModule, checkTitle), `views/` (TitleProposal, T
 | `content-key.test.ts` | titleContentKey determinism + input sensitivity (#408) |
 | `settings-section.test.ts` | renderTitleSettings accordion + duplicateHandling default (#408) |
 | `duplicate-handling.test.ts` | collision resolution: conflict flag, iterate, merge, live recheck, reject-loop dedup (#408) |
+| `backlink-remediation.test.ts` | link rewrite forms + collection, remediation across plain/iterate/merge/auto-accept branches, per-file failure isolation (#485) |
 | `auto-accept.test.ts` | Auto-accept flow (#228) |
 | `review-toast.test.ts` | Review toast notification behavior |

--- a/src/title/backlink-remediation.test.ts
+++ b/src/title/backlink-remediation.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+	collectInboundLinks,
+	rewriteLinkText,
+	rewriteContent,
+	InboundLinkRef,
+} from './backlink-remediation';
+import { TitleModule } from './index';
+import { DEFAULT_SETTINGS } from '../settings';
+import { NotificationManager } from '../shared';
+import { TFile, TFolder, Notice } from '../__mocks__/obsidian';
+
+const OLD = 'Inbox/Untitled.md';
+const NEW = 'Inbox/Neural Networks.md';
+
+describe('rewriteLinkText', () => {
+	it('aliases a bare wikilink with its old written path so the reader sees no change', () => {
+		expect(rewriteLinkText('[[Untitled]]', OLD, NEW)).toBe('[[Neural Networks|Untitled]]');
+	});
+
+	it('keeps an existing alias verbatim', () => {
+		expect(rewriteLinkText('[[Untitled|Custom]]', OLD, NEW)).toBe('[[Neural Networks|Custom]]');
+	});
+
+	it('keeps an empty alias verbatim', () => {
+		expect(rewriteLinkText('[[Untitled|]]', OLD, NEW)).toBe('[[Neural Networks|]]');
+	});
+
+	it('retargets a heading link and aliases with the old path', () => {
+		expect(rewriteLinkText('[[Untitled#Setup]]', OLD, NEW)).toBe('[[Neural Networks#Setup|Untitled]]');
+	});
+
+	it('retargets a block ref the same way', () => {
+		expect(rewriteLinkText('[[Untitled#^abc123]]', OLD, NEW)).toBe('[[Neural Networks#^abc123|Untitled]]');
+	});
+
+	it('keeps a custom alias on a heading link untouched', () => {
+		expect(rewriteLinkText('[[Untitled#Setup|see setup]]', OLD, NEW)).toBe('[[Neural Networks#Setup|see setup]]');
+	});
+
+	it('preserves a folder prefix and .md extension as written', () => {
+		expect(rewriteLinkText('[[Inbox/Untitled]]', OLD, NEW)).toBe('[[Inbox/Neural Networks|Inbox/Untitled]]');
+		expect(rewriteLinkText('[[Inbox/Untitled.md|Custom]]', OLD, NEW)).toBe('[[Inbox/Neural Networks.md|Custom]]');
+	});
+
+	it('matches the written basename case-insensitively but rewrites to the real new name', () => {
+		expect(rewriteLinkText('[[untitled]]', OLD, NEW)).toBe('[[Neural Networks|untitled]]');
+	});
+
+	it('retargets an embed without adding an alias', () => {
+		expect(rewriteLinkText('![[Untitled]]', OLD, NEW)).toBe('![[Neural Networks]]');
+	});
+
+	it('keeps an existing embed alias (e.g. sizing)', () => {
+		expect(rewriteLinkText('![[Untitled|300]]', OLD, NEW)).toBe('![[Neural Networks|300]]');
+	});
+
+	it('retargets an embed subpath without adding an alias', () => {
+		expect(rewriteLinkText('![[Untitled#Setup]]', OLD, NEW)).toBe('![[Neural Networks#Setup]]');
+	});
+
+	it('rewrites only the path of a markdown link, re-encoding it', () => {
+		expect(rewriteLinkText('[my text](Untitled.md)', OLD, NEW)).toBe('[my text](Neural%20Networks.md)');
+	});
+
+	it('decodes percent-encoded markdown paths and keeps the anchor', () => {
+		expect(rewriteLinkText('[t](Old%20Note.md#sec)', 'Old Note.md', 'New Note.md')).toBe('[t](New%20Note.md#sec)');
+	});
+
+	it('keeps angle-bracket markdown targets unencoded', () => {
+		expect(rewriteLinkText('[t](<Old Note.md#sec>)', 'Old Note.md', 'New Note.md')).toBe('[t](<New Note.md#sec>)');
+	});
+
+	it('returns null for a link that does not target the old note', () => {
+		expect(rewriteLinkText('[[Other Note]]', OLD, NEW)).toBeNull();
+		expect(rewriteLinkText('[t](Other%20Note.md)', OLD, NEW)).toBeNull();
+	});
+
+	it('returns null for unrecognized text', () => {
+		expect(rewriteLinkText('plain prose', OLD, NEW)).toBeNull();
+		expect(rewriteLinkText('[[Untitled]] trailing', OLD, NEW)).toBeNull();
+	});
+});
+
+describe('rewriteContent', () => {
+	it('replaces every exact occurrence of each collected link', () => {
+		const content = 'See [[Untitled]] and again [[Untitled]] plus [[Untitled|Custom]].';
+		const out = rewriteContent(content, ['[[Untitled]]', '[[Untitled|Custom]]'], OLD, NEW);
+		expect(out).toBe(
+			'See [[Neural Networks|Untitled]] and again [[Neural Networks|Untitled]] plus [[Neural Networks|Custom]].'
+		);
+	});
+
+	it('leaves content untouched when no collected link matches the old note', () => {
+		const content = 'See [[Other Note]].';
+		expect(rewriteContent(content, ['[[Other Note]]'], OLD, NEW)).toBe(content);
+	});
+
+	it('leaves non-link originals untouched (never corrupts prose)', () => {
+		const content = 'Untitled appears as a plain word here.';
+		expect(rewriteContent(content, ['Untitled'], OLD, NEW)).toBe(content);
+	});
+});
+
+describe('collectInboundLinks', () => {
+	const file = new TFile(OLD) as never;
+
+	function appWith(getBacklinksForFile: unknown) {
+		return { metadataCache: { getBacklinksForFile } } as never;
+	}
+
+	it('returns [] when getBacklinksForFile is unavailable', () => {
+		expect(collectInboundLinks({ metadataCache: {} } as never, file)).toEqual([]);
+	});
+
+	it('reads a Map-shaped data dict', () => {
+		const data = new Map([['A.md', [{ link: 'Untitled', original: '[[Untitled]]' }]]]);
+		const refs = collectInboundLinks(appWith(() => ({ data })), file);
+		expect(refs).toEqual([{ sourcePath: 'A.md', original: '[[Untitled]]' }]);
+	});
+
+	it('reads a plain-object data dict', () => {
+		const data = { 'B.md': [{ link: 'Untitled', original: '[[Untitled|x]]' }] };
+		const refs = collectInboundLinks(appWith(() => ({ data })), file);
+		expect(refs).toEqual([{ sourcePath: 'B.md', original: '[[Untitled|x]]' }]);
+	});
+
+	it('skips entries without a usable original and survives a throwing cache', () => {
+		const data = new Map([['A.md', [{ link: 'Untitled' }, null, { original: '' }]]]);
+		expect(collectInboundLinks(appWith(() => ({ data })), file)).toEqual([]);
+		expect(collectInboundLinks(appWith(() => { throw new Error('boom'); }), file)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration: remediation wired into TitleModule.acceptProposal
+// ---------------------------------------------------------------------------
+
+const mockSuggester = vi.hoisted(() => ({
+	title: 'Neural Networks',
+	reasoning: 'Content is about neural networks',
+}));
+
+vi.mock('./title-suggester', () => ({
+	TitleSuggester: class MockTitleSuggester {
+		constructor(_client: unknown) {}
+		suggestTitle = vi.fn(async () => ({ title: mockSuggester.title, reasoning: mockSuggester.reasoning }));
+		checkTitleMismatch = vi.fn(async () => ({ isMismatch: false }));
+	},
+}));
+
+/** In-memory adapter so TitleProposalStore round-trips proposals via JSON. */
+function createMemoryAdapter() {
+	const files = new Map<string, string>();
+	return {
+		read: vi.fn(async (path: string) => {
+			if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+			return files.get(path)!;
+		}),
+		write: vi.fn(async (path: string, content: string) => { files.set(path, content); }),
+		exists: vi.fn(async (path: string) => {
+			if (files.has(path)) return true;
+			for (const key of files.keys()) if (key.startsWith(path + '/')) return true;
+			return false;
+		}),
+		remove: vi.fn(async (path: string) => { files.delete(path); }),
+		list: vi.fn(async (folder: string) => {
+			const out: string[] = [];
+			for (const key of files.keys()) if (key.startsWith(folder + '/')) out.push(key);
+			return { files: out, folders: [] };
+		}),
+	};
+}
+
+/** A TFile whose `parent` folder path is derived from the path. */
+function makeFile(path: string): TFile {
+	const file = new TFile(path);
+	const slash = path.lastIndexOf('/');
+	if (slash >= 0) file.parent = new TFolder(path.slice(0, slash));
+	return file;
+}
+
+/**
+ * TitleModule over an in-memory vault whose metadataCache derives backlinks
+ * from a declared `links` map: target path -> refs pointing at it.
+ */
+function harness(
+	notes: Record<string, string>,
+	links: Record<string, InboundLinkRef[]>,
+	opts?: { autoAccept?: boolean }
+) {
+	const adapter = createMemoryAdapter();
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	if (opts?.autoAccept) settings.autoAccept.title = true;
+	const notifications = new NotificationManager();
+
+	const files = new Map<string, TFile | TFolder>();
+	const contents = new Map<string, string>();
+	for (const [path, content] of Object.entries(notes)) {
+		files.set(path, makeFile(path));
+		contents.set(path, content);
+	}
+
+	const renameSpy = vi.fn(async (file: TFile, newPath: string) => {
+		contents.set(newPath, contents.get(file.path) ?? '');
+		contents.delete(file.path);
+		files.delete(file.path);
+		files.set(newPath, makeFile(newPath));
+	});
+	const processSpy = vi.fn(async (file: TFile, fn: (c: string) => string) => {
+		const next = fn(contents.get(file.path) ?? '');
+		contents.set(file.path, next);
+		return next;
+	});
+	const trashSpy = vi.fn(async (file: TFile) => {
+		files.delete(file.path);
+		contents.delete(file.path);
+	});
+
+	const mockPlugin = {
+		app: {
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) => files.get(path) ?? null),
+				read: vi.fn(async (file: TFile) => contents.get(file.path) ?? ''),
+				rename: renameSpy,
+				process: processSpy,
+				createFolder: vi.fn().mockResolvedValue(undefined),
+				adapter,
+			},
+			fileManager: { trashFile: trashSpy },
+			metadataCache: {
+				getFileCache: vi.fn().mockReturnValue(null),
+				getBacklinksForFile: vi.fn((file: TFile) => ({
+					data: new Map(
+						Object.entries(
+							(links[file.path] ?? []).reduce<Record<string, { original: string }[]>>((acc, ref) => {
+								(acc[ref.sourcePath] ??= []).push({ original: ref.original });
+								return acc;
+							}, {})
+						)
+					),
+				})),
+			},
+		},
+	};
+
+	const mod = new TitleModule(
+		mockPlugin as never,
+		() => settings,
+		notifications,
+		() => settings.autoAccept.title,
+	);
+
+	return { mod, settings, contents, files, processSpy, renameSpy, trashSpy };
+}
+
+const SOURCE = 'Inbox/Untitled.md';
+const TARGET = 'Inbox/Neural Networks.md';
+const BODY = '# Notes\n\nDetailed content about neural networks and training.';
+
+async function firstPending(mod: TitleModule) {
+	const pending = await mod.getPendingProposals();
+	return pending[0];
+}
+
+describe('TitleModule backlink remediation (#485)', () => {
+	beforeEach(() => {
+		Notice.instances.length = 0;
+		mockSuggester.title = 'Neural Networks';
+	});
+	afterEach(() => { vi.restoreAllMocks(); });
+
+	it('plain rename: rewrites every inbound link form, preserving display text byte-for-byte', async () => {
+		const refA = 'Intro: [[Untitled]] then [[Untitled|the draft]] and [[Untitled#Setup]].';
+		const refB = 'Embed ![[Untitled]] plus md [link text](Untitled.md).';
+		const h = harness(
+			{ [SOURCE]: BODY, 'Refs/A.md': refA, 'Refs/B.md': refB },
+			{
+				[SOURCE]: [
+					{ sourcePath: 'Refs/A.md', original: '[[Untitled]]' },
+					{ sourcePath: 'Refs/A.md', original: '[[Untitled|the draft]]' },
+					{ sourcePath: 'Refs/A.md', original: '[[Untitled#Setup]]' },
+					{ sourcePath: 'Refs/B.md', original: '![[Untitled]]' },
+					{ sourcePath: 'Refs/B.md', original: '[link text](Untitled.md)' },
+				],
+			}
+		);
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		await h.mod.acceptProposal(p.id);
+
+		expect(h.renameSpy).toHaveBeenCalledTimes(1);
+		expect(h.contents.get('Refs/A.md')).toBe(
+			'Intro: [[Neural Networks|Untitled]] then [[Neural Networks|the draft]] and [[Neural Networks#Setup|Untitled]].'
+		);
+		expect(h.contents.get('Refs/B.md')).toBe(
+			'Embed ![[Neural Networks]] plus md [link text](Neural%20Networks.md).'
+		);
+	});
+
+	it('iterate resolution: links retarget to the suffixed path actually used', async () => {
+		const h = harness(
+			{ [SOURCE]: BODY, [TARGET]: 'existing', 'Refs/A.md': 'See [[Untitled]].' },
+			{ [SOURCE]: [{ sourcePath: 'Refs/A.md', original: '[[Untitled]]' }] }
+		);
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		await h.mod.acceptProposal(p.id, { resolution: 'iterate' });
+
+		expect(h.renameSpy.mock.calls[0][1]).toBe('Inbox/Neural Networks-1.md');
+		expect(h.contents.get('Refs/A.md')).toBe('See [[Neural Networks-1|Untitled]].');
+	});
+
+	it('merge resolution: links to the trashed source retarget to the surviving note', async () => {
+		const h = harness(
+			{ [SOURCE]: 'Source body', [TARGET]: 'Target body', 'Refs/A.md': 'See [[Untitled|the draft]].' },
+			{ [SOURCE]: [{ sourcePath: 'Refs/A.md', original: '[[Untitled|the draft]]' }] }
+		);
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		await h.mod.acceptProposal(p.id, { resolution: 'merge' });
+
+		expect(h.trashSpy).toHaveBeenCalledTimes(1);
+		expect(h.contents.get('Refs/A.md')).toBe('See [[Neural Networks|the draft]].');
+	});
+
+	it('self-links: a note linking to itself is rewritten at its NEW path after the rename', async () => {
+		const h = harness(
+			{ [SOURCE]: `${BODY}\n\nSee [[Untitled#Setup]].` },
+			{ [SOURCE]: [{ sourcePath: SOURCE, original: '[[Untitled#Setup]]' }] }
+		);
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		await h.mod.acceptProposal(p.id);
+
+		expect(h.contents.get(TARGET)).toContain('See [[Neural Networks#Setup|Untitled]].');
+	});
+
+	it('auto-accept path remediates too', async () => {
+		const h = harness(
+			{ [SOURCE]: BODY, 'Refs/A.md': 'See [[Untitled]].' },
+			{ [SOURCE]: [{ sourcePath: 'Refs/A.md', original: '[[Untitled]]' }] },
+			{ autoAccept: true }
+		);
+		await h.mod.onload();
+
+		await h.mod.checkUntitled(SOURCE);
+
+		expect(h.renameSpy).toHaveBeenCalledTimes(1);
+		expect(h.contents.get('Refs/A.md')).toBe('See [[Neural Networks|Untitled]].');
+	});
+
+	it('a failing rewrite in one note neither corrupts it nor blocks other notes or the accept', async () => {
+		const h = harness(
+			{ [SOURCE]: BODY, 'Refs/A.md': 'See [[Untitled]].', 'Refs/B.md': 'Also [[Untitled]].' },
+			{
+				[SOURCE]: [
+					{ sourcePath: 'Refs/A.md', original: '[[Untitled]]' },
+					{ sourcePath: 'Refs/B.md', original: '[[Untitled]]' },
+				],
+			}
+		);
+		const realProcess = h.processSpy.getMockImplementation()!;
+		h.processSpy.mockImplementation(async (file: TFile, fn: (c: string) => string) => {
+			if (file.path === 'Refs/A.md') throw new Error('disk full');
+			return realProcess(file, fn);
+		});
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		const outcome = await h.mod.acceptProposal(p.id);
+
+		expect(outcome.status).toBe('renamed');
+		expect(h.contents.get('Refs/A.md')).toBe('See [[Untitled]].'); // untouched, not corrupted
+		expect(h.contents.get('Refs/B.md')).toBe('Also [[Neural Networks|Untitled]].');
+		expect(warn).toHaveBeenCalled();
+		expect(await h.mod.getPendingProposals()).toHaveLength(0);
+	});
+
+	it('a referencing note that vanished before remediation is skipped without error', async () => {
+		const h = harness(
+			{ [SOURCE]: BODY },
+			{ [SOURCE]: [{ sourcePath: 'Refs/Gone.md', original: '[[Untitled]]' }] }
+		);
+		await h.mod.onload();
+		await h.mod.checkUntitled(SOURCE);
+		const p = await firstPending(h.mod);
+
+		const outcome = await h.mod.acceptProposal(p.id);
+
+		expect(outcome.status).toBe('renamed');
+	});
+});

--- a/src/title/backlink-remediation.ts
+++ b/src/title/backlink-remediation.ts
@@ -1,0 +1,170 @@
+import { App, TFile } from 'obsidian';
+
+/**
+ * Backlink remediation for title renames (#485).
+ *
+ * `vault.rename` deliberately bypasses Obsidian's automatic link updating
+ * (which would rewrite `[[Old Title]]` to `[[New Title]]` and silently change
+ * the visible prose of referencing notes). Instead, the title module snapshots
+ * inbound links BEFORE the rename and rewrites each one afterwards, retargeting
+ * the link while preserving its rendered display text byte-for-byte:
+ *
+ * - `[[Old Title]]`          -> `[[New Title|Old Title]]`
+ * - `[[Old Title|Custom]]`   -> `[[New Title|Custom]]`
+ * - `[[Old Title#Heading]]`  -> `[[New Title#Heading|Old Title]]` (and `#^block`)
+ * - `[text](Old%20Title.md)` -> `[text](New%20Title.md)` (path only)
+ * - `![[Old Title]]`         -> `![[New Title]]` (embeds render content, not text)
+ */
+
+/** A snapshot of one inbound link, captured BEFORE the rename. */
+export interface InboundLinkRef {
+	/** Vault path of the note containing the link. */
+	sourcePath: string;
+	/** The link exactly as written in that note, e.g. `[[Old Title|Custom]]`. */
+	original: string;
+}
+
+/** Minimal shape of the unexposed `metadataCache.getBacklinksForFile` result. */
+interface BacklinkDict {
+	data: Map<string, unknown[]> | Record<string, unknown[]>;
+}
+
+type BacklinkCapableCache = {
+	getBacklinksForFile?: (file: TFile) => BacklinkDict | null | undefined;
+};
+
+/**
+ * Snapshot all inbound links to `file` via `metadataCache.getBacklinksForFile`.
+ * The method is not in the public typings, so it is feature-detected: on an
+ * Obsidian build without it this returns `[]` and remediation is a no-op.
+ * `.data` is a Map on current builds but was a plain object historically —
+ * both shapes are accepted.
+ */
+export function collectInboundLinks(app: App, file: TFile): InboundLinkRef[] {
+	const cache = app.metadataCache as unknown as BacklinkCapableCache;
+	if (typeof cache.getBacklinksForFile !== 'function') return [];
+
+	let dict: BacklinkDict | null | undefined;
+	try {
+		dict = cache.getBacklinksForFile(file);
+	} catch {
+		return [];
+	}
+	const data = dict?.data;
+	if (!data) return [];
+
+	const entries: Iterable<[string, unknown]> =
+		data instanceof Map ? data.entries() : Object.entries(data);
+
+	const refs: InboundLinkRef[] = [];
+	for (const [sourcePath, links] of entries) {
+		if (!Array.isArray(links)) continue;
+		for (const link of links) {
+			const original = (link as { original?: unknown } | null)?.original;
+			if (typeof original === 'string' && original.length > 0) {
+				refs.push({ sourcePath, original });
+			}
+		}
+	}
+	return refs;
+}
+
+/** Final path segment without a trailing `.md`, e.g. `Inbox/Old.md` -> `Old`. */
+function noteBasename(path: string): string {
+	const name = path.split('/').pop() ?? path;
+	return name.replace(/\.md$/i, '');
+}
+
+/**
+ * Retarget the path portion of a link from the old note to the new one,
+ * preserving how the author wrote it: folder prefix and `.md` extension are
+ * kept if present. Returns `null` when the written path does not end in the
+ * old note's basename (resolved some other way — do not guess).
+ */
+function retargetLinkpath(linkpath: string, oldPath: string, newPath: string): string | null {
+	if (!linkpath) return null;
+	const slash = linkpath.lastIndexOf('/');
+	const dir = slash >= 0 ? linkpath.slice(0, slash + 1) : '';
+	const name = linkpath.slice(slash + 1);
+	const hadExt = /\.md$/i.test(name);
+	const base = hadExt ? name.slice(0, -3) : name;
+	if (base.toLowerCase() !== noteBasename(oldPath).toLowerCase()) return null;
+	return dir + noteBasename(newPath) + (hadExt ? '.md' : '');
+}
+
+const WIKILINK_RE = /^(!?)\[\[([^\][|]*)(?:\|([^\][]*))?\]\]$/;
+const MARKDOWN_RE = /^(!?)\[([^\]]*)\]\(([^)]*)\)$/;
+
+/**
+ * Rewrite a single link (as written) so it targets `newPath` while its
+ * rendered text stays byte-identical. Returns `null` when the text is not a
+ * recognized link form or does not target `oldPath` — callers must leave the
+ * original untouched in that case.
+ */
+export function rewriteLinkText(original: string, oldPath: string, newPath: string): string | null {
+	const wiki = WIKILINK_RE.exec(original);
+	if (wiki) {
+		const [, bang, target, alias] = wiki;
+		const hash = target.indexOf('#');
+		const linkpath = hash >= 0 ? target.slice(0, hash) : target;
+		const subpath = hash >= 0 ? target.slice(hash) : '';
+		const newLinkpath = retargetLinkpath(linkpath, oldPath, newPath);
+		if (newLinkpath === null) return null;
+		if (bang === '!') {
+			// Embeds render content, not text — retarget without adding an alias,
+			// but keep an existing one (it may carry sizing like `|300`).
+			const aliasPart = alias !== undefined ? `|${alias}` : '';
+			return `![[${newLinkpath}${subpath}${aliasPart}]]`;
+		}
+		// Preserve rendered text: an existing alias is kept verbatim; otherwise
+		// the old written path becomes the alias so the reader sees no change.
+		const display = alias !== undefined ? alias : linkpath;
+		return `[[${newLinkpath}${subpath}|${display}]]`;
+	}
+
+	const md = MARKDOWN_RE.exec(original);
+	if (md) {
+		const [, bang, text, rawTarget] = md;
+		const wrapped = rawTarget.startsWith('<') && rawTarget.endsWith('>');
+		const target = wrapped ? rawTarget.slice(1, -1) : rawTarget;
+		const hash = target.indexOf('#');
+		const pathPart = hash >= 0 ? target.slice(0, hash) : target;
+		const anchor = hash >= 0 ? target.slice(hash) : '';
+		let decoded = pathPart;
+		try {
+			decoded = decodeURIComponent(pathPart);
+		} catch {
+			// Not valid percent-encoding — treat as a literal path.
+		}
+		const newLinkpath = retargetLinkpath(decoded, oldPath, newPath);
+		if (newLinkpath === null) return null;
+		const newTarget = wrapped ? `<${newLinkpath}${anchor}>` : `${encodeURI(newLinkpath)}${anchor}`;
+		return `${bang}[${text}](${newTarget})`;
+	}
+
+	return null;
+}
+
+/**
+ * Rewrite every collected link occurrence inside one note's content. Only
+ * exact matches of the recorded `original` text are replaced (identical links
+ * get identical rewrites), so a stale cache entry can never corrupt prose —
+ * unrecognized or non-matching links are left untouched.
+ */
+export function rewriteContent(
+	content: string,
+	originals: string[],
+	oldPath: string,
+	newPath: string
+): string {
+	let out = content;
+	const seen = new Set<string>();
+	for (const original of originals) {
+		if (seen.has(original)) continue;
+		seen.add(original);
+		const rewritten = rewriteLinkText(original, oldPath, newPath);
+		if (rewritten === null || rewritten === original) continue;
+		out = out.split(original).join(rewritten);
+	}
+	return out;
+}

--- a/src/title/index.ts
+++ b/src/title/index.ts
@@ -5,6 +5,7 @@ import {
 	findAvailableVaultPath, parseFrontmatter, serializeFrontmatter, mergeTags, normalizeFrontmatterTags,
 } from '../shared';
 import { TitleProposalStore } from './title-store';
+import { collectInboundLinks, rewriteContent, InboundLinkRef } from './backlink-remediation';
 import { TitleSuggester } from './title-suggester';
 import { isUntitled } from './title-detector';
 import { titleContentKey } from './content-key';
@@ -304,6 +305,9 @@ export class TitleModule {
 	 * Auto-accept passes `silent: true` and lets the resolution default to
 	 * `settings.title.duplicateHandling`. Returns a {@link TitleAcceptOutcome} so
 	 * auto-accept can announce the real result.
+	 *
+	 * Every resolving branch remediates inbound links afterwards, preserving
+	 * each link's rendered display text (#485) — see {@link remediateBacklinks}.
 	 */
 	async acceptProposal(
 		id: string,
@@ -326,11 +330,17 @@ export class TitleModule {
 		const existing = this.plugin.app.vault.getAbstractFileByPath(targetPath);
 		const collision = !!existing && existing.path !== file.path;
 
+		// Snapshot inbound links BEFORE any rename/merge: vault.rename does not
+		// update links, so every branch below remediates them afterwards (#485).
+		const oldPath = file.path;
+		const inboundLinks = collectInboundLinks(this.plugin.app, file);
+
 		try {
 			if (!collision) {
 				// Happy path: target is free (or the collision vanished since the
 				// proposal was created) — plain rename, no suffix.
 				await this.plugin.app.vault.rename(file, targetPath);
+				await this.remediateBacklinks(inboundLinks, oldPath, targetPath);
 				await this.store.updateStatus(id, 'accepted');
 				await this.announceAccept(options?.silent, `Renamed to "${this.baseName(targetPath)}"`);
 				return { status: 'renamed', path: targetPath };
@@ -356,6 +366,9 @@ export class TitleModule {
 			if (resolution === 'merge') {
 				if (existing instanceof TFile) {
 					await this.mergeNotes(file, existing);
+					// The source's content (and identity) now lives in the target:
+					// retarget links from the trashed title to the survivor (#485).
+					await this.remediateBacklinks(inboundLinks, oldPath, existing.path);
 					await this.store.updateStatus(id, 'accepted');
 					await this.announceAccept(options?.silent, `Merged into "${this.baseName(existing.path)}"`);
 					return { status: 'merged', into: existing.path };
@@ -364,6 +377,7 @@ export class TitleModule {
 				// plain rename so the accept still resolves, with a heads-up.
 				this.notifications.info('Nothing to merge into — renamed instead');
 				await this.plugin.app.vault.rename(file, targetPath);
+				await this.remediateBacklinks(inboundLinks, oldPath, targetPath);
 				await this.store.updateStatus(id, 'accepted');
 				if (!options?.silent) await this.refreshView();
 				return { status: 'renamed', path: targetPath };
@@ -373,6 +387,7 @@ export class TitleModule {
 			// note is never clobbered.
 			const freePath = findAvailableVaultPath(this.plugin.app, targetPath);
 			await this.plugin.app.vault.rename(file, freePath);
+			await this.remediateBacklinks(inboundLinks, oldPath, freePath);
 			await this.store.updateStatus(id, 'accepted');
 			await this.announceAccept(options?.silent, `Renamed to "${this.baseName(freePath)}"`);
 			return { status: 'renamed', path: freePath };
@@ -380,6 +395,45 @@ export class TitleModule {
 			const msg = error instanceof Error ? error.message : String(error);
 			this.notifications.notifyError('Failed to rename note', error);
 			throw new Error(`Rename failed: ${msg}`);
+		}
+	}
+
+	/**
+	 * Rewrite the pre-rename snapshot of inbound links so each still resolves
+	 * after the note moved from `oldPath` to `newPath`, preserving rendered
+	 * display text (#485). Per-file rewrites are independent and atomic
+	 * (`vault.process` + exact-match replacement), so one failure neither
+	 * corrupts that note nor blocks the others — it is logged and skipped, and
+	 * the accept itself never fails on remediation.
+	 */
+	private async remediateBacklinks(
+		refs: InboundLinkRef[],
+		oldPath: string,
+		newPath: string
+	): Promise<void> {
+		if (refs.length === 0) return;
+
+		const bySource = new Map<string, string[]>();
+		for (const ref of refs) {
+			// A self-link's content now lives at the new path (rename) or inside
+			// the merge target — remediate it there.
+			const sourcePath = ref.sourcePath === oldPath ? newPath : ref.sourcePath;
+			const originals = bySource.get(sourcePath) ?? [];
+			originals.push(ref.original);
+			bySource.set(sourcePath, originals);
+		}
+
+		for (const [sourcePath, originals] of bySource) {
+			try {
+				const refFile = this.plugin.app.vault.getAbstractFileByPath(sourcePath);
+				if (!(refFile instanceof TFile)) continue;
+				await this.plugin.app.vault.process(refFile, (content) =>
+					rewriteContent(content, originals, oldPath, newPath)
+				);
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				console.warn(`[Synapse] Backlink update failed for ${sourcePath}: ${msg}`);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Accepting a title proposal renamed the note with `vault.rename`, which bypasses Obsidian's link updating — every inbound `[[wikilink]]` was orphaned. Switching to `fileManager.renameFile` was deliberately rejected: its automatic rewrite changes how referencing notes *read*.

This PR makes all three accept branches in `TitleModule.acceptProposal` (plain rename, iterate/suffix, merge) remediate inbound links while preserving each link's rendered display text byte-for-byte:

- `[[Old Title]]` → `[[New Title|Old Title]]` (reader sees no change)
- `[[Old Title|Custom]]` → `[[New Title|Custom]]` (existing alias kept verbatim)
- `[[Old Title#Heading]]` / `[[Old Title#^block]]` → `[[New Title#Heading|Old Title]]`
- `[text](Old%20Title.md)` → path-only update, re-encoded; link text untouched
- `![[Old Title]]` → `![[New Title]]` (embeds render content, not text; sizing aliases like `|300` kept)

Mechanics:

- **Snapshot before, rewrite after.** `collectInboundLinks` captures `metadataCache.getBacklinksForFile(file)` before any rename/merge; each referencing note is then rewritten via `vault.process`. The method is not in the public typings, so it is feature-detected — without it, remediation is a no-op and behavior is unchanged.
- **Merge branch** retargets links from the trashed source title to the surviving note — including the source's own self-links, which now live in the merged body (a self-link's source path is remapped to the note's new location).
- **Auto-accept** (`maybeAutoAccept`) flows through `acceptProposal`, so it is covered by the same wiring.
- **Failure isolation:** only exact matches of the recorded link text are replaced (a stale cache entry can never corrupt prose), per-file rewrites are independent and atomic, and a failing note is logged and skipped — remediation never fails the accept.

New helper module: `src/title/backlink-remediation.ts` (`collectInboundLinks`, `rewriteLinkText`, `rewriteContent`); wiring plus a `remediateBacklinks` applier in `src/title/index.ts`; `src/title/AGENTS.md` updated.

## Test plan

- New `src/title/backlink-remediation.test.ts`: 30 tests — pure rewrite coverage for every link form (bare/aliased/empty-alias wikilinks, heading + block refs, folder-prefixed and `.md`-suffixed paths, case-insensitive basenames, embeds with/without sizing alias, markdown links incl. percent-encoding, anchors, and angle-bracket targets, non-matching/unrecognized text), Map- and object-shaped backlink dicts, missing/throwing `getBacklinksForFile`, and integration through all three accept branches, the auto-accept path, self-links, a vanished referencing note, and a mid-remediation failure (no corruption, other notes still rewritten, accept still succeeds).
- [x] Lint passes (`npm run lint`)
- [x] Types pass (`npx tsc --noEmit --skipLibCheck`)
- [x] Tests pass (`npm test` — 147 files, 1992 tests)
- [x] `node scripts/check-top-level-requires.mjs`
- [x] `node scripts/version-bump.mjs --check`
- [x] Build passes (`node esbuild.config.mjs production`)

Closes #485

Co-Authored-By: Claude <bot@wafflenet.io>
